### PR TITLE
FEAT Add User AuthN Support to AOAI Chat Targets

### DIFF
--- a/doc/code/targets/prompt_targets.ipynb
+++ b/doc/code/targets/prompt_targets.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "bd08f274",
+   "id": "bfde31d7",
    "metadata": {},
    "source": [
     "## Prompt Targets\n",
@@ -18,13 +18,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "df35340a",
+   "id": "db7c4187",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-28T22:39:39.793385Z",
-     "iopub.status.busy": "2024-04-28T22:39:39.793385Z",
-     "iopub.status.idle": "2024-04-28T22:39:39.989879Z",
-     "shell.execute_reply": "2024-04-28T22:39:39.989879Z"
+     "iopub.execute_input": "2024-04-30T18:52:31.063534Z",
+     "iopub.status.busy": "2024-04-30T18:52:31.063534Z",
+     "iopub.status.idle": "2024-04-30T18:52:31.330192Z",
+     "shell.execute_reply": "2024-04-30T18:52:31.330192Z"
     }
    },
    "outputs": [
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc66bdc6",
+   "id": "2b881887",
    "metadata": {},
    "source": [
     "The `AzureOpenAIChatTarget` inherits from the `PromptChatTarget` class, which expands upon the `PromptTarget` class by adding functionality to set a system prompt.\n",
@@ -67,13 +67,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "45429ad3",
+   "id": "266b36cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-28T22:39:39.991392Z",
-     "iopub.status.busy": "2024-04-28T22:39:39.991392Z",
-     "iopub.status.idle": "2024-04-28T22:39:48.534396Z",
-     "shell.execute_reply": "2024-04-28T22:39:48.534396Z"
+     "iopub.execute_input": "2024-04-30T18:52:31.332712Z",
+     "iopub.status.busy": "2024-04-30T18:52:31.332712Z",
+     "iopub.status.idle": "2024-04-30T18:52:39.392816Z",
+     "shell.execute_reply": "2024-04-30T18:52:39.392816Z"
     }
    },
    "outputs": [
@@ -98,13 +98,17 @@
     ").to_prompt_request_response()\n",
     "\n",
     "\n",
-    "with AzureOpenAIChatTarget() as azure_openai_chat_target:\n",
+    "# By default, AOAI Chat Targets will use an API Key configured within environment variables to authenticate\n",
+    "# There is an option to use the DefaultAzureCredential for User Authentication as well, for all AOAI Chat Targets.\n",
+    "# When `use_aad_auth=True`, ensure the user has 'Cognitive Service OpenAI User' role assigned on the AOAI Resource\n",
+    "# and `az login` is used to authenticate with the correct identity\n",
+    "with AzureOpenAIChatTarget(use_aad_auth=False) as azure_openai_chat_target:\n",
     "    print(azure_openai_chat_target.send_prompt(prompt_request=request))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "34b22036",
+   "id": "b2646ed7",
    "metadata": {},
    "source": [
     "The `AzureBlobStorageTarget` inherits from `PromptTarget`, meaning it has functionality to send prompts. In contrast to `PromptChatTarget`s, `PromptTarget`s do not interact with chat assistants.\n",
@@ -119,13 +123,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "a9513d25",
+   "id": "b8def498",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-28T22:39:48.534396Z",
-     "iopub.status.busy": "2024-04-28T22:39:48.534396Z",
-     "iopub.status.idle": "2024-04-28T22:39:49.239144Z",
-     "shell.execute_reply": "2024-04-28T22:39:49.239144Z"
+     "iopub.execute_input": "2024-04-30T18:52:39.392816Z",
+     "iopub.status.busy": "2024-04-30T18:52:39.392816Z",
+     "iopub.status.idle": "2024-04-30T18:52:40.114640Z",
+     "shell.execute_reply": "2024-04-30T18:52:40.114640Z"
     }
    },
    "outputs": [
@@ -133,7 +137,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "None: user: https://pyritxpiatest.blob.core.windows.net/xpia/8ad97712-90f4-4d89-a41d-4e9201d3106c.txt\n"
+      "None: user: https://pyritxpiatest.blob.core.windows.net/xpia/2d618097-b50f-4dc7-ae45-3c491586864e.txt\n"
      ]
     }
    ],
@@ -167,9 +171,9 @@
    "cell_metadata_filter": "-all"
   },
   "kernelspec": {
-   "display_name": "pyrit-311",
+   "display_name": "pyrit-311-kernel",
    "language": "python",
-   "name": "pyrit-311"
+   "name": "pyrit-311-kernel"
   },
   "language_info": {
    "codemirror_mode": {

--- a/doc/code/targets/prompt_targets.py
+++ b/doc/code/targets/prompt_targets.py
@@ -42,7 +42,11 @@ request = PromptRequestPiece(
 ).to_prompt_request_response()
 
 
-with AzureOpenAIChatTarget() as azure_openai_chat_target:
+# By default, AOAI Chat Targets will use an API Key configured within environment variables to authenticate
+# There is an option to use the DefaultAzureCredential for User Authentication as well, for all AOAI Chat Targets.
+# When `use_aad_auth=True`, ensure the user has 'Cognitive Service OpenAI User' role assigned on the AOAI Resource
+# and `az login` is used to authenticate with the correct identity
+with AzureOpenAIChatTarget(use_aad_auth=False) as azure_openai_chat_target:
     print(azure_openai_chat_target.send_prompt(prompt_request=request))
 
 # %% [markdown]

--- a/pyrit/auth/auth_config.py
+++ b/pyrit/auth/auth_config.py
@@ -4,3 +4,4 @@
 # The standard pattern for refreshing a token is to trigger 300 ms before the token expires to prevent users from
 # having an expired token.
 REFRESH_TOKEN_BEFORE_MSEC: int = 300
+AZURE_COGNITIVE_SERVICES_DEFAULT_SCOPE: str = "https://cognitiveservices.azure.com/.default"

--- a/pyrit/auth/azure_auth.py
+++ b/pyrit/auth/azure_auth.py
@@ -9,9 +9,10 @@ from azure.core.credentials import AccessToken
 from azure.identity import AzureCliCredential
 from azure.identity import ManagedIdentityCredential
 from azure.identity import InteractiveBrowserCredential
+from azure.identity import DefaultAzureCredential
 from azure.identity import get_bearer_token_provider
 
-from pyrit.auth.auth_config import REFRESH_TOKEN_BEFORE_MSEC
+from pyrit.auth.auth_config import AZURE_COGNITIVE_SERVICES_DEFAULT_SCOPE, REFRESH_TOKEN_BEFORE_MSEC
 from pyrit.interfaces import Authenticator
 
 
@@ -64,53 +65,70 @@ class AzureAuth(Authenticator):
         """
         return self.token
 
-    def get_access_token_from_azure_msi(self, client_id, *, scope="https://cognitiveservices.azure.com/.default"):
-        """Connect to to AOAI endpoint via managed identity credential attached to an Azure resource.
-        For proper setup and configuration of MSI
-        https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview.
 
-        Args:
-            client id of the service
+def get_access_token_from_azure_msi(client_id, *, scope=AZURE_COGNITIVE_SERVICES_DEFAULT_SCOPE):
+    """Connect to an AOAI endpoint via managed identity credential attached to an Azure resource.
+    For proper setup and configuration of MSI
+    https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview.
 
-        Returns:
-            authentication token
-        """
-        try:
-            credential = ManagedIdentityCredential(client_id=client_id)
-            token = credential.get_token(scope)
-            return token.token
-        except Exception as e:
-            logger.error(f"Failed to obtain token for '{scope}' with client ID '{client_id}': {e}")
-            raise
+    Args:
+        client id of the service
 
-    def get_access_token_from_msa_public_client(self, client_id, scope="https://cognitiveservices.azure.com/.default"):
-        """uses MSA account to connect to an AOAI endpoint via interactive login. A browser window
-        will open and ask for login credentials.
+    Returns:
+        Authentication token
+    """
+    try:
+        credential = ManagedIdentityCredential(client_id=client_id)
+        token = credential.get_token(scope)
+        return token.token
+    except Exception as e:
+        logger.error(f"Failed to obtain token for '{scope}' with client ID '{client_id}': {e}")
+        raise
 
-        Args:
-            client id
 
-        Returns:
-            authentication token
-        """
-        try:
-            app = msal.PublicClientApplication(client_id)
-            result = app.acquire_token_interactive(scopes=[scope])
-            return result["access_token"]
-        except Exception as e:
-            logger.error(f"Failed to obtain token for '{scope}' with client ID '{client_id}': {e}")
-            raise
+def get_access_token_from_msa_public_client(client_id, scope=AZURE_COGNITIVE_SERVICES_DEFAULT_SCOPE):
+    """Uses MSA account to connect to an AOAI endpoint via interactive login. A browser window
+    will open and ask for login credentials.
 
-    def get_access_token_from_interactive_login(self, scope="https://cognitiveservices.azure.com/.default"):
-        """connects to an OpenAI endpoint with an interactive login from Azure. A browser window will
-        open and ask for login credentials.  The token will be scoped for Azure Cognitive services.
+    Args:
+        client id
 
-        Returns:
-            authentication token
-        """
-        try:
-            token_provider = get_bearer_token_provider(InteractiveBrowserCredential(), scope)
-            return token_provider()
-        except Exception as e:
-            logger.error(f"Failed to obtain token for '{scope}': {e}")
-            raise
+    Returns:
+        Authentication token
+    """
+    try:
+        app = msal.PublicClientApplication(client_id)
+        result = app.acquire_token_interactive(scopes=[scope])
+        return result["access_token"]
+    except Exception as e:
+        logger.error(f"Failed to obtain token for '{scope}' with client ID '{client_id}': {e}")
+        raise
+
+
+def get_access_token_from_interactive_login(scope=AZURE_COGNITIVE_SERVICES_DEFAULT_SCOPE):
+    """Connects to an OpenAI endpoint with an interactive login from Azure. A browser window will
+    open and ask for login credentials.  The token will be scoped for Azure Cognitive services.
+
+    Returns:
+        Authentication token
+    """
+    try:
+        token_provider = get_bearer_token_provider(InteractiveBrowserCredential(), scope)
+        return token_provider()
+    except Exception as e:
+        logger.error(f"Failed to obtain token for '{scope}': {e}")
+        raise
+
+
+def get_token_provider_from_default_azure_credential(scope=AZURE_COGNITIVE_SERVICES_DEFAULT_SCOPE):
+    """Connect to an AOAI endpoint via default Azure credential.
+
+    Returns:
+        Authentication token provider
+    """
+    try:
+        token_provider = get_bearer_token_provider(DefaultAzureCredential(), scope)
+        return token_provider
+    except Exception as e:
+        logger.error(f"Failed to obtain token for '{scope}': {e}")
+        raise

--- a/pyrit/auth/azure_auth.py
+++ b/pyrit/auth/azure_auth.py
@@ -66,7 +66,7 @@ class AzureAuth(Authenticator):
         return self.token
 
 
-def get_access_token_from_azure_msi(client_id, *, scope=AZURE_COGNITIVE_SERVICES_DEFAULT_SCOPE):
+def get_access_token_from_azure_msi(*, client_id: str, scope: str = AZURE_COGNITIVE_SERVICES_DEFAULT_SCOPE):
     """Connect to an AOAI endpoint via managed identity credential attached to an Azure resource.
     For proper setup and configuration of MSI
     https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview.
@@ -86,7 +86,7 @@ def get_access_token_from_azure_msi(client_id, *, scope=AZURE_COGNITIVE_SERVICES
         raise
 
 
-def get_access_token_from_msa_public_client(client_id, scope=AZURE_COGNITIVE_SERVICES_DEFAULT_SCOPE):
+def get_access_token_from_msa_public_client(*, client_id: str, scope: str = AZURE_COGNITIVE_SERVICES_DEFAULT_SCOPE):
     """Uses MSA account to connect to an AOAI endpoint via interactive login. A browser window
     will open and ask for login credentials.
 
@@ -105,7 +105,7 @@ def get_access_token_from_msa_public_client(client_id, scope=AZURE_COGNITIVE_SER
         raise
 
 
-def get_access_token_from_interactive_login(scope=AZURE_COGNITIVE_SERVICES_DEFAULT_SCOPE):
+def get_access_token_from_interactive_login(scope: str = AZURE_COGNITIVE_SERVICES_DEFAULT_SCOPE):
     """Connects to an OpenAI endpoint with an interactive login from Azure. A browser window will
     open and ask for login credentials.  The token will be scoped for Azure Cognitive services.
 
@@ -120,7 +120,7 @@ def get_access_token_from_interactive_login(scope=AZURE_COGNITIVE_SERVICES_DEFAU
         raise
 
 
-def get_token_provider_from_default_azure_credential(scope=AZURE_COGNITIVE_SERVICES_DEFAULT_SCOPE):
+def get_token_provider_from_default_azure_credential(scope: str = AZURE_COGNITIVE_SERVICES_DEFAULT_SCOPE):
     """Connect to an AOAI endpoint via default Azure credential.
 
     Returns:

--- a/pyrit/prompt_target/azure_openai_completion_target.py
+++ b/pyrit/prompt_target/azure_openai_completion_target.py
@@ -2,12 +2,12 @@
 # Licensed under the MIT license.
 
 import asyncio
-from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 import concurrent.futures
 import logging
 from openai import AsyncAzureOpenAI
 from openai.types.completion import Completion
 
+from pyrit.auth.azure_auth import get_token_provider_from_default_azure_credential
 from pyrit.common import default_values
 from pyrit.memory import MemoryInterface
 from pyrit.models import PromptResponse
@@ -85,10 +85,8 @@ class AzureOpenAICompletionTarget(PromptTarget):
         )
 
         if use_aad_auth:
-            logger.info("Authenticating with DefaultAzureCredential() for https://cognitiveservices.azure.com/.default")
-            token_provider = get_bearer_token_provider(
-                DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
-            )
+            logger.info("Authenticating with DefaultAzureCredential() for Azure Cognitive Services")
+            token_provider = get_token_provider_from_default_azure_credential()
 
             self._async_client = AsyncAzureOpenAI(
                 azure_ad_token_provider=token_provider,

--- a/pyrit/prompt_target/azure_openai_completion_target.py
+++ b/pyrit/prompt_target/azure_openai_completion_target.py
@@ -83,10 +83,12 @@ class AzureOpenAICompletionTarget(PromptTarget):
         self._model = default_values.get_required_value(
             env_var_name=self.DEPLOYMENT_ENVIRONMENT_VARIABLE, passed_value=deployment_name
         )
-     
+
         if use_aad_auth:
             logger.info("Authenticating with DefaultAzureCredential() for https://cognitiveservices.azure.com/.default")
-            token_provider = get_bearer_token_provider(DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default")
+            token_provider = get_bearer_token_provider(
+                DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
+            )
 
             self._async_client = AsyncAzureOpenAI(
                 azure_ad_token_provider=token_provider,

--- a/pyrit/prompt_target/dall_e_target.py
+++ b/pyrit/prompt_target/dall_e_target.py
@@ -90,10 +90,7 @@ class DALLETarget(PromptTarget):
             )
         else:
             self.image_target = AzureOpenAIChatTarget(
-                deployment_name=deployment_name,
-                endpoint=endpoint,
-                api_key=api_key,
-                api_version=api_version
+                deployment_name=deployment_name, endpoint=endpoint, api_key=api_key, api_version=api_version
             )
 
     def send_prompt(

--- a/pyrit/prompt_target/dall_e_target.py
+++ b/pyrit/prompt_target/dall_e_target.py
@@ -28,6 +28,10 @@ class DALLETarget(PromptTarget):
         deployment_name (str): The name of the deployment.
         endpoint (str): The endpoint URL for the service.
         api_key (str): The API key for accessing the service.
+        use_aad_auth (bool, optional): When set to True, user authentication is used
+            instead of API Key. DefaultAzureCredential is taken for
+            https://cognitiveservices.azure.com/.default. Please run `az login` locally
+            to leverage user AuthN.
         api_version (str, optional): The API version. Defaults to "2024-02-01".
         image_size (str, optional): The size of the image to output, must be a value of VALID_SIZES.
             Defaults to 1024x1024.
@@ -46,6 +50,7 @@ class DALLETarget(PromptTarget):
         deployment_name: str = None,
         endpoint: str = None,
         api_key: str = None,
+        use_aad_auth: bool = False,
         api_version: str = "2024-02-01",
         image_size: Literal["256x256", "512x512", "1024x1024"] = "1024x1024",
         num_images: int = 1,
@@ -73,12 +78,23 @@ class DALLETarget(PromptTarget):
         self.n = num_images
 
         self.deployment_name = deployment_name
-        self.image_target = AzureOpenAIChatTarget(
-            deployment_name=deployment_name, endpoint=endpoint, api_key=api_key, api_version=api_version
-        )
         self.output_dir = pathlib.Path(RESULTS_PATH) / "images"
-
         self.headers = headers
+
+        if use_aad_auth:
+            self.image_target = AzureOpenAIChatTarget(
+                deployment_name=deployment_name,
+                endpoint=endpoint,
+                api_version=api_version,
+                use_aad_auth=True,
+            )
+        else:
+            self.image_target = AzureOpenAIChatTarget(
+                deployment_name=deployment_name,
+                endpoint=endpoint,
+                api_key=api_key,
+                api_version=api_version
+            )
 
     def send_prompt(
         self,

--- a/pyrit/prompt_target/prompt_chat_target/azure_openai_gptv_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/azure_openai_gptv_chat_target.py
@@ -108,13 +108,21 @@ class AzureOpenAIGPTVChatTarget(PromptChatTarget):
 
         if use_aad_auth:
             logger.info("Authenticating with DefaultAzureCredential() for https://cognitiveservices.azure.com/.default")
-            token_provider = get_bearer_token_provider(DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default")
+            token_provider = get_bearer_token_provider(
+                DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
+            )
 
             self._client = AzureOpenAI(
-                azure_ad_token_provider=token_provider, api_version=api_version, azure_endpoint=endpoint, default_headers=final_headers
+                azure_ad_token_provider=token_provider,
+                api_version=api_version,
+                azure_endpoint=endpoint,
+                default_headers=final_headers,
             )
             self._async_client = AsyncAzureOpenAI(
-                azure_ad_token_provider=token_provider, api_version=api_version, azure_endpoint=endpoint, default_headers=final_headers
+                azure_ad_token_provider=token_provider,
+                api_version=api_version,
+                azure_endpoint=endpoint,
+                default_headers=final_headers,
             )
         else:
             api_key = default_values.get_required_value(

--- a/pyrit/prompt_target/prompt_chat_target/azure_openai_gptv_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/azure_openai_gptv_chat_target.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT license.
 
 import asyncio
-from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 import concurrent.futures
 import logging
 import json
@@ -10,6 +9,7 @@ import json
 from openai import AsyncAzureOpenAI, AzureOpenAI
 from openai.types.chat import ChatCompletion
 
+from pyrit.auth.azure_auth import get_token_provider_from_default_azure_credential
 from pyrit.common import default_values
 from pyrit.memory import MemoryInterface
 from pyrit.models import ChatMessageListContent
@@ -107,10 +107,8 @@ class AzureOpenAIGPTVChatTarget(PromptChatTarget):
             logger.info("No headers have been passed, setting empty default headers")
 
         if use_aad_auth:
-            logger.info("Authenticating with DefaultAzureCredential() for https://cognitiveservices.azure.com/.default")
-            token_provider = get_bearer_token_provider(
-                DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
-            )
+            logger.info("Authenticating with DefaultAzureCredential() for Azure Cognitive Services")
+            token_provider = get_token_provider_from_default_azure_credential()
 
             self._client = AzureOpenAI(
                 azure_ad_token_provider=token_provider,

--- a/pyrit/prompt_target/prompt_chat_target/openai_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/openai_chat_target.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT license.
 
 from abc import abstractmethod
-from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 import logging
 import json
 from typing import Optional
@@ -10,6 +9,7 @@ from typing import Optional
 from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
 from openai.types.chat import ChatCompletion
 
+from pyrit.auth.azure_auth import get_token_provider_from_default_azure_credential
 from pyrit.common import default_values
 from pyrit.memory import MemoryInterface
 from pyrit.models import ChatMessage
@@ -259,10 +259,8 @@ class AzureOpenAIChatTarget(OpenAIChatInterface):
         )
 
         if use_aad_auth:
-            logger.info("Authenticating with DefaultAzureCredential() for https://cognitiveservices.azure.com/.default")
-            token_provider = get_bearer_token_provider(
-                DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
-            )
+            logger.info("Authenticating with DefaultAzureCredential() for Azure Cognitive Services")
+            token_provider = get_token_provider_from_default_azure_credential()
 
             self._client = AzureOpenAI(
                 azure_ad_token_provider=token_provider,

--- a/pyrit/prompt_target/prompt_chat_target/openai_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/openai_chat_target.py
@@ -260,13 +260,15 @@ class AzureOpenAIChatTarget(OpenAIChatInterface):
 
         if use_aad_auth:
             logger.info("Authenticating with DefaultAzureCredential() for https://cognitiveservices.azure.com/.default")
-            token_provider = get_bearer_token_provider(DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default")
+            token_provider = get_bearer_token_provider(
+                DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
+            )
 
             self._client = AzureOpenAI(
                 azure_ad_token_provider=token_provider,
                 api_version=api_version,
                 azure_endpoint=endpoint,
-                )
+            )
             self._async_client = AsyncAzureOpenAI(
                 azure_ad_token_provider=token_provider,
                 api_version=api_version,

--- a/pyrit/prompt_target/prompt_chat_target/openai_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/openai_chat_target.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 from abc import abstractmethod
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 import logging
 import json
 from typing import Optional
@@ -202,6 +203,7 @@ class AzureOpenAIChatTarget(OpenAIChatInterface):
         deployment_name: str = None,
         endpoint: str = None,
         api_key: str = None,
+        use_aad_auth: bool = False,
         memory: MemoryInterface = None,
         api_version: str = "2023-08-01-preview",
         max_tokens: int = 1024,
@@ -222,6 +224,10 @@ class AzureOpenAIChatTarget(OpenAIChatInterface):
                 Defaults to the AZURE_OPENAI_CHAT_ENDPOINT environment variable.
             api_key (str, optional): The API key for accessing the Azure OpenAI service.
                 Defaults to the AZURE_OPENAI_CHAT_KEY environment variable.
+            use_aad_auth (bool, optional): When set to True, user authentication is used
+                instead of API Key. DefaultAzureCredential is taken for
+                https://cognitiveservices.azure.com/.default. Please run `az login` locally
+                to leverage user AuthN.
             memory (MemoryInterface, optional): An instance of the MemoryInterface class
                 for storing conversation history. Defaults to None.
             api_version (str, optional): The version of the Azure OpenAI API. Defaults to
@@ -251,20 +257,36 @@ class AzureOpenAIChatTarget(OpenAIChatInterface):
         endpoint = default_values.get_required_value(
             env_var_name=self.ENDPOINT_URI_ENVIRONMENT_VARIABLE, passed_value=endpoint
         )
-        api_key = default_values.get_required_value(
-            env_var_name=self.API_KEY_ENVIRONMENT_VARIABLE, passed_value=api_key
-        )
 
-        self._client = AzureOpenAI(
-            api_key=api_key,
-            api_version=api_version,
-            azure_endpoint=endpoint,
-        )
-        self._async_client = AsyncAzureOpenAI(
-            api_key=api_key,
-            api_version=api_version,
-            azure_endpoint=endpoint,
-        )
+        if use_aad_auth:
+            logger.info("Authenticating with DefaultAzureCredential() for https://cognitiveservices.azure.com/.default")
+            token_provider = get_bearer_token_provider(DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default")
+
+            self._client = AzureOpenAI(
+                azure_ad_token_provider=token_provider,
+                api_version=api_version,
+                azure_endpoint=endpoint,
+                )
+            self._async_client = AsyncAzureOpenAI(
+                azure_ad_token_provider=token_provider,
+                api_version=api_version,
+                azure_endpoint=endpoint,
+            )
+        else:
+            api_key = default_values.get_required_value(
+                env_var_name=self.API_KEY_ENVIRONMENT_VARIABLE, passed_value=api_key
+            )
+
+            self._client = AzureOpenAI(
+                api_key=api_key,
+                api_version=api_version,
+                azure_endpoint=endpoint,
+            )
+            self._async_client = AsyncAzureOpenAI(
+                api_key=api_key,
+                api_version=api_version,
+                azure_endpoint=endpoint,
+            )
 
 
 class OpenAIChatTarget(OpenAIChatInterface):

--- a/tests/test_azure_auth.py
+++ b/tests/test_azure_auth.py
@@ -5,7 +5,7 @@ import time
 from unittest.mock import Mock, patch
 
 from pyrit.auth.auth_config import REFRESH_TOKEN_BEFORE_MSEC
-from pyrit.auth.azure_auth import AzureAuth
+from pyrit.auth.azure_auth import AzureAuth, get_token_provider_from_default_azure_credential
 
 curr_epoch_time = int(time.time())
 mock_token = "fake token"
@@ -36,3 +36,10 @@ def test_refresh_expiration():
         token = test_instance.refresh_token()
         assert token
         assert mock_get_token.call_count == 2
+
+
+def test_get_token_provider_from_default_azure_credential():
+    with patch("azure.identity.DefaultAzureCredential.get_token") as mock_default_cred:
+        mock_default_cred.return_value = Mock(token=mock_token, expires_on=curr_epoch_time)
+        token_provider = get_token_provider_from_default_azure_credential(scope="https://mocked_endpoint.azure.com")
+        assert token_provider() == mock_token


### PR DESCRIPTION
<!--- Please add one of the following as a prefix to the pull request title: -->
<!--- DOC for documentation changes -->
<!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
<!--- FIX for bug fixes -->
<!--- TEST for adding tests -->
<!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
<!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->
Adds `use_aad_auth` parameter to all AOAIChatTarget implementations.

FYI: @rdheekonda @rlundeen2 

<!--- If you are considering making a contribution please open an issue first. -->
<!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
<!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->


## Tests and Documentation

<!--- Contributions require tests and documentation (if applicable). -->
<!--- Include a description of tests and documentation updated (if applicable) -->
* Unit Test added for DefaultAzureCredential happy path
* Docs: Added example of `use_aad_auth` flag to `prompt_targets.py` and ran Jupytext on that notebook

<!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
<!--- Include how you/if ran JupyText here -->
<!--- This is described at: https://github.com/Azure/PyRIT/tree/main/doc  -->
