### PR TITLE
Add Jupyter Dependencies + aiohttp to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "azure-identity>=1.12.0",
     "jsonpickle>=3.0.2",
     "logzero>=1.7.0",
+    "ipykernel>=6.22.0",
     "onnxruntime>=1.14.1",
     "onnx>=1.14.0",
     "pydantic>2",
@@ -58,7 +59,6 @@ dev = [
     "black>=23.3.0",
     "flake8>=6.0.0",
     "types-PyYAML>=6.0.12.9",
-    "ipykernel>=6.22.0",
     "semantic-kernel==0.4.1.dev0",
     "pre-commit>=3.3.3",
     "flake8-copyright>=0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,36 +32,36 @@ requires-python = ">=3.10, <3.11"
 dependencies = [
     "azure-core>=1.26.1",
     "azure-identity>=1.12.0",
+    "ipykernel>=6.22.0",
     "jsonpickle>=3.0.2",
     "jupyter>=1.0.0",
     "logzero>=1.7.0",
-    "ipykernel>=6.22.0",
+    "numpy>=1.26.2",
     "onnxruntime>=1.14.1",
     "onnx>=1.14.0",
+    "openai>=1.5.0",
     "pydantic>2",
     "python-dotenv>=1.0.0",
-    "openai>=1.5.0",
+    "scikit-learn>=1.3.2",
     "termcolor>=2.3.0",
     "tenacity>=8.2.2",
     "tokenizers>=0.15.0",
-    "transformers>=4.36.0",
     "torch==2.1.2",
-    "types-requests>=2.31.0.2",
-    "scikit-learn>=1.3.2",
-    "numpy>=1.26.2"
+    "transformers>=4.36.0",
+    "types-requests>=2.31.0.2"
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.3.1",
-    "pytest-cov>=4.0.0",
-    "mypy>=1.2.0",
     "black>=23.3.0",
     "flake8>=6.0.0",
-    "types-PyYAML>=6.0.12.9",
-    "semantic-kernel==0.4.1.dev0",
+    "flake8-copyright>=0.2.0",
+    "mypy>=1.2.0",
     "pre-commit>=3.3.3",
-    "flake8-copyright>=0.2.0"
+    "pytest>=7.3.1",
+    "pytest-cov>=4.0.0",
+    "semantic-kernel==0.4.1.dev0",
+    "types-PyYAML>=6.0.12.9"
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
 ]
 requires-python = ">=3.10, <3.11"
 dependencies = [
-    "aiohttp>=3.9.3",
     "azure-core>=1.26.1",
     "azure-identity>=1.12.0",
     "jsonpickle>=3.0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,11 @@ classifiers = [
 ]
 requires-python = ">=3.10, <3.11"
 dependencies = [
+    "aiohttp>=3.9.3",
     "azure-core>=1.26.1",
     "azure-identity>=1.12.0",
     "jsonpickle>=3.0.2",
+    "jupyter>=1.0.0",
     "logzero>=1.7.0",
     "ipykernel>=6.22.0",
     "onnxruntime>=1.14.1",
@@ -54,7 +56,6 @@ dependencies = [
 dev = [
     "pytest>=7.3.1",
     "pytest-cov>=4.0.0",
-    "jupyter>=1.0.0",
     "mypy>=1.2.0",
     "black>=23.3.0",
     "flake8>=6.0.0",


### PR DESCRIPTION
## Description
Most users of PyRIT interact with Jupyter Notebooks when ramping up, or when leveraging library functionality. Users have given feedback that setting up with these notebooks is confusing. This is a step to move dependencies from dev --> all that relate to Notebook usage so users don't need to also install [dev] dependencies.

- Adding `ipykernel` `jupyter` to pyproject.toml dependencies (general)
- `jupyter` also added to dependencies (general) to address "TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html" that was present when only `ipykernel` was moved.
- cleanup ordering of deps, to be alphabetical

## Tests
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
- [x] no documentation changes needed
- [ ] documentation added or edited
- [ ] example notebook added or updated
