### PR TITLE
Component governance: generate requirements.txt file

### DIFF
--- a/component-governance.yml
+++ b/component-governance.yml
@@ -1,4 +1,7 @@
 # Run Component Governance to register all dependencies.
+# Component Detection with Poetry is currently in beta,
+# so as a workaround we generate the requirements.txt file
+# to help Component Governance detect the components.
 
 trigger:
   - main
@@ -7,4 +10,24 @@ pool:
   vmImage: "ubuntu-latest"
 
 steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.10'
+    displayName: 'Use Python 3.10'
+
+  - script: |
+      curl -sSL https://install.python-poetry.org | python3 -
+    displayName: Install Poetry
+
+  - script: |
+      poetry install --with=dev
+    displayName: Create Poetry Environment
+
+  - task: CmdLine@2
+    displayName: 'Generate requirements.txt using poetry'
+    inputs:
+      script: |
+        poetry export --without-hashes --format=requirements.txt > requirements.txt
+        cat requirements.txt
+
   - task: ComponentGovernanceComponentDetection@0


### PR DESCRIPTION
## Description
Component governance didn't manage to detect our dependencies since we're using poetry (which is in beta right now). To remedy this, I generated the requirements.txt file before running component detection. This appears to work in a little test I conducted ahead of this PR. Once poetry is supported properly we can remove this workaround, but we don't have a concrete target date at this point.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no documentation changes needed
- [ ] documentation added or edited
- [ ] example notebook added or updated
