### PR TITLE
FEAT: added a ChatMessageNormalizer that formats messages in the template specified by a Hugging Face tokenizer

### DIFF
--- a/doc/code/memory/chat_message.ipynb
+++ b/doc/code/memory/chat_message.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "fe8f7647",
+   "id": "87dabc0e",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -23,13 +23,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "e12a1b6a",
+   "id": "f0a62dad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-03-18T19:55:24.275657Z",
-     "iopub.status.busy": "2024-03-18T19:55:24.275657Z",
-     "iopub.status.idle": "2024-03-18T19:55:24.481666Z",
-     "shell.execute_reply": "2024-03-18T19:55:24.480766Z"
+     "iopub.execute_input": "2024-03-29T16:11:15.074711Z",
+     "iopub.status.busy": "2024-03-29T16:11:15.074711Z",
+     "iopub.status.idle": "2024-03-29T16:11:18.560630Z",
+     "shell.execute_reply": "2024-03-29T16:11:18.560630Z"
     }
    },
    "outputs": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f5edca8b",
+   "id": "7aa9902e",
    "metadata": {},
    "source": [
     "\n",
@@ -79,13 +79,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "83bdae5e",
+   "id": "333b76a9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-03-18T19:55:24.485407Z",
-     "iopub.status.busy": "2024-03-18T19:55:24.485407Z",
-     "iopub.status.idle": "2024-03-18T19:55:24.498582Z",
-     "shell.execute_reply": "2024-03-18T19:55:24.496749Z"
+     "iopub.execute_input": "2024-03-29T16:11:18.560630Z",
+     "iopub.status.busy": "2024-03-29T16:11:18.560630Z",
+     "iopub.status.idle": "2024-03-29T16:11:18.576257Z",
+     "shell.execute_reply": "2024-03-29T16:11:18.576257Z"
     }
    },
    "outputs": [
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8bccadfd",
+   "id": "cabdf4fa",
    "metadata": {},
    "source": [
     "To see how to use this in action, check out the [aml endpoint](./aml_endpoints.ipynb) notebook. It takes a `chat_message_normalizer` parameter so that an AML model can support various chat message formats."
@@ -122,17 +122,26 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c236840",
+   "id": "6aee4e44",
    "metadata": {},
    "source": [
-    "Besides ChatML, there are many other chat templates that a model might be trained on. If you would like to apply the template stored in a Hugging Face tokenizer, you can utilize `ChatMessageNormalizerTokenizerTemplate`. In the example below, we load the tokenizer for Mistral-7B-Instruct-v0.1 and apply its chat template to the messages. Note that this template only adds `[INST]` and `[/INST]` tokens to the user messages for instruction fine-tuning."
+    "Besides chatml, there are many other chat templates that a model might be trained on. If you would like to apply the template stored in a Hugging Face tokenizer, \n",
+    "you can utilize `ChatMessageNormalizerTokenizerTemplate`. In the example below, we load the tokenizer for Mistral-7B-Instruct-v0.1 and apply its chat template to \n",
+    "the messages. Note that this template only adds `[INST]` and `[/INST]` tokens to the user messages for instruction fine-tuning."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "e8b156a1",
-   "metadata": {},
+   "id": "687bc021",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-29T16:11:18.576257Z",
+     "iopub.status.busy": "2024-03-29T16:11:18.576257Z",
+     "iopub.status.idle": "2024-03-29T16:11:19.451079Z",
+     "shell.execute_reply": "2024-03-29T16:11:19.451079Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",

--- a/doc/code/memory/chat_message.ipynb
+++ b/doc/code/memory/chat_message.ipynb
@@ -119,6 +119,48 @@
    "source": [
     "To see how to use this in action, check out the [aml endpoint](./aml_endpoints.ipynb) notebook. It takes a `chat_message_normalizer` parameter so that an AML model can support various chat message formats."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c236840",
+   "metadata": {},
+   "source": [
+    "Besides ChatML, there are many other chat templates that a model might be trained on. If you would like to apply the template stored in a Hugging Face tokenizer, you can utilize `ChatMessageNormalizerTokenizerTemplate`. In the example below, we load the tokenizer for Mistral-7B-Instruct-v0.1 and apply its chat template to the messages. Note that this template only adds `[INST]` and `[/INST]` tokens to the user messages for instruction fine-tuning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e8b156a1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<s>[INST] Hello, how are you? [/INST]I'm doing well, thanks for asking.</s> [INST] What is your favorite food? [/INST]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyrit.chat_message_normalizer import ChatMessageNormalizerTokenizerTemplate\n",
+    "from transformers import AutoTokenizer\n",
+    "\n",
+    "messages = [\n",
+    "    ChatMessage(role=\"user\", content=\"Hello, how are you?\"),\n",
+    "    ChatMessage(role=\"assistant\", content=\"I'm doing well, thanks for asking.\"),\n",
+    "    ChatMessage(role=\"user\", content=\"What is your favorite food?\")\n",
+    "]\n",
+    "\n",
+    "# load the tokenizer\n",
+    "tokenizer = AutoTokenizer.from_pretrained(\"mistralai/Mistral-7B-Instruct-v0.1\")\n",
+    "\n",
+    "# create the normalizer and pass in the tokenizer\n",
+    "normalizer = ChatMessageNormalizerTokenizerTemplate(tokenizer)\n",
+    "\n",
+    "tokenizer_template_messages = normalizer.normalize(messages)\n",
+    "print(tokenizer_template_messages)"
+   ]
   }
  ],
  "metadata": {
@@ -126,9 +168,9 @@
    "cell_metadata_filter": "-all"
   },
   "kernelspec": {
-   "display_name": "pyrit-kernel",
+   "display_name": "pyrit_kernel",
    "language": "python",
-   "name": "pyrit-kernel"
+   "name": "pyrit_kernel"
   },
   "language_info": {
    "codemirror_mode": {

--- a/doc/code/memory/chat_message.ipynb
+++ b/doc/code/memory/chat_message.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "87dabc0e",
+   "id": "6b35a22f",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -23,13 +23,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "f0a62dad",
+   "id": "cfdb5cbf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-03-29T16:11:15.074711Z",
-     "iopub.status.busy": "2024-03-29T16:11:15.074711Z",
-     "iopub.status.idle": "2024-03-29T16:11:18.560630Z",
-     "shell.execute_reply": "2024-03-29T16:11:18.560630Z"
+     "iopub.execute_input": "2024-03-29T21:27:55.175471Z",
+     "iopub.status.busy": "2024-03-29T21:27:55.175471Z",
+     "iopub.status.idle": "2024-03-29T21:27:59.086189Z",
+     "shell.execute_reply": "2024-03-29T21:27:59.085182Z"
     }
    },
    "outputs": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7aa9902e",
+   "id": "773b9e41",
    "metadata": {},
    "source": [
     "\n",
@@ -79,13 +79,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "333b76a9",
+   "id": "7bbef6a1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-03-29T16:11:18.560630Z",
-     "iopub.status.busy": "2024-03-29T16:11:18.560630Z",
-     "iopub.status.idle": "2024-03-29T16:11:18.576257Z",
-     "shell.execute_reply": "2024-03-29T16:11:18.576257Z"
+     "iopub.execute_input": "2024-03-29T21:27:59.089740Z",
+     "iopub.status.busy": "2024-03-29T21:27:59.089740Z",
+     "iopub.status.idle": "2024-03-29T21:27:59.101747Z",
+     "shell.execute_reply": "2024-03-29T21:27:59.100746Z"
     }
    },
    "outputs": [
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cabdf4fa",
+   "id": "6f803626",
    "metadata": {},
    "source": [
     "To see how to use this in action, check out the [aml endpoint](./aml_endpoints.ipynb) notebook. It takes a `chat_message_normalizer` parameter so that an AML model can support various chat message formats."
@@ -122,24 +122,24 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6aee4e44",
+   "id": "c97cf4c4",
    "metadata": {},
    "source": [
-    "Besides chatml, there are many other chat templates that a model might be trained on. If you would like to apply the template stored in a Hugging Face tokenizer, \n",
-    "you can utilize `ChatMessageNormalizerTokenizerTemplate`. In the example below, we load the tokenizer for Mistral-7B-Instruct-v0.1 and apply its chat template to \n",
+    "Besides chatml, there are many other chat templates that a model might be trained on. If you would like to apply the template stored in a Hugging Face tokenizer,\n",
+    "you can utilize `ChatMessageNormalizerTokenizerTemplate`. In the example below, we load the tokenizer for Mistral-7B-Instruct-v0.1 and apply its chat template to\n",
     "the messages. Note that this template only adds `[INST]` and `[/INST]` tokens to the user messages for instruction fine-tuning."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "687bc021",
+   "id": "1e674217",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-03-29T16:11:18.576257Z",
-     "iopub.status.busy": "2024-03-29T16:11:18.576257Z",
-     "iopub.status.idle": "2024-03-29T16:11:19.451079Z",
-     "shell.execute_reply": "2024-03-29T16:11:19.451079Z"
+     "iopub.execute_input": "2024-03-29T21:27:59.104752Z",
+     "iopub.status.busy": "2024-03-29T21:27:59.104752Z",
+     "iopub.status.idle": "2024-03-29T21:27:59.795124Z",
+     "shell.execute_reply": "2024-03-29T21:27:59.794119Z"
     }
    },
    "outputs": [
@@ -158,16 +158,16 @@
     "messages = [\n",
     "    ChatMessage(role=\"user\", content=\"Hello, how are you?\"),\n",
     "    ChatMessage(role=\"assistant\", content=\"I'm doing well, thanks for asking.\"),\n",
-    "    ChatMessage(role=\"user\", content=\"What is your favorite food?\")\n",
+    "    ChatMessage(role=\"user\", content=\"What is your favorite food?\"),\n",
     "]\n",
     "\n",
     "# load the tokenizer\n",
     "tokenizer = AutoTokenizer.from_pretrained(\"mistralai/Mistral-7B-Instruct-v0.1\")\n",
     "\n",
     "# create the normalizer and pass in the tokenizer\n",
-    "normalizer = ChatMessageNormalizerTokenizerTemplate(tokenizer)\n",
+    "tokenizer_normalizer = ChatMessageNormalizerTokenizerTemplate(tokenizer)\n",
     "\n",
-    "tokenizer_template_messages = normalizer.normalize(messages)\n",
+    "tokenizer_template_messages = tokenizer_normalizer.normalize(messages)\n",
     "print(tokenizer_template_messages)"
    ]
   }

--- a/doc/code/memory/chat_message.py
+++ b/doc/code/memory/chat_message.py
@@ -69,7 +69,7 @@ messages = [
 tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-Instruct-v0.1")
 
 # create the normalizer and pass in the tokenizer
-normalizer = ChatMessageNormalizerTokenizerTemplate(tokenizer)
+tokenizer_normalizer = ChatMessageNormalizerTokenizerTemplate(tokenizer)
 
-tokenizer_template_messages = normalizer.normalize(messages)
+tokenizer_template_messages = tokenizer_normalizer.normalize(messages)
 print(tokenizer_template_messages)

--- a/doc/code/memory/chat_message.py
+++ b/doc/code/memory/chat_message.py
@@ -51,8 +51,8 @@ print(chat_messages)
 # To see how to use this in action, check out the [aml endpoint](./aml_endpoints.ipynb) notebook. It takes a `chat_message_normalizer` parameter so that an AML model can support various chat message formats.
 
 # %% [markdown]
-# Besides chatml, there are many other chat templates that a model might be trained on. If you would like to apply the template stored in a Hugging Face tokenizer, 
-# you can utilize `ChatMessageNormalizerTokenizerTemplate`. In the example below, we load the tokenizer for Mistral-7B-Instruct-v0.1 and apply its chat template to 
+# Besides chatml, there are many other chat templates that a model might be trained on. If you would like to apply the template stored in a Hugging Face tokenizer,
+# you can utilize `ChatMessageNormalizerTokenizerTemplate`. In the example below, we load the tokenizer for Mistral-7B-Instruct-v0.1 and apply its chat template to
 # the messages. Note that this template only adds `[INST]` and `[/INST]` tokens to the user messages for instruction fine-tuning.
 
 # %%
@@ -62,7 +62,7 @@ from transformers import AutoTokenizer
 messages = [
     ChatMessage(role="user", content="Hello, how are you?"),
     ChatMessage(role="assistant", content="I'm doing well, thanks for asking."),
-    ChatMessage(role="user", content="What is your favorite food?")
+    ChatMessage(role="user", content="What is your favorite food?"),
 ]
 
 # load the tokenizer

--- a/doc/code/memory/chat_message.py
+++ b/doc/code/memory/chat_message.py
@@ -49,3 +49,27 @@ print(chat_messages)
 
 # %% [markdown]
 # To see how to use this in action, check out the [aml endpoint](./aml_endpoints.ipynb) notebook. It takes a `chat_message_normalizer` parameter so that an AML model can support various chat message formats.
+
+# %% [markdown]
+# Besides chatml, there are many other chat templates that a model might be trained on. If you would like to apply the template stored in a Hugging Face tokenizer, 
+# you can utilize `ChatMessageNormalizerTokenizerTemplate`. In the example below, we load the tokenizer for Mistral-7B-Instruct-v0.1 and apply its chat template to 
+# the messages. Note that this template only adds `[INST]` and `[/INST]` tokens to the user messages for instruction fine-tuning.
+
+# %%
+from pyrit.chat_message_normalizer import ChatMessageNormalizerTokenizerTemplate
+from transformers import AutoTokenizer
+
+messages = [
+    ChatMessage(role="user", content="Hello, how are you?"),
+    ChatMessage(role="assistant", content="I'm doing well, thanks for asking."),
+    ChatMessage(role="user", content="What is your favorite food?")
+]
+
+# load the tokenizer
+tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-Instruct-v0.1")
+
+# create the normalizer and pass in the tokenizer
+normalizer = ChatMessageNormalizerTokenizerTemplate(tokenizer)
+
+tokenizer_template_messages = normalizer.normalize(messages)
+print(tokenizer_template_messages)

--- a/pyrit/chat_message_normalizer/__init__.py
+++ b/pyrit/chat_message_normalizer/__init__.py
@@ -6,10 +6,12 @@ from pyrit.chat_message_normalizer.chat_message_normalizer import ChatMessageNor
 from pyrit.chat_message_normalizer.chat_message_nop import ChatMessageNop
 from pyrit.chat_message_normalizer.generic_system_squash import GenericSystemSquash
 from pyrit.chat_message_normalizer.chat_message_normalizer_chatml import ChatMessageNormalizerChatML
+from pyrit.chat_message_normalizer.chat_message_normalizer_tokenizer import ChatMessageNormalizerTokenizerTemplate
 
 __all__ = [
     "ChatMessageNormalizer",
     "ChatMessageNop",
     "GenericSystemSquash",
     "ChatMessageNormalizerChatML",
+    "ChatMessageNormalizerTokenizerTemplate",
 ]

--- a/pyrit/chat_message_normalizer/chat_message_normalizer_tokenizer.py
+++ b/pyrit/chat_message_normalizer/chat_message_normalizer_tokenizer.py
@@ -7,15 +7,30 @@ from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 
 
 class ChatMessageNormalizerTokenizerTemplate(ChatMessageNormalizer[str]):
+    """
+    This class enables you to apply the chat template stored in a Hugging Face tokenizer
+    to a list of chat messages. For more details, see
+    https://huggingface.co/docs/transformers/main/en/chat_templating
+    """
 
     def __init__(self, tokenizer: PreTrainedTokenizer | PreTrainedTokenizerFast):
+        """
+        Initializes an instance of the ChatMessageNormalizerTokenizerTemplate class.
+
+        Args:
+            tokenizer (PreTrainedTokenizer | PreTrainedTokenizerFast): A Hugging Face tokenizer.
+        """
         self.tokenizer = tokenizer
 
     def normalize(self, messages: list[ChatMessage]) -> str:
-        """Convert a string of text to the format specified by the chat
-        template loaded in a custom Hugging Face tokenizer.
-        This method utilizes the `apply_chat_template` method documented at
-        https://huggingface.co/docs/transformers/main/en/chat_templating
+        """
+        Applies the chat template stored in the tokenizer to a list of chat messages.
+
+        Args:
+            messages (list[ChatMessage]): A list of ChatMessage objects.
+
+        Returns:
+            str: The formatted chat messages.
         """
 
         messages_list = []

--- a/pyrit/chat_message_normalizer/chat_message_normalizer_tokenizer.py
+++ b/pyrit/chat_message_normalizer/chat_message_normalizer_tokenizer.py
@@ -1,0 +1,31 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from pyrit.models import ChatMessage
+from pyrit.chat_message_normalizer import ChatMessageNormalizer
+from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
+
+
+class ChatMessageNormalizerTokenizerTemplate(ChatMessageNormalizer[str]):
+
+    def __init__(self, tokenizer: PreTrainedTokenizer | PreTrainedTokenizerFast):
+        self.tokenizer = tokenizer
+
+    def normalize(self, messages: list[ChatMessage]) -> str:
+        """Convert a string of text to the format specified by the chat
+        template loaded in a custom Hugging Face tokenizer.
+        This method utilizes the `apply_chat_template` method documented at
+        https://huggingface.co/docs/transformers/main/en/chat_templating
+        """
+
+        messages_list = []
+
+        formatted_messages: str = ""
+        for m in messages:
+            messages_list.append({"role": m.role, "content": m.content})
+        formatted_messages = self.tokenizer.apply_chat_template(
+            messages_list,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        return formatted_messages

--- a/tests/test_chat_normalizer_tokenizer.py
+++ b/tests/test_chat_normalizer_tokenizer.py
@@ -1,0 +1,58 @@
+import pytest 
+from pyrit.models import ChatMessage
+from pyrit.chat_message_normalizer import ChatMessageNormalizerTokenizerTemplate
+from transformers import AutoTokenizer
+import textwrap
+
+@pytest.fixture
+def blenderbot_tokenizer_normalizer():
+    tokenizer = AutoTokenizer.from_pretrained("facebook/blenderbot-400M-distill")
+    return ChatMessageNormalizerTokenizerTemplate(tokenizer)
+
+@pytest.fixture
+def mistral_tokenizer_normalizer():
+    tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-Instruct-v0.1")
+    return ChatMessageNormalizerTokenizerTemplate(tokenizer)
+
+@pytest.fixture
+def chatml_tokenizer_normalizer():
+    tokenizer = AutoTokenizer.from_pretrained("HuggingFaceH4/zephyr-7b-beta")
+    return ChatMessageNormalizerTokenizerTemplate(tokenizer)
+
+def test_normalize_blenderbot(blenderbot_tokenizer_normalizer: ChatMessageNormalizerTokenizerTemplate):
+    messages = [
+        ChatMessage(role="user", content="Hello, how are you?"), 
+        ChatMessage(role="assistant", content="I'm doing great. How can I help you today?"),
+        ChatMessage(role="user", content="I'd like to show off how chat templating works!")
+    ]
+    expected = " Hello, how are you?  I'm doing great. How can I help you today?   I'd like to show off how chat templating works!</s>"
+
+    assert blenderbot_tokenizer_normalizer.normalize(messages) == expected
+
+
+def test_normalize_mistral(mistral_tokenizer_normalizer: ChatMessageNormalizerTokenizerTemplate):
+    messages = [
+        ChatMessage(role="user", content="Hello, how are you?"), 
+        ChatMessage(role="assistant", content="I'm doing great. How can I help you today?"),
+        ChatMessage(role="user", content="I'd like to show off how chat templating works!")
+    ]
+    expected = "<s>[INST] Hello, how are you? [/INST]I'm doing great. How can I help you today?</s> [INST] I'd like to show off how chat templating works! [/INST]"
+
+    assert mistral_tokenizer_normalizer.normalize(messages) == expected
+
+def test_normalize_chatml(chatml_tokenizer_normalizer: ChatMessageNormalizerTokenizerTemplate):
+    messages = [
+        ChatMessage(role="system", content="You are a friendly chatbot who always responds in the style of a pirate"), 
+        ChatMessage(role="user", content="How many helicopters can a human eat in one sitting?"),
+    ]
+    expected = textwrap.dedent(
+        """\
+        <|system|>
+        You are a friendly chatbot who always responds in the style of a pirate</s>
+        <|user|>
+        How many helicopters can a human eat in one sitting?</s>
+        <|assistant|>
+        """
+    )
+
+    assert chatml_tokenizer_normalizer.normalize(messages) == expected

--- a/tests/test_chat_normalizer_tokenizer.py
+++ b/tests/test_chat_normalizer_tokenizer.py
@@ -29,7 +29,11 @@ def test_normalize_blenderbot(blenderbot_tokenizer_normalizer: ChatMessageNormal
         ChatMessage(role="assistant", content="I'm doing great. How can I help you today?"),
         ChatMessage(role="user", content="I'd like to show off how chat templating works!"),
     ]
-    expected = " Hello, how are you?  I'm doing great. How can I help you today?   I'd like to show off how chat templating works!</s>"
+    expected = (
+        " Hello, how are you?  I'm doing great. "
+        "How can I help you today?   "
+        "I'd like to show off how chat templating works!</s>"
+    )
 
     assert blenderbot_tokenizer_normalizer.normalize(messages) == expected
 
@@ -40,7 +44,10 @@ def test_normalize_mistral(mistral_tokenizer_normalizer: ChatMessageNormalizerTo
         ChatMessage(role="assistant", content="I'm doing great. How can I help you today?"),
         ChatMessage(role="user", content="I'd like to show off how chat templating works!"),
     ]
-    expected = "<s>[INST] Hello, how are you? [/INST]I'm doing great. How can I help you today?</s> [INST] I'd like to show off how chat templating works! [/INST]"
+    expected = (
+        "<s>[INST] Hello, how are you? [/INST]I'm doing great. How can I help you today?</s> "
+        "[INST] I'd like to show off how chat templating works! [/INST]"
+    )
 
     assert mistral_tokenizer_normalizer.normalize(messages) == expected
 

--- a/tests/test_chat_normalizer_tokenizer.py
+++ b/tests/test_chat_normalizer_tokenizer.py
@@ -1,29 +1,33 @@
-import pytest 
+import pytest
 from pyrit.models import ChatMessage
 from pyrit.chat_message_normalizer import ChatMessageNormalizerTokenizerTemplate
 from transformers import AutoTokenizer
 import textwrap
+
 
 @pytest.fixture
 def blenderbot_tokenizer_normalizer():
     tokenizer = AutoTokenizer.from_pretrained("facebook/blenderbot-400M-distill")
     return ChatMessageNormalizerTokenizerTemplate(tokenizer)
 
+
 @pytest.fixture
 def mistral_tokenizer_normalizer():
     tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-Instruct-v0.1")
     return ChatMessageNormalizerTokenizerTemplate(tokenizer)
+
 
 @pytest.fixture
 def chatml_tokenizer_normalizer():
     tokenizer = AutoTokenizer.from_pretrained("HuggingFaceH4/zephyr-7b-beta")
     return ChatMessageNormalizerTokenizerTemplate(tokenizer)
 
+
 def test_normalize_blenderbot(blenderbot_tokenizer_normalizer: ChatMessageNormalizerTokenizerTemplate):
     messages = [
-        ChatMessage(role="user", content="Hello, how are you?"), 
+        ChatMessage(role="user", content="Hello, how are you?"),
         ChatMessage(role="assistant", content="I'm doing great. How can I help you today?"),
-        ChatMessage(role="user", content="I'd like to show off how chat templating works!")
+        ChatMessage(role="user", content="I'd like to show off how chat templating works!"),
     ]
     expected = " Hello, how are you?  I'm doing great. How can I help you today?   I'd like to show off how chat templating works!</s>"
 
@@ -32,17 +36,18 @@ def test_normalize_blenderbot(blenderbot_tokenizer_normalizer: ChatMessageNormal
 
 def test_normalize_mistral(mistral_tokenizer_normalizer: ChatMessageNormalizerTokenizerTemplate):
     messages = [
-        ChatMessage(role="user", content="Hello, how are you?"), 
+        ChatMessage(role="user", content="Hello, how are you?"),
         ChatMessage(role="assistant", content="I'm doing great. How can I help you today?"),
-        ChatMessage(role="user", content="I'd like to show off how chat templating works!")
+        ChatMessage(role="user", content="I'd like to show off how chat templating works!"),
     ]
     expected = "<s>[INST] Hello, how are you? [/INST]I'm doing great. How can I help you today?</s> [INST] I'd like to show off how chat templating works! [/INST]"
 
     assert mistral_tokenizer_normalizer.normalize(messages) == expected
 
+
 def test_normalize_chatml(chatml_tokenizer_normalizer: ChatMessageNormalizerTokenizerTemplate):
     messages = [
-        ChatMessage(role="system", content="You are a friendly chatbot who always responds in the style of a pirate"), 
+        ChatMessage(role="system", content="You are a friendly chatbot who always responds in the style of a pirate"),
         ChatMessage(role="user", content="How many helicopters can a human eat in one sitting?"),
     ]
     expected = textwrap.dedent(


### PR DESCRIPTION
## Description

I added a chat message normalizer called `ChatMessageNormalizerTokenizerTemplate`, which takes a Hugging Face tokenizer as input and allows you to convert a list of chat messages into the format specified by that tokenizer. This might be the ChatML format (which @dlmgary created a custom normalizer `ChatMessageNormalizerChatML` for) or some other custom format that was used to train the model.

## Tests and Documentation

I added tests to demonstrate that the normalizer works on three different Hugging Face tokenizers and some example usage to the `chat_message.ipynb` demo notebook.