### PR TITLE
MAINT: Deprecated send_prompt methods

### DIFF
--- a/doc/code/targets/azure_ml_chat.ipynb
+++ b/doc/code/targets/azure_ml_chat.ipynb
@@ -74,7 +74,7 @@
     ").to_prompt_request_response()\n",
     "\n",
     "with AzureMLChatTarget() as azure_ml_chat_target:\n",
-    "    print(azure_ml_chat_target.send_prompt(prompt_request=request))"
+    "    print(await azure_ml_chat_target.send_prompt_async(prompt_request=request))"
    ]
   },
   {

--- a/doc/code/targets/azure_ml_chat.py
+++ b/doc/code/targets/azure_ml_chat.py
@@ -39,7 +39,7 @@ request = PromptRequestPiece(
 ).to_prompt_request_response()
 
 with AzureMLChatTarget() as azure_ml_chat_target:
-    print(azure_ml_chat_target.send_prompt(prompt_request=request))
+    print(await azure_ml_chat_target.send_prompt_async(prompt_request=request))
 
 # %% [markdown]
 #

--- a/doc/code/targets/azure_ml_chat.py
+++ b/doc/code/targets/azure_ml_chat.py
@@ -39,7 +39,7 @@ request = PromptRequestPiece(
 ).to_prompt_request_response()
 
 with AzureMLChatTarget() as azure_ml_chat_target:
-    print(await azure_ml_chat_target.send_prompt_async(prompt_request=request))
+    print(await azure_ml_chat_target.send_prompt_async(prompt_request=request))  # type: ignore
 
 # %% [markdown]
 #

--- a/doc/code/targets/prompt_targets.ipynb
+++ b/doc/code/targets/prompt_targets.ipynb
@@ -103,7 +103,7 @@
     "# When `use_aad_auth=True`, ensure the user has 'Cognitive Service OpenAI User' role assigned on the AOAI Resource\n",
     "# and `az login` is used to authenticate with the correct identity\n",
     "with AzureOpenAIChatTarget(use_aad_auth=False) as azure_openai_chat_target:\n",
-    "    print(azure_openai_chat_target.send_prompt(prompt_request=request))"
+    "    print(await azure_openai_chat_target.send_prompt_async(prompt_request=request))"
    ]
   },
   {
@@ -162,7 +162,7 @@
     "    sas_token=os.environ.get(\"AZURE_STORAGE_ACCOUNT_SAS_TOKEN\"),\n",
     ") as abs_prompt_target:\n",
     "\n",
-    "    print(abs_prompt_target.send_prompt(prompt_request=request))"
+    "    print(await abs_prompt_target.send_prompt_async(prompt_request=request))"
    ]
   }
  ],

--- a/doc/code/targets/prompt_targets.py
+++ b/doc/code/targets/prompt_targets.py
@@ -47,7 +47,7 @@ request = PromptRequestPiece(
 # When `use_aad_auth=True`, ensure the user has 'Cognitive Service OpenAI User' role assigned on the AOAI Resource
 # and `az login` is used to authenticate with the correct identity
 with AzureOpenAIChatTarget(use_aad_auth=False) as azure_openai_chat_target:
-    print(azure_openai_chat_target.send_prompt(prompt_request=request))
+    print(await azure_openai_chat_target.send_prompt_async(prompt_request=request))
 
 # %% [markdown]
 # The `AzureBlobStorageTarget` inherits from `PromptTarget`, meaning it has functionality to send prompts. In contrast to `PromptChatTarget`s, `PromptTarget`s do not interact with chat assistants.
@@ -79,4 +79,4 @@ with AzureBlobStorageTarget(
     sas_token=os.environ.get("AZURE_STORAGE_ACCOUNT_SAS_TOKEN"),
 ) as abs_prompt_target:
 
-    print(abs_prompt_target.send_prompt(prompt_request=request))
+    print(await abs_prompt_target.send_prompt_async(prompt_request=request))

--- a/doc/code/targets/prompt_targets.py
+++ b/doc/code/targets/prompt_targets.py
@@ -47,7 +47,7 @@ request = PromptRequestPiece(
 # When `use_aad_auth=True`, ensure the user has 'Cognitive Service OpenAI User' role assigned on the AOAI Resource
 # and `az login` is used to authenticate with the correct identity
 with AzureOpenAIChatTarget(use_aad_auth=False) as azure_openai_chat_target:
-    print(await azure_openai_chat_target.send_prompt_async(prompt_request=request))
+    print(await azure_openai_chat_target.send_prompt_async(prompt_request=request))  # type: ignore
 
 # %% [markdown]
 # The `AzureBlobStorageTarget` inherits from `PromptTarget`, meaning it has functionality to send prompts. In contrast to `PromptChatTarget`s, `PromptTarget`s do not interact with chat assistants.
@@ -79,4 +79,4 @@ with AzureBlobStorageTarget(
     sas_token=os.environ.get("AZURE_STORAGE_ACCOUNT_SAS_TOKEN"),
 ) as abs_prompt_target:
 
-    print(await abs_prompt_target.send_prompt_async(prompt_request=request))
+    print(await abs_prompt_target.send_prompt_async(prompt_request=request))  # type: ignore

--- a/doc/how_to_guide.ipynb
+++ b/doc/how_to_guide.ipynb
@@ -69,7 +69,7 @@
     "        role=\"user\",\n",
     "        original_value=\"this is a test prompt\",\n",
     "    ).to_prompt_request_response()\n",
-    "    target_llm.send_prompt(prompt_request=request)"
+    "    await target_llm.send_prompt_async(prompt_request=request)"
    ]
   },
   {
@@ -164,7 +164,7 @@
     "- run a single turn of the attack strategy or\n",
     "- try to achieve the goal as specified in the attack strategy which may take multiple turns.\n",
     "\n",
-    "The single turn is executed with the `send_prompt()` method. It generates the prompt using the red\n",
+    "The single turn is executed with the `send_prompt_async()` method. It generates the prompt using the red\n",
     "teaming LLM and sends it to the target.\n",
     "The full execution of the attack strategy over potentially multiple turns requires a mechanism\n",
     "to determine if the goal has been achieved.\n",
@@ -569,7 +569,7 @@
     "    # or the maximum number of turns is reached.\n",
     "    red_teaming_orchestrator.apply_attack_strategy_until_completion(max_turns=5)\n",
     "\n",
-    "    # Alternatively, use send_prompt() to generate just a single turn of the attack strategy."
+    "    # Alternatively, use send_prompt_async() to generate just a single turn of the attack strategy."
    ]
   },
   {

--- a/doc/how_to_guide.py
+++ b/doc/how_to_guide.py
@@ -49,7 +49,7 @@ with AzureOpenAIChatTarget(
         role="user",
         original_value="this is a test prompt",
     ).to_prompt_request_response()
-    target_llm.send_prompt(prompt_request=request)
+    await target_llm.send_prompt_async(prompt_request=request)
 
 # %% [markdown]
 # To expand to a wider variety of harms, it may be beneficial to write prompt templates instead of the
@@ -101,7 +101,7 @@ prompt = template.apply_custom_metaprompt_parameters(food_item="pizza", food_loc
 # - run a single turn of the attack strategy or
 # - try to achieve the goal as specified in the attack strategy which may take multiple turns.
 #
-# The single turn is executed with the `send_prompt()` method. It generates the prompt using the red
+# The single turn is executed with the `send_prompt_async()` method. It generates the prompt using the red
 # teaming LLM and sends it to the target.
 # The full execution of the attack strategy over potentially multiple turns requires a mechanism
 # to determine if the goal has been achieved.
@@ -158,7 +158,7 @@ with EndTokenRedTeamingOrchestrator(
     # or the maximum number of turns is reached.
     red_teaming_orchestrator.apply_attack_strategy_until_completion(max_turns=5)
 
-    # Alternatively, use send_prompt() to generate just a single turn of the attack strategy.
+    # Alternatively, use send_prompt_async() to generate just a single turn of the attack strategy.
 
 # %% [markdown]
 # Going a step further, we can generalize the attack strategy into templates as mentioned in an earlier

--- a/doc/how_to_guide.py
+++ b/doc/how_to_guide.py
@@ -49,7 +49,7 @@ with AzureOpenAIChatTarget(
         role="user",
         original_value="this is a test prompt",
     ).to_prompt_request_response()
-    await target_llm.send_prompt_async(prompt_request=request)
+    await target_llm.send_prompt_async(prompt_request=request)  # type: ignore
 
 # %% [markdown]
 # To expand to a wider variety of harms, it may be beneficial to write prompt templates instead of the

--- a/pyrit/prompt_target/azure_openai_completion_target.py
+++ b/pyrit/prompt_target/azure_openai_completion_target.py
@@ -4,6 +4,7 @@
 import asyncio
 import concurrent.futures
 import logging
+
 from openai import AsyncAzureOpenAI
 from openai.types.completion import Completion
 
@@ -13,7 +14,6 @@ from pyrit.memory import MemoryInterface
 from pyrit.models import PromptResponse
 from pyrit.models.prompt_request_response import PromptRequestResponse
 from pyrit.prompt_target.prompt_target import PromptTarget
-
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +106,7 @@ class AzureOpenAICompletionTarget(PromptTarget):
 
     def send_prompt(self, *, prompt_request: PromptRequestResponse) -> PromptRequestResponse:
         """
-        Sends a normalized prompt to the prompt target and adds the request and response to memory
+        Deprecated. Sends a normalized prompt to the prompt target and adds the request and response to memory
         """
         pool = concurrent.futures.ThreadPoolExecutor()
         return pool.submit(asyncio.run, self.send_prompt_async(prompt_request=prompt_request)).result()

--- a/pyrit/prompt_target/prompt_chat_target/azure_ml_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/azure_ml_chat_target.py
@@ -101,44 +101,6 @@ class AzureMLChatTarget(PromptChatTarget):
 
         return response_entry
 
-    def _complete_chat(
-        self,
-        messages: list[ChatMessage],
-        max_tokens: int = 400,
-        temperature: float = 1.0,
-        top_p: int = 1,
-        repetition_penalty: float = 1.2,
-    ) -> str:
-        """
-        Completes a chat interaction by generating a response to the given input prompt.
-
-        This is a synchronous wrapper for the asynchronous _generate_and_extract_response method.
-
-        Args:
-            messages (list[ChatMessage]): The chat messages objects containing the role and content.
-            max_tokens (int, optional): The maximum number of tokens to generate. Defaults to 400.
-            temperature (float, optional): Controls randomness in the response generation.
-                Defaults to 1.0. 1 is more random, 0 is less.
-            top_p (int, optional): Controls diversity of the response generation. Defaults to 1.
-                1 is more random, 0 is less.
-            repetition_penalty (float, optional): Controls repetition in the response generation.
-                Defaults to 1.2.
-
-        Raises:
-            Exception: For any errors during the process.
-
-        Returns:
-            str: The generated response message.
-        """
-        headers = self._get_headers()
-        payload = self._construct_http_body(messages, max_tokens, temperature, top_p, repetition_penalty)
-
-        response = net_utility.make_request_and_raise_if_error(
-            endpoint_uri=self.endpoint_uri, method="POST", request_body=payload, headers=headers
-        )
-
-        return response.json()["output"]
-
     async def _complete_chat_async(
         self,
         messages: list[ChatMessage],

--- a/pyrit/prompt_target/prompt_chat_target/ollama_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/ollama_chat_target.py
@@ -68,19 +68,6 @@ class OllamaChatTarget(PromptChatTarget):
 
         return response_entry
 
-    def _complete_chat(
-        self,
-        messages: list[ChatMessage],
-    ) -> str:
-        headers = self._get_headers()
-        payload = self._construct_http_body(messages)
-
-        response = net_utility.make_request_and_raise_if_error(
-            endpoint_uri=self.endpoint_uri, method="POST", request_body=payload, headers=headers
-        )
-
-        return response.json()["message"]["content"]
-
     async def _complete_chat_async(
         self,
         messages: list[ChatMessage],

--- a/pyrit/prompt_target/prompt_chat_target/ollama_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/ollama_chat_target.py
@@ -1,12 +1,13 @@
 # Copyright (c) Adriano Maia <adriano@drstrange.wtf>
 # Licensed under the MIT license.
+import asyncio
+import concurrent.futures
 import logging
 
-from pyrit.chat_message_normalizer import ChatMessageNormalizer, ChatMessageNop
+from pyrit.chat_message_normalizer import ChatMessageNop, ChatMessageNormalizer
 from pyrit.common import default_values, net_utility
 from pyrit.memory import MemoryInterface
-from pyrit.models import ChatMessage
-from pyrit.models import PromptRequestPiece, PromptRequestResponse
+from pyrit.models import ChatMessage, PromptRequestPiece, PromptRequestResponse
 from pyrit.prompt_target import PromptChatTarget
 
 logger = logging.getLogger(__name__)
@@ -36,28 +37,11 @@ class OllamaChatTarget(PromptChatTarget):
         self.chat_message_normalizer = chat_message_normalizer
 
     def send_prompt(self, *, prompt_request: PromptRequestResponse) -> PromptRequestResponse:
-        self._validate_request(prompt_request=prompt_request)
-        request: PromptRequestPiece = prompt_request.request_pieces[0]
-
-        messages = self._memory.get_chat_messages_with_conversation_id(conversation_id=request.conversation_id)
-        messages.append(request.to_chat_message())
-
-        logger.info(f"Sending the following prompt to the prompt target: {self} {request}")
-
-        self._memory.add_request_response_to_memory(request=prompt_request)
-
-        resp = self._complete_chat(
-            messages=messages,
-        )
-
-        if not resp:
-            raise ValueError("The chat returned an empty response.")
-
-        logger.info(f'Received the following response from the prompt target "{resp}"')
-
-        response_entry = self._memory.add_response_entries_to_memory(request=request, response_text_pieces=[resp])
-
-        return response_entry
+        """
+        Deprecated. Use send_prompt_async instead.
+        """
+        pool = concurrent.futures.ThreadPoolExecutor()
+        return pool.submit(asyncio.run, self.send_prompt_async(prompt_request=prompt_request)).result()
 
     async def send_prompt_async(self, *, prompt_request: PromptRequestResponse) -> PromptRequestResponse:
 

--- a/pyrit/prompt_target/prompt_chat_target/openai_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/openai_chat_target.py
@@ -1,9 +1,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from abc import abstractmethod
-import logging
+import asyncio
+import concurrent.futures
 import json
+import logging
+from abc import abstractmethod
 from typing import Optional
 
 from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
@@ -12,8 +14,7 @@ from openai.types.chat import ChatCompletion
 from pyrit.auth.azure_auth import get_token_provider_from_default_azure_credential
 from pyrit.common import default_values
 from pyrit.memory import MemoryInterface
-from pyrit.models import ChatMessage
-from pyrit.models import PromptRequestResponse, PromptRequestPiece
+from pyrit.models import ChatMessage, PromptRequestPiece, PromptRequestResponse
 from pyrit.prompt_target import PromptChatTarget
 
 logger = logging.getLogger(__name__)
@@ -37,32 +38,11 @@ class OpenAIChatInterface(PromptChatTarget):
         pass
 
     def send_prompt(self, *, prompt_request: PromptRequestResponse) -> PromptRequestResponse:
-
-        request: PromptRequestPiece = prompt_request.request_pieces[0]
-
-        messages = self._memory.get_chat_messages_with_conversation_id(conversation_id=request.conversation_id)
-        messages.append(request.to_chat_message())
-
-        logger.info(f"Sending the following prompt to the prompt target: {request}")
-
-        self._memory.add_request_response_to_memory(request=prompt_request)
-
-        resp_text = self._complete_chat(
-            messages=messages,
-            top_p=self._top_p,
-            temperature=self._temperature,
-            frequency_penalty=self._frequency_penalty,
-            presence_penalty=self._presence_penalty,
-        )
-
-        if not resp_text:
-            raise ValueError("The chat returned an empty response.")
-
-        logger.info(f'Received the following response from the prompt target "{resp_text}"')
-
-        response_entry = self._memory.add_response_entries_to_memory(request=request, response_text_pieces=[resp_text])
-
-        return response_entry
+        """
+        Deprecated. Use send_prompt_async instead.
+        """
+        pool = concurrent.futures.ThreadPoolExecutor()
+        return pool.submit(asyncio.run, self.send_prompt_async(prompt_request=prompt_request)).result()
 
     async def send_prompt_async(self, *, prompt_request: PromptRequestResponse) -> PromptRequestResponse:
         self._validate_request(prompt_request=prompt_request)

--- a/pyrit/prompt_target/prompt_chat_target/openai_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/openai_chat_target.py
@@ -35,7 +35,6 @@ class OpenAIChatInterface(PromptChatTarget):
         """
         pass
 
-
     def send_prompt(self, *, prompt_request: PromptRequestResponse) -> PromptRequestResponse:
         self._validate_request(prompt_request=prompt_request)
         request: PromptRequestPiece = prompt_request.request_pieces[0]
@@ -63,6 +62,7 @@ class OpenAIChatInterface(PromptChatTarget):
         response_entry = self._memory.add_response_entries_to_memory(request=request, response_text_pieces=[resp_text])
 
         return response_entry
+
     async def send_prompt_async(self, *, prompt_request: PromptRequestResponse) -> PromptRequestResponse:
         self._validate_request(prompt_request=prompt_request)
         request: PromptRequestPiece = prompt_request.request_pieces[0]

--- a/pyrit/prompt_target/prompt_chat_target/prompt_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/prompt_chat_target.py
@@ -1,7 +1,5 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
-import asyncio
-import concurrent.futures
 from typing import Optional
 
 from pyrit.memory import MemoryInterface

--- a/pyrit/prompt_target/prompt_chat_target/prompt_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/prompt_chat_target.py
@@ -51,18 +51,24 @@ class PromptChatTarget(PromptTarget):
         labels: Optional[dict[str, str]] = None,
     ) -> PromptRequestResponse:
         """
-        Deprecated. Use send_chat_prompt_async instead.
+        Sends a text prompt to the target without having to build the prompt request.
         """
-        pool = concurrent.futures.ThreadPoolExecutor()
-        return pool.submit(
-            asyncio.run,
-            self.send_chat_prompt_async(
-                prompt=prompt,
-                conversation_id=conversation_id,
-                orchestrator_identifier=orchestrator_identifier,
-                labels=labels,
-            ),
-        ).result()
+
+        request = PromptRequestResponse(
+            request_pieces=[
+                PromptRequestPiece(
+                    role="user",
+                    conversation_id=conversation_id,
+                    original_value=prompt,
+                    converted_value=prompt,
+                    prompt_target_identifier=self.get_identifier(),
+                    orchestrator_identifier=orchestrator_identifier,
+                    labels=labels,
+                )
+            ]
+        )
+
+        return self.send_prompt(prompt_request=request)
 
     async def send_chat_prompt_async(
         self,

--- a/tests/target/test_aml_online_endpoint_chat.py
+++ b/tests/target/test_aml_online_endpoint_chat.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import os
 import pytest
@@ -53,24 +53,25 @@ def test_get_headers_with_valid_api_key(aml_online_chat: AzureMLChatTarget):
     }
     assert aml_online_chat._get_headers() == expected_headers
 
-
-def test_complete_chat(aml_online_chat: AzureMLChatTarget):
+@pytest.mark.asyncio
+async def test_complete_chat_async(aml_online_chat: AzureMLChatTarget):
     messages = [
         ChatMessage(role="user", content="user content"),
     ]
 
-    with patch("pyrit.common.net_utility.make_request_and_raise_if_error") as mock:
+    with patch("pyrit.common.net_utility.make_request_and_raise_if_error_async") as mock:
         mock_response = Mock()
         mock_response.json.return_value = {"output": "extracted response"}
         mock.return_value = mock_response
-        response = aml_online_chat._complete_chat(messages)
+        response = await aml_online_chat._complete_chat_async(messages)
         assert response == "extracted response"
         mock.assert_called_once()
 
 
 # The None parameter checks the default is the same as ChatMessageNop
+@pytest.mark.asyncio
 @pytest.mark.parametrize("message_normalizer", [None, ChatMessageNop()])
-def test_complete_chat_with_nop_normalizer(
+async def test_complete_chat_async_with_nop_normalizer(
     aml_online_chat: AzureMLChatTarget, message_normalizer: ChatMessageNormalizer
 ):
     if message_normalizer:
@@ -81,11 +82,11 @@ def test_complete_chat_with_nop_normalizer(
         ChatMessage(role="user", content="user content"),
     ]
 
-    with patch("pyrit.common.net_utility.make_request_and_raise_if_error") as mock:
+    with patch("pyrit.common.net_utility.make_request_and_raise_if_error_async", new_callable=AsyncMock) as mock:
         mock_response = Mock()
         mock_response.json.return_value = {"output": "extracted response"}
         mock.return_value = mock_response
-        response = aml_online_chat._complete_chat(messages)
+        response = await aml_online_chat._complete_chat_async(messages)
         assert response == "extracted response"
 
         args, kwargs = mock.call_args
@@ -95,8 +96,8 @@ def test_complete_chat_with_nop_normalizer(
         assert len(body["input_data"]["input_string"]) == 2
         assert body["input_data"]["input_string"][0]["role"] == "system"
 
-
-def test_complete_chat_with_squashnormalizer(aml_online_chat: AzureMLChatTarget):
+@pytest.mark.asyncio
+async def test_complete_chat_async_with_squashnormalizer(aml_online_chat: AzureMLChatTarget):
     aml_online_chat.chat_message_normalizer = GenericSystemSquash()
 
     messages = [
@@ -104,11 +105,11 @@ def test_complete_chat_with_squashnormalizer(aml_online_chat: AzureMLChatTarget)
         ChatMessage(role="user", content="user content"),
     ]
 
-    with patch("pyrit.common.net_utility.make_request_and_raise_if_error") as mock:
+    with patch("pyrit.common.net_utility.make_request_and_raise_if_error_async" , new_callable=AsyncMock) as mock:
         mock_response = Mock()
         mock_response.json.return_value = {"output": "extracted response"}
         mock.return_value = mock_response
-        response = aml_online_chat._complete_chat(messages)
+        response = await aml_online_chat._complete_chat_async(messages)
         assert response == "extracted response"
 
         args, kwargs = mock.call_args
@@ -118,18 +119,18 @@ def test_complete_chat_with_squashnormalizer(aml_online_chat: AzureMLChatTarget)
         assert len(body["input_data"]["input_string"]) == 1
         assert body["input_data"]["input_string"][0]["role"] == "user"
 
-
-def test_complete_chat_bad_json_response(aml_online_chat: AzureMLChatTarget):
+@pytest.mark.asyncio
+async def test_complete_chat_async_bad_json_response(aml_online_chat: AzureMLChatTarget):
     messages = [
         ChatMessage(role="user", content="user content"),
     ]
 
-    with patch("pyrit.common.net_utility.make_request_and_raise_if_error") as mock:
+    with patch("pyrit.common.net_utility.make_request_and_raise_if_error_async", new_callable=AsyncMock) as mock:
         mock_response = Mock()
         mock_response.json.return_value = {"bad response"}
         mock.return_value = mock_response
         with pytest.raises(TypeError):
-            aml_online_chat._complete_chat(messages)
+            await aml_online_chat._complete_chat_async(messages)
 
 
 @pytest.mark.asyncio

--- a/tests/target/test_aml_online_endpoint_chat.py
+++ b/tests/target/test_aml_online_endpoint_chat.py
@@ -53,6 +53,7 @@ def test_get_headers_with_valid_api_key(aml_online_chat: AzureMLChatTarget):
     }
     assert aml_online_chat._get_headers() == expected_headers
 
+
 @pytest.mark.asyncio
 async def test_complete_chat_async(aml_online_chat: AzureMLChatTarget):
     messages = [
@@ -96,6 +97,7 @@ async def test_complete_chat_async_with_nop_normalizer(
         assert len(body["input_data"]["input_string"]) == 2
         assert body["input_data"]["input_string"][0]["role"] == "system"
 
+
 @pytest.mark.asyncio
 async def test_complete_chat_async_with_squashnormalizer(aml_online_chat: AzureMLChatTarget):
     aml_online_chat.chat_message_normalizer = GenericSystemSquash()
@@ -105,7 +107,7 @@ async def test_complete_chat_async_with_squashnormalizer(aml_online_chat: AzureM
         ChatMessage(role="user", content="user content"),
     ]
 
-    with patch("pyrit.common.net_utility.make_request_and_raise_if_error_async" , new_callable=AsyncMock) as mock:
+    with patch("pyrit.common.net_utility.make_request_and_raise_if_error_async", new_callable=AsyncMock) as mock:
         mock_response = Mock()
         mock_response.json.return_value = {"output": "extracted response"}
         mock.return_value = mock_response
@@ -118,6 +120,7 @@ async def test_complete_chat_async_with_squashnormalizer(aml_online_chat: AzureM
         assert body
         assert len(body["input_data"]["input_string"]) == 1
         assert body["input_data"]["input_string"][0]["role"] == "user"
+
 
 @pytest.mark.asyncio
 async def test_complete_chat_async_bad_json_response(aml_online_chat: AzureMLChatTarget):

--- a/tests/target/test_openai_chat_target.py
+++ b/tests/target/test_openai_chat_target.py
@@ -74,19 +74,6 @@ def prompt_request_response() -> PromptRequestResponse:
         ]
     )
 
-
-def execute_openai_send_prompt(
-    target: OpenAIChatInterface,
-    prompt_request_response: PromptRequestResponse,
-    mock_return: ChatCompletion,
-):
-    with patch("openai.resources.chat.Completions.create") as mock_create:
-        mock_create.return_value = mock_return
-        response: PromptRequestResponse = target.send_prompt(prompt_request=prompt_request_response)
-        assert len(response.request_pieces) == 1
-        assert response.request_pieces[0].converted_value == "hi"
-
-
 async def execute_openai_send_prompt_async(
     target: OpenAIChatInterface,
     prompt_request_response: PromptRequestResponse,
@@ -115,22 +102,6 @@ async def test_openai_complete_chat_async_return(
     prompt_request_response: PromptRequestResponse,
 ):
     await execute_openai_send_prompt_async(openai_chat_target, prompt_request_response, openai_mock_return)
-
-
-def test_azure_complete_chat_return(
-    openai_mock_return: ChatCompletion,
-    azure_chat_target: AzureOpenAIChatTarget,
-    prompt_request_response: PromptRequestResponse,
-):
-    execute_openai_send_prompt(azure_chat_target, prompt_request_response, openai_mock_return)
-
-
-def test_openai_complete_chat_return(
-    openai_mock_return: ChatCompletion,
-    openai_chat_target: OpenAIChatTarget,
-    prompt_request_response: PromptRequestResponse,
-):
-    execute_openai_send_prompt(openai_chat_target, prompt_request_response, openai_mock_return)
 
 
 @pytest.mark.asyncio

--- a/tests/target/test_openai_chat_target.py
+++ b/tests/target/test_openai_chat_target.py
@@ -74,6 +74,7 @@ def prompt_request_response() -> PromptRequestResponse:
         ]
     )
 
+
 async def execute_openai_send_prompt_async(
     target: OpenAIChatInterface,
     prompt_request_response: PromptRequestResponse,

--- a/tests/target/test_prompt_target.py
+++ b/tests/target/test_prompt_target.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 from typing import Generator
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from openai.types.chat import ChatCompletion, ChatCompletionMessage
@@ -74,20 +74,20 @@ def test_set_system_prompt(azure_openai_target: AzureOpenAIChatTarget):
     assert chats[0].role == "system"
     assert chats[0].converted_value == "system prompt"
 
-
-def test_send_prompt_user_no_system(
+@pytest.mark.asyncio
+async def test_send_prompt_user_no_system(
     azure_openai_target: AzureOpenAIChatTarget,
     openai_mock_return: ChatCompletion,
     sample_entries: list[PromptRequestPiece],
 ):
 
-    with patch("openai.resources.chat.Completions.create") as mock:
+    with patch("openai.resources.chat.AsyncCompletions.create", new_callable=AsyncMock) as mock:
         mock.return_value = openai_mock_return
 
         request = sample_entries[0]
         request.converted_value = "hi, I am a victim chatbot, how can I help?"
 
-        azure_openai_target.send_prompt(prompt_request=PromptRequestResponse(request_pieces=[request]))
+        await azure_openai_target.send_prompt_async(prompt_request=PromptRequestResponse(request_pieces=[request]))
 
         chats = azure_openai_target._memory._get_prompt_pieces_with_conversation_id(
             conversation_id=request.conversation_id
@@ -96,14 +96,14 @@ def test_send_prompt_user_no_system(
         assert chats[0].role == "user"
         assert chats[1].role == "assistant"
 
-
-def test_send_prompt_with_system(
+@pytest.mark.asyncio
+async def test_send_prompt_with_system(
     azure_openai_target: AzureOpenAIChatTarget,
     openai_mock_return: ChatCompletion,
     sample_entries: list[PromptRequestPiece],
 ):
 
-    with patch("openai.resources.chat.Completions.create") as mock:
+    with patch("openai.resources.chat.AsyncCompletions.create" , new_callable=AsyncMock) as mock:
         mock.return_value = openai_mock_return
 
         azure_openai_target.set_system_prompt(
@@ -117,21 +117,21 @@ def test_send_prompt_with_system(
         request.converted_value = "hi, I am a victim chatbot, how can I help?"
         request.conversation_id = "1"
 
-        azure_openai_target.send_prompt(prompt_request=PromptRequestResponse(request_pieces=[request]))
+        await azure_openai_target.send_prompt_async(prompt_request=PromptRequestResponse(request_pieces=[request]))
 
         chats = azure_openai_target._memory._get_prompt_pieces_with_conversation_id(conversation_id="1")
         assert len(chats) == 3, f"Expected 3 chats, got {len(chats)}"
         assert chats[0].role == "system"
         assert chats[1].role == "user"
 
-
-def test_send_prompt_with_system_calls_chat_complete(
+@pytest.mark.asyncio
+async def test_send_prompt_with_system_calls_chat_complete(
     azure_openai_target: AzureOpenAIChatTarget,
     openai_mock_return: ChatCompletion,
     sample_entries: list[PromptRequestPiece],
 ):
 
-    with patch("openai.resources.chat.Completions.create") as mock:
+    with patch("openai.resources.chat.AsyncCompletions.create", new_callable=AsyncMock) as mock:
         mock.return_value = openai_mock_return
 
         azure_openai_target.set_system_prompt(
@@ -145,6 +145,6 @@ def test_send_prompt_with_system_calls_chat_complete(
         request.converted_value = "hi, I am a victim chatbot, how can I help?"
         request.conversation_id = "1"
 
-        azure_openai_target.send_prompt(prompt_request=PromptRequestResponse(request_pieces=[request]))
+        await azure_openai_target.send_prompt_async(prompt_request=PromptRequestResponse(request_pieces=[request]))
 
         mock.assert_called_once()

--- a/tests/target/test_prompt_target.py
+++ b/tests/target/test_prompt_target.py
@@ -74,6 +74,7 @@ def test_set_system_prompt(azure_openai_target: AzureOpenAIChatTarget):
     assert chats[0].role == "system"
     assert chats[0].converted_value == "system prompt"
 
+
 @pytest.mark.asyncio
 async def test_send_prompt_user_no_system(
     azure_openai_target: AzureOpenAIChatTarget,
@@ -96,6 +97,7 @@ async def test_send_prompt_user_no_system(
         assert chats[0].role == "user"
         assert chats[1].role == "assistant"
 
+
 @pytest.mark.asyncio
 async def test_send_prompt_with_system(
     azure_openai_target: AzureOpenAIChatTarget,
@@ -103,7 +105,7 @@ async def test_send_prompt_with_system(
     sample_entries: list[PromptRequestPiece],
 ):
 
-    with patch("openai.resources.chat.AsyncCompletions.create" , new_callable=AsyncMock) as mock:
+    with patch("openai.resources.chat.AsyncCompletions.create", new_callable=AsyncMock) as mock:
         mock.return_value = openai_mock_return
 
         azure_openai_target.set_system_prompt(
@@ -123,6 +125,7 @@ async def test_send_prompt_with_system(
         assert len(chats) == 3, f"Expected 3 chats, got {len(chats)}"
         assert chats[0].role == "system"
         assert chats[1].role == "user"
+
 
 @pytest.mark.asyncio
 async def test_send_prompt_with_system_calls_chat_complete(

--- a/tests/test_ollama_chat_target.py
+++ b/tests/test_ollama_chat_target.py
@@ -63,6 +63,7 @@ async def test_ollama_complete_chat_async_return(ollama_chat_engine: OllamaChatT
         ret = await ollama_chat_engine._complete_chat_async(messages=[ChatMessage(role="user", content="hello")])
         assert ret == " Hello."
 
+
 def test_ollama_invalid_model_raises():
     os.environ[OllamaChatTarget.MODEL_NAME_ENVIRONMENT_VARIABLE] = ""
     with pytest.raises(ValueError):

--- a/tests/test_ollama_chat_target.py
+++ b/tests/test_ollama_chat_target.py
@@ -63,28 +63,6 @@ async def test_ollama_complete_chat_async_return(ollama_chat_engine: OllamaChatT
         ret = await ollama_chat_engine._complete_chat_async(messages=[ChatMessage(role="user", content="hello")])
         assert ret == " Hello."
 
-
-def test_ollama_complete_chat_return(ollama_chat_engine: OllamaChatTarget):
-    with patch("pyrit.common.net_utility.make_request_and_raise_if_error") as mock_create:
-        mock_create.return_value = httpx.Response(
-            200,
-            json={
-                "model": "mistral",
-                "created_at": "2024-04-13T16:14:52.69602Z",
-                "message": {"role": "assistant", "content": " Hello."},
-                "done": True,
-                "total_duration": 254579625,
-                "load_duration": 276542,
-                "prompt_eval_count": 20,
-                "prompt_eval_duration": 222911000,
-                "eval_count": 3,
-                "eval_duration": 30879000,
-            },
-        )
-        ret = ollama_chat_engine._complete_chat(messages=[ChatMessage(role="user", content="hello")])
-        assert ret == " Hello."
-
-
 def test_ollama_invalid_model_raises():
     os.environ[OllamaChatTarget.MODEL_NAME_ENVIRONMENT_VARIABLE] = ""
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Description
- Finished the deprecation send_prompts methods in Prompt Targets. There is now a single code path for each Prompt Target. 


## Tests and Documentation
- Updated unit tests to use async version. There's still some work to do on the orchestrator to use async methods. This PR does not address this part.
