### PR TITLE
FEAT: Added support to target an Ollama endpoint as a prompt chat target

### DIFF
--- a/pyrit/prompt_target/__init__.py
+++ b/pyrit/prompt_target/__init__.py
@@ -9,6 +9,7 @@ from pyrit.prompt_target.prompt_chat_target.openai_chat_target import AzureOpenA
 from pyrit.prompt_target.gandalf_target import GandalfTarget
 from pyrit.prompt_target.text_target import TextTarget
 from pyrit.prompt_target.image_target import ImageTarget
+from pyrit.prompt_target.prompt_chat_target.ollama_chat_target import OllamaChatTarget
 
 
 __all__ = [
@@ -21,4 +22,5 @@ __all__ = [
     "PromptChatTarget",
     "PromptTarget",
     "TextTarget",
+    "OllamaChatTarget",
 ]

--- a/pyrit/prompt_target/prompt_chat_target/ollama_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/ollama_chat_target.py
@@ -10,6 +10,7 @@ from pyrit.prompt_target import PromptChatTarget
 
 logger = logging.getLogger(__name__)
 
+
 class OllamaChatTarget(PromptChatTarget):
 
     ENDPOINT_URI_ENVIRONMENT_VARIABLE = "OLLAMA_ENDPOINT"
@@ -22,7 +23,6 @@ class OllamaChatTarget(PromptChatTarget):
         model_name: str = None,
         chat_message_normalizer: ChatMessageNormalizer = ChatMessageNop(),
         memory: MemoryInterface = None,
-
     ) -> None:
         PromptChatTarget.__init__(self, memory=memory)
 
@@ -39,7 +39,7 @@ class OllamaChatTarget(PromptChatTarget):
 
         if messages:
             raise RuntimeError("Conversation already exists, system prompt needs to be set at the beginning")
-        
+
         self._memory.add_chat_message_to_memory(
             conversation=ChatMessage(role="system", content=prompt),
             conversation_id=conversation_id,
@@ -63,7 +63,7 @@ class OllamaChatTarget(PromptChatTarget):
 
         if not resp:
             raise ValueError("The chat returned an empty response.")
-        
+
         logger.info(f'Received the following response from the prompt target "{resp}"')
 
         messages.append(ChatMessage(role="assistant", content=resp))
@@ -74,7 +74,7 @@ class OllamaChatTarget(PromptChatTarget):
         )
 
         return resp
-    
+
     async def send_prompt_async(
         self,
         *,
@@ -92,7 +92,7 @@ class OllamaChatTarget(PromptChatTarget):
 
         if not resp:
             raise ValueError("The chat returned an empty response.")
-        
+
         logger.info(f'Received the following response from the prompt target "{resp}"')
 
         self._memory.add_chat_message_to_memory(
@@ -102,7 +102,7 @@ class OllamaChatTarget(PromptChatTarget):
         )
 
         return resp
-    
+
     def _complete_chat(
         self,
         messages: list[ChatMessage],
@@ -115,7 +115,7 @@ class OllamaChatTarget(PromptChatTarget):
         )
 
         return response.json()["message"]["content"]
-        
+
     async def _complete_chat_async(
         self,
         messages: list[ChatMessage],
@@ -128,14 +128,14 @@ class OllamaChatTarget(PromptChatTarget):
         )
 
         return response.json()["message"]["content"]
-    
+
     def _prepare_message(self, normalized_prompt: str, conversation_id: str, normalizer_id: str) -> list[ChatMessage]:
         messages = self._memory.get_chat_messages_with_conversation_id(conversation_id=conversation_id)
         msg = ChatMessage(role="user", content=normalized_prompt)
         messages.append(msg)
         self._memory.add_chat_message_to_memory(msg, conversation_id, normalizer_id)
         return messages
-    
+
     def _construct_http_body(
         self,
         messages: list[ChatMessage],

--- a/pyrit/prompt_target/prompt_chat_target/ollama_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/ollama_chat_target.py
@@ -1,0 +1,157 @@
+# Copyright (c) Adriano Maia <adriano@drstrange.wtf>
+# Licensed under the MIT license.
+import logging
+
+from pyrit.chat_message_normalizer import ChatMessageNormalizer, ChatMessageNop
+from pyrit.common import default_values, net_utility
+from pyrit.memory import MemoryInterface
+from pyrit.models import ChatMessage
+from pyrit.prompt_target import PromptChatTarget
+
+logger = logging.getLogger(__name__)
+
+class OllamaChatTarget(PromptChatTarget):
+
+    ENDPOINT_URI_ENVIRONMENT_VARIABLE = "OLLAMA_ENDPOINT"
+    MODEL_NAME_ENVIRONMENT_VARIABLE = "OLLAMA_MODEL_NAME"
+
+    def __init__(
+        self,
+        *,
+        endpoint_uri: str = None,
+        model_name: str = None,
+        chat_message_normalizer: ChatMessageNormalizer = ChatMessageNop(),
+        memory: MemoryInterface = None,
+
+    ) -> None:
+        PromptChatTarget.__init__(self, memory=memory)
+
+        self.endpoint_uri = endpoint_uri or default_values.get_required_value(
+            env_var_name=self.ENDPOINT_URI_ENVIRONMENT_VARIABLE, passed_value=endpoint_uri
+        )
+        self.model_name = model_name or default_values.get_required_value(
+            env_var_name=self.MODEL_NAME_ENVIRONMENT_VARIABLE, passed_value=model_name
+        )
+        self.chat_message_normalizer = chat_message_normalizer
+
+    def set_system_prompt(self, *, prompt: str, conversation_id: str, normalizer_id: str) -> None:
+        messages = self._memory.get_prompt_entries_with_conversation_id(conversation_id=conversation_id)
+
+        if messages:
+            raise RuntimeError("Conversation already exists, system prompt needs to be set at the beginning")
+        
+        self._memory.add_chat_message_to_memory(
+            conversation=ChatMessage(role="system", content=prompt),
+            conversation_id=conversation_id,
+            normalizer_id=normalizer_id,
+        )
+
+    def send_prompt(
+        self,
+        *,
+        normalized_prompt: str,
+        conversation_id: str,
+        normalizer_id: str,
+    ) -> str:
+        messages = self._prepare_message(normalized_prompt, conversation_id, normalizer_id)
+
+        logger.info(f"Sending the following prompt to the prompt target: {normalized_prompt}")
+
+        resp = self._complete_chat(
+            messages=messages,
+        )
+
+        if not resp:
+            raise ValueError("The chat returned an empty response.")
+        
+        logger.info(f'Received the following response from the prompt target "{resp}"')
+
+        messages.append(ChatMessage(role="assistant", content=resp))
+        self._memory.add_chat_message_to_memory(
+            ChatMessage(role="assistant", content=resp),
+            conversation_id=conversation_id,
+            normalizer_id=normalizer_id,
+        )
+
+        return resp
+    
+    async def send_prompt_async(
+        self,
+        *,
+        normalized_prompt: str,
+        conversation_id: str,
+        normalizer_id: str,
+    ) -> str:
+        messages = self._prepare_message(normalized_prompt, conversation_id, normalizer_id)
+
+        logger.info(f"Sending the following prompt to the prompt target: {normalized_prompt}")
+
+        resp = await self._complete_chat_async(
+            messages=messages,
+        )
+
+        if not resp:
+            raise ValueError("The chat returned an empty response.")
+        
+        logger.info(f'Received the following response from the prompt target "{resp}"')
+
+        self._memory.add_chat_message_to_memory(
+            ChatMessage(role="assistant", content=resp),
+            conversation_id=conversation_id,
+            normalizer_id=normalizer_id,
+        )
+
+        return resp
+    
+    def _complete_chat(
+        self,
+        messages: list[ChatMessage],
+    ) -> str:
+        headers = self._get_headers()
+        payload = self._construct_http_body(messages)
+
+        response = net_utility.make_request_and_raise_if_error(
+            endpoint_uri=self.endpoint_uri, method="POST", request_body=payload, headers=headers
+        )
+
+        return response.json()["message"]["content"]
+        
+    async def _complete_chat_async(
+        self,
+        messages: list[ChatMessage],
+    ) -> str:
+        headers = self._get_headers()
+        payload = self._construct_http_body(messages)
+
+        response = await net_utility.make_request_and_raise_if_error_async(
+            endpoint_uri=self.endpoint_uri, method="POST", request_body=payload, headers=headers
+        )
+
+        return response.json()["message"]["content"]
+    
+    def _prepare_message(self, normalized_prompt: str, conversation_id: str, normalizer_id: str) -> list[ChatMessage]:
+        messages = self._memory.get_chat_messages_with_conversation_id(conversation_id=conversation_id)
+        msg = ChatMessage(role="user", content=normalized_prompt)
+        messages.append(msg)
+        self._memory.add_chat_message_to_memory(msg, conversation_id, normalizer_id)
+        return messages
+    
+    def _construct_http_body(
+        self,
+        messages: list[ChatMessage],
+    ) -> dict:
+        squased_messages = self.chat_message_normalizer.normalize(messages)
+        messages_dict = [message.model_dump(exclude_none=True) for message in squased_messages]
+        data = {
+            "model": self.model_name,
+            "messages": messages_dict,
+            "stream": False,
+        }
+        return data
+
+    def _get_headers(self) -> dict:
+        headers: dict = {
+            "Content-Type": "application/json",
+        }
+
+        return headers

--- a/tests/test_ollama_chat_target.py
+++ b/tests/test_ollama_chat_target.py
@@ -3,12 +3,10 @@
 
 import os
 
-from contextlib import AbstractAsyncContextManager
 from unittest.mock import AsyncMock, patch
 
 import pytest
 import httpx
-from pyrit.common import default_values, net_utility
 from pyrit.prompt_target import OllamaChatTarget
 from pyrit.models import ChatMessage
 

--- a/tests/test_ollama_chat_target.py
+++ b/tests/test_ollama_chat_target.py
@@ -1,0 +1,54 @@
+# Copyright (c) Adriano Maia <adriano@drstrange.wtf>
+# Licensed under the MIT license.
+
+import os
+
+from contextlib import AbstractAsyncContextManager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import httpx
+from pyrit.common import default_values, net_utility
+from pyrit.prompt_target import OllamaChatTarget
+from pyrit.models import ChatMessage
+
+@pytest.fixture
+def ollama_mock_return() -> dict:
+    return {"model":"mistral","created_at":"2024-04-13T16:14:52.69602Z","message":{"role":"assistant","content":" Hello."},"done":True,"total_duration":254579625,"load_duration":276542,"prompt_eval_count":20,"prompt_eval_duration":222911000,"eval_count":3,"eval_duration":30879000}
+
+@pytest.fixture
+def ollama_chat_engine() -> OllamaChatTarget:
+    return OllamaChatTarget(
+        endpoint_uri="http://mock.ollama.com:11434/api/chat",
+        model_name="mistral",
+    )
+
+@pytest.mark.asyncio
+async def test_ollama_complete_chat_async_return(ollama_mock_return: dict, ollama_chat_engine: OllamaChatTarget):
+    with patch("pyrit.common.net_utility.make_request_and_raise_if_error_async", new_callable=AsyncMock) as mock_create:
+        mock_create.return_value = ollama_mock_return
+        ret = await ollama_chat_engine._complete_chat_async(messages=[ChatMessage(role="user", content="hello")])
+        assert ret == " Hello."
+
+def test_ollama_complete_chat_return(ollama_mock_return: dict, ollama_chat_engine: OllamaChatTarget):
+    with patch("pyrit.common.net_utility.make_request_and_raise_if_error") as mock_create:
+        mock_create.return_value = httpx.Response(200, json={"model":"mistral","created_at":"2024-04-13T16:14:52.69602Z","message":{"role":"assistant","content":" Hello."},"done":True,"total_duration":254579625,"load_duration":276542,"prompt_eval_count":20,"prompt_eval_duration":222911000,"eval_count":3,"eval_duration":30879000})
+        ret = ollama_chat_engine._complete_chat(messages=[ChatMessage(role="user", content="hello")])
+        assert ret == " Hello."
+
+def test_ollama_invalid_model_raises():
+    os.environ[OllamaChatTarget.MODEL_NAME_ENVIRONMENT_VARIABLE] = ""
+    with pytest.raises(ValueError):
+        OllamaChatTarget(
+            endpoint_uri="http://mock.ollama.com:11434/api/chat",
+            model_name="",
+        )   
+
+def test_ollama_invalid_endpoint_uri_raises():
+    os.environ[OllamaChatTarget.ENDPOINT_URI_ENVIRONMENT_VARIABLE] = ""
+    with pytest.raises(ValueError):
+        OllamaChatTarget(
+            endpoint_uri="",
+            model_name="mistral",
+        )
+

--- a/tests/test_ollama_chat_target.py
+++ b/tests/test_ollama_chat_target.py
@@ -10,9 +10,22 @@ import httpx
 from pyrit.prompt_target import OllamaChatTarget
 from pyrit.models import ChatMessage
 
+
 @pytest.fixture
 def ollama_mock_return() -> dict:
-    return {"model":"mistral","created_at":"2024-04-13T16:14:52.69602Z","message":{"role":"assistant","content":" Hello."},"done":True,"total_duration":254579625,"load_duration":276542,"prompt_eval_count":20,"prompt_eval_duration":222911000,"eval_count":3,"eval_duration":30879000}
+    return {
+        "model": "mistral",
+        "created_at": "2024-04-13T16:14:52.69602Z",
+        "message": {"role": "assistant", "content": " Hello."},
+        "done": True,
+        "total_duration": 254579625,
+        "load_duration": 276542,
+        "prompt_eval_count": 20,
+        "prompt_eval_duration": 222911000,
+        "eval_count": 3,
+        "eval_duration": 30879000,
+    }
+
 
 @pytest.fixture
 def ollama_chat_engine() -> OllamaChatTarget:
@@ -21,18 +34,49 @@ def ollama_chat_engine() -> OllamaChatTarget:
         model_name="mistral",
     )
 
+
 @pytest.mark.asyncio
 async def test_ollama_complete_chat_async_return(ollama_chat_engine: OllamaChatTarget):
     with patch("pyrit.common.net_utility.make_request_and_raise_if_error_async", new_callable=AsyncMock) as mock_create:
-        mock_create.return_value = httpx.Response(200, json={"model":"mistral","created_at":"2024-04-13T16:14:52.69602Z","message":{"role":"assistant","content":" Hello."},"done":True,"total_duration":254579625,"load_duration":276542,"prompt_eval_count":20,"prompt_eval_duration":222911000,"eval_count":3,"eval_duration":30879000})
+        mock_create.return_value = httpx.Response(
+            200,
+            json={
+                "model": "mistral",
+                "created_at": "2024-04-13T16:14:52.69602Z",
+                "message": {"role": "assistant", "content": " Hello."},
+                "done": True,
+                "total_duration": 254579625,
+                "load_duration": 276542,
+                "prompt_eval_count": 20,
+                "prompt_eval_duration": 222911000,
+                "eval_count": 3,
+                "eval_duration": 30879000,
+            },
+        )
         ret = await ollama_chat_engine._complete_chat_async(messages=[ChatMessage(role="user", content="hello")])
         assert ret == " Hello."
 
+
 def test_ollama_complete_chat_return(ollama_chat_engine: OllamaChatTarget):
     with patch("pyrit.common.net_utility.make_request_and_raise_if_error") as mock_create:
-        mock_create.return_value = httpx.Response(200, json={"model":"mistral","created_at":"2024-04-13T16:14:52.69602Z","message":{"role":"assistant","content":" Hello."},"done":True,"total_duration":254579625,"load_duration":276542,"prompt_eval_count":20,"prompt_eval_duration":222911000,"eval_count":3,"eval_duration":30879000})
+        mock_create.return_value = httpx.Response(
+            200,
+            json={
+                "model": "mistral",
+                "created_at": "2024-04-13T16:14:52.69602Z",
+                "message": {"role": "assistant", "content": " Hello."},
+                "done": True,
+                "total_duration": 254579625,
+                "load_duration": 276542,
+                "prompt_eval_count": 20,
+                "prompt_eval_duration": 222911000,
+                "eval_count": 3,
+                "eval_duration": 30879000,
+            },
+        )
         ret = ollama_chat_engine._complete_chat(messages=[ChatMessage(role="user", content="hello")])
         assert ret == " Hello."
+
 
 def test_ollama_invalid_model_raises():
     os.environ[OllamaChatTarget.MODEL_NAME_ENVIRONMENT_VARIABLE] = ""
@@ -40,7 +84,8 @@ def test_ollama_invalid_model_raises():
         OllamaChatTarget(
             endpoint_uri="http://mock.ollama.com:11434/api/chat",
             model_name="",
-        )   
+        )
+
 
 def test_ollama_invalid_endpoint_uri_raises():
     os.environ[OllamaChatTarget.ENDPOINT_URI_ENVIRONMENT_VARIABLE] = ""
@@ -49,4 +94,3 @@ def test_ollama_invalid_endpoint_uri_raises():
             endpoint_uri="",
             model_name="mistral",
         )
-

--- a/tests/test_ollama_chat_target.py
+++ b/tests/test_ollama_chat_target.py
@@ -24,13 +24,13 @@ def ollama_chat_engine() -> OllamaChatTarget:
     )
 
 @pytest.mark.asyncio
-async def test_ollama_complete_chat_async_return(ollama_mock_return: dict, ollama_chat_engine: OllamaChatTarget):
+async def test_ollama_complete_chat_async_return(ollama_chat_engine: OllamaChatTarget):
     with patch("pyrit.common.net_utility.make_request_and_raise_if_error_async", new_callable=AsyncMock) as mock_create:
-        mock_create.return_value = ollama_mock_return
+        mock_create.return_value = httpx.Response(200, json={"model":"mistral","created_at":"2024-04-13T16:14:52.69602Z","message":{"role":"assistant","content":" Hello."},"done":True,"total_duration":254579625,"load_duration":276542,"prompt_eval_count":20,"prompt_eval_duration":222911000,"eval_count":3,"eval_duration":30879000})
         ret = await ollama_chat_engine._complete_chat_async(messages=[ChatMessage(role="user", content="hello")])
         assert ret == " Hello."
 
-def test_ollama_complete_chat_return(ollama_mock_return: dict, ollama_chat_engine: OllamaChatTarget):
+def test_ollama_complete_chat_return(ollama_chat_engine: OllamaChatTarget):
     with patch("pyrit.common.net_utility.make_request_and_raise_if_error") as mock_create:
         mock_create.return_value = httpx.Response(200, json={"model":"mistral","created_at":"2024-04-13T16:14:52.69602Z","message":{"role":"assistant","content":" Hello."},"done":True,"total_duration":254579625,"load_duration":276542,"prompt_eval_count":20,"prompt_eval_duration":222911000,"eval_count":3,"eval_duration":30879000})
         ret = ollama_chat_engine._complete_chat(messages=[ChatMessage(role="user", content="hello")])


### PR DESCRIPTION
## Description
This is a basic implementation for a prompt target for Ollama endpoint. This allows to use all kinds of models locally. A few benefits here are it allows to get it started with pyRIT a lot easier, no cloud environment required. Also allows for testing models locally without making them available online/sharing.

## Tests and Documentation

Example of how to use the prompt target:

```
import os
import uuid

from pyrit.prompt_target import OllamaChatTarget

with OllamaChatTarget(
    endpoint_uri="http://127.0.0.1:11434/api/chat",
    model_name="mistral",
    ) as target_llm:

    prompt = "test"
    print(target_llm.send_prompt(normalized_prompt=prompt, conversation_id=str(uuid.uuid4()), normalizer_id=None))
```
