### PR TITLE
FIX Fixed mypy Type Failures

### DIFF
--- a/pyrit/memory/azure_sql_memory.py
+++ b/pyrit/memory/azure_sql_memory.py
@@ -239,7 +239,7 @@ class AzureSQLMemory(MemoryInterface, metaclass=Singleton):
                 query = session.query(model)
                 if conditions is not None:
                     query = query.filter(conditions)
-                return query.all()  # TODO: use generics to make types work
+                return query.all()
             except SQLAlchemyError as e:
                 logger.exception(f"Error fetching data from table {model.__tablename__}: {e}")
 

--- a/pyrit/memory/azure_sql_memory.py
+++ b/pyrit/memory/azure_sql_memory.py
@@ -4,7 +4,7 @@
 import logging
 
 from contextlib import closing
-from typing import MutableSequence, Optional, Sequence
+from typing import Optional, Sequence
 
 from sqlalchemy import create_engine, func, and_
 from sqlalchemy.engine.base import Engine
@@ -78,7 +78,7 @@ class AzureSQLMemory(MemoryInterface, metaclass=Singleton):
         """
         self._insert_entries(entries=embedding_data)
 
-    def _get_prompt_pieces_by_orchestrator(self, *, orchestrator_id: int) -> Sequence[PromptRequestPiece]:
+    def _get_prompt_pieces_by_orchestrator(self, *, orchestrator_id: int) -> list[PromptRequestPiece]:
         """
         Retrieves a list of PromptRequestPiece objects that have the specified orchestrator ID.
 
@@ -103,7 +103,7 @@ class AzureSQLMemory(MemoryInterface, metaclass=Singleton):
             )
             return []
 
-    def _get_prompt_pieces_with_conversation_id(self, *, conversation_id: str) -> MutableSequence[PromptRequestPiece]:
+    def _get_prompt_pieces_with_conversation_id(self, *, conversation_id: str) -> list[PromptRequestPiece]:
         """
         Retrieves a list of PromptRequestPiece objects that have the specified conversation ID.
 
@@ -157,7 +157,7 @@ class AzureSQLMemory(MemoryInterface, metaclass=Singleton):
         result: list[PromptMemoryEntry] = self.query_entries(PromptMemoryEntry)
         return [entry.get_prompt_request_piece() for entry in result]
 
-    def get_prompt_request_pieces_by_id(self, *, prompt_ids: list[str]) -> Sequence[PromptRequestPiece]:
+    def get_prompt_request_pieces_by_id(self, *, prompt_ids: list[str]) -> list[PromptRequestPiece]:
         """
         Retrieves a list of PromptRequestPiece objects that have the specified prompt ids.
 

--- a/pyrit/memory/azure_sql_memory.py
+++ b/pyrit/memory/azure_sql_memory.py
@@ -4,7 +4,7 @@
 import logging
 
 from contextlib import closing
-from typing import Optional
+from typing import MutableSequence, Optional, Sequence
 
 from sqlalchemy import create_engine, func, and_
 from sqlalchemy.engine.base import Engine
@@ -78,7 +78,7 @@ class AzureSQLMemory(MemoryInterface, metaclass=Singleton):
         """
         self._insert_entries(entries=embedding_data)
 
-    def _get_prompt_pieces_by_orchestrator(self, *, orchestrator_id: int) -> list[PromptRequestPiece]:
+    def _get_prompt_pieces_by_orchestrator(self, *, orchestrator_id: int) -> Sequence[PromptRequestPiece]:
         """
         Retrieves a list of PromptRequestPiece objects that have the specified orchestrator ID.
 
@@ -96,14 +96,14 @@ class AzureSQLMemory(MemoryInterface, metaclass=Singleton):
                     func.ISJSON(PromptMemoryEntry.orchestrator_identifier) > 0,
                     func.JSON_VALUE(PromptMemoryEntry.orchestrator_identifier, "$.id") == str(orchestrator_id),
                 ),
-            )
+            )  # type: ignore
         except Exception as e:
             logger.exception(
                 f"Unexpected error: Failed to retrieve ConversationData with orchestrator {orchestrator_id}. {e}"
             )
             return []
 
-    def _get_prompt_pieces_with_conversation_id(self, *, conversation_id: str) -> list[PromptRequestPiece]:
+    def _get_prompt_pieces_with_conversation_id(self, *, conversation_id: str) -> MutableSequence[PromptRequestPiece]:
         """
         Retrieves a list of PromptRequestPiece objects that have the specified conversation ID.
 
@@ -117,12 +117,12 @@ class AzureSQLMemory(MemoryInterface, metaclass=Singleton):
             return self.query_entries(
                 PromptMemoryEntry,
                 conditions=PromptMemoryEntry.conversation_id == conversation_id,
-            )
+            )  # type: ignore
         except Exception as e:
             logger.exception(f"Failed to retrieve conversation_id {conversation_id} with error {e}")
             return []
 
-    def add_request_pieces_to_memory(self, *, request_pieces: list[PromptRequestPiece]) -> None:
+    def add_request_pieces_to_memory(self, *, request_pieces: Sequence[PromptRequestPiece]) -> None:
         """
         Inserts a list of prompt request pieces into the memory storage.
 
@@ -157,7 +157,7 @@ class AzureSQLMemory(MemoryInterface, metaclass=Singleton):
         result: list[PromptMemoryEntry] = self.query_entries(PromptMemoryEntry)
         return [entry.get_prompt_request_piece() for entry in result]
 
-    def get_prompt_request_pieces_by_id(self, *, prompt_ids: list[str]) -> list[PromptRequestPiece]:
+    def get_prompt_request_pieces_by_id(self, *, prompt_ids: list[str]) -> Sequence[PromptRequestPiece]:
         """
         Retrieves a list of PromptRequestPiece objects that have the specified prompt ids.
 
@@ -171,7 +171,7 @@ class AzureSQLMemory(MemoryInterface, metaclass=Singleton):
             return self.query_entries(
                 PromptMemoryEntry,
                 conditions=PromptMemoryEntry.id.in_(prompt_ids),
-            )
+            )  # type: ignore
         except Exception as e:
             logger.exception(
                 f"Unexpected error: Failed to retrieve ConversationData with orchestrator {prompt_ids}. {e}"
@@ -239,7 +239,7 @@ class AzureSQLMemory(MemoryInterface, metaclass=Singleton):
                 query = session.query(model)
                 if conditions is not None:
                     query = query.filter(conditions)
-                return query.all()
+                return query.all()  # TODO: use generics to make types work
             except SQLAlchemyError as e:
                 logger.exception(f"Error fetching data from table {model.__tablename__}: {e}")
 

--- a/pyrit/memory/duckdb_memory.py
+++ b/pyrit/memory/duckdb_memory.py
@@ -80,22 +80,22 @@ class DuckDBMemory(MemoryInterface, metaclass=Singleton):
         except Exception as e:
             logger.error(f"Error during table creation: {e}")
 
-    def get_all_prompt_pieces(self) -> Sequence[PromptRequestPiece]:
+    def get_all_prompt_pieces(self) -> list[PromptRequestPiece]:
         """
         Fetches all entries from the specified table and returns them as model instances.
         """
         entries = self.query_entries(PromptMemoryEntry)
-        result: Sequence[PromptRequestPiece] = [entry.get_prompt_request_piece() for entry in entries]
+        result: list[PromptRequestPiece] = [entry.get_prompt_request_piece() for entry in entries]
         return result
 
-    def get_all_embeddings(self) -> Sequence[EmbeddingData]:
+    def get_all_embeddings(self) -> list[EmbeddingData]:
         """
         Fetches all entries from the specified table and returns them as model instances.
         """
-        result = self.query_entries(EmbeddingData)
+        result: list[EmbeddingData] = self.query_entries(EmbeddingData)
         return result
 
-    def _get_prompt_pieces_with_conversation_id(self, *, conversation_id: str) -> MutableSequence[PromptRequestPiece]:
+    def _get_prompt_pieces_with_conversation_id(self, *, conversation_id: str) -> list[PromptRequestPiece]:
         """
         Retrieves a list of PromptRequestPiece objects that have the specified conversation ID.
 
@@ -106,7 +106,7 @@ class DuckDBMemory(MemoryInterface, metaclass=Singleton):
             list[PromptRequestPiece]: A list of PromptRequestPieces with the specified conversation ID.
         """
         try:
-            result: MutableSequence[PromptRequestPiece] = self.query_entries(
+            result: list[PromptRequestPiece] = self.query_entries(
                 PromptMemoryEntry, conditions=PromptMemoryEntry.conversation_id == conversation_id
             )  # type: ignore
             return result
@@ -114,7 +114,7 @@ class DuckDBMemory(MemoryInterface, metaclass=Singleton):
             logger.exception(f"Failed to retrieve conversation_id {conversation_id} with error {e}")
             return []
 
-    def get_prompt_request_pieces_by_id(self, *, prompt_ids: list[str]) -> Sequence[PromptRequestPiece]:
+    def get_prompt_request_pieces_by_id(self, *, prompt_ids: list[str]) -> list[PromptRequestPiece]:
         """
         Retrieves a list of PromptRequestPiece objects that have the specified prompt ids.
 
@@ -128,14 +128,14 @@ class DuckDBMemory(MemoryInterface, metaclass=Singleton):
             return self.query_entries(
                 PromptMemoryEntry,
                 conditions=PromptMemoryEntry.id.in_(prompt_ids),
-            )
+            )  # type: ignore
         except Exception as e:
             logger.exception(
                 f"Unexpected error: Failed to retrieve ConversationData with orchestrator {prompt_ids}. {e}"
             )
             return []
 
-    def _get_prompt_pieces_by_orchestrator(self, *, orchestrator_id: int) -> Sequence[PromptRequestPiece]:
+    def _get_prompt_pieces_by_orchestrator(self, *, orchestrator_id: int) -> list[PromptRequestPiece]:
         """
         Retrieves a list of PromptRequestPiece objects that have the specified orchestrator ID.
 
@@ -147,10 +147,11 @@ class DuckDBMemory(MemoryInterface, metaclass=Singleton):
             list[PromptRequestPiece]: A list of PromptRequestPiece objects matching the specified orchestrator ID.
         """
         try:
-            return self.query_entries(
+            result: list[PromptRequestPiece] = self.query_entries(
                 PromptMemoryEntry,
                 conditions=PromptMemoryEntry.orchestrator_identifier.op("->>")("id") == str(orchestrator_id),
-            )
+            )  # type: ignore
+            return result
         except Exception as e:
             logger.exception(
                 f"Unexpected error: Failed to retrieve ConversationData with orchestrator {orchestrator_id}. {e}"
@@ -252,7 +253,7 @@ class DuckDBMemory(MemoryInterface, metaclass=Singleton):
                 logger.exception(f"Error inserting multiple entries into the table: {e}")
                 raise
 
-    def query_entries(self, model, *, conditions: Optional = None) -> MutableSequence[Base]:  # type: ignore
+    def query_entries(self, model, *, conditions: Optional = None) -> list[Base]:  # type: ignore
         """
         Fetches data from the specified table model with optional conditions.
 

--- a/pyrit/memory/duckdb_memory.py
+++ b/pyrit/memory/duckdb_memory.py
@@ -269,7 +269,7 @@ class DuckDBMemory(MemoryInterface, metaclass=Singleton):
                 query = session.query(model)
                 if conditions is not None:
                     query = query.filter(conditions)
-                return query.all()  # TODO: use generics to make types work
+                return query.all()
             except SQLAlchemyError as e:
                 logger.exception(f"Error fetching data from table {model.__tablename__}: {e}")
 

--- a/pyrit/memory/memory_interface.py
+++ b/pyrit/memory/memory_interface.py
@@ -65,7 +65,7 @@ class MemoryInterface(abc.ABC):
             conversation_id (str): The conversation ID to match.
 
         Returns:
-            list[PromptRequestPiece]: A list of chat memory entries with the specified conversation ID.
+            MutableSequence[PromptRequestPiece]: A list of chat memory entries with the specified conversation ID.
         """
 
     @abc.abstractmethod
@@ -78,7 +78,7 @@ class MemoryInterface(abc.ABC):
                 Can be retrieved by calling orchestrator.get_identifier()["id"]
 
         Returns:
-            list[PromptRequestPiece]: A list of PromptMemoryEntry objects matching the specified orchestrator ID.
+            Sequence[PromptRequestPiece]: A list of PromptMemoryEntry objects matching the specified orchestrator ID.
         """
 
     @abc.abstractmethod
@@ -113,9 +113,9 @@ class MemoryInterface(abc.ABC):
             conversation_id (str): The conversation ID to match.
 
         Returns:
-            list[PromptRequestResponse]: A list of chat memory entries with the specified conversation ID.
+            MutableSequence[PromptRequestResponse]: A list of chat memory entries with the specified conversation ID.
         """
-        request_pieces: Sequence = self._get_prompt_pieces_with_conversation_id(conversation_id=conversation_id)
+        request_pieces = self._get_prompt_pieces_with_conversation_id(conversation_id=conversation_id)
         return group_conversation_request_pieces_by_sequence(request_pieces=request_pieces)
 
     @abc.abstractmethod
@@ -127,7 +127,7 @@ class MemoryInterface(abc.ABC):
             prompt_ids (list[int]): The prompt IDs to match.
 
         Returns:
-            list[PromptRequestPiece]: A list of PromptRequestPiece with the specified conversation ID.
+            Sequence[PromptRequestPiece]: A list of PromptRequestPiece with the specified conversation ID.
         """
 
     def get_prompt_request_piece_by_orchestrator_id(self, *, orchestrator_id: int) -> list[PromptRequestPiece]:

--- a/pyrit/memory/memory_interface.py
+++ b/pyrit/memory/memory_interface.py
@@ -4,7 +4,7 @@
 import abc
 from pathlib import Path
 
-from typing import Optional
+from typing import MutableSequence, Optional, Sequence
 from uuid import uuid4
 
 from pyrit.common.path import RESULTS_PATH
@@ -45,19 +45,19 @@ class MemoryInterface(abc.ABC):
         self.memory_embedding = None
 
     @abc.abstractmethod
-    def get_all_prompt_pieces(self) -> list[PromptRequestPiece]:
+    def get_all_prompt_pieces(self) -> Sequence[PromptRequestPiece]:
         """
         Loads all ConversationData from the memory storage handler.
         """
 
     @abc.abstractmethod
-    def get_all_embeddings(self) -> list[EmbeddingData]:
+    def get_all_embeddings(self) -> Sequence[EmbeddingData]:
         """
         Loads all EmbeddingData from the memory storage handler.
         """
 
     @abc.abstractmethod
-    def _get_prompt_pieces_with_conversation_id(self, *, conversation_id: str) -> list[PromptRequestPiece]:
+    def _get_prompt_pieces_with_conversation_id(self, *, conversation_id: str) -> MutableSequence[PromptRequestPiece]:
         """
         Retrieves a list of PromptRequestPiece objects that have the specified conversation ID.
 
@@ -69,7 +69,7 @@ class MemoryInterface(abc.ABC):
         """
 
     @abc.abstractmethod
-    def _get_prompt_pieces_by_orchestrator(self, *, orchestrator_id: int) -> list[PromptRequestPiece]:
+    def _get_prompt_pieces_by_orchestrator(self, *, orchestrator_id: int) -> Sequence[PromptRequestPiece]:
         """
         Retrieves a list of PromptRequestPiece objects that have the specified orchestrator ID.
 
@@ -82,7 +82,7 @@ class MemoryInterface(abc.ABC):
         """
 
     @abc.abstractmethod
-    def add_request_pieces_to_memory(self, *, request_pieces: list[PromptRequestPiece]) -> None:
+    def add_request_pieces_to_memory(self, *, request_pieces: Sequence[PromptRequestPiece]) -> None:
         """
         Inserts a list of prompt request pieces into the memory storage.
         """
@@ -105,7 +105,7 @@ class MemoryInterface(abc.ABC):
         Gets a list of scores based on prompt_request_response_ids.
         """
 
-    def get_conversation(self, *, conversation_id: str) -> list[PromptRequestResponse]:
+    def get_conversation(self, *, conversation_id: str) -> MutableSequence[PromptRequestResponse]:
         """
         Retrieves a list of PromptRequestResponse objects that have the specified conversation ID.
 
@@ -115,11 +115,11 @@ class MemoryInterface(abc.ABC):
         Returns:
             list[PromptRequestResponse]: A list of chat memory entries with the specified conversation ID.
         """
-        request_pieces = self._get_prompt_pieces_with_conversation_id(conversation_id=conversation_id)
+        request_pieces: Sequence = self._get_prompt_pieces_with_conversation_id(conversation_id=conversation_id)
         return group_conversation_request_pieces_by_sequence(request_pieces=request_pieces)
 
     @abc.abstractmethod
-    def get_prompt_request_pieces_by_id(self, *, prompt_ids: list[str]) -> list[PromptRequestPiece]:
+    def get_prompt_request_pieces_by_id(self, *, prompt_ids: list[str]) -> Sequence[PromptRequestPiece]:
         """
         Retrieves a list of PromptRequestPiece objects that have the specified prompt ids.
 

--- a/pyrit/models/prompt_request_response.py
+++ b/pyrit/models/prompt_request_response.py
@@ -59,12 +59,12 @@ def group_conversation_request_pieces_by_sequence(
     This is done using the sequence number and conversation ID.
 
     Args:
-        request_pieces (list[PromptRequestPiece]): A list of PromptRequestPiece objects representing individual
+        request_pieces (Sequence[PromptRequestPiece]): A list of PromptRequestPiece objects representing individual
             request pieces.
 
     Returns:
-        list[PromptRequestResponse]: A list of PromptRequestResponse objects representing grouped request pieces.
-            this is ordered by the sequence number
+        MutableSequence[PromptRequestResponse]: A list of PromptRequestResponse objects representing grouped request
+            pieces. This is ordered by the sequence number
 
     Raises:
         ValueError: If the conversation ID of any request piece does not match the conversation ID of the first

--- a/pyrit/models/prompt_request_response.py
+++ b/pyrit/models/prompt_request_response.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from typing import Optional
+from typing import MutableSequence, Optional, Sequence
 
 from pyrit.models import PromptRequestPiece
 from pyrit.models.literals import PromptDataType, PromptResponseError
@@ -51,8 +51,8 @@ class PromptRequestResponse:
 
 
 def group_conversation_request_pieces_by_sequence(
-    request_pieces: list[PromptRequestPiece],
-) -> list[PromptRequestResponse]:
+    request_pieces: Sequence[PromptRequestPiece],
+) -> MutableSequence[PromptRequestResponse]:
     """
     Groups prompt request pieces from the same conversation into PromptRequestResponses.
 

--- a/pyrit/orchestrator/orchestrator_class.py
+++ b/pyrit/orchestrator/orchestrator_class.py
@@ -45,7 +45,7 @@ class Orchestrator(abc.ABC, Identifier):
 
     def dispose_db_engine(self) -> None:
         """
-        Dispose DuckDB database engine to release database connections and resources.
+        Dispose database engine to release database connections and resources.
         """
         self._memory.dispose_engine()
 

--- a/pyrit/orchestrator/scoring_orchestrator.py
+++ b/pyrit/orchestrator/scoring_orchestrator.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import logging
+from typing import Sequence
 
 from pyrit.memory import MemoryInterface
 from pyrit.models.prompt_request_piece import PromptRequestPiece
@@ -60,7 +61,7 @@ class ScoringOrchestrator(Orchestrator):
         Scores prompts using the Scorer for prompts with the prompt_ids
         """
 
-        requests: list[PromptRequestPiece] = []
+        requests: Sequence[PromptRequestPiece] = []
         requests = self._memory.get_prompt_request_pieces_by_id(prompt_ids=prompt_ids)
 
         return await self._score_prompts_batch_async(prompts=requests, scorer=scorer)
@@ -71,7 +72,7 @@ class ScoringOrchestrator(Orchestrator):
         """
         return [response for response in request_responses if response.role == "assistant"]
 
-    async def _score_prompts_batch_async(self, prompts: list[PromptRequestPiece], scorer: Scorer) -> list[Score]:
+    async def _score_prompts_batch_async(self, prompts: Sequence[PromptRequestPiece], scorer: Scorer) -> list[Score]:
         results = []
 
         for prompts_batch in self._chunked_prompts(prompts, self._batch_size):

--- a/pyrit/prompt_target/prompt_chat_target/azure_openai_gptv_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/azure_openai_gptv_chat_target.py
@@ -3,6 +3,7 @@
 
 import logging
 import json
+from typing import MutableSequence
 
 from openai import AsyncAzureOpenAI
 from openai import BadRequestError
@@ -190,7 +191,9 @@ class AzureOpenAIGPTVChatTarget(PromptChatTarget):
         # https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/gpt-with-vision?tabs=rest%2Csystem-assigned%2Cresource#use-a-local-image
         return f"data:{mime_type};base64,{base64_encoded_data}"
 
-    def _build_chat_messages(self, prompt_req_res_entries: list[PromptRequestResponse]) -> list[ChatMessageListContent]:
+    def _build_chat_messages(
+        self, prompt_req_res_entries: MutableSequence[PromptRequestResponse]
+    ) -> list[ChatMessageListContent]:
         """
         Builds chat messages based on prompt request response entries.
 


### PR DESCRIPTION
## Description

Previously, `# mypy: ignore-errors` was present at the module level in `pyrit.memory.memory_models`. In order to have better code safety, we want to remove this line and add proper type-checking. This commit adds in much more type checking, with only a few uses of `# type: ignore`. In some cases, those are necessary, though a few can likely be mitigated with the use of generics, particularly in `pyrit.memory.duckdb_memory` and `pyrit.memory.azure_sql_memory`. 

CC: @rdheekonda @rdheekonda @romanlutz 
