### PR TITLE
Expand pre-commit hook to all files

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -55,4 +55,4 @@ jobs:
           output: both
           thresholds: '60 80'
       - name: "Run pre-commit hooks"
-        run: git ls-files -- $(package_name) | xargs poetry run pre-commit run --files
+        run: git ls-files -- . | xargs poetry run pre-commit run --files


### PR DESCRIPTION
The existing configuration targets only `$(package_name)` which is the package directory. This change expands this to run on all files in the repo.