### PR TITLE
fixing bug where default was set to debug

### DIFF
--- a/pyrit/common/net_utility.py
+++ b/pyrit/common/net_utility.py
@@ -22,13 +22,13 @@ def make_request_and_raise_if_error(
     method: str,
     request_body: dict[str, str] = None,
     headers: dict[str, str] = None,
-    use_proxy: bool = True,
+    debug: bool = False,
 ) -> httpx.Response:
     """Make a request and raise an exception if it fails."""
     headers = headers or {}
     request_body = request_body or {}
 
-    with get_httpx_client(debug=use_proxy) as client:
+    with get_httpx_client(debug=debug) as client:
         if request_body:
             headers["Content-Type"] = "application/json"
             response = client.request(method=method, url=endpoint_uri, json=request_body, headers=headers)

--- a/tests/test_common_net_utility.py
+++ b/tests/test_common_net_utility.py
@@ -1,6 +1,8 @@
 import pytest
 import httpx
 import respx
+
+from unittest.mock import patch, MagicMock
 from tenacity import RetryError
 from pyrit.common.net_utility import get_httpx_client, make_request_and_raise_if_error
 
@@ -61,3 +63,13 @@ def test_make_request_and_raise_if_error_retries():
         make_request_and_raise_if_error(endpoint_uri=url, method=method)
     assert call_count == 2, "The request should have been retried exactly once."
     assert mock_route.called
+
+
+def test_debug_is_false_by_default():
+    with patch("pyrit.common.net_utility.get_httpx_client") as mock_get_httpx_client:
+        mock_client_instance = MagicMock()
+        mock_get_httpx_client.return_value = mock_client_instance
+
+        make_request_and_raise_if_error(endpoint_uri="http://example.com", method="GET")
+
+        mock_get_httpx_client.assert_called_with(debug=False)


### PR DESCRIPTION
## Description
When debugging AML endpoints, I accidentally left the debug flag on. This PR fixes that

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [x] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no documentation changes needed
- [ ] documentation added or edited
- [ ] example notebook added or updated
