### PR TITLE
MAINT: Removing torch dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ dependencies = [
     "termcolor>=2.4.0",
     "tenacity>=8.2.3",
     "tokenizers>=0.19.1",
-    "torch==2.1.2",
     "transformers>=4.40.0",
     "types-requests>=2.31.0.20240406",
 ]


### PR DESCRIPTION
## Description

This doesn't appear to be used anywhere; I searched for it in the code base


## Tests and Documentation


- Both unit tests and jupy notebook runs pass after pip remove torch
- (After removing) on fresh install executed `pip install torch` and `pip install tensor` with no issue
