### PR TITLE
FIX: Making RESULTS_PATH be sane in pip packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "aiofiles>=23.2.1",
     "aiohttp>=3.9.3",
     "aiosignal>=1.3.1",
+    "appdirs>=1.4.0",
     "art==6.1.0",
     "azure-cognitiveservices-speech>=1.36.0",
     "azure-core>=1.26.1",

--- a/pyrit/common/path.py
+++ b/pyrit/common/path.py
@@ -10,7 +10,7 @@ def get_default_results_path() -> pathlib.Path:
     if in_git_repo():
         return pathlib.Path(PYRIT_PATH, "..", "results").resolve()
     else:
-        return pathlib.Path(user_data_dir("pyrit"), "results").resolve()
+        return pathlib.Path(user_data_dir("results", "pyrit")).resolve()
 
 
 def in_git_repo() -> bool:

--- a/pyrit/common/path.py
+++ b/pyrit/common/path.py
@@ -5,11 +5,13 @@ import pathlib
 
 from appdirs import user_data_dir
 
+
 def get_default_results_path() -> pathlib.Path:
     if in_git_repo():
         return pathlib.Path(PYRIT_PATH, "..", "results").resolve()
     else:
         return pathlib.Path(user_data_dir("pyrit"), "results").resolve()
+
 
 def in_git_repo() -> bool:
     return pathlib.Path(HOME_PATH, ".git").exists()
@@ -32,5 +34,3 @@ RESULTS_PATH.mkdir(parents=True, exist_ok=True)
 # Path to where the logs are located
 LOG_PATH = pathlib.Path(RESULTS_PATH, "logs.txt").resolve()
 LOG_PATH.touch(exist_ok=True)
-
-

--- a/pyrit/common/path.py
+++ b/pyrit/common/path.py
@@ -3,13 +3,19 @@
 
 import pathlib
 
+from appdirs import user_data_dir
+
+def get_default_results_path() -> pathlib.Path:
+    if in_git_repo():
+        return pathlib.Path(PYRIT_PATH, "..", "results").resolve()
+    else:
+        return pathlib.Path(user_data_dir("pyrit"), "results").resolve()
+
+def in_git_repo() -> bool:
+    return pathlib.Path(HOME_PATH, ".git").exists()
+
+
 PYRIT_PATH = pathlib.Path(__file__, "..", "..").resolve()
-# Path to where all the results files will be stores
-RESULTS_PATH = pathlib.Path(PYRIT_PATH, "..", "results").resolve()
-RESULTS_PATH.mkdir(parents=True, exist_ok=True)
-# Path to where the logs are located
-LOG_PATH = pathlib.Path(PYRIT_PATH, "..", "results", "logs.txt").resolve()
-LOG_PATH.touch(exist_ok=True)
 
 DATASETS_PATH = pathlib.Path(PYRIT_PATH, "datasets").resolve()
 CONTENT_CLASSIFIERS_PATH = pathlib.Path(DATASETS_PATH, "score", "content_classifiers").resolve()
@@ -18,3 +24,13 @@ SCORING_INSTRUCTIONS_PATH = pathlib.Path(DATASETS_PATH, "score", "scoring_instru
 
 # Points to the root of the project
 HOME_PATH = pathlib.Path(PYRIT_PATH, "..").resolve()
+
+# Path to where all the results files and database will be stored
+RESULTS_PATH = get_default_results_path()
+RESULTS_PATH.mkdir(parents=True, exist_ok=True)
+
+# Path to where the logs are located
+LOG_PATH = pathlib.Path(RESULTS_PATH, "logs.txt").resolve()
+LOG_PATH.touch(exist_ok=True)
+
+


### PR DESCRIPTION
## Description

Making default RESULTS_PATH be sane in pip packages

## Tests and Documentation

- Tested that it works in a repo
- Tested if you manually set it to be outside of a repo, the DATASETS path works as expected in windows