### PR TITLE
Fixing bug with RedTeamingBot attack strategy

### DIFF
--- a/pyrit/agent/red_teaming_bot.py
+++ b/pyrit/agent/red_teaming_bot.py
@@ -53,6 +53,11 @@ class RedTeamingBot:
             )
         )
 
+        if RED_TEAM_CONVERSATION_END_TOKEN not in self._attack_strategy.template:
+            raise ValueError(
+                f"Attack strategy must have a way to detect end of conversation and include {RED_TEAM_CONVERSATION_END_TOKEN} token."
+            )
+
         self._global_memory_labels = memory_labels
 
         # Form the system prompt

--- a/pyrit/agent/red_teaming_bot.py
+++ b/pyrit/agent/red_teaming_bot.py
@@ -1,11 +1,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import pathlib
 from uuid import uuid4
 
 from pyrit.interfaces import ChatSupport
 from pyrit.memory import FileMemory, MemoryInterface
 from pyrit.models import ChatMessage, PromptTemplate
+from pyrit.common.path import HOME_PATH
 
 RED_TEAM_CHATBOT_ROLE_PREFIX = "airt-bot-uuid"
 RED_TEAM_CONVERSATION_END_TOKEN = "<|done|>"
@@ -19,7 +21,7 @@ class RedTeamingBot:
         *,
         conversation_objective: str,
         chat_engine: ChatSupport,
-        attack_strategy: PromptTemplate,
+        attack_strategy: PromptTemplate = None,
         attack_strategy_kwargs: dict[str, str] = None,
         memory: MemoryInterface = None,
         conversation_id: str = None,
@@ -32,15 +34,25 @@ class RedTeamingBot:
             base args: Arguments for AzureOpenAIChat
             attack_strategy: The attack strategy to follow by the bot. This can be used to guide the bot to achieve
                 the conversation objective in a more direct and structured way. It is a string that can be written in
-                a single sentence or paragraph. If not provided, the bot will use an empty string and it will try to
-                achieve the conversation objective by itself.
+                a single sentence or paragraph. If not provided, the bot will use red_team_chatbot_with_objective.
             attack_strategy_kwargs: The attack strategy parameters to use to fill the attack strategy template.
             memory: The memory to use to store the chat messages. If not provided, a FileMemory will be used.
             conversation_id: The session ID to use for the bot. If not provided, a random UUID will be used.
             memory_labels: The labels to use for the memory. This is useful to identify the bot messages in the memory.
         """
         self._chat_engine = chat_engine
-        self._attack_strategy = attack_strategy
+        self._attack_strategy = (
+            attack_strategy
+            if attack_strategy
+            else PromptTemplate.from_yaml_file(
+                pathlib.Path(HOME_PATH)
+                / "datasets"
+                / "attack_strategies"
+                / "multi_turn_chat"
+                / "red_team_chatbot_with_objective.yaml"
+            )
+        )
+
         self._global_memory_labels = memory_labels
 
         # Form the system prompt
@@ -48,11 +60,7 @@ class RedTeamingBot:
         kwargs_to_apply["conversation_objective"] = conversation_objective
         self._system_prompt = self._attack_strategy.apply_custom_metaprompt_parameters(**kwargs_to_apply)
 
-        if not memory:
-            self._conversation_memory = FileMemory()
-        else:
-            self._conversation_memory = memory
-
+        self._conversation_memory = memory if memory else FileMemory()
         self.conversation_id = conversation_id if conversation_id else str(uuid4())
 
     def __str__(self):

--- a/pyrit/agent/red_teaming_bot.py
+++ b/pyrit/agent/red_teaming_bot.py
@@ -55,7 +55,8 @@ class RedTeamingBot:
 
         if RED_TEAM_CONVERSATION_END_TOKEN not in self._attack_strategy.template:
             raise ValueError(
-                f"Attack strategy must have a way to detect end of conversation and include {RED_TEAM_CONVERSATION_END_TOKEN} token."
+                f"Attack strategy must have a way to detect end of conversation and include \
+                {RED_TEAM_CONVERSATION_END_TOKEN} token."
             )
 
         self._global_memory_labels = memory_labels

--- a/tests/test_red_teaming_bot.py
+++ b/tests/test_red_teaming_bot.py
@@ -131,3 +131,17 @@ def test_default_attack_strategy_set_with_end_token(chat_completion_engine: Chat
 
     assert bot._attack_strategy is not None
     assert pyrit.agent.red_teaming_bot.RED_TEAM_CONVERSATION_END_TOKEN in bot._attack_strategy.template
+
+
+def test_attack_strategy_without_token_raises(chat_completion_engine: ChatCompletion, tmp_path: pathlib.Path):
+    file_memory = FileMemory(filepath=tmp_path / "test.json.memory")
+
+    invalid_strategy = PromptTemplate(template="This is a bad strategy")
+
+    with pytest.raises(ValueError):
+        RedTeamingBot(
+            conversation_objective="Do bad stuff",
+            attack_strategy=invalid_strategy,
+            chat_engine=chat_completion_engine,
+            memory=file_memory,
+        )

--- a/tests/test_red_teaming_bot.py
+++ b/tests/test_red_teaming_bot.py
@@ -124,7 +124,7 @@ def test_is_conversation_complete_true(red_teaming_bot: RedTeamingBot):
         ), "Conversation should be complete, objective is realized"
 
 
-def test_default_attack_strategy_set_with_end_token(chat_completion_engine: ChatCompletion, tmp_path: pathlib.Path):
+def test_default_attack_strategy_set_with_end_token(chat_completion_engine: AzureOpenAIChat, tmp_path: pathlib.Path):
     file_memory = FileMemory(filepath=tmp_path / "test.json.memory")
 
     bot = RedTeamingBot(conversation_objective="Do bad stuff", chat_engine=chat_completion_engine, memory=file_memory)
@@ -133,7 +133,7 @@ def test_default_attack_strategy_set_with_end_token(chat_completion_engine: Chat
     assert pyrit.agent.red_teaming_bot.RED_TEAM_CONVERSATION_END_TOKEN in bot._attack_strategy.template
 
 
-def test_attack_strategy_without_token_raises(chat_completion_engine: ChatCompletion, tmp_path: pathlib.Path):
+def test_attack_strategy_without_token_raises(chat_completion_engine: AzureOpenAIChat, tmp_path: pathlib.Path):
     file_memory = FileMemory(filepath=tmp_path / "test.json.memory")
 
     invalid_strategy = PromptTemplate(template="This is a bad strategy")

--- a/tests/test_red_teaming_bot.py
+++ b/tests/test_red_teaming_bot.py
@@ -8,6 +8,7 @@ import pytest
 from openai.types.chat import ChatCompletion, ChatCompletionMessage
 from openai.types.chat.chat_completion import Choice
 
+import pyrit.agent.red_teaming_bot
 from pyrit.agent import RedTeamingBot
 from pyrit.chat import AzureOpenAIChat
 from pyrit.models import PromptTemplate
@@ -121,3 +122,12 @@ def test_is_conversation_complete_true(red_teaming_bot: RedTeamingBot):
         assert (
             red_teaming_bot.is_conversation_complete() is True
         ), "Conversation should be complete, objective is realized"
+
+
+def test_default_attack_strategy_set_with_end_token(chat_completion_engine: ChatCompletion, tmp_path: pathlib.Path):
+    file_memory = FileMemory(filepath=tmp_path / "test.json.memory")
+
+    bot = RedTeamingBot(conversation_objective="Do bad stuff", chat_engine=chat_completion_engine, memory=file_memory)
+
+    assert bot._attack_strategy is not None
+    assert pyrit.agent.red_teaming_bot.RED_TEAM_CONVERSATION_END_TOKEN in bot._attack_strategy.template


### PR DESCRIPTION
## Description

Previously in `RedTeamingBot`, attack_strategy was mandatory but documented as okay to be empty. This is problematic because then the `is_chat_complete` function doesn't always detect the end of a conversation since the token isn't present. A couple of our notebooks were broken because of this. This PR does the following:

- Sets attack_strategy by default to a valid value
- In init, check that the complete token is present in the attack_strategy

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [x] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no documentation changes needed
- [x] documentation added or edited
- [ ] example notebook added or updated
