### PR TITLE
Small refactor of promptTarget

### DIFF
--- a/pyrit/prompt_target/__init__.py
+++ b/pyrit/prompt_target/__init__.py
@@ -2,8 +2,9 @@
 # Licensed under the MIT license.
 
 from pyrit.prompt_target.prompt_target import PromptTarget
+from pyrit.prompt_target.prompt_chat_target import PromptChatTarget
 from pyrit.prompt_target.azure_openai_chat_target import AzureOpenAIChatTarget
 from pyrit.prompt_target.no_op_target import NoOpTarget
 
 
-__all__ = ["AzureOpenAIChatTarget", "PromptTarget", "NoOpTarget"]
+__all__ = ["PromptChatTarget", "AzureOpenAIChatTarget", "PromptTarget", "NoOpTarget"]

--- a/pyrit/prompt_target/azure_openai_chat_target.py
+++ b/pyrit/prompt_target/azure_openai_chat_target.py
@@ -2,12 +2,12 @@
 # Licensed under the MIT license.
 
 from pyrit.chat.azure_openai_chat import AzureOpenAIChat
-from pyrit.memory import FileMemory, MemoryInterface
+from pyrit.memory import MemoryInterface
 from pyrit.models import ChatMessage
-from pyrit.prompt_target import PromptTarget
+from pyrit.prompt_target import PromptChatTarget
 
 
-class AzureOpenAIChatTarget(AzureOpenAIChat, PromptTarget):
+class AzureOpenAIChatTarget(AzureOpenAIChat, PromptChatTarget):
     def __init__(
         self,
         *,
@@ -18,9 +18,11 @@ class AzureOpenAIChatTarget(AzureOpenAIChat, PromptTarget):
         api_version: str = "2023-08-01-preview",
         temperature: float = 1.0,
     ) -> None:
-        super().__init__(deployment_name=deployment_name, endpoint=endpoint, api_key=api_key, api_version=api_version)
+        AzureOpenAIChat.__init__(
+            self, deployment_name=deployment_name, endpoint=endpoint, api_key=api_key, api_version=api_version
+        )
+        PromptChatTarget.__init__(self, memory=memory)
 
-        self.memory = memory if memory else FileMemory()
         self.temperature = temperature
 
     def set_system_prompt(self, prompt: str, conversation_id: str, normalizer_id: str) -> None:

--- a/pyrit/prompt_target/no_op_target.py
+++ b/pyrit/prompt_target/no_op_target.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from pyrit.memory import FileMemory, MemoryInterface
+from pyrit.memory import MemoryInterface
 from pyrit.models import ChatMessage
 from pyrit.prompt_target import PromptTarget
 
@@ -15,19 +15,7 @@ class NoOpTarget(PromptTarget):
     """
 
     def __init__(self, *, memory: MemoryInterface = None) -> None:
-        self.memory = memory if memory else FileMemory()
-
-    def set_system_prompt(self, prompt: str, conversation_id: str, normalizer_id: str) -> None:
-        messages = self.memory.get_memories_with_conversation_id(conversation_id=conversation_id)
-
-        if messages:
-            raise RuntimeError("Conversation already exists, system prompt needs to be set at the beginning")
-
-        self.memory.add_chat_message_to_memory(
-            conversation=ChatMessage(role="system", content=prompt),
-            conversation_id=conversation_id,
-            normalizer_id=normalizer_id,
-        )
+        super().__init__(memory)
 
     def send_prompt(self, normalized_prompt: str, conversation_id: str, normalizer_id: str) -> str:
         msg = ChatMessage(role="user", content=normalized_prompt)

--- a/pyrit/prompt_target/prompt_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target.py
@@ -1,0 +1,19 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import abc
+
+from pyrit.prompt_target import PromptTarget
+from pyrit.memory import MemoryInterface
+
+
+class PromptChatTarget(PromptTarget):
+
+    def __init__(self, memory: MemoryInterface) -> None:
+        super().__init__(memory)
+
+    @abc.abstractmethod
+    def set_system_prompt(self, prompt: str, conversation_id: str, normalizer_id: str) -> None:
+        """
+        Sets the system prompt for the prompt target
+        """

--- a/pyrit/prompt_target/prompt_target.py
+++ b/pyrit/prompt_target/prompt_target.py
@@ -3,6 +3,7 @@
 
 import abc
 from pyrit.memory import MemoryInterface
+from pyrit.memory.file_memory import FileMemory
 
 
 class PromptTarget(abc.ABC):
@@ -15,13 +16,7 @@ class PromptTarget(abc.ABC):
     supported_converters: list
 
     def __init__(self, memory: MemoryInterface) -> None:
-        self.memory = memory
-
-    @abc.abstractmethod
-    def set_system_prompt(self, prompt: str, conversation_id: str, normalizer_id: str) -> None:
-        """
-        Sets the system prompt for the prompt target
-        """
+        self.memory = memory if memory else FileMemory()
 
     @abc.abstractmethod
     def send_prompt(self, normalized_prompt: str, conversation_id: str, normalizer_id: str) -> str:

--- a/tests/test_prompt_target_no_op.py
+++ b/tests/test_prompt_target_no_op.py
@@ -14,17 +14,6 @@ def memory(tmp_path: pathlib.Path):
     return FileMemory(filepath=tmp_path / "target_no_op_test.json.memory")
 
 
-def test_set_system_prompt(memory: FileMemory):
-    no_op = NoOpTarget(memory=memory)
-
-    no_op.set_system_prompt(prompt="system prompt", conversation_id="1", normalizer_id="2")
-
-    chats = no_op.memory.get_memories_with_conversation_id(conversation_id="1")
-    assert len(chats) == 1, f"Expected 1 chat, got {len(chats)}"
-    assert chats[0].role == "system"
-    assert chats[0].content == "system prompt"
-
-
 def test_send_prompt_user_no_system(memory: FileMemory):
     no_op = NoOpTarget(memory=memory)
 


### PR DESCRIPTION
## Description

Some versions of PromptTarget will not have a `set_system_prompt` function, but others will need that function depending on the type of target. This PR separates the two situations.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no documentation changes needed
- [ ] documentation added or edited
- [ ] example notebook added or updated
