### PR TITLE
FIX: Removing Deployment directory from jupytext runs

### DIFF
--- a/doc/run_jupytext.ps1
+++ b/doc/run_jupytext.ps1
@@ -1,3 +1,6 @@
+# Find all .py files in the same directory as this script and convert them to .ipynb
+# This excludes the deployment directory
+
 $currDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
 $files = Get-ChildItem -Path $currDir -Recurse -Include *.py -File|
 Where-Object { -not $_.FullName.ToLower().Contains("\deployment\") }

--- a/doc/run_jupytext.ps1
+++ b/doc/run_jupytext.ps1
@@ -1,5 +1,6 @@
 $currDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
-$files = Get-ChildItem -Path $currDir -Recurse -Include *.py -File
+$files = Get-ChildItem -Path $currDir -Recurse -Include *.py -File|
+Where-Object { -not $_.FullName.ToLower().Contains("\deployment\") }
 
 foreach ($file in $files) {
     write-host "Processing $file"

--- a/doc/run_jupytext.sh
+++ b/doc/run_jupytext.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Find all .py files in the same directory as this script and convert them to .ipynb
+# This excludes the deployment directory
+
 curr_dir="$(dirname "$(realpath "$0")")"
 find "$curr_dir" \( -type d -name "deployment" -prune \) -o \( -type f -name "*.py" -print0 \) | while IFS= read -r -d '' file
 do

--- a/doc/run_jupytext.sh
+++ b/doc/run_jupytext.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 curr_dir="$(dirname "$(realpath "$0")")"
-find "$curr_dir" -type f -name "*.py" -print0 | while IFS= read -r -d '' file
+find "$curr_dir" \( -type d -name "deployment" -prune \) -o \( -type f -name "*.py" -print0 \) | while IFS= read -r -d '' file
 do
     echo "Processing $file"
     jupytext --execute --to notebook "$file"


### PR DESCRIPTION
## Description

These scripts were trying to run jupytext on deployment directories, but those are not run automatically. Previously, it was being run on deployment directories, but these should be excluded.


## Tests and Documentation

I ran both of these and jupytext were passing
