### PR TITLE
Fixing bug with pypi package directory

### DIFF
--- a/doc/code/huggingface_endpoints.ipynb
+++ b/doc/code/huggingface_endpoints.ipynb
@@ -65,6 +65,15 @@
    "cell_metadata_filter": "-all",
    "main_language": "python",
    "notebook_metadata_filter": "-all"
+  },
+  "kernelspec": {
+   "display_name": "pyrit-dev",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/doc/code/huggingface_endpoints.ipynb
+++ b/doc/code/huggingface_endpoints.ipynb
@@ -65,15 +65,6 @@
    "cell_metadata_filter": "-all",
    "main_language": "python",
    "notebook_metadata_filter": "-all"
-  },
-  "kernelspec": {
-   "display_name": "pyrit-dev",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/pyrit/common/default_values.py
+++ b/pyrit/common/default_values.py
@@ -9,13 +9,14 @@ from pyrit.common import path
 
 def load_default_env() -> None:
     """
-    Loads an environment file from the given path, or the $PROJECT_ROOT/.env file if no path is given
-    Throws an exception if the file is not found
+    Loads an environment file from the $PROJECT_ROOT/.env file if it exists,
+    or if not, loads from the default dotenv .env file
     """
     file_path = path.HOME_PATH / ".env"
 
     if not file_path.exists():
-        raise FileNotFoundError(f"Environment file not found at {file_path}")
+        dotenv.load_dotenv()
+        return
 
     dotenv.load_dotenv(file_path, override=True)
 


### PR DESCRIPTION
## Description

The `.env` structure was convenient for development, but buried for users installing with pip. This respects default `.env` files.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no documentation changes needed
- [ ] documentation added or edited
- [ ] example notebook added or updated
