### PR TITLE
Update pyproject.toml to find packages/modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,9 +80,6 @@ line-length = 120
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["pyrit"]
-
 [tool.setuptools.packages.find]
 include = ["pyrit", "pyrit.*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,9 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 packages = ["pyrit"]
 
+[tool.setuptools.packages.find]
+include = ["pyrit", "pyrit.*"]
+
 [tool.ruff]
 line-length = 120
 fixable = [


### PR DESCRIPTION
## Description
We got reports that in certain cases the modules (`auth`, `chat`, etc.) are not found after installing PyRIT. This small change should fix that. We have one person reporting that this fixed it (although I could never reproduce the issue to begin with).

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no documentation changes needed
- [ ] documentation added or edited
- [ ] example notebook added or updated
