### PR TITLE
Add pull request and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_template.md
+++ b/.github/ISSUE_TEMPLATE/blank_template.md
@@ -1,0 +1,8 @@
+---
+name: Other
+about: For all other issues to reach the community...
+title: ''
+labels: ''
+assignees: ''
+
+---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,54 @@
+---
+name: Bug report
+about: Create a report to help us reproduce and correct the bug
+title: ''
+labels: 'Bug: triage'
+assignees: ''
+
+---
+
+<!--
+Before submitting a bug, please make sure the issue hasn't been already
+addressed by searching through the past issues.
+-->
+
+#### Describe the bug
+<!--
+A clear and concise description of what the bug is.
+-->
+
+#### Steps/Code to Reproduce
+<!--
+Please add a minimal example (in the form of code) that reproduces the error.
+Be as succinct as possible, do not depend on external data. In short, we are
+going to copy-paste your code and we expect to get the same result as you.
+-->
+
+```python
+Sample code to reproduce the problem
+```
+
+#### Expected Results
+<!-- Example: No error is thrown. Please paste or describe the expected results.-->
+
+#### Actual Results
+<!-- Please paste or specifically describe the actual output or traceback. -->
+
+#### Screenshots
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+#### Versions
+<!--
+Please provide the following information:
+- OS: [e.g. Windows]
+- Browser (if you're reporting a bug in jupyter): [e.g. Edge, Firefox, Chrome, Safari]
+- Python version: [e.g. 3.10.11]
+- PyRIT version: [e.g. 0.1.0 or installed from main branch in editable mode]
+- version of Python packages: please run the following snippet and paste the output:
+  ```python
+  import pyrit
+  pyrit.show_versions()
+  ```
+-->
+
+<!-- Thanks for contributing! -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/doc_improvement.md
+++ b/.github/ISSUE_TEMPLATE/doc_improvement.md
@@ -1,0 +1,20 @@
+---
+name: Documentation improvement
+about: Create a report to help us improve the documentation. Alternatively you can just open a pull request with the suggested change.
+title: ''
+labels: Documentation
+assignees: ''
+
+---
+
+#### Describe the issue linked to the documentation
+
+<!--
+Tell us what's confusing or missing in the documentation.
+-->
+
+#### Suggest a potential alternative/fix
+
+<!--
+Tell us how we could improve the documentation in this regard.
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: feature-request
+assignees: ''
+
+---
+
+#### Is your feature request related to a problem? Please describe.
+<!-- A clear and concise description of what the problem is. E.g., I'm always
+frustrated when ... -->
+
+#### Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen. -->
+
+#### Describe alternatives you've considered, if relevant
+<!-- A clear and concise description of any alternative solutions or features
+you've considered. -->
+
+#### Additional context
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Description
+<!--- Provide a general summary of your changes. -->
+<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
+<!--- Tag people for whom this PR may be of interest using @<username>. -->
+
+## Tests
+<!--- Select all that apply by putting an x between the brackets: [x] -->
+- [ ] no new tests required
+- [ ] new tests added
+- [ ] existing tests adjusted
+
+## Documentation
+<!--- Select all that apply by putting an x between the brackets: [x] -->
+- [ ] no documentation changes needed
+- [ ] documentation added or edited
+- [ ] example notebook added or updated

--- a/pyrit/__init__.py
+++ b/pyrit/__init__.py
@@ -1,2 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+
+from .show_versions import show_versions  # noqa: F401
+
+
+__name__ = "pyrit"
+# Remove dev suffix when releasing and keep in sync with pyproject.toml
+__version__ = "0.1.0.dev0"

--- a/pyrit/show_versions.py
+++ b/pyrit/show_versions.py
@@ -1,0 +1,83 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""Utility methods to print system info for debugging.
+
+Adapted from :py:func:`pandas.show_versions` and :py:func:`sklearn.show_versions`.
+"""  # noqa: RST304
+
+import platform
+import sys
+
+
+def _get_sys_info():
+    """System information.
+
+    Returns
+    -------
+    sys_info : dict
+        system and Python version information
+    """
+    python = sys.version.replace("\n", " ")
+
+    blob = [
+        ("python", python),
+        ("executable", sys.executable),
+        ("machine", platform.platform()),
+    ]
+
+    return dict(blob)
+
+
+def _get_deps_info():
+    """Overview of the installed version of main dependencies.
+
+    This function does not import the modules to collect the version numbers
+    but instead relies on standard Python package metadata.
+
+    Returns
+    -------
+    deps_info: dict
+        version information on relevant Python libraries
+    """
+    deps = sorted(
+        [
+            "pip",
+            "setuptools",
+            "numpy",
+            "scipy",
+            "Cython",
+            "scikit-learn",
+            "openai",
+            "torch",
+            "tensorflow",
+            "transformers",
+        ]
+    )
+
+    from pyrit import __version__
+
+    deps_info = {"pyrit": __version__}
+
+    from importlib.metadata import PackageNotFoundError, version
+
+    for modname in deps:
+        try:
+            deps_info[modname] = version(modname)
+        except PackageNotFoundError:
+            deps_info[modname] = None
+    return deps_info
+
+
+def show_versions():
+    """Print useful debugging information."""
+    sys_info = _get_sys_info()
+    deps_info = _get_deps_info()
+
+    print("\nSystem:")
+    for k, stat in sys_info.items():
+        print("{k:>10}: {stat}".format(k=k, stat=stat))
+
+    print("\nPython dependencies:")
+    for k, stat in deps_info.items():
+        print("{k:>13}: {stat}".format(k=k, stat=stat))


### PR DESCRIPTION
Adding PR and issue templates to prompt for essential information.

To enable better bug reports I've also added `show_versions` which collects the relevant system and package versions. This is loosely based on the ones we created for Fairlearn a while ago, but with relevant adjustments and modifications.