### PR TITLE
FEAT Add UTR39 confusability converter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "azure-identity>=1.12.0",
     "azure-ai-ml==1.13.0",
     "azure-storage-blob>=12.19.0",
+    "confusables>=1.2.0",
     "duckdb==0.10.0",
     "duckdb-engine==0.11.2",
     "jsonpickle>=3.0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "azure-identity>=1.12.0",
     "azure-ai-ml==1.13.0",
     "azure-storage-blob>=12.19.0",
-    "confusables>=1.2.0",
+    "confusables==1.2.0",
     "duckdb==0.10.0",
     "duckdb-engine==0.11.2",
     "jsonpickle>=3.0.2",

--- a/pyrit/prompt_converter/__init__.py
+++ b/pyrit/prompt_converter/__init__.py
@@ -9,8 +9,10 @@ from pyrit.prompt_converter.no_op_converter import NoOpConverter
 from pyrit.prompt_converter.rot13_converter import ROT13Converter
 from pyrit.prompt_converter.string_join_converter import StringJoinConverter
 from pyrit.prompt_converter.translation_converter import TranslationConverter
+from pyrit.prompt_converter.unicode_confusable_converter import UnicodeConfusableConverter
 from pyrit.prompt_converter.unicode_sub_converter import UnicodeSubstitutionConverter
 from pyrit.prompt_converter.variation_converter import VariationConverter
+
 
 __all__ = [
     "AsciiArtConverter",
@@ -19,7 +21,9 @@ __all__ = [
     "PromptConverter",
     "ROT13Converter",
     "StringJoinConverter",
+    "StringJoinConverter",
     "TranslationConverter",
+    "UnicodeConfusableConverter",
     "UnicodeSubstitutionConverter",
     "VariationConverter",
 ]

--- a/pyrit/prompt_converter/__init__.py
+++ b/pyrit/prompt_converter/__init__.py
@@ -21,7 +21,6 @@ __all__ = [
     "PromptConverter",
     "ROT13Converter",
     "StringJoinConverter",
-    "StringJoinConverter",
     "TranslationConverter",
     "UnicodeConfusableConverter",
     "UnicodeSubstitutionConverter",

--- a/pyrit/prompt_converter/unicode_confusable_converter.py
+++ b/pyrit/prompt_converter/unicode_confusable_converter.py
@@ -32,11 +32,10 @@ class UnicodeConfusableConverter(PromptConverter):
 
     def _confusable(self, char: str) -> str:
         """Pick a confusable character for the given character."""
-        if char == " ":
-            return char
-
         confusable_options = confusable_characters(char)
-        if len(confusable_options) < 2 or self.deterministic:
+        if not confusable_options or char == " ":
+            return char
+        elif self.deterministic or len(confusable_options) == 1:
             return confusable_options[-1]
         else:
             return random.choice(confusable_options)

--- a/pyrit/prompt_converter/unicode_confusable_converter.py
+++ b/pyrit/prompt_converter/unicode_confusable_converter.py
@@ -27,10 +27,16 @@ class UnicodeConfusableConverter(PromptConverter):
         """
         return ["".join(self._confusable(c) for c in prompt) for prompt in prompts]
 
+    def is_one_to_one_converter(self) -> bool:
+        return True
+
     def _confusable(self, char: str) -> str:
         """Pick a confusable character for the given character."""
         if char == " ":
             return char
 
-        choices = confusable_characters(char)
-        return choices[-1] if len(choices) == 1 or self.deterministic else random.choice(choices)
+        confusable_options = confusable_characters(char)
+        if len(confusable_options) < 2 or self.deterministic:
+            return confusable_options[-1]
+        else:
+            return random.choice(confusable_options)

--- a/pyrit/prompt_converter/unicode_confusable_converter.py
+++ b/pyrit/prompt_converter/unicode_confusable_converter.py
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import random
+from pyrit.prompt_converter import PromptConverter
+from confusables import confusable_characters
+
+
+class UnicodeConfusableConverter(PromptConverter):
+    def __init__(self, deterministic: bool = False):
+        """Set up a converter. The 'deterministic' argument is for unittesting only."""
+        self.deterministic = deterministic
+
+    def convert(self, prompts: list[str]) -> list[str]:
+        """
+        Converts the given prompts into things that look similar, but are actually different,
+        using Unicode confusables -- e.g., replacing a Latin 'a' with a Cyrillic 'а'.
+
+        This is sort of running UTR-39 in reverse, *introducing* confusables rather than
+        removing them. (https://www.unicode.org/reports/tr39/tr39-1.html)
+
+        Args:
+            prompts (list[str]): The prompts to be converted.
+
+        Returns:
+            list[str]: The converted representations of the prompts.
+        """
+        return ["".join(self._confusable(c) for c in prompt) for prompt in prompts]
+
+    def _confusable(self, char: str) -> str:
+        """Pick a confusable character for the given character."""
+        if char == " ":
+            return char
+
+        choices = confusable_characters(char)
+        return choices[-1] if len(choices) == 1 or self.deterministic else random.choice(choices)

--- a/tests/test_prompt_converter.py
+++ b/tests/test_prompt_converter.py
@@ -5,6 +5,7 @@ from pyrit.prompt_converter import (
     Base64Converter,
     NoOpConverter,
     UnicodeSubstitutionConverter,
+    UnicodeConfusableConverter,
     StringJoinConverter,
     ROT13Converter,
     AsciiArtConverter,
@@ -106,3 +107,8 @@ def test_translator_converter_languages_validation_throws(languages):
     prompt_target = MockPromptTarget()
     with pytest.raises(ValueError):
         TranslationConverter(converter_target=prompt_target, languages=languages)
+
+
+def test_unicode_confusable_converter() -> None:
+    converter = UnicodeConfusableConverter(deterministic=True)
+    assert converter.convert(["lorem ipsum dolor sit amet"]) == ["ïỎ𐒴ḕ𝗠 ïṗṡ𝘶𝗠 𝑫ỎïỎ𐒴 ṡï𝚝 ḁ𝗠ḕ𝚝"]


### PR DESCRIPTION
## Description
Add a new converter that uses UTR-39 Unicode confusability to try to work around filters.

## Tests
- [ ] no new tests required
- [X] new tests added
- [ ] existing tests adjusted

## Documentation
- [X] no documentation changes needed
- [ ] documentation added or edited
- [ ] example notebook added or updated
