### PR TITLE
Add permissions for test result publishing

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -26,6 +26,12 @@ jobs:
         python: ["3.10"]
         package_name: ["pyrit"]
     runs-on: ${{ matrix.os }}
+    # EnricoMi/publish-unit-test-result-action@v2 requires the following permissions
+    permissions:
+      contents: read
+      issues: read
+      checks: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3


### PR DESCRIPTION
## Description
The GitHub action we use to display test results in the PR comment thread requires a few additional permissions to work on all forks. This PR adds the minimal set required.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no documentation changes needed
- [ ] documentation added or edited
- [ ] example notebook added or updated
