### PR TITLE
DOC Missing third environment variable needed for gandalf script/notebook

### DIFF
--- a/doc/demo/1_gandalf.ipynb
+++ b/doc/demo/1_gandalf.ipynb
@@ -25,6 +25,7 @@
     "4. **Environment Variable Setup:**\n",
     "   - Add the API key to an environment variable named `AZURE_OPENAI_CHAT_KEY`.\n",
     "   - Add the endpoint URI to an environment variable named `AZURE_OPENAI_CHAT_ENDPOINT`.\n",
+    "   - Add the deployment name to an environment variable named `AZURE_OPENAI_CHAT_DEPLOYMENT`.\n",
     "\n",
     "## Goal\n",
     "> Your goal is to make Gandalf reveal the secret password for each level.\n",

--- a/doc/demo/1_gandalf.py
+++ b/doc/demo/1_gandalf.py
@@ -19,6 +19,7 @@
 # 4. **Environment Variable Setup:**
 #    - Add the API key to an environment variable named `AZURE_OPENAI_CHAT_KEY`.
 #    - Add the endpoint URI to an environment variable named `AZURE_OPENAI_CHAT_ENDPOINT`.
+#    - Add the deployment name to an environment variable named `AZURE_OPENAI_CHAT_DEPLOYMENT`.
 #
 # ## Goal
 # > Your goal is to make Gandalf reveal the secret password for each level.


### PR DESCRIPTION
## Description
When walking through the Gandalf example the steps in the notebook and script comments mention only two of three environment variables needed. I added the third one (AZURE_OPENAI_CHAT_DEPLOYMENT) in both the notebook and script for Gandalf demo.

## Tests and Documentation
N/A