### PR TITLE
Adding NoOpTarget

### DIFF
--- a/pyrit/prompt_target/__init__.py
+++ b/pyrit/prompt_target/__init__.py
@@ -3,6 +3,7 @@
 
 from pyrit.prompt_target.prompt_target import PromptTarget
 from pyrit.prompt_target.azure_openai_chat_target import AzureOpenAIChatTarget
+from pyrit.prompt_target.no_op_target import NoOpTarget
 
 
-__all__ = ["AzureOpenAIChatTarget", "PromptTarget"]
+__all__ = ["AzureOpenAIChatTarget", "PromptTarget", "NoOpTarget"]

--- a/pyrit/prompt_target/no_op_target.py
+++ b/pyrit/prompt_target/no_op_target.py
@@ -1,13 +1,19 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from pyrit.chat.azure_openai_chat import AzureOpenAIChat
 from pyrit.memory import FileMemory, MemoryInterface
 from pyrit.models import ChatMessage
 from pyrit.prompt_target import PromptTarget
 
 
-class AzureOpenAIChatTarget(PromptTarget):
+class NoOpTarget(PromptTarget):
+    """
+    The NoOpTarget takes prompts, adds them to memory and prints them, but doesn't send them anywhere
+
+    This can be useful in various situations, for example, if operators want to generate prompts
+    but enter them manually.
+    """
+
     def __init__(self, *, memory: MemoryInterface = None) -> None:
         self.memory = memory if memory else FileMemory()
 
@@ -24,22 +30,11 @@ class AzureOpenAIChatTarget(PromptTarget):
         )
 
     def send_prompt(self, normalized_prompt: str, conversation_id: str, normalizer_id: str) -> str:
-        messages = self.memory.get_chat_messages_with_conversation_id(conversation_id=conversation_id)
-
         msg = ChatMessage(role="user", content=normalized_prompt)
-
-        messages.append(msg)
+        print(msg)
 
         self.memory.add_chat_message_to_memory(
             conversation=msg, conversation_id=conversation_id, normalizer_id=normalizer_id
         )
 
-        resp = super().complete_chat(messages=messages, temperature=self.temperature)
-
-        self.memory.add_chat_message_to_memory(
-            conversation=ChatMessage(role="assistant", content=resp),
-            conversation_id=conversation_id,
-            normalizer_id=normalizer_id,
-        )
-
-        return resp
+        return ""

--- a/pyrit/prompt_target/no_op_target.py
+++ b/pyrit/prompt_target/no_op_target.py
@@ -1,0 +1,45 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from pyrit.chat.azure_openai_chat import AzureOpenAIChat
+from pyrit.memory import FileMemory, MemoryInterface
+from pyrit.models import ChatMessage
+from pyrit.prompt_target import PromptTarget
+
+
+class AzureOpenAIChatTarget(PromptTarget):
+    def __init__(self, *, memory: MemoryInterface = None) -> None:
+        self.memory = memory if memory else FileMemory()
+
+    def set_system_prompt(self, prompt: str, conversation_id: str, normalizer_id: str) -> None:
+        messages = self.memory.get_memories_with_conversation_id(conversation_id=conversation_id)
+
+        if messages:
+            raise RuntimeError("Conversation already exists, system prompt needs to be set at the beginning")
+
+        self.memory.add_chat_message_to_memory(
+            conversation=ChatMessage(role="system", content=prompt),
+            conversation_id=conversation_id,
+            normalizer_id=normalizer_id,
+        )
+
+    def send_prompt(self, normalized_prompt: str, conversation_id: str, normalizer_id: str) -> str:
+        messages = self.memory.get_chat_messages_with_conversation_id(conversation_id=conversation_id)
+
+        msg = ChatMessage(role="user", content=normalized_prompt)
+
+        messages.append(msg)
+
+        self.memory.add_chat_message_to_memory(
+            conversation=msg, conversation_id=conversation_id, normalizer_id=normalizer_id
+        )
+
+        resp = super().complete_chat(messages=messages, temperature=self.temperature)
+
+        self.memory.add_chat_message_to_memory(
+            conversation=ChatMessage(role="assistant", content=resp),
+            conversation_id=conversation_id,
+            normalizer_id=normalizer_id,
+        )
+
+        return resp

--- a/tests/test_prompt_target.py
+++ b/tests/test_prompt_target.py
@@ -57,7 +57,7 @@ def test_set_system_prompt(azure_openai_target: AzureOpenAIChatTarget):
     assert chats[0].content == "system prompt"
 
 
-def test_complete_chat_user_no_system(azure_openai_target: AzureOpenAIChatTarget, openai_mock_return: ChatCompletion):
+def test_send_prompt_user_no_system(azure_openai_target: AzureOpenAIChatTarget, openai_mock_return: ChatCompletion):
     with patch("openai.resources.chat.Completions.create") as mock:
         mock.return_value = openai_mock_return
         azure_openai_target.send_prompt(
@@ -70,7 +70,7 @@ def test_complete_chat_user_no_system(azure_openai_target: AzureOpenAIChatTarget
         assert chats[1].role == "assistant"
 
 
-def test_complete_chat_user_with_system(azure_openai_target: AzureOpenAIChatTarget, openai_mock_return: ChatCompletion):
+def test_send_prompt_with_system(azure_openai_target: AzureOpenAIChatTarget, openai_mock_return: ChatCompletion):
     with patch("openai.resources.chat.Completions.create") as mock:
         mock.return_value = openai_mock_return
 
@@ -86,7 +86,7 @@ def test_complete_chat_user_with_system(azure_openai_target: AzureOpenAIChatTarg
         assert chats[1].role == "user"
 
 
-def test_complete_chat_user_with_system_calls_chat_complete(
+def test_send_prompt_with_system_calls_chat_complete(
     azure_openai_target: AzureOpenAIChatTarget, openai_mock_return: ChatCompletion
 ):
     with patch("openai.resources.chat.Completions.create") as mock:

--- a/tests/test_prompt_target_no_op.py
+++ b/tests/test_prompt_target_no_op.py
@@ -1,0 +1,37 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import pathlib
+
+import pytest
+
+from pyrit.memory import FileMemory
+from pyrit.prompt_target import NoOpTarget
+
+
+@pytest.fixture
+def memory(tmp_path: pathlib.Path):
+    return FileMemory(filepath=tmp_path / "target_no_op_test.json.memory")
+
+
+def test_set_system_prompt(memory: FileMemory):
+    no_op = NoOpTarget(memory=memory)
+
+    no_op.set_system_prompt(prompt="system prompt", conversation_id="1", normalizer_id="2")
+
+    chats = no_op.memory.get_memories_with_conversation_id(conversation_id="1")
+    assert len(chats) == 1, f"Expected 1 chat, got {len(chats)}"
+    assert chats[0].role == "system"
+    assert chats[0].content == "system prompt"
+
+
+def test_send_prompt_user_no_system(memory: FileMemory):
+    no_op = NoOpTarget(memory=memory)
+
+    no_op.send_prompt(
+        normalized_prompt="hi, I am a victim chatbot, how can I help?", conversation_id="1", normalizer_id="2"
+    )
+
+    chats = no_op.memory.get_memories_with_conversation_id(conversation_id="1")
+    assert len(chats) == 1, f"Expected 1 chat, got {len(chats)}"
+    assert chats[0].role == "user"


### PR DESCRIPTION
## Description

The NoOpTarget takes prompts, adds them to memory and prints them, but doesn't send them anywhere.

This can be useful in various situations, for example, if operators want to generate prompts, but enter them manually.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [x] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no documentation changes needed
- [ ] documentation added or edited
- [ ] example notebook added or updated
