### PR TITLE
Adding StringJoinConverter

### DIFF
--- a/pyrit/prompt_converter/__init__.py
+++ b/pyrit/prompt_converter/__init__.py
@@ -8,8 +8,10 @@ from pyrit.prompt_converter.str_join_converter import StrJoinConverter
 from pyrit.prompt_converter.unicode_sub_converter import UnicodeSubstitutionConverter
 
 
-__all__ = ["PromptConverter",
-           "Base64Converter",
-           "NoOpConverter",
-           "StrJoinConverter",
-           "UnicodeSubstitutionConverter",]
+__all__ = [
+    "PromptConverter",
+    "Base64Converter",
+    "NoOpConverter",
+    "StrJoinConverter",
+    "UnicodeSubstitutionConverter",
+]

--- a/pyrit/prompt_converter/__init__.py
+++ b/pyrit/prompt_converter/__init__.py
@@ -4,7 +4,7 @@
 from pyrit.prompt_converter.prompt_converter import PromptConverter
 from pyrit.prompt_converter.base64_converter import Base64Converter
 from pyrit.prompt_converter.no_op_converter import NoOpConverter
-from pyrit.prompt_converter.str_join_converter import StrJoinConverter
+from pyrit.prompt_converter.string_join_converter import StringJoinConverter
 from pyrit.prompt_converter.unicode_sub_converter import UnicodeSubstitutionConverter
 
 
@@ -12,6 +12,6 @@ __all__ = [
     "PromptConverter",
     "Base64Converter",
     "NoOpConverter",
-    "StrJoinConverter",
+    "StringJoinConverter",
     "UnicodeSubstitutionConverter",
 ]

--- a/pyrit/prompt_converter/__init__.py
+++ b/pyrit/prompt_converter/__init__.py
@@ -4,7 +4,12 @@
 from pyrit.prompt_converter.prompt_converter import PromptConverter
 from pyrit.prompt_converter.base64_converter import Base64Converter
 from pyrit.prompt_converter.no_op_converter import NoOpConverter
+from pyrit.prompt_converter.str_join_converter import StrJoinConverter
 from pyrit.prompt_converter.unicode_sub_converter import UnicodeSubstitutionConverter
 
 
-__all__ = ["PromptConverter", "Base64Converter", "NoOpConverter", "UnicodeSubstitutionConverter"]
+__all__ = ["PromptConverter",
+           "Base64Converter",
+           "NoOpConverter",
+           "StrJoinConverter",
+           "UnicodeSubstitutionConverter",]

--- a/pyrit/prompt_converter/str_join_converter.py
+++ b/pyrit/prompt_converter/str_join_converter.py
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from pyrit.prompt_converter import PromptConverter
+
+
+class StrJoinConverter(PromptConverter):
+
+    def __init__(self, join_value="-"):
+        self.join_value = join_value
+
+    def convert(self, prompt: str) -> str:
+        """
+        Simple converter that uses str join for letters between
+
+        This can sometimes bypass LLM logic
+        """
+        return self.join_value.join(prompt)

--- a/pyrit/prompt_converter/string_join_converter.py
+++ b/pyrit/prompt_converter/string_join_converter.py
@@ -4,15 +4,22 @@
 from pyrit.prompt_converter import PromptConverter
 
 
-class StrJoinConverter(PromptConverter):
+class StringJoinConverter(PromptConverter):
 
     def __init__(self, join_value="-"):
         self.join_value = join_value
 
     def convert(self, prompt: str) -> str:
         """
-        Simple converter that uses str join for letters between
+        Simple converter that uses str join for letters between. E.g. with a "-"
+        it converts a promtp of test to t-e-s-t
 
         This can sometimes bypass LLM logic
+
+        Args:
+            prompt (str): The prompt to be converted.
+
+        Returns:
+            str: The converted prompt.
         """
         return self.join_value.join(prompt)

--- a/pyrit/prompt_converter/string_join_converter.py
+++ b/pyrit/prompt_converter/string_join_converter.py
@@ -11,8 +11,8 @@ class StringJoinConverter(PromptConverter):
 
     def convert(self, prompt: str) -> str:
         """
-        Simple converter that uses str join for letters between. E.g. with a "-"
-        it converts a promtp of test to t-e-s-t
+        Simple converter that uses str join for letters between. E.g. with a `-`
+        it converts a prompt of `test` to `t-e-s-t`
 
         This can sometimes bypass LLM logic
 

--- a/tests/test_prompt_converter.py
+++ b/tests/test_prompt_converter.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from pyrit.prompt_converter import Base64Converter, NoOpConverter, UnicodeSubstitutionConverter
+from pyrit.prompt_converter import Base64Converter, NoOpConverter, UnicodeSubstitutionConverter, StrJoinConverter
 
 
 def test_prompt_converter() -> None:
@@ -22,3 +22,11 @@ def test_unicode_sub_default_prompt_converter() -> None:
 def test_unicode_sub_ascii_prompt_converter() -> None:
     converter = UnicodeSubstitutionConverter(0x00000)
     assert converter.convert("test") == "\U00000074\U00000065\U00000073\U00000074"
+
+def test_str_join_converter_default() -> None:
+    converter = StrJoinConverter()
+    assert converter.convert("test") == "t-e-s-t"
+
+def test_str_join_converter_init() -> None:
+    converter = StrJoinConverter("***")
+    assert converter.convert("test") == "t***e***s***t"

--- a/tests/test_prompt_converter.py
+++ b/tests/test_prompt_converter.py
@@ -23,9 +23,11 @@ def test_unicode_sub_ascii_prompt_converter() -> None:
     converter = UnicodeSubstitutionConverter(0x00000)
     assert converter.convert("test") == "\U00000074\U00000065\U00000073\U00000074"
 
+
 def test_str_join_converter_default() -> None:
     converter = StrJoinConverter()
     assert converter.convert("test") == "t-e-s-t"
+
 
 def test_str_join_converter_init() -> None:
     converter = StrJoinConverter("***")

--- a/tests/test_prompt_converter.py
+++ b/tests/test_prompt_converter.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from pyrit.prompt_converter import Base64Converter, NoOpConverter, UnicodeSubstitutionConverter, StrJoinConverter
+from pyrit.prompt_converter import Base64Converter, NoOpConverter, UnicodeSubstitutionConverter, StringJoinConverter
 
 
 def test_prompt_converter() -> None:
@@ -25,10 +25,10 @@ def test_unicode_sub_ascii_prompt_converter() -> None:
 
 
 def test_str_join_converter_default() -> None:
-    converter = StrJoinConverter()
+    converter = StringJoinConverter()
     assert converter.convert("test") == "t-e-s-t"
 
 
 def test_str_join_converter_init() -> None:
-    converter = StrJoinConverter("***")
+    converter = StringJoinConverter("***")
     assert converter.convert("test") == "t***e***s***t"


### PR DESCRIPTION
## Description

Simple converter that uses str join for letters between. This can sometimes bypass LLM logic

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [x] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no documentation changes needed
- [ ] documentation added or edited
- [ ] example notebook added or updated
