### PR TITLE
Change README content to say "prompt injection attacks"

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Additionally, this tool allows researchers to iterate and improve their
 mitigations against different harms.
 For example, at Microsoft we are using this tool to iterate on different
 versions of a product (and its metaprompt) so that we can more effectively
-protect against prompt extraction attacks.
+protect against prompt injection attacks.
 
 ![PyRIT architecture](./assets/pyrit_architecture.png)
 


### PR DESCRIPTION
## Description

Making a small correction. We don't have examples for metaprompt extraction at this point.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no documentation changes needed
- [x] documentation added or edited
- [ ] example notebook added or updated
