### PR TITLE
FIX: Fixing score conversation history

### DIFF
--- a/pyrit/score/self_ask_category_scorer.py
+++ b/pyrit/score/self_ask_category_scorer.py
@@ -62,13 +62,6 @@ class SelfAskCategoryScorer(Scorer):
         )
 
         self._chat_target: PromptChatTarget = chat_target
-        self._conversation_id = str(uuid.uuid4())
-
-        self._chat_target.set_system_prompt(
-            system_prompt=self._system_prompt,
-            conversation_id=self._conversation_id,
-            orchestrator_identifier=None,
-        )
 
     def _content_classifier_to_string(self, categories: list[Dict[str, str]]) -> str:
         """
@@ -111,12 +104,20 @@ class SelfAskCategoryScorer(Scorer):
         """
         self.validate(request_response)
 
+        conversation_id = str(uuid.uuid4())
+
+        self._chat_target.set_system_prompt(
+            system_prompt=self._system_prompt,
+            conversation_id=conversation_id,
+            orchestrator_identifier=None,
+        )
+
         request = PromptRequestResponse(
             [
                 PromptRequestPiece(
                     role="user",
                     original_value=request_response.converted_value,
-                    conversation_id=self._conversation_id,
+                    conversation_id=conversation_id,
                     prompt_target_identifier=self._chat_target.get_identifier(),
                 )
             ]

--- a/pyrit/score/self_ask_conversation_objective_scorer.py
+++ b/pyrit/score/self_ask_conversation_objective_scorer.py
@@ -54,13 +54,6 @@ class SelfAskObjectiveScorer(Scorer):
         )
 
         self._chat_target: PromptChatTarget = chat_target
-        self._conversation_id = str(uuid.uuid4())
-
-        self._chat_target.set_system_prompt(
-            system_prompt=self._system_prompt,
-            conversation_id=self._conversation_id,
-            orchestrator_identifier=None,
-        )
 
     async def score_async(self, request_response: PromptRequestPiece) -> list[Score]:
         """
@@ -78,12 +71,20 @@ class SelfAskObjectiveScorer(Scorer):
 
         self.validate(request_response)
 
+        conversation_id = str(uuid.uuid4())
+
+        self._chat_target.set_system_prompt(
+            system_prompt=self._system_prompt,
+            conversation_id=conversation_id,
+            orchestrator_identifier=None,
+        )
+
         request = PromptRequestResponse(
             [
                 PromptRequestPiece(
                     role="user",
                     original_value=request_response.converted_value,
-                    conversation_id=self._conversation_id,
+                    conversation_id=conversation_id,
                     prompt_target_identifier=self._chat_target.get_identifier(),
                 )
             ]

--- a/pyrit/score/self_ask_likert_scorer.py
+++ b/pyrit/score/self_ask_likert_scorer.py
@@ -55,13 +55,6 @@ class SelfAskLikertScorer(Scorer):
         )
 
         self._chat_target: PromptChatTarget = chat_target
-        self._conversation_id = str(uuid.uuid4())
-
-        self._chat_target.set_system_prompt(
-            system_prompt=self._system_prompt,
-            conversation_id=self._conversation_id,
-            orchestrator_identifier=None,
-        )
 
     def _likert_scale_description_to_string(self, descriptions: list[Dict[str, str]]) -> str:
         """
@@ -105,12 +98,20 @@ class SelfAskLikertScorer(Scorer):
         """
         self.validate(request_response)
 
+        conversation_id = str(uuid.uuid4())
+
+        self._chat_target.set_system_prompt(
+            system_prompt=self._system_prompt,
+            conversation_id=conversation_id,
+            orchestrator_identifier=None,
+        )
+
         request = PromptRequestResponse(
             [
                 PromptRequestPiece(
                     role="user",
                     original_value=request_response.converted_value,
-                    conversation_id=self._conversation_id,
+                    conversation_id=conversation_id,
                     prompt_target_identifier=self._chat_target.get_identifier(),
                 )
             ]

--- a/pyrit/score/self_ask_meta_scorer.py
+++ b/pyrit/score/self_ask_meta_scorer.py
@@ -49,13 +49,6 @@ class SelfAskMetaScorer(Scorer):
         )
 
         self._chat_target: PromptChatTarget = chat_target
-        self._conversation_id = str(uuid.uuid4())
-
-        self._chat_target.set_system_prompt(
-            system_prompt=self._system_prompt,
-            conversation_id=self._conversation_id,
-            orchestrator_identifier=None,
-        )
 
     async def score_async(self, request_response: PromptRequestPiece) -> list[Score]:
         """
@@ -73,12 +66,20 @@ class SelfAskMetaScorer(Scorer):
 
         self.validate(request_response)
 
+        conversation_id = str(uuid.uuid4())
+
+        self._chat_target.set_system_prompt(
+            system_prompt=self._system_prompt,
+            conversation_id=conversation_id,
+            orchestrator_identifier=None,
+        )
+
         request = PromptRequestResponse(
             [
                 PromptRequestPiece(
                     role="user",
                     original_value=request_response.converted_value,
-                    conversation_id=self._conversation_id,
+                    conversation_id=conversation_id,
                     prompt_target_identifier=self._chat_target.get_identifier(),
                 )
             ]

--- a/pyrit/score/self_ask_true_false_scorer.py
+++ b/pyrit/score/self_ask_true_false_scorer.py
@@ -53,13 +53,6 @@ class SelfAskTrueFalseScorer(Scorer):
         )
 
         self._chat_target: PromptChatTarget = chat_target
-        self._conversation_id = str(uuid.uuid4())
-
-        self._chat_target.set_system_prompt(
-            system_prompt=self._system_prompt,
-            conversation_id=self._conversation_id,
-            orchestrator_identifier=None,
-        )
 
     async def score_async(self, request_response: PromptRequestPiece) -> list[Score]:
         """
@@ -77,6 +70,14 @@ class SelfAskTrueFalseScorer(Scorer):
 
         self.validate(request_response)
 
+        conversation_id = str(uuid.uuid4())
+
+        self._chat_target.set_system_prompt(
+            system_prompt=self._system_prompt,
+            conversation_id=conversation_id,
+            orchestrator_identifier=None,
+        )
+
         request = PromptRequestResponse(
             [
                 PromptRequestPiece(
@@ -85,7 +86,7 @@ class SelfAskTrueFalseScorer(Scorer):
                     original_value_data_type=request_response.original_value_data_type,
                     converted_value=request_response.converted_value,
                     converted_value_data_type=request_response.converted_value_data_type,
-                    conversation_id=self._conversation_id,
+                    conversation_id=conversation_id,
                     prompt_target_identifier=self._chat_target.get_identifier(),
                 )
             ]

--- a/tests/score/test_self_ask_likert.py
+++ b/tests/score/test_self_ask_likert.py
@@ -42,13 +42,17 @@ def memory() -> Generator[MemoryInterface, None, None]:
     yield from get_memory_interface()
 
 
-def test_likert_scorer_set_system_prompt():
+@pytest.mark.asyncio
+async def test_likert_scorer_set_system_prompt(scorer_likert_response: PromptRequestResponse):
+    memory = MagicMock(MemoryInterface)
     chat_target = MagicMock()
+    chat_target.send_prompt_async = AsyncMock(return_value=scorer_likert_response)
 
     scorer = SelfAskLikertScorer(
-        chat_target=chat_target,
-        likert_scale_path=LikertScalePaths.CYBER_SCALE.value,
+        chat_target=chat_target, likert_scale_path=LikertScalePaths.CYBER_SCALE.value, memory=memory
     )
+
+    await scorer.score_text_async(text="string")
 
     chat_target.set_system_prompt.assert_called_once()
 

--- a/tests/score/test_self_ask_meta_scorer.py
+++ b/tests/score/test_self_ask_meta_scorer.py
@@ -57,14 +57,18 @@ async def test_meta_scorer_score(memory: MemoryInterface, scorer_meta_response: 
     assert score[0].scorer_class_identifier["__type__"] == "SelfAskMetaScorer"
 
 
-def test_meta_scorer_set_system_prompt(memory: MemoryInterface):
+@pytest.mark.asyncio
+async def test_meta_scorer_set_system_prompt(memory: MemoryInterface, scorer_meta_response: PromptRequestResponse):
     chat_target = MagicMock()
+    chat_target.send_prompt_async = AsyncMock(return_value=scorer_meta_response)
 
     scorer = SelfAskMetaScorer(
         chat_target=chat_target,
         meta_scorer_question_path=MetaScorerQuestionPaths.META_JUDGE_PROMPT.value,
         memory=memory,
     )
+
+    await scorer.score_text_async("true false")
 
     chat_target.set_system_prompt.assert_called_once()
 

--- a/tests/score/test_self_ask_objective_scorer.py
+++ b/tests/score/test_self_ask_objective_scorer.py
@@ -57,14 +57,18 @@ async def test_meta_scorer_score(memory: MemoryInterface, scorer_meta_response: 
     assert score[0].scorer_class_identifier["__type__"] == "SelfAskObjectiveScorer"
 
 
-def test_meta_scorer_set_system_prompt(memory: MemoryInterface):
+@pytest.mark.asyncio
+async def test_meta_scorer_set_system_prompt(memory: MemoryInterface, scorer_meta_response: PromptRequestResponse):
     chat_target = MagicMock()
+    chat_target.send_prompt_async = AsyncMock(return_value=scorer_meta_response)
 
     scorer = SelfAskObjectiveScorer(
         chat_target=chat_target,
         objective_question_path=ObjectiveQuestionPaths.REFUSAL.value,
         memory=memory,
     )
+
+    await scorer.score_text_async("true false")
 
     chat_target.set_system_prompt.assert_called_once()
 

--- a/tests/score/test_self_ask_true_false.py
+++ b/tests/score/test_self_ask_true_false.py
@@ -57,12 +57,18 @@ async def test_true_false_scorer_score(memory: MemoryInterface, scorer_true_fals
     assert score[0].scorer_class_identifier["__type__"] == "SelfAskTrueFalseScorer"
 
 
-def test_true_false_scorer_set_system_prompt(memory: MemoryInterface):
+@pytest.mark.asyncio
+async def test_true_false_scorer_set_system_prompt(
+    memory: MemoryInterface, scorer_true_false_response: PromptRequestResponse
+):
     chat_target = MagicMock()
+    chat_target.send_prompt_async = AsyncMock(return_value=scorer_true_false_response)
 
     scorer = SelfAskTrueFalseScorer(
         chat_target=chat_target, true_false_question_path=TrueFalseQuestionPaths.GROUNDED.value, memory=memory
     )
+
+    await scorer.score_text_async("true false")
 
     chat_target.set_system_prompt.assert_called_once()
 


### PR DESCRIPTION
## Description

There was a bug in scorers where if you reuse a scoring object it'll just keep adding to the history. This broke a bunch of our self-ask scorers in several situations.

