### PR TITLE
[DRAFT] [FIX] Replace Orchestrator ID with UUID

### DIFF
--- a/pyrit/memory/azure_sql_memory.py
+++ b/pyrit/memory/azure_sql_memory.py
@@ -78,7 +78,7 @@ class AzureSQLMemory(MemoryInterface, metaclass=Singleton):
         """
         self._insert_entries(entries=embedding_data)
 
-    def _get_prompt_pieces_by_orchestrator(self, *, orchestrator_id: int) -> list[PromptRequestPiece]:
+    def _get_prompt_pieces_by_orchestrator(self, *, orchestrator_id: str) -> list[PromptRequestPiece]:
         """
         Retrieves a list of PromptRequestPiece objects that have the specified orchestrator ID.
 
@@ -94,7 +94,7 @@ class AzureSQLMemory(MemoryInterface, metaclass=Singleton):
                 PromptMemoryEntry,
                 conditions=and_(
                     func.ISJSON(PromptMemoryEntry.orchestrator_identifier) > 0,
-                    func.JSON_VALUE(PromptMemoryEntry.orchestrator_identifier, "$.id") == str(orchestrator_id),
+                    func.JSON_VALUE(PromptMemoryEntry.orchestrator_identifier, "$.id") == orchestrator_id,
                 ),
             )  # type: ignore
         except Exception as e:

--- a/pyrit/memory/duckdb_memory.py
+++ b/pyrit/memory/duckdb_memory.py
@@ -135,7 +135,7 @@ class DuckDBMemory(MemoryInterface, metaclass=Singleton):
             )
             return []
 
-    def _get_prompt_pieces_by_orchestrator(self, *, orchestrator_id: int) -> list[PromptRequestPiece]:
+    def _get_prompt_pieces_by_orchestrator(self, *, orchestrator_id: str) -> list[PromptRequestPiece]:
         """
         Retrieves a list of PromptRequestPiece objects that have the specified orchestrator ID.
 
@@ -149,7 +149,7 @@ class DuckDBMemory(MemoryInterface, metaclass=Singleton):
         try:
             result: list[PromptRequestPiece] = self.query_entries(
                 PromptMemoryEntry,
-                conditions=PromptMemoryEntry.orchestrator_identifier.op("->>")("id") == str(orchestrator_id),
+                conditions=PromptMemoryEntry.orchestrator_identifier.op("->>")("id") == orchestrator_id,
             )  # type: ignore
             return result
         except Exception as e:

--- a/pyrit/memory/memory_interface.py
+++ b/pyrit/memory/memory_interface.py
@@ -69,7 +69,7 @@ class MemoryInterface(abc.ABC):
         """
 
     @abc.abstractmethod
-    def _get_prompt_pieces_by_orchestrator(self, *, orchestrator_id: int) -> Sequence[PromptRequestPiece]:
+    def _get_prompt_pieces_by_orchestrator(self, *, orchestrator_id: str) -> Sequence[PromptRequestPiece]:
         """
         Retrieves a list of PromptRequestPiece objects that have the specified orchestrator ID.
 
@@ -105,7 +105,7 @@ class MemoryInterface(abc.ABC):
         Gets a list of scores based on prompt_request_response_ids.
         """
 
-    def get_scores_by_orchestrator_id(self, *, orchestrator_id: int) -> list[Score]:
+    def get_scores_by_orchestrator_id(self, *, orchestrator_id: str) -> list[Score]:
         """
         Retrieves a list of Score objects associated with the PromptRequestPiece objects
         which have the specified orchestrator ID.
@@ -147,12 +147,12 @@ class MemoryInterface(abc.ABC):
             Sequence[PromptRequestPiece]: A list of PromptRequestPiece with the specified conversation ID.
         """
 
-    def get_prompt_request_piece_by_orchestrator_id(self, *, orchestrator_id: int) -> list[PromptRequestPiece]:
+    def get_prompt_request_piece_by_orchestrator_id(self, *, orchestrator_id: str) -> list[PromptRequestPiece]:
         """
         Retrieves a list of PromptRequestPiece objects that have the specified orchestrator ID.
 
         Args:
-            orchestrator_id (int): The orchestrator ID to match.
+            orchestrator_id (str): The orchestrator ID to match.
 
         Returns:
             list[PromptRequestPiece]: A list of PromptRequestPiece with the specified conversation ID.
@@ -161,7 +161,7 @@ class MemoryInterface(abc.ABC):
         prompt_pieces = self._get_prompt_pieces_by_orchestrator(orchestrator_id=orchestrator_id)
         return sorted(prompt_pieces, key=lambda x: (x.conversation_id, x.timestamp))
 
-    def get_prompt_ids_by_orchestrator(self, *, orchestrator_id: int) -> list[str]:
+    def get_prompt_ids_by_orchestrator(self, *, orchestrator_id: str) -> list[str]:
         prompt_pieces = self._get_prompt_pieces_by_orchestrator(orchestrator_id=orchestrator_id)
 
         prompt_ids = []
@@ -204,7 +204,7 @@ class MemoryInterface(abc.ABC):
         self.add_request_pieces_to_memory(request_pieces=prompt_pieces)
 
     def export_conversation_by_orchestrator_id(
-        self, *, orchestrator_id: int, file_path: Path = None, export_type: str = "json"
+        self, *, orchestrator_id: str, file_path: Path = None, export_type: str = "json"
     ):
         """
         Exports conversation data with the given orchestrator ID to a specified file.

--- a/pyrit/orchestrator/orchestrator_class.py
+++ b/pyrit/orchestrator/orchestrator_class.py
@@ -30,6 +30,7 @@ class Orchestrator(abc.ABC, Identifier):
         self._prompt_converters = prompt_converters if prompt_converters else []
         self._memory = memory or DuckDBMemory()
         self._verbose = verbose
+        self._id = uuid.uuid4()
 
         self._global_memory_labels = memory_labels if memory_labels else {}
 
@@ -71,18 +72,18 @@ class Orchestrator(abc.ABC, Identifier):
         """
         Retrieves the memory associated with this orchestrator.
         """
-        return self._memory.get_prompt_request_piece_by_orchestrator_id(orchestrator_id=id(self))
+        return self._memory.get_prompt_request_piece_by_orchestrator_id(orchestrator_id=self._id)
 
     def get_score_memory(self):
         """
         Retrieves the scores of the PromptRequestPieces associated with this orchestrator.
         These exist if a scorer is provided to the orchestrator.
         """
-        return self._memory.get_scores_by_orchestrator_id(orchestrator_id=id(self))
+        return self._memory.get_scores_by_orchestrator_id(orchestrator_id=self._id)
 
     def get_identifier(self) -> dict[str, str]:
         orchestrator_dict = {}
         orchestrator_dict["__type__"] = self.__class__.__name__
         orchestrator_dict["__module__"] = self.__class__.__module__
-        orchestrator_dict["id"] = str(uuid.uuid4())
+        orchestrator_dict["id"] = str(self._id)
         return orchestrator_dict

--- a/pyrit/orchestrator/orchestrator_class.py
+++ b/pyrit/orchestrator/orchestrator_class.py
@@ -3,6 +3,7 @@
 
 import abc
 import logging
+import uuid
 
 from typing import Optional
 
@@ -83,5 +84,5 @@ class Orchestrator(abc.ABC, Identifier):
         orchestrator_dict = {}
         orchestrator_dict["__type__"] = self.__class__.__name__
         orchestrator_dict["__module__"] = self.__class__.__module__
-        orchestrator_dict["id"] = str(id(self))
+        orchestrator_dict["id"] = str(uuid.uuid4())
         return orchestrator_dict

--- a/pyrit/orchestrator/scoring_orchestrator.py
+++ b/pyrit/orchestrator/scoring_orchestrator.py
@@ -40,7 +40,7 @@ class ScoringOrchestrator(Orchestrator):
         self,
         *,
         scorer: Scorer,
-        orchestrator_ids: list[int],
+        orchestrator_ids: list[str],
         responses_only: bool = True,
     ) -> list[Score]:
         """
@@ -49,7 +49,7 @@ class ScoringOrchestrator(Orchestrator):
 
         request_pieces: list[PromptRequestPiece] = []
         for id in orchestrator_ids:
-            request_pieces.extend(self._memory.get_prompt_request_piece_by_orchestrator_id(orchestrator_id=int(id)))
+            request_pieces.extend(self._memory.get_prompt_request_piece_by_orchestrator_id(orchestrator_id=id))
 
         if responses_only:
             request_pieces = self._extract_responses_only(request_pieces)

--- a/tests/memory/test_azure_sql_memory.py
+++ b/tests/memory/test_azure_sql_memory.py
@@ -260,7 +260,7 @@ def test_get_memories_with_orchestrator_id(memory_interface: AzureSQLMemory):
         ),
     ]
 
-    orchestrator1_id = int(orchestrator1.get_identifier()["id"])
+    orchestrator1_id = orchestrator1.get_identifier()["id"]
 
     session_mock = UnifiedAlchemyMagicMock(
         data=[
@@ -270,7 +270,7 @@ def test_get_memories_with_orchestrator_id(memory_interface: AzureSQLMemory):
                     mock.call.filter(
                         and_(
                             func.ISJSON(PromptMemoryEntry.orchestrator_identifier) > 0,
-                            func.JSON_VALUE(PromptMemoryEntry.orchestrator_identifier, "$.id") == str(orchestrator1_id),
+                            func.JSON_VALUE(PromptMemoryEntry.orchestrator_identifier, "$.id") == orchestrator1_id,
                         )
                     ),
                 ],

--- a/tests/memory/test_duckdb_memory.py
+++ b/tests/memory/test_duckdb_memory.py
@@ -425,7 +425,7 @@ def test_get_memories_with_orchestrator_id(memory_interface: DuckDBMemory):
 
     memory_interface._insert_entries(entries=entries)
 
-    orchestrator1_id = int(orchestrator1.get_identifier()["id"])
+    orchestrator1_id = orchestrator1.get_identifier()["id"]
 
     # Use the get_memories_with_normalizer_id method to retrieve entries with the specific normalizer_id
     retrieved_entries = memory_interface.get_prompt_request_piece_by_orchestrator_id(orchestrator_id=orchestrator1_id)
@@ -433,7 +433,7 @@ def test_get_memories_with_orchestrator_id(memory_interface: DuckDBMemory):
     # Verify that the retrieved entries match the expected normalizer_id
     assert len(retrieved_entries) == 2  # Two entries should have the specific normalizer_id
     for retrieved_entry in retrieved_entries:
-        assert retrieved_entry.orchestrator_identifier["id"] == str(orchestrator1_id)
+        assert retrieved_entry.orchestrator_identifier["id"] == orchestrator1_id
         assert "Hello" in retrieved_entry.original_value  # Basic check to ensure content is as expected
 
 

--- a/tests/memory/test_memory_interface.py
+++ b/tests/memory/test_memory_interface.py
@@ -294,7 +294,7 @@ def test_get_orchestrator_conversation_sorting(memory: MemoryInterface, sample_c
     with patch("pyrit.memory.duckdb_memory.DuckDBMemory._get_prompt_pieces_by_orchestrator") as mock_get:
 
         mock_get.return_value = sample_conversations
-        orchestrator_id = int(sample_conversations[0].orchestrator_identifier["id"])
+        orchestrator_id = sample_conversations[0].orchestrator_identifier["id"]
 
         response = memory.get_prompt_request_piece_by_orchestrator_id(orchestrator_id=orchestrator_id)
 
@@ -312,14 +312,14 @@ def test_export_conversation_by_orchestrator_id_file_created(
     orchestrator1_id = sample_conversation_entries[0].get_prompt_request_piece().orchestrator_identifier["id"]
 
     # Default path in export_conversation_by_orchestrator_id()
-    file_name = f"{str(orchestrator1_id)}.json"
+    file_name = f"{orchestrator1_id}.json"
     file_path = Path(RESULTS_PATH, file_name)
 
     memory.exporter = MemoryExporter()
 
     with patch("pyrit.memory.duckdb_memory.DuckDBMemory._get_prompt_pieces_by_orchestrator") as mock_get:
         mock_get.return_value = sample_conversation_entries
-        memory.export_conversation_by_orchestrator_id(orchestrator_id=int(orchestrator1_id))
+        memory.export_conversation_by_orchestrator_id(orchestrator_id=orchestrator1_id)
 
         # Verify file was created
         assert file_path.exists()
@@ -334,7 +334,7 @@ def test_get_prompt_ids_by_orchestrator(memory: MemoryInterface, sample_conversa
 
     with patch("pyrit.memory.duckdb_memory.DuckDBMemory._get_prompt_pieces_by_orchestrator") as mock_get:
         mock_get.return_value = sample_conversation_entries
-        prompt_ids = memory.get_prompt_ids_by_orchestrator(orchestrator_id=int(orchestrator1_id))
+        prompt_ids = memory.get_prompt_ids_by_orchestrator(orchestrator_id=orchestrator1_id)
 
         assert sample_conversation_ids == prompt_ids
 
@@ -362,7 +362,7 @@ def test_get_scores_by_orchestrator_id(memory: MemoryInterface, sample_conversat
 
     # Fetch the score we just added
     db_score = memory.get_scores_by_orchestrator_id(
-        orchestrator_id=int(sample_conversations[0].orchestrator_identifier["id"])
+        orchestrator_id=sample_conversations[0].orchestrator_identifier["id"]
     )
 
     assert len(db_score) == 1

--- a/tests/orchestrator/test_prompt_orchestrator.py
+++ b/tests/orchestrator/test_prompt_orchestrator.py
@@ -225,10 +225,7 @@ def test_orchestrator_unique_id(orchestrator_count: int):
         if id in orchestrator_ids:
             duplicate_found = True
             break
-        
+
         orchestrator_ids.append(id)
 
     assert not duplicate_found
-
-
-

--- a/tests/orchestrator/test_prompt_orchestrator.py
+++ b/tests/orchestrator/test_prompt_orchestrator.py
@@ -213,3 +213,22 @@ async def test_orchestrator_get_score_memory(mock_target: MockPromptTarget):
     scores = orchestrator.get_score_memory()
     assert len(scores) == 1
     assert scores[0].prompt_request_response_id == request.id
+
+
+@pytest.mark.parametrize("orchestrator_count", [10, 100])
+def test_orchestrator_unique_id(orchestrator_count: int):
+    orchestrator_ids = []
+    duplicate_found = False
+    for n in range(orchestrator_count):
+        id = PromptSendingOrchestrator(prompt_target=MagicMock()).get_identifier()["id"]
+
+        if id in orchestrator_ids:
+            duplicate_found = True
+            break
+        
+        orchestrator_ids.append(id)
+
+    assert not duplicate_found
+
+
+

--- a/tests/orchestrator/test_prompt_orchestrator.py
+++ b/tests/orchestrator/test_prompt_orchestrator.py
@@ -217,7 +217,7 @@ async def test_orchestrator_get_score_memory(mock_target: MockPromptTarget):
 
 @pytest.mark.parametrize("orchestrator_count", [10, 100])
 def test_orchestrator_unique_id(orchestrator_count: int):
-    orchestrator_ids = []
+    orchestrator_ids = set()
     duplicate_found = False
     for n in range(orchestrator_count):
         id = PromptSendingOrchestrator(prompt_target=MagicMock()).get_identifier()["id"]
@@ -226,6 +226,6 @@ def test_orchestrator_unique_id(orchestrator_count: int):
             duplicate_found = True
             break
 
-        orchestrator_ids.append(id)
+        orchestrator_ids.add(id)
 
     assert not duplicate_found

--- a/tests/orchestrator/test_scoring_orchestrator.py
+++ b/tests/orchestrator/test_scoring_orchestrator.py
@@ -3,6 +3,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
+import uuid
 
 from pyrit.models.prompt_request_piece import PromptRequestPiece
 from pyrit.orchestrator.scoring_orchestrator import ScoringOrchestrator
@@ -39,7 +40,9 @@ async def test_score_prompts_by_orchestrator_only_responses(sample_conversations
     orchestrator = ScoringOrchestrator(memory=memory)
 
     with patch.object(orchestrator, "_score_prompts_batch_async", new_callable=AsyncMock) as mock_score:
-        await orchestrator.score_prompts_by_orchestrator_id_async(scorer=MagicMock(), orchestrator_ids=[123])
+        await orchestrator.score_prompts_by_orchestrator_id_async(
+            scorer=MagicMock(), orchestrator_ids=[str(uuid.uuid4())]
+        )
 
         mock_score.assert_called_once()
         _, called_kwargs = mock_score.call_args
@@ -57,7 +60,7 @@ async def test_score_prompts_by_orchestrator_includes_requests(sample_conversati
 
     with patch.object(orchestrator, "_score_prompts_batch_async", new_callable=AsyncMock) as mock_score:
         await orchestrator.score_prompts_by_orchestrator_id_async(
-            scorer=MagicMock(), orchestrator_ids=[123], responses_only=False
+            scorer=MagicMock(), orchestrator_ids=[str(uuid.uuid4())], responses_only=False
         )
 
         mock_score.assert_called_once()


### PR DESCRIPTION
<!--- Please add one of the following as a prefix to the pull request title: -->
<!--- DOC for documentation changes -->
<!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
<!--- FIX for bug fixes -->
<!--- TEST for adding tests -->
<!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
<!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->
It was discovered that `id()` sometimes would assign orchestrators a non-unique ID. This PR leverages the `uuid.uuid4()` func as the orchestrator instead.

<!--- If you are considering making a contribution please open an issue first. -->
<!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
<!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->


## Tests and Documentation

<!--- Contributions require tests and documentation (if applicable). -->
<!--- Include a description of tests and documentation updated (if applicable) -->
Unit test added to ensure that ids are unique.

<!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
<!--- Include how you/if ran JupyText here -->
<!--- This is described at: https://github.com/Azure/PyRIT/tree/main/doc  -->
