### PR TITLE
FEAT: Add repeated token attack converter

### DIFF
--- a/pyrit/prompt_converter/__init__.py
+++ b/pyrit/prompt_converter/__init__.py
@@ -17,6 +17,7 @@ from pyrit.prompt_converter.unicode_sub_converter import UnicodeSubstitutionConv
 from pyrit.prompt_converter.variation_converter import VariationConverter
 from pyrit.prompt_converter.azure_speech_text_to_audio_converter import AzureSpeechTextToAudioConverter
 from pyrit.prompt_converter.suffix_append_converter import SuffixAppendConverter
+from pyrit.prompt_converter.repeat_token_converter import RepeatTokenConverter
 
 
 __all__ = [
@@ -36,4 +37,5 @@ __all__ = [
     "VariationConverter",
     "AzureSpeechTextToAudioConverter",
     "SuffixAppendConverter",
+    "RepeatTokenConverter",
 ]

--- a/pyrit/prompt_converter/repeat_token_converter.py
+++ b/pyrit/prompt_converter/repeat_token_converter.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 import re
 import asyncio
 
@@ -8,6 +11,8 @@ from pyrit.prompt_converter import PromptConverter, ConverterResult
 class RepeatTokenConverter(PromptConverter):
     """
     Repeat a specified token a specified number of times in addition to a given prompt.
+    Based on:
+    https://dropbox.tech/machine-learning/bye-bye-bye-evolution-of-repeated-token-attacks-on-chatgpt-models
 
     Parameters
     ---

--- a/pyrit/prompt_converter/repeat_token_converter.py
+++ b/pyrit/prompt_converter/repeat_token_converter.py
@@ -1,0 +1,84 @@
+import re
+import asyncio
+
+from pyrit.models import PromptDataType
+from pyrit.prompt_converter import PromptConverter, ConverterResult
+
+
+class RepeatTokenConverter(PromptConverter):
+    """
+    Repeat a specified token a specified number of times in addition to a given prompt.
+
+    Parameters
+    ---
+    token_to_repeat: string, default=None
+        The string to be repeated
+
+    times_to_repeat: int, default=None
+        The number of times the string will be repeated
+
+    token_insert_mode: {"split", "prepend", "append", "repeat"}, default="prepend"
+        Method to insert repeated tokens:
+
+        If "split" prompt text will be split on the first occurance of (.?!) punctuation,
+        and repeated tokens will be inserted at location of split.
+
+        If "prepend" repeated tokens will be inserted before the prompt text.
+
+        If "append" repeated tokens will be inserted after the prompt text.
+
+        If "repeat" prompt text will be ignored and result will only be repeated tokens.
+    """
+
+    def __init__(
+        self, *, token_to_repeat: str = None, times_to_repeat: int = None, token_insert_mode: str = "split"
+    ) -> None:
+        self.token_to_repeat = " " + token_to_repeat.strip()
+        self.times_to_repeat = times_to_repeat
+        match token_insert_mode:
+            case "split":
+                # function to split prompt on first punctuation (.?! only), preserve punctuation, 2 parts max.
+                def insert(text: str) -> list:
+                    parts = re.split(r"(\?|\.|\!)", text, 1)
+                    if len(parts) == 3:  # if split mode with no punctuation
+                        return [parts[0] + parts[1], parts[2]]
+                    return ["", text]
+
+                self.insert = insert
+            case "prepend":
+
+                def insert(text: str) -> list:
+                    return ["", text]
+
+                self.insert = insert
+            case "append":
+
+                def insert(text: str) -> list:
+                    return [text, ""]
+
+                self.insert = insert
+            case "repeat":
+
+                def insert(text: str) -> list:
+                    return ["", ""]
+
+                self.insert = insert
+            case _:
+                raise ValueError('Invalid insert mode. Must be one of "split", "prepend", "append", or "repeat".')
+
+    async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
+        """
+        Converter to insert repeated tokens into the prompt.
+        """
+        if not self.input_supported(input_type):
+            raise ValueError("Input type not supported")
+        prompt_parts = self.insert(prompt)
+
+        await asyncio.sleep(0)
+        return ConverterResult(
+            output_text=f"{prompt_parts[0]}{self.token_to_repeat * self.times_to_repeat}{prompt_parts[1]}",
+            output_type="text",
+        )
+
+    def input_supported(self, input_type: PromptDataType) -> bool:
+        return input_type == "text"

--- a/tests/test_prompt_converter.py
+++ b/tests/test_prompt_converter.py
@@ -271,10 +271,26 @@ async def test_repeat_token_converter_append() -> None:
 
 
 @pytest.mark.asyncio
-async def test_repeat_token_converter_split() -> None:
+async def test_repeat_token_converter_split_two_sentence() -> None:
     converter = RepeatTokenConverter(token_to_repeat="test", times_to_repeat=3, token_insert_mode="split")
     output = await converter.convert_async(prompt="how to cut down a tree? I need to know.", input_type="text")
     assert output.output_text == "how to cut down a tree? test test test I need to know."
+    assert output.output_type == "text"
+
+
+@pytest.mark.asyncio
+async def test_repeat_token_converter_split_one_sentence() -> None:
+    converter = RepeatTokenConverter(token_to_repeat="test", times_to_repeat=3, token_insert_mode="split")
+    output = await converter.convert_async(prompt="how to cut down a tree?", input_type="text")
+    assert output.output_text == "how to cut down a tree? test test test"
+    assert output.output_type == "text"
+
+
+@pytest.mark.asyncio
+async def test_repeat_token_converter_split_no_punctuation() -> None:
+    converter = RepeatTokenConverter(token_to_repeat="test", times_to_repeat=3, token_insert_mode="split")
+    output = await converter.convert_async(prompt="how to cut down a tree", input_type="text")
+    assert output.output_text == " test test testhow to cut down a tree"
     assert output.output_type == "text"
 
 

--- a/tests/test_prompt_converter.py
+++ b/tests/test_prompt_converter.py
@@ -16,6 +16,7 @@ from pyrit.prompt_converter import (
     UnicodeConfusableConverter,
     VariationConverter,
     SuffixAppendConverter,
+    RepeatTokenConverter,
 )
 import pytest
 import os
@@ -251,3 +252,35 @@ async def test_add_text_image_converter() -> None:
     assert os.path.exists(converted_image.output_text)
     os.remove(converted_image.output_text)
     os.remove("test.png")
+
+
+@pytest.mark.asyncio
+async def test_repeat_token_converter_prepend() -> None:
+    converter = RepeatTokenConverter(token_to_repeat="test", times_to_repeat=3, token_insert_mode="prepend")
+    output = await converter.convert_async(prompt="how to cut down a tree?", input_type="text")
+    assert output.output_text == " test test testhow to cut down a tree?"
+    assert output.output_type == "text"
+
+
+@pytest.mark.asyncio
+async def test_repeat_token_converter_append() -> None:
+    converter = RepeatTokenConverter(token_to_repeat="test", times_to_repeat=3, token_insert_mode="append")
+    output = await converter.convert_async(prompt="how to cut down a tree?", input_type="text")
+    assert output.output_text == "how to cut down a tree? test test test"
+    assert output.output_type == "text"
+
+
+@pytest.mark.asyncio
+async def test_repeat_token_converter_split() -> None:
+    converter = RepeatTokenConverter(token_to_repeat="test", times_to_repeat=3, token_insert_mode="split")
+    output = await converter.convert_async(prompt="how to cut down a tree? I need to know.", input_type="text")
+    assert output.output_text == "how to cut down a tree? test test test I need to know."
+    assert output.output_type == "text"
+
+
+@pytest.mark.asyncio
+async def test_repeat_token_converter_repeat() -> None:
+    converter = RepeatTokenConverter(token_to_repeat="test", times_to_repeat=3, token_insert_mode="repeat")
+    output = await converter.convert_async(prompt="how to cut down a tree? I need to know.", input_type="text")
+    assert output.output_text == " test test test"
+    assert output.output_type == "text"


### PR DESCRIPTION
<!--- Please add one of the following as a prefix to the pull request title: -->
<!--- DOC for documentation changes -->
<!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
<!--- FIX for bug fixes -->
<!--- TEST for adding tests -->
<!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
<!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

<!--- If you are considering making a contribution please open an issue first. -->
<!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
<!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->
Add a converter based on [this paper](https://dropbox.tech/machine-learning/bye-bye-bye-evolution-of-repeated-token-attacks-on-chatgpt-models) that repeats a specified token a specified number of times in one of four modes:
1. Prepend repeated tokens to prompt
2. Append repeated tokens to prompt
3. Add repeated tokens after first sentence of prompt (after first '.' '!' or '?' character). Remainder of prompt appended after repeated tokens.
    - default option, if no punctuation will prepend repeated tokens to prompt.
4. Ignore prompt, repeat tokens only

## Tests and Documentation

<!--- Contributions require tests and documentation (if applicable). -->
<!--- Include a description of tests and documentation updated (if applicable) -->

<!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
<!--- Include how you/if ran JupyText here -->
<!--- This is described at: https://github.com/Azure/PyRIT/tree/main/doc  -->
Added tests to test_prompt_converter.py, one for each insert mode, repeats 'test' three times.
