### PR TITLE
FIX simplify flow in red teaming orchestrator code

### DIFF
--- a/pyrit/orchestrator/red_teaming_orchestrator.py
+++ b/pyrit/orchestrator/red_teaming_orchestrator.py
@@ -190,13 +190,13 @@ class RedTeamingOrchestrator(Orchestrator):
         )
         response = self._prompt_normalizer.send_prompt(prompt=target_prompt_obj)[0]
         logger.log(logging.INFO, f'Received the following response from the prompt target "{response}"')
-        if completion_state and self.is_conversation_complete(
-            target_messages
-            + [
-                ChatMessage(role="user", content=prompt),
-                ChatMessage(role="assistant", content=response),
-            ],
-            red_teaming_chat_role="user",
-        ):
-            completion_state.is_complete = True
+        if completion_state:
+            completion_state.is_complete = self.is_conversation_complete(
+                target_messages
+                + [
+                    ChatMessage(role="user", content=prompt),
+                    ChatMessage(role="assistant", content=response),
+                ],
+                red_teaming_chat_role="user",
+            )
         return response

--- a/pyrit/orchestrator/red_teaming_orchestrator.py
+++ b/pyrit/orchestrator/red_teaming_orchestrator.py
@@ -193,7 +193,5 @@ class RedTeamingOrchestrator(Orchestrator):
         if completion_state:
             target_messages.append(ChatMessage(role="user", content=prompt))
             target_messages.append(ChatMessage(role="assistant", content=response))
-            completion_state.is_complete = self.is_conversation_complete(
-                target_messages, red_teaming_chat_role="user"                
-            )
+            completion_state.is_complete = self.is_conversation_complete(target_messages, red_teaming_chat_role="user")
         return response

--- a/pyrit/orchestrator/red_teaming_orchestrator.py
+++ b/pyrit/orchestrator/red_teaming_orchestrator.py
@@ -191,12 +191,9 @@ class RedTeamingOrchestrator(Orchestrator):
         response = self._prompt_normalizer.send_prompt(prompt=target_prompt_obj)[0]
         logger.log(logging.INFO, f'Received the following response from the prompt target "{response}"')
         if completion_state:
+            target_messages.append(ChatMessage(role="user", content=prompt))
+            target_messages.append(ChatMessage(role="assistant", content=response))
             completion_state.is_complete = self.is_conversation_complete(
-                target_messages
-                + [
-                    ChatMessage(role="user", content=prompt),
-                    ChatMessage(role="assistant", content=response),
-                ],
-                red_teaming_chat_role="user",
+                target_messages, red_teaming_chat_role="user"                
             )
         return response


### PR DESCRIPTION
## Description
This PR addresses a comment by @dlmgary from #84 about readability of the control flow that I didn't have time to address then. 

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no documentation changes needed
- [ ] documentation added or edited
- [ ] example notebook added or updated
