### PR TITLE
Standardize Endpoints and API Keys for AML Chat

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,4 +1,5 @@
 # The following are used in objects to set values by default
+# And are used in notebooks
 
 # To get credentials go to
 # ms.portal.azure.com > Cognitive Services > Azure Open AI > Keys and Endpoint
@@ -16,6 +17,10 @@ AZURE_OPENAI_COMPLETION_DEPLOYMENT="completion_deployment_name"
 AZURE_OPENAI_EMBEDDING_ENDPOINT="https://embeddingendpoint.openai.azure.com/"
 AZURE_OPENAI_EMBEDDING_KEY="xxxxxxx"
 AZURE_OPENAI_EMBEDDING_DEPLOYMENT="embedding_deployment_name"
+
+# TODO fill out more completely
+AZURE_AML_API_KEY="xxxxxxx"
+AZURE_AML_MANAGED_ENDPOINT="https://amlendpoint"
 
 
 # The following are not used to set objects by default

--- a/.env_example
+++ b/.env_example
@@ -19,8 +19,8 @@ AZURE_OPENAI_EMBEDDING_KEY="xxxxxxx"
 AZURE_OPENAI_EMBEDDING_DEPLOYMENT="embedding_deployment_name"
 
 # TODO fill out more completely
-AZURE_AML_API_KEY="xxxxxxx"
-AZURE_AML_MANAGED_ENDPOINT="https://amlendpoint"
+AZURE_ML_API_KEY="xxxxxxx"
+AZURE_ML_MANAGED_ENDPOINT="https://amlendpoint"
 
 
 # The following are not used to set objects by default

--- a/.env_example
+++ b/.env_example
@@ -18,9 +18,10 @@ AZURE_OPENAI_EMBEDDING_ENDPOINT="https://embeddingendpoint.openai.azure.com/"
 AZURE_OPENAI_EMBEDDING_KEY="xxxxxxx"
 AZURE_OPENAI_EMBEDDING_DEPLOYMENT="embedding_deployment_name"
 
-# TODO fill out more completely
+# To get credentials go to
+# ms.portal.azure.com > AIRedTeamHub > Endpoints > Endpoints
 AZURE_ML_API_KEY="xxxxxxx"
-AZURE_ML_MANAGED_ENDPOINT="https://amlendpoint"
+AZURE_ML_MANAGED_ENDPOINT="https://aml-endpoint.inference.ml.azure.com/score"
 
 
 # The following are not used to set objects by default

--- a/examples/demo/3_gandalf_AML_endpoint_red_team_bot.ipynb
+++ b/examples/demo/3_gandalf_AML_endpoint_red_team_bot.ipynb
@@ -259,7 +259,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/pyrit/chat/aml_online_endpoint_chat.py
+++ b/pyrit/chat/aml_online_endpoint_chat.py
@@ -10,6 +10,7 @@ import requests
 from pyrit.common.constants import MAX_RETRY_API_COUNT
 from pyrit.common.net import HttpClientSession
 from pyrit.common.prompt_template_generator import PromptTemplateGenerator
+from pyrit.common import environment_variables
 from pyrit.interfaces import ChatSupport
 from pyrit.models import ChatMessage
 
@@ -28,17 +29,16 @@ class AMLOnlineEndpointChat(ChatSupport):
     def __init__(
         self,
         *,
-        endpoint_uri: str,
-        api_key: str,
+        endpoint_uri: str = None,
+        api_key: str = None,
     ) -> None:
         """
         Args:
             endpoint_uri: AML online endpoint URI.
             api_key: api key for the endpoint
         """
-        # AML online endpoint details
-        self.endpoint_uri: str = endpoint_uri
-        self.api_key: str = api_key
+        self.endpoint_uri: str = environment_variables.get_required_value("AZURE_AML_API_KEY", endpoint_uri)
+        self.api_key: str = environment_variables.get_required_value("AZURE_AML_MANAGED_ENDPOINT", api_key)
 
         self.prompt_template_generator = PromptTemplateGenerator()
 

--- a/pyrit/chat/aml_online_endpoint_chat.py
+++ b/pyrit/chat/aml_online_endpoint_chat.py
@@ -26,6 +26,9 @@ class AMLOnlineEndpointChat(ChatSupport):
         ChatSupport (abc.ABC): Implementing methods for interactions with the AML endpoint
     """
 
+    API_KEY_ENVIRONMENT_VARIABLE: str = "AZURE_ML_API_KEY"
+    ENDPOINT_URI_ENVIRONMENT_VARIABLE: str = "AZURE_ML_MANAGED_ENDPOINT"
+
     def __init__(
         self,
         *,
@@ -37,8 +40,10 @@ class AMLOnlineEndpointChat(ChatSupport):
             endpoint_uri: AML online endpoint URI.
             api_key: api key for the endpoint
         """
-        self.endpoint_uri: str = environment_variables.get_required_value("AZURE_AML_API_KEY", endpoint_uri)
-        self.api_key: str = environment_variables.get_required_value("AZURE_AML_MANAGED_ENDPOINT", api_key)
+        self.endpoint_uri: str = environment_variables.get_required_value(
+            self.API_KEY_ENVIRONMENT_VARIABLE, endpoint_uri
+        )
+        self.api_key: str = environment_variables.get_required_value(self.ENDPOINT_URI_ENVIRONMENT_VARIABLE, api_key)
 
         self.prompt_template_generator = PromptTemplateGenerator()
 

--- a/pyrit/chat/azure_openai_chat.py
+++ b/pyrit/chat/azure_openai_chat.py
@@ -9,6 +9,9 @@ from pyrit.models import ChatMessage
 
 
 class AzureOpenAIChat(ChatSupport):
+    API_KEY_ENVIRONMENT_VARIABLE: str = "AZURE_OPENAI_API_KEY"
+    ENDPOINT_URI_ENVIRONMENT_VARIABLE: str = "AZURE_OPENAI_ENDPOINT"
+
     def __init__(
         self,
         *,
@@ -19,8 +22,8 @@ class AzureOpenAIChat(ChatSupport):
     ) -> None:
         self._deployment_name = deployment_name
 
-        endpoint = environment_variables.get_required_value("AZURE_OPENAI_ENDPOINT", endpoint)
-        api_key = environment_variables.get_required_value("AZURE_OPENAI_API_KEY", api_key)
+        endpoint = environment_variables.get_required_value(self.ENDPOINT_URI_ENVIRONMENT_VARIABLE, endpoint)
+        api_key = environment_variables.get_required_value(self.API_KEY_ENVIRONMENT_VARIABLE, api_key)
 
         self._client = AzureOpenAI(
             api_key=api_key,

--- a/pyrit/chat/azure_openai_chat.py
+++ b/pyrit/chat/azure_openai_chat.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 from openai import AsyncAzureOpenAI, AzureOpenAI
 from openai.types.chat import ChatCompletion
+from pyrit.common import environment_variables
 
 from pyrit.interfaces import ChatSupport
 from pyrit.models import ChatMessage
@@ -12,13 +13,15 @@ class AzureOpenAIChat(ChatSupport):
         self,
         *,
         deployment_name: str,
-        endpoint: str,
-        api_key: str,
+        endpoint: str = None,
+        api_key: str = None,
         api_version: str = "2023-08-01-preview",
     ) -> None:
         self._deployment_name = deployment_name
-        if not api_key:
-            raise ValueError("api_key must be provided")
+
+        endpoint = environment_variables.get_required_value("AZURE_OPENAI_ENDPOINT", endpoint)
+        api_key = environment_variables.get_required_value("AZURE_OPENAI_API_KEY", api_key)
+
         self._client = AzureOpenAI(
             api_key=api_key,
             api_version=api_version,

--- a/pyrit/common/environment_variables.py
+++ b/pyrit/common/environment_variables.py
@@ -1,0 +1,14 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import os
+
+def get_required_value(environment_variable_name: str, passed_value: str) -> str:
+    if passed_value:
+        return passed_value
+
+    value = os.environ.get(environment_variable_name)
+    if value:
+        return value
+
+    raise ValueError(f"Environment variable {environment_variable_name} is required")

--- a/pyrit/common/environment_variables.py
+++ b/pyrit/common/environment_variables.py
@@ -5,6 +5,12 @@ import os
 
 
 def get_required_value(environment_variable_name: str, passed_value: str) -> str:
+    """
+    Gets a required value from an environment variable or a passed value,
+    prefering the passed value
+
+    If no value is found, raises a ValueError
+    """
     if passed_value:
         return passed_value
 

--- a/pyrit/common/environment_variables.py
+++ b/pyrit/common/environment_variables.py
@@ -3,6 +3,7 @@
 
 import os
 
+
 def get_required_value(environment_variable_name: str, passed_value: str) -> str:
     if passed_value:
         return passed_value

--- a/pyrit/common/environment_variables.py
+++ b/pyrit/common/environment_variables.py
@@ -10,6 +10,14 @@ def get_required_value(environment_variable_name: str, passed_value: str) -> str
     prefering the passed value
 
     If no value is found, raises a KeyError
+
+    :param environment_variable_name: The name of the environment variable
+    :type environment_variable_name: str
+    :param passed_value: The value passed as an argument
+    :type passed_value: str
+    :return: The required value
+    :rtype: str
+    :raises ValueError: If no value is found
     """
     if passed_value:
         return passed_value

--- a/pyrit/common/environment_variables.py
+++ b/pyrit/common/environment_variables.py
@@ -9,7 +9,7 @@ def get_required_value(environment_variable_name: str, passed_value: str) -> str
     Gets a required value from an environment variable or a passed value,
     prefering the passed value
 
-    If no value is found, raises a ValueError
+    If no value is found, raises a KeyError
     """
     if passed_value:
         return passed_value

--- a/tests/test_aml_online_endpoint_chat.py
+++ b/tests/test_aml_online_endpoint_chat.py
@@ -34,13 +34,13 @@ def test_initialization_with_required_parameters(
 
 
 def test_initialization_with_no_key_raises():
-    os.environ["AZURE_AML_API_KEY"] = ""
+    os.environ[AMLOnlineEndpointChat.API_KEY_ENVIRONMENT_VARIABLE] = ""
     with pytest.raises(ValueError):
         AMLOnlineEndpointChat(endpoint_uri="http://aml-test-endpoint.com")
 
 
 def test_initialization_with_no_api_raises():
-    os.environ["AZURE_AML_MANAGED_ENDPOINT"] = ""
+    os.environ[AMLOnlineEndpointChat.ENDPOINT_URI_ENVIRONMENT_VARIABLE] = ""
     with pytest.raises(ValueError):
         AMLOnlineEndpointChat(api_key="xxxxx")
 

--- a/tests/test_aml_online_endpoint_chat.py
+++ b/tests/test_aml_online_endpoint_chat.py
@@ -32,10 +32,12 @@ def test_initialization_with_required_parameters(
     assert aml_online_chat.endpoint_uri == "http://aml-test-endpoint.com"
     assert aml_online_chat.api_key == "valid_api_key"
 
+
 def test_initialization_with_no_key_raises():
     os.environ["AZURE_AML_API_KEY"] = ""
     with pytest.raises(ValueError):
         AMLOnlineEndpointChat(endpoint_uri="http://aml-test-endpoint.com")
+
 
 def test_initialization_with_no_api_raises():
     os.environ["AZURE_AML_MANAGED_ENDPOINT"] = ""

--- a/tests/test_aml_online_endpoint_chat.py
+++ b/tests/test_aml_online_endpoint_chat.py
@@ -4,6 +4,7 @@
 import asyncio
 from unittest.mock import Mock, patch
 
+import os
 import pytest
 import requests
 
@@ -30,6 +31,16 @@ def test_initialization_with_required_parameters(
 ):
     assert aml_online_chat.endpoint_uri == "http://aml-test-endpoint.com"
     assert aml_online_chat.api_key == "valid_api_key"
+
+def test_initialization_with_no_key_raises():
+    os.environ["AZURE_AML_API_KEY"] = ""
+    with pytest.raises(ValueError):
+        AMLOnlineEndpointChat(endpoint_uri="http://aml-test-endpoint.com")
+
+def test_initialization_with_no_api_raises():
+    os.environ["AZURE_AML_MANAGED_ENDPOINT"] = ""
+    with pytest.raises(ValueError):
+        AMLOnlineEndpointChat(api_key="xxxxx")
 
 
 def test_get_headers_with_valid_api_key(aml_online_chat: AMLOnlineEndpointChat):

--- a/tests/test_azure_openai_chat.py
+++ b/tests/test_azure_openai_chat.py
@@ -98,6 +98,7 @@ def test_invalid_key_raises():
             api_version="some_version",
         )
 
+
 def test_invalid_endpoint_raises():
     os.environ["AZURE_OPENAI_ENDPOINT"] = ""
     with pytest.raises(ValueError):

--- a/tests/test_azure_openai_chat.py
+++ b/tests/test_azure_openai_chat.py
@@ -89,7 +89,7 @@ def test_complete_chat_return(openai_mock_return: ChatCompletion, chat_engine: A
 
 
 def test_invalid_key_raises():
-    os.environ["AZURE_OPENAI_API_KEY"] = ""
+    os.environ[AzureOpenAIChat.API_KEY_ENVIRONMENT_VARIABLE] = ""
     with pytest.raises(ValueError):
         AzureOpenAIChat(
             deployment_name="gpt-4",
@@ -100,7 +100,7 @@ def test_invalid_key_raises():
 
 
 def test_invalid_endpoint_raises():
-    os.environ["AZURE_OPENAI_ENDPOINT"] = ""
+    os.environ[AzureOpenAIChat.ENDPOINT_URI_ENVIRONMENT_VARIABLE] = ""
     with pytest.raises(ValueError):
         AzureOpenAIChat(
             deployment_name="gpt-4",

--- a/tests/test_azure_openai_chat.py
+++ b/tests/test_azure_openai_chat.py
@@ -2,6 +2,8 @@
 # Licensed under the MIT license.
 
 import asyncio
+import os
+
 from contextlib import AbstractAsyncContextManager
 from unittest.mock import AsyncMock, patch
 
@@ -86,11 +88,22 @@ def test_complete_chat_return(openai_mock_return: ChatCompletion, chat_engine: A
         assert ret == "hi"
 
 
-def test_invalid_endpoint_raises():
+def test_invalid_key_raises():
+    os.environ["AZURE_OPENAI_API_KEY"] = ""
     with pytest.raises(ValueError):
         AzureOpenAIChat(
             deployment_name="gpt-4",
             endpoint="https://mock.azure.com/",
             api_key="",
+            api_version="some_version",
+        )
+
+def test_invalid_endpoint_raises():
+    os.environ["AZURE_OPENAI_ENDPOINT"] = ""
+    with pytest.raises(ValueError):
+        AzureOpenAIChat(
+            deployment_name="gpt-4",
+            endpoint="",
+            api_key="xxxxx",
             api_version="some_version",
         )

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,21 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import os
+import pytest
+
+from pyrit.common import environment_variables
+
+
+def test_environment_variables_prefers_passed():
+    os.environ["TEST_ENV_VAR"] = "fail"
+    assert environment_variables.get_required_value("TEST_ENV_VAR", "passed") == "passed"
+
+def test_environment_variables_uses_default():
+    os.environ["TEST_ENV_VAR"] = "default"
+    assert environment_variables.get_required_value("TEST_ENV_VAR", "") == "default"
+
+def test_environment_variables_throws_if_not_set():
+    os.environ["TEST_ENV_VAR"] = ""
+    with pytest.raises(ValueError):
+        environment_variables.get_required_value("TEST_ENV_VAR", "") == "default"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -11,9 +11,11 @@ def test_environment_variables_prefers_passed():
     os.environ["TEST_ENV_VAR"] = "fail"
     assert environment_variables.get_required_value("TEST_ENV_VAR", "passed") == "passed"
 
+
 def test_environment_variables_uses_default():
     os.environ["TEST_ENV_VAR"] = "default"
     assert environment_variables.get_required_value("TEST_ENV_VAR", "") == "default"
+
 
 def test_environment_variables_throws_if_not_set():
     os.environ["TEST_ENV_VAR"] = ""


### PR DESCRIPTION
## Description

Running the AML notebooks, they weren't working due to not configuring endpoints. This PR makes the arguments more consistent with how we want to handle default endpoints and keys.

- checks/gets default values for AML endpoints. This makes it more consistent with AzureOpenAI
- Adds a way to try to get required default values from environment variables if not provided as an argument

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [x] new tests added
- [x] existing tests adjusted

## Documentation
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no documentation changes needed
- [ ] documentation added or edited
- [ ] example notebook added or updated
