### PR TITLE
FEAT: Add GPT4-o chat target

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -18,6 +18,12 @@ AZURE_OPENAI_GPTV_CHAT_ENDPOINT="https://endpoint.openai.azure.com/"
 AZURE_OPENAI_GPTV_CHAT_KEY="<Provide Azure OpenAI key here>"
 AZURE_OPENAI_GPTV_CHAT_DEPLOYMENT="<Provide Azure OpenAI GPT-V chat deployment name here>"
 
+# To get credentials of GPT4-o deployment go to
+# ms.portal.azure.com > Cognitive Services > Azure OpenAI > Keys and Endpoint
+AZURE_OPENAI_GPT4O_CHAT_ENDPOINT="https://lion-prod-completion.openai.azure.com/"
+AZURE_OPENAI_GPT4O_CHAT_KEY="<Provide Azure OpenAI key here>"
+AZURE_OPENAI_GPT4O_CHAT_DEPLOYMENT="<Provide Azure OpenAI GPT4-o chat deployment name here>"
+
 # To get credentials go to
 # ms.portal.azure.com > Cognitive Services > Azure OpenAI > Keys and Endpoint
 AZURE_OPENAI_COMPLETION_ENDPOINT="https://completionendpoint.openai.azure.com/"

--- a/doc/code/targets/gpt_4o_target.ipynb
+++ b/doc/code/targets/gpt_4o_target.ipynb
@@ -1,0 +1,371 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "84ee13da",
+   "metadata": {},
+   "source": [
+    "## Azure OpenAI GPT4-o Target Demo\n",
+    "This notebook demonstrates how to use the Azure OpenAI GPT4-o target to accept multimodal input (text+image) and generate text output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "83a4b9b2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-26T03:47:40.839505Z",
+     "iopub.status.busy": "2024-07-26T03:47:40.839505Z",
+     "iopub.status.idle": "2024-07-26T03:47:44.098303Z",
+     "shell.execute_reply": "2024-07-26T03:47:44.098303Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Copyright (c) Microsoft Corporation.\n",
+    "# Licensed under the MIT license.\n",
+    "\n",
+    "\n",
+    "from pyrit.models import PromptRequestPiece, PromptRequestResponse\n",
+    "from pyrit.prompt_target import AzureOpenAIGPT4OChatTarget\n",
+    "from pyrit.common import default_values\n",
+    "import pathlib\n",
+    "from pyrit.common.path import HOME_PATH\n",
+    "import uuid\n",
+    "\n",
+    "default_values.load_default_env()\n",
+    "test_conversation_id = str(uuid.uuid4())\n",
+    "\n",
+    "# use the image from our docs\n",
+    "image_path = pathlib.Path(HOME_PATH) / \"assets\" / \"pyrit_architecture.png\"\n",
+    "\n",
+    "request_pieces = [\n",
+    "    PromptRequestPiece(\n",
+    "        role=\"user\",\n",
+    "        conversation_id=test_conversation_id,\n",
+    "        original_value=\"Describe this picture:\",\n",
+    "        original_value_data_type=\"text\",\n",
+    "        converted_value_data_type=\"text\",\n",
+    "    ),\n",
+    "    PromptRequestPiece(\n",
+    "        role=\"user\",\n",
+    "        conversation_id=test_conversation_id,\n",
+    "        original_value=str(image_path),\n",
+    "        original_value_data_type=\"image_path\",\n",
+    "        converted_value_data_type=\"image_path\",\n",
+    "    ),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "63359a90",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-26T03:47:44.098303Z",
+     "iopub.status.busy": "2024-07-26T03:47:44.098303Z",
+     "iopub.status.idle": "2024-07-26T03:47:44.106634Z",
+     "shell.execute_reply": "2024-07-26T03:47:44.106634Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "prompt_request_response = PromptRequestResponse(request_pieces=request_pieces)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ad937ed3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-26T03:47:44.111638Z",
+     "iopub.status.busy": "2024-07-26T03:47:44.106634Z",
+     "iopub.status.idle": "2024-07-26T03:47:48.006250Z",
+     "shell.execute_reply": "2024-07-26T03:47:48.005100Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None: assistant: The image is a structured chart detailing the components of PyRIT with two primary columns: \"Interface\" and \"Implementation.\"\n",
+      "\n",
+      "- **Target**:\n",
+      "  - Local: local model (e.g., ONNX)\n",
+      "  - Remote: API or web app\n",
+      "\n",
+      "- **Datasets**:\n",
+      "  - Static: Prompts\n",
+      "  - Dynamic: Prompt templates\n",
+      "\n",
+      "- **Scoring Engine**:\n",
+      "  - PyRIT Itself: Self Evaluation\n",
+      "  - API: Existing content classifiers\n",
+      "\n",
+      "- **Attack Strategy**:\n",
+      "  - Single Turn: Using static prompts\n",
+      "  - Multi Turn: Multiple conversations using prompt templates\n",
+      "\n",
+      "- **Memory**:\n",
+      "  - Storage: JSON, Database\n",
+      "  - Utils: Conversation, retrieval and storage, memory sharing, data analysis\n"
+     ]
+    }
+   ],
+   "source": [
+    "with AzureOpenAIGPT4OChatTarget() as azure_openai_chat_target:\n",
+    "    resp = await azure_openai_chat_target.send_prompt_async(prompt_request=prompt_request_response)  # type: ignore\n",
+    "    print(resp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a799e04",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0901b69c",
+   "metadata": {},
+   "source": [
+    "## Multimodal Demo using AzureOpenAIGPT4OChatTarget and PromptSendingOrchestrator\n",
+    "This demo showcases the capabilities of AzureOpenAIGPT4OChatTarget for generating text based on multimodal inputs, including both text and images using PromptSendingOrchestrator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "91518dfd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-26T03:47:48.006704Z",
+     "iopub.status.busy": "2024-07-26T03:47:48.006704Z",
+     "iopub.status.idle": "2024-07-26T03:47:48.552887Z",
+     "shell.execute_reply": "2024-07-26T03:47:48.552887Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from pyrit.common import default_values\n",
+    "import pathlib\n",
+    "from pyrit.common.path import HOME_PATH\n",
+    "\n",
+    "from pyrit.prompt_target import AzureOpenAIGPT4OChatTarget\n",
+    "from pyrit.prompt_normalizer.normalizer_request import NormalizerRequestPiece\n",
+    "from pyrit.prompt_normalizer.normalizer_request import NormalizerRequest\n",
+    "from pyrit.orchestrator import PromptSendingOrchestrator\n",
+    "\n",
+    "default_values.load_default_env()\n",
+    "\n",
+    "azure_openai_gpt4o_chat_target = AzureOpenAIGPT4OChatTarget()\n",
+    "\n",
+    "image_path = pathlib.Path(HOME_PATH) / \"assets\" / \"pyrit_architecture.png\"\n",
+    "data = [\n",
+    "    [\n",
+    "        {\"prompt_text\": \"Describe this picture:\", \"prompt_data_type\": \"text\"},\n",
+    "        {\"prompt_text\": str(image_path), \"prompt_data_type\": \"image_path\"},\n",
+    "    ],\n",
+    "    [{\"prompt_text\": \"Tell me about something?\", \"prompt_data_type\": \"text\"}],\n",
+    "    [{\"prompt_text\": str(image_path), \"prompt_data_type\": \"image_path\"}],\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd35816c",
+   "metadata": {},
+   "source": [
+    "Construct list of NormalizerRequest objects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ab70dc73",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-26T03:47:48.552887Z",
+     "iopub.status.busy": "2024-07-26T03:47:48.552887Z",
+     "iopub.status.idle": "2024-07-26T03:47:48.561971Z",
+     "shell.execute_reply": "2024-07-26T03:47:48.561971Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "normalizer_requests = []\n",
+    "\n",
+    "for piece_data in data:\n",
+    "    request_pieces = []\n",
+    "\n",
+    "    for item in piece_data:\n",
+    "        prompt_text = item.get(\"prompt_text\", \"\")  # type: ignore\n",
+    "        prompt_data_type = item.get(\"prompt_data_type\", \"\")\n",
+    "        converters = []  # type: ignore\n",
+    "        request_piece = NormalizerRequestPiece(\n",
+    "            prompt_value=prompt_text, prompt_data_type=prompt_data_type, request_converters=converters  # type: ignore\n",
+    "        )\n",
+    "        request_pieces.append(request_piece)\n",
+    "\n",
+    "    normalizer_request = NormalizerRequest(request_pieces)\n",
+    "    normalizer_requests.append(normalizer_request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "3c6522f6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-26T03:47:48.561971Z",
+     "iopub.status.busy": "2024-07-26T03:47:48.561971Z",
+     "iopub.status.idle": "2024-07-26T03:47:48.573397Z",
+     "shell.execute_reply": "2024-07-26T03:47:48.573397Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(normalizer_requests)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "14579342",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-26T03:47:48.573397Z",
+     "iopub.status.busy": "2024-07-26T03:47:48.573397Z",
+     "iopub.status.idle": "2024-07-26T03:47:53.969405Z",
+     "shell.execute_reply": "2024-07-26T03:47:53.969405Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AzureOpenAIGPT4OChatTarget: user: E:\\OSS_Tools\\PyRIT-internal\\PyRIT\\assets\\pyrit_architecture.png\n",
+      "AzureOpenAIGPT4OChatTarget: assistant: The image provides a detailed breakdown of the components of PyRIT, an AI-based system. Here is a summary of each component and its implementation:\n",
+      "\n",
+      "### Interface: \n",
+      "#### Target\n",
+      "- **Local:** local model (e.g., ONNX)\n",
+      "- **Remote:** API or web app\n",
+      "\n",
+      "### Datasets\n",
+      "- **Static:** prompts\n",
+      "- **Dynamic:** Prompt templates\n",
+      "\n",
+      "### Scoring Engine\n",
+      "- **PyRIT Itself:** Self Evaluation\n",
+      "- **API:** Existing content classifiers\n",
+      "\n",
+      "### Attack Strategy\n",
+      "- **Single Turn:** Using static prompts\n",
+      "- **Multi Turn:** Multiple conversations using prompt templates\n",
+      "\n",
+      "### Memory\n",
+      "- **Storage:** JSON, Database\n",
+      "- **Utils:** Conversation, retrieval and storage, memory sharing, data analysis\n",
+      "\n",
+      "Each section defines key functionalities and methods that PyRIT leverages for processing and interaction within its framework.\n",
+      "AzureOpenAIGPT4OChatTarget: user: Tell me about something?\n",
+      "AzureOpenAIGPT4OChatTarget: assistant: Sure, I'd be happy to share information on a topic of interest to you! Is there something specific you're curious about? It could range from science and technology, culture, history, current events, hobbies, or anything else. Just let me know what you're interested in!\n",
+      "AzureOpenAIGPT4OChatTarget: user: Describe this picture:\n",
+      "AzureOpenAIGPT4OChatTarget: user: E:\\OSS_Tools\\PyRIT-internal\\PyRIT\\assets\\pyrit_architecture.png\n",
+      "AzureOpenAIGPT4OChatTarget: assistant: This image is a diagram titled \"PyRIT Components\" and depicts various elements of the PyRIT system organized into two columns under the headings \"Interface\" and \"Implementation.\"\n",
+      "\n",
+      "### Components:\n",
+      "1. **Target**\n",
+      "   - **Local:** Local model (e.g., ONNX)\n",
+      "   - **Remote:** API or web app\n",
+      "2. **Datasets**\n",
+      "   - **Static:** Prompts\n",
+      "   - **Dynamic:** Prompt templates\n",
+      "3. **Scoring Engine**\n",
+      "   - **PyRIT Itself:** Self Evaluation\n",
+      "   - **API:** Existing content classifiers\n",
+      "4. **Attack Strategy**\n",
+      "   - **Single Turn:** Using static prompts\n",
+      "   - **Multi Turn:** Multiple conversations using prompt templates\n",
+      "5. **Memory**\n",
+      "   - **Storage:** JSON, Database\n",
+      "   - **Utils:** Conversation, retrieval and storage, memory sharing, data analysis\n",
+      "\n",
+      "The components are identified in the left column under \"Interface,\" and their corresponding implementations are described on the right side under \"Implementation.\" The sections use different background colors to visually differentiate between them.\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "with PromptSendingOrchestrator(prompt_target=azure_openai_gpt4o_chat_target) as orchestrator:\n",
+    "\n",
+    "    await orchestrator.send_normalizer_requests_async(prompt_request_list=normalizer_requests)  # type: ignore\n",
+    "\n",
+    "    memory = orchestrator.get_memory()\n",
+    "\n",
+    "    for entry in memory:\n",
+    "        print(entry)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db2d43c2",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all"
+  },
+  "kernelspec": {
+   "display_name": "pyrit-dev",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/code/targets/gpt_4o_target.py
+++ b/doc/code/targets/gpt_4o_target.py
@@ -1,0 +1,114 @@
+# %% [markdown]
+# ## Azure OpenAI GPT4-o Target Demo
+# This notebook demonstrates how to use the Azure OpenAI GPT4-o target to accept multimodal input (text+image) and generate text output.
+
+# %%
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+
+from pyrit.models import PromptRequestPiece, PromptRequestResponse
+from pyrit.prompt_target import AzureOpenAIGPT4OChatTarget
+from pyrit.common import default_values
+import pathlib
+from pyrit.common.path import HOME_PATH
+import uuid
+
+default_values.load_default_env()
+test_conversation_id = str(uuid.uuid4())
+
+# use the image from our docs
+image_path = pathlib.Path(HOME_PATH) / "assets" / "pyrit_architecture.png"
+
+request_pieces = [
+    PromptRequestPiece(
+        role="user",
+        conversation_id=test_conversation_id,
+        original_value="Describe this picture:",
+        original_value_data_type="text",
+        converted_value_data_type="text",
+    ),
+    PromptRequestPiece(
+        role="user",
+        conversation_id=test_conversation_id,
+        original_value=str(image_path),
+        original_value_data_type="image_path",
+        converted_value_data_type="image_path",
+    ),
+]
+
+# %%
+prompt_request_response = PromptRequestResponse(request_pieces=request_pieces)
+
+# %%
+with AzureOpenAIGPT4OChatTarget() as azure_openai_chat_target:
+    resp = await azure_openai_chat_target.send_prompt_async(prompt_request=prompt_request_response)  # type: ignore
+    print(resp)
+
+# %%
+
+# %% [markdown]
+# ## Multimodal Demo using AzureOpenAIGPT4OChatTarget and PromptSendingOrchestrator
+# This demo showcases the capabilities of AzureOpenAIGPT4OChatTarget for generating text based on multimodal inputs, including both text and images using PromptSendingOrchestrator.
+
+# %%
+from pyrit.common import default_values
+import pathlib
+from pyrit.common.path import HOME_PATH
+
+from pyrit.prompt_target import AzureOpenAIGPT4OChatTarget
+from pyrit.prompt_normalizer.normalizer_request import NormalizerRequestPiece
+from pyrit.prompt_normalizer.normalizer_request import NormalizerRequest
+from pyrit.orchestrator import PromptSendingOrchestrator
+
+default_values.load_default_env()
+
+azure_openai_gpt4o_chat_target = AzureOpenAIGPT4OChatTarget()
+
+image_path = pathlib.Path(HOME_PATH) / "assets" / "pyrit_architecture.png"
+data = [
+    [
+        {"prompt_text": "Describe this picture:", "prompt_data_type": "text"},
+        {"prompt_text": str(image_path), "prompt_data_type": "image_path"},
+    ],
+    [{"prompt_text": "Tell me about something?", "prompt_data_type": "text"}],
+    [{"prompt_text": str(image_path), "prompt_data_type": "image_path"}],
+]
+
+# %% [markdown]
+# Construct list of NormalizerRequest objects
+
+# %%
+
+normalizer_requests = []
+
+for piece_data in data:
+    request_pieces = []
+
+    for item in piece_data:
+        prompt_text = item.get("prompt_text", "")  # type: ignore
+        prompt_data_type = item.get("prompt_data_type", "")
+        converters = []  # type: ignore
+        request_piece = NormalizerRequestPiece(
+            prompt_value=prompt_text, prompt_data_type=prompt_data_type, request_converters=converters  # type: ignore
+        )
+        request_pieces.append(request_piece)  # type: ignore
+
+    normalizer_request = NormalizerRequest(request_pieces)  # type: ignore
+    normalizer_requests.append(normalizer_request)
+
+# %%
+len(normalizer_requests)
+
+# %%
+
+with PromptSendingOrchestrator(prompt_target=azure_openai_gpt4o_chat_target) as orchestrator:
+
+    await orchestrator.send_normalizer_requests_async(prompt_request_list=normalizer_requests)  # type: ignore
+
+    memory = orchestrator.get_memory()
+
+    for entry in memory:
+        print(entry)
+
+# %%

--- a/pyrit/models/__init__.py
+++ b/pyrit/models/__init__.py
@@ -12,7 +12,7 @@ from pyrit.models.data_type_serializer import (
     ImagePathDataTypeSerializer,
     AudioPathDataTypeSerializer,
 )
-from pyrit.models.chat_message import ChatMessage, ChatMessageListContent
+from pyrit.models.chat_message import ChatMessage, ChatMessageListContent, ChatMessageListDictContent
 from pyrit.models.prompt_request_piece import PromptRequestPiece
 from pyrit.models.prompt_request_response import (
     PromptRequestResponse,
@@ -29,6 +29,7 @@ __all__ = [
     "ChatMessage",
     "ChatMessageRole",
     "ChatMessageListContent",
+    "ChatMessageListDictContent",
     "construct_response_from_request",
     "DataTypeSerializer",
     "data_serializer_factory",

--- a/pyrit/models/chat_message.py
+++ b/pyrit/models/chat_message.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from typing import Optional
+from typing import Optional, Any
 from pydantic import BaseModel, ConfigDict
 
 from pyrit.models import ChatMessageRole
@@ -27,6 +27,15 @@ class ChatMessageListContent(BaseModel):
     model_config = ConfigDict(extra="forbid")
     role: ChatMessageRole
     content: list[dict[str, str]]
+    name: Optional[str] = None
+    tool_calls: Optional[list[ToolCall]] = None
+    tool_call_id: Optional[str] = None
+
+
+class ChatMessageListDictContent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    role: ChatMessageRole
+    content: list[dict[str, Any]]  # type: ignore
     name: Optional[str] = None
     tool_calls: Optional[list[ToolCall]] = None
     tool_call_id: Optional[str] = None

--- a/pyrit/prompt_target/__init__.py
+++ b/pyrit/prompt_target/__init__.py
@@ -7,6 +7,7 @@ from pyrit.prompt_target.azure_blob_storage_target import AzureBlobStorageTarget
 from pyrit.prompt_target.prompt_chat_target.azure_ml_chat_target import AzureMLChatTarget
 from pyrit.prompt_target.prompt_chat_target.openai_chat_target import AzureOpenAIChatTarget, OpenAIChatTarget
 from pyrit.prompt_target.prompt_chat_target.azure_openai_gptv_chat_target import AzureOpenAIGPTVChatTarget
+from pyrit.prompt_target.prompt_chat_target.azure_openai_gpto_chat_target import AzureOpenAIGPT4OChatTarget
 from pyrit.prompt_target.gandalf_target import GandalfTarget, GandalfLevel
 from pyrit.prompt_target.crucible_target import CrucibleTarget
 from pyrit.prompt_target.text_target import TextTarget
@@ -20,8 +21,9 @@ __all__ = [
     "AzureBlobStorageTarget",
     "AzureMLChatTarget",
     "AzureOpenAIChatTarget",
-    "AzureOpenAIGPTVChatTarget",
     "AzureOpenAICompletionTarget",
+    "AzureOpenAIGPTVChatTarget",
+    "AzureOpenAIGPT4OChatTarget",
     "AzureTTSTarget",
     "CrucibleTarget",
     "GandalfTarget",

--- a/pyrit/prompt_target/prompt_chat_target/azure_openai_gpto_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/azure_openai_gpto_chat_target.py
@@ -1,0 +1,328 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import logging
+import json
+from typing import MutableSequence
+
+from openai import AsyncAzureOpenAI
+from openai import BadRequestError
+from openai.types.chat import ChatCompletion
+
+
+from pyrit.auth.azure_auth import get_token_provider_from_default_azure_credential
+from pyrit.common import default_values
+from pyrit.exceptions import PyritException, EmptyResponseException
+from pyrit.exceptions import handle_bad_request_exception, pyrit_target_retry
+from pyrit.memory import MemoryInterface
+from pyrit.models import ChatMessageListDictContent, PromptRequestResponse, PromptRequestPiece, DataTypeSerializer
+from pyrit.models import data_serializer_factory, construct_response_from_request
+from pyrit.prompt_target import PromptChatTarget
+
+logger = logging.getLogger(__name__)
+
+# Supported image formats for Azure OpenAI GPT-4o,
+# https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/use-your-image-data
+AZURE_OPENAI_GPT4O_SUPPORTED_IMAGE_FORMATS = [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", "tif"]
+
+
+class AzureOpenAIGPT4OChatTarget(PromptChatTarget):
+    """This class facilitates multimodal (image and text) input and text output generation"""
+
+    API_KEY_ENVIRONMENT_VARIABLE: str = "AZURE_OPENAI_GPT4O_CHAT_KEY"
+    ENDPOINT_URI_ENVIRONMENT_VARIABLE: str = "AZURE_OPENAI_GPT4O_CHAT_ENDPOINT"
+    DEPLOYMENT_ENVIRONMENT_VARIABLE: str = "AZURE_OPENAI_GPT4O_CHAT_DEPLOYMENT"
+    ADDITIONAL_REQUEST_HEADERS: str = "AZURE_OPENAI_CHAT_ADDITIONAL_REQUEST_HEADERS"
+
+    def __init__(
+        self,
+        *,
+        deployment_name: str = None,
+        endpoint: str = None,
+        api_key: str = None,
+        headers: str = None,
+        use_aad_auth: bool = False,
+        memory: MemoryInterface = None,
+        api_version: str = "2024-02-01",
+        max_tokens: int = 1024,
+        temperature: float = 1.0,
+        top_p: int = 1,
+        frequency_penalty: float = 0.5,
+        presence_penalty: float = 0.5,
+    ) -> None:
+        """
+        Class that initializes an Azure Open AI GPT-o chat target
+
+        Args:
+            deployment_name (str, optional): The name of the deployment. Defaults to the
+                DEPLOYMENT_ENVIRONMENT_VARIABLE environment variable .
+            endpoint (str, optional): The endpoint URL for the Azure OpenAI service.
+                Defaults to the ENDPOINT_URI_ENVIRONMENT_VARIABLE environment variable.
+            api_key (str, optional): The API key for accessing the Azure OpenAI service.
+                Defaults to the API_KEY_ENVIRONMENT_VARIABLE environment variable.
+            use_aad_auth (bool, optional): When set to True, user authentication is used
+                instead of API Key. DefaultAzureCredential is taken for
+                https://cognitiveservices.azure.com/.default. Please run `az login` locally
+                to leverage user AuthN.
+            memory (MemoryInterface, optional): An instance of the MemoryInterface class
+                for storing conversation history. Defaults to None.
+            api_version (str, optional): The version of the Azure OpenAI API. Defaults to
+                "2024-02-01".
+            headers (str, optional): Headers of the endpoint.
+            max_tokens (int, optional): The maximum number of tokens to generate in the response.
+                Defaults to 1024.
+            temperature (float, optional): The temperature parameter for controlling the
+                randomness of the response. Defaults to 1.0.
+            top_p (int, optional): The top-p parameter for controlling the diversity of the
+                response. Defaults to 1.
+            frequency_penalty (float, optional): The frequency penalty parameter for penalizing
+                frequently generated tokens. Defaults to 0.5.
+            presence_penalty (float, optional): The presence penalty parameter for penalizing
+                tokens that are already present in the conversation history. Defaults to 0.5.
+        """
+        PromptChatTarget.__init__(self, memory=memory)
+
+        self._max_tokens = max_tokens
+        self._temperature = temperature
+        self._top_p = top_p
+        self._frequency_penalty = frequency_penalty
+        self._presence_penalty = presence_penalty
+
+        self._deployment_name = default_values.get_required_value(
+            env_var_name=self.DEPLOYMENT_ENVIRONMENT_VARIABLE, passed_value=deployment_name
+        )
+        endpoint = default_values.get_required_value(
+            env_var_name=self.ENDPOINT_URI_ENVIRONMENT_VARIABLE, passed_value=endpoint
+        )
+
+        final_headers: dict = {}
+        try:
+            request_headers = default_values.get_required_value(
+                env_var_name=self.ADDITIONAL_REQUEST_HEADERS, passed_value=headers
+            )
+            if isinstance(request_headers, str):
+                try:
+                    final_headers = json.loads(request_headers)
+                except json.JSONDecodeError as e:
+                    logger.error(f"Error decoding JSON: {e}")
+        except ValueError:
+            logger.info("No headers have been passed, setting empty default headers")
+
+        if use_aad_auth:
+            logger.info("Authenticating with DefaultAzureCredential() for Azure Cognitive Services")
+            token_provider = get_token_provider_from_default_azure_credential()
+
+            self._async_client = AsyncAzureOpenAI(
+                azure_ad_token_provider=token_provider,
+                api_version=api_version,
+                azure_endpoint=endpoint,
+                default_headers=final_headers,
+            )
+        else:
+            api_key = default_values.get_required_value(
+                env_var_name=self.API_KEY_ENVIRONMENT_VARIABLE, passed_value=api_key
+            )
+
+            self._async_client = AsyncAzureOpenAI(
+                api_key=api_key, api_version=api_version, azure_endpoint=endpoint, default_headers=final_headers
+            )
+
+    async def send_prompt_async(self, *, prompt_request: PromptRequestResponse) -> PromptRequestResponse:
+        """Asynchronously sends a prompt request and handles the response within a managed conversation context.
+
+        Args:
+            prompt_request (PromptRequestResponse): The prompt request response object.
+
+        Returns:
+            PromptRequestResponse: The updated conversation entry with the response from the prompt target.
+        """
+        self._validate_request(prompt_request=prompt_request)
+        request: PromptRequestPiece = prompt_request.request_pieces[0]
+
+        prompt_req_res_entries = self._memory.get_conversation(conversation_id=request.conversation_id)
+        prompt_req_res_entries.append(prompt_request)
+
+        logger.info(f"Sending the following prompt to the prompt target: {prompt_request}")
+
+        messages = self._build_chat_messages(prompt_req_res_entries)
+        try:
+            resp_text = await self._complete_chat_async(
+                messages=messages,
+                top_p=self._top_p,
+                temperature=self._temperature,
+                frequency_penalty=self._frequency_penalty,
+                presence_penalty=self._presence_penalty,
+            )
+
+            logger.info(f'Received the following response from the prompt target "{resp_text}"')
+
+            response_entry = construct_response_from_request(request=request, response_text_pieces=[resp_text])
+        except BadRequestError as bre:
+            response_entry = handle_bad_request_exception(response_text=bre.message, request=request)
+
+        return response_entry
+
+    def _convert_local_image_to_data_url(self, image_path: str) -> str:
+        """Converts a local image file to a data URL encoded in base64.
+
+        Args:
+            image_path (str): The file system path to the image file.
+
+        Raises:
+            FileNotFoundError: If no file is found at the specified `image_path`.
+            ValueError: If the image file's extension is not in the supported formats list.
+
+        Returns:
+            str: A string containing the MIME type and the base64-encoded data of the image, formatted as a data URL.
+        """
+        ext = DataTypeSerializer.get_extension(image_path)
+        if ext.lower() not in AZURE_OPENAI_GPT4O_SUPPORTED_IMAGE_FORMATS:
+            raise ValueError(
+                f"Unsupported image format: {ext}. Supported formats are: {AZURE_OPENAI_GPT4O_SUPPORTED_IMAGE_FORMATS}"
+            )
+
+        mime_type = DataTypeSerializer.get_mime_type(image_path)
+        if not mime_type:
+            mime_type = "application/octet-stream"
+
+        image_serializer = data_serializer_factory(value=image_path, data_type="image_path", extension=ext)
+        base64_encoded_data = image_serializer.read_data_base64()
+        # Azure OpenAI GPT-4o documentation doesn't specify the local image upload format for API.
+        # GPT-4o image upload format is determined using "view code" functionality in Azure OpenAI deployments
+        # The image upload format is same as GPT-4 Turbo.
+        # Construct the data URL, as per Azure OpenAI GPT-4 Turbo local image format
+        # https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/gpt-with-vision?tabs=rest%2Csystem-assigned%2Cresource#call-the-chat-completion-apis
+        return f"data:{mime_type};base64,{base64_encoded_data}"
+
+    def _build_chat_messages(
+        self, prompt_req_res_entries: MutableSequence[PromptRequestResponse]
+    ) -> list[ChatMessageListDictContent]:
+        """
+        Builds chat messages based on prompt request response entries.
+
+        Args:
+            prompt_req_res_entries (list[PromptRequestResponse]): A list of PromptRequestResponse objects.
+
+        Returns:
+            list[ChatMessageListDictContent]: The list of constructed chat messages.
+        """
+        chat_messages: list[ChatMessageListDictContent] = []
+        for prompt_req_resp_entry in prompt_req_res_entries:
+            prompt_request_pieces = prompt_req_resp_entry.request_pieces
+
+            content = []
+            role = None
+            for prompt_request_piece in prompt_request_pieces:
+                role = prompt_request_piece.role
+                if prompt_request_piece.converted_value_data_type == "text":
+                    entry = {"type": "text", "text": prompt_request_piece.converted_value}
+                    content.append(entry)
+                elif prompt_request_piece.converted_value_data_type == "image_path":
+                    data_base64_encoded_url = self._convert_local_image_to_data_url(
+                        prompt_request_piece.converted_value
+                    )
+                    image_url_entry = {"url": data_base64_encoded_url}
+                    entry = {"type": "image_url", "image_url": image_url_entry}  # type: ignore
+                    content.append(entry)
+                else:
+                    raise ValueError(
+                        f"Multimodal data type {prompt_request_piece.converted_value_data_type} is not yet supported."
+                    )
+
+            if not role:
+                raise ValueError("No role could be determined from the prompt request pieces.")
+
+            chat_message = ChatMessageListDictContent(role=role, content=content)  # type: ignore
+            chat_messages.append(chat_message)
+        return chat_messages
+
+    def _parse_chat_completion(self, response):
+        """
+        Parses chat message to get response
+
+        Args:
+            response (ChatMessage): The chat messages object containing the generated response message
+
+        Returns:
+            str: The generated response message
+        """
+        response_message = response.choices[0].message.content
+        return response_message
+
+    @pyrit_target_retry
+    async def _complete_chat_async(
+        self,
+        messages: list[ChatMessageListDictContent],
+        max_tokens: int = 1024,
+        temperature: float = 1.0,
+        top_p: int = 1,
+        frequency_penalty: float = 0.5,
+        presence_penalty: float = 0.5,
+    ) -> str:
+        """
+        Completes asynchronous chat request.
+
+        Sends a chat message to the OpenAI chat model and retrieves the generated response.
+
+        Args:
+            messages (list[ChatMessageListDictContent]): The chat message objects containing the role and content.
+            max_tokens (int, optional): The maximum number of tokens to generate.
+                Defaults to 1024.
+            temperature (float, optional): Controls randomness in the response generation.
+                Defaults to 1.0.
+            top_p (int, optional): Controls diversity of the response generation.
+                Defaults to 1.
+            frequency_penalty (float, optional): Controls the frequency of generating the same lines of text.
+                Defaults to 0.5.
+            presence_penalty (float, optional): Controls the likelihood to talk about new topics.
+                Defaults to 0.5.
+
+        Returns:
+            str: The generated response message.
+        """
+
+        response: ChatCompletion = await self._async_client.chat.completions.create(
+            model=self._deployment_name,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            frequency_penalty=frequency_penalty,
+            presence_penalty=presence_penalty,
+            n=1,
+            stream=False,
+            messages=[{"role": msg.role, "content": msg.content} for msg in messages],  # type: ignore
+        )
+        finish_reason = response.choices[0].finish_reason
+        extracted_response: str = ""
+        # finish_reason="stop" means API returned complete message and
+        # "length" means API returned incomplete message due to max_tokens limit.
+        if finish_reason in ["stop", "length"]:
+            extracted_response = self._parse_chat_completion(response)
+            # Handle empty response
+            if not extracted_response:
+                raise EmptyResponseException(message="The chat returned an empty response.")
+        else:
+            raise PyritException(message=f"Unknown finish_reason {finish_reason}")
+
+        return extracted_response
+
+    def _validate_request(self, *, prompt_request: PromptRequestResponse) -> None:
+        """Validates the structure and content of a prompt request for compatibility of this target.
+
+        Args:
+            prompt_request (PromptRequestResponse): The prompt request response object.
+
+        Raises:
+            ValueError: If more than two request pieces are provided.
+            ValueError: If any of the request pieces have a data type other than 'text' or 'image_path'.
+        """
+        # As of April 26, 2024, the Azure OpenAI GPT-o model only accepts text and image as input.
+        if len(prompt_request.request_pieces) > 2:
+            raise ValueError("This target only supports a two prompt request pieces text and image_path.")
+
+        converted_prompt_data_types = [
+            request_piece.converted_value_data_type for request_piece in prompt_request.request_pieces
+        ]
+        for prompt_data_type in converted_prompt_data_types:
+            if prompt_data_type not in ["text", "image_path"]:
+                raise ValueError("This target only supports text and image_path.")

--- a/tests/target/test_azure_openai_gpto_chat_target.py
+++ b/tests/target/test_azure_openai_gpto_chat_target.py
@@ -1,0 +1,511 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import os
+import pytest
+
+from contextlib import AbstractAsyncContextManager
+from unittest.mock import AsyncMock, MagicMock, patch
+from tempfile import NamedTemporaryFile
+
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
+from openai import BadRequestError, RateLimitError
+
+from pyrit.exceptions.exception_classes import EmptyResponseException
+from pyrit.memory.duckdb_memory import DuckDBMemory
+from pyrit.memory.memory_interface import MemoryInterface
+from pyrit.models.prompt_request_piece import PromptRequestPiece
+from pyrit.models.prompt_request_response import PromptRequestResponse
+from pyrit.prompt_target import AzureOpenAIGPT4OChatTarget
+from pyrit.models import ChatMessageListContent
+from pyrit.common import constants
+
+from tests.mocks import get_image_request_piece
+
+
+@pytest.fixture
+def azure_gpt4o_chat_engine() -> AzureOpenAIGPT4OChatTarget:
+    return AzureOpenAIGPT4OChatTarget(
+        deployment_name="gpt-v",
+        endpoint="https://mock.azure.com/",
+        api_key="mock-api-key",
+        api_version="some_version",
+        memory=DuckDBMemory(db_path=":memory:"),
+    )
+
+
+@pytest.fixture
+def azure_openai_mock_return() -> ChatCompletion:
+    return ChatCompletion(
+        id="12345678-1a2b-3c4e5f-a123-12345678abcd",
+        object="chat.completion",
+        choices=[
+            Choice(
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content="hi"),
+                finish_reason="stop",
+                logprobs=None,
+            )
+        ],
+        created=1629389505,
+        model="gpt-4-v",
+    )
+
+
+class MockChatCompletionsAsync(AbstractAsyncContextManager):
+    async def __call__(self, *args, **kwargs):
+        self.mock_chat_completion = ChatCompletion(
+            id="12345678-1a2b-3c4e5f-a123-12345678abcd",
+            object="chat.completion",
+            choices=[
+                Choice(
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="hi"),
+                    finish_reason="stop",
+                    logprobs=None,
+                )
+            ],
+            created=1629389505,
+            model="gpt-4",
+        )
+        return self.mock_chat_completion
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def __aenter__(self):
+        pass
+
+
+@patch(
+    "openai.resources.chat.AsyncCompletions.create",
+    new_callable=lambda: MockChatCompletionsAsync(),
+)
+@pytest.mark.asyncio
+async def test_complete_chat_async_return(
+    openai_mock_return: ChatCompletion, azure_gpt4o_chat_engine: AzureOpenAIGPT4OChatTarget
+):
+    with patch("openai.resources.chat.Completions.create") as mock_create:
+        mock_create.return_value = openai_mock_return
+        ret = await azure_gpt4o_chat_engine._complete_chat_async(
+            messages=[ChatMessageListContent(role="user", content=[{"text": "hello"}])]
+        )
+        assert ret == "hi"
+
+
+def test_init_with_no_api_key_var_raises():
+    os.environ[AzureOpenAIGPT4OChatTarget.API_KEY_ENVIRONMENT_VARIABLE] = ""
+    with pytest.raises(ValueError):
+        AzureOpenAIGPT4OChatTarget(
+            deployment_name="gpt-4",
+            endpoint="https://mock.azure.com/",
+            api_key="",
+            api_version="some_version",
+        )
+
+
+def test_init_with_no_deployment_var_raises():
+    os.environ[AzureOpenAIGPT4OChatTarget.DEPLOYMENT_ENVIRONMENT_VARIABLE] = ""
+    with pytest.raises(ValueError):
+        AzureOpenAIGPT4OChatTarget()
+
+
+def test_init_with_no_endpoint_uri_var_raises():
+    os.environ[AzureOpenAIGPT4OChatTarget.ENDPOINT_URI_ENVIRONMENT_VARIABLE] = ""
+    with pytest.raises(ValueError):
+        AzureOpenAIGPT4OChatTarget(
+            deployment_name="gpt-4",
+            endpoint="",
+            api_key="xxxxx",
+            api_version="some_version",
+        )
+
+
+def test_init_with_no_additional_request_headers_var_raises():
+    os.environ[AzureOpenAIGPT4OChatTarget.ADDITIONAL_REQUEST_HEADERS] = ""
+    with pytest.raises(ValueError):
+        AzureOpenAIGPT4OChatTarget(
+            deployment_name="gpt-4", endpoint="", api_key="xxxxx", api_version="some_version", headers=""
+        )
+
+
+def test_convert_image_to_data_url_file_not_found(azure_gpt4o_chat_engine: AzureOpenAIGPT4OChatTarget):
+    with pytest.raises(FileNotFoundError):
+        azure_gpt4o_chat_engine._convert_local_image_to_data_url("nonexistent.jpg")
+
+
+def test_convert_image_with_unsupported_extension(azure_gpt4o_chat_engine: AzureOpenAIGPT4OChatTarget):
+
+    with NamedTemporaryFile(mode="w+", suffix=".txt", delete=False) as tmp_file:
+        tmp_file_name = tmp_file.name
+
+    assert os.path.exists(tmp_file_name)
+
+    with pytest.raises(ValueError) as exc_info:
+        azure_gpt4o_chat_engine._convert_local_image_to_data_url(tmp_file_name)
+
+    assert "Unsupported image format" in str(exc_info.value)
+
+    os.remove(tmp_file_name)
+
+
+@patch("os.path.exists", return_value=True)
+@patch("mimetypes.guess_type", return_value=("image/jpg", None))
+@patch("pyrit.models.data_type_serializer.ImagePathDataTypeSerializer")
+def test_convert_image_to_data_url_success(
+    mock_serializer_class, mock_guess_type, mock_exists, azure_gpt4o_chat_engine: AzureOpenAIGPT4OChatTarget
+):
+    with NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
+        tmp_file_name = tmp_file.name
+    mock_serializer_instance = MagicMock()
+    mock_serializer_instance.read_data_base64.return_value = "encoded_base64_string"
+    mock_serializer_class.return_value = mock_serializer_instance
+
+    assert os.path.exists(tmp_file_name)
+
+    result = azure_gpt4o_chat_engine._convert_local_image_to_data_url(tmp_file_name)
+    assert "data:image/jpeg;base64,encoded_base64_string" in result
+
+    # Assertions for the mocks
+    mock_serializer_class.assert_called_once_with(prompt_text=tmp_file_name)
+    mock_serializer_instance.read_data_base64.assert_called_once()
+
+    os.remove(tmp_file_name)
+
+
+def test_build_chat_messages_with_consistent_roles(azure_gpt4o_chat_engine: AzureOpenAIGPT4OChatTarget):
+
+    image_request = get_image_request_piece()
+    entries = [
+        PromptRequestResponse(
+            request_pieces=[
+                PromptRequestPiece(
+                    role="user",
+                    converted_value_data_type="text",
+                    original_value="Hello",
+                ),
+                image_request,
+            ]
+        )
+    ]
+    with patch.object(
+        azure_gpt4o_chat_engine,
+        "_convert_local_image_to_data_url",
+        return_value="data:image/jpeg;base64,encoded_string",
+    ):
+        messages = azure_gpt4o_chat_engine._build_chat_messages(entries)
+
+    assert len(messages) == 1
+    assert messages[0].role == "user"
+    assert messages[0].content[0]["type"] == "text"  # type: ignore
+    assert messages[0].content[1]["type"] == "image_url"  # type: ignore
+
+    os.remove(image_request.original_value)
+
+
+def test_build_chat_messages_with_unsupported_data_types(azure_gpt4o_chat_engine: AzureOpenAIGPT4OChatTarget):
+    # Like an image_path, the audio_path requires a file, but doesn't validate any contents
+    entry = get_image_request_piece()
+    entry.converted_value_data_type = "audio_path"
+
+    with pytest.raises(ValueError) as excinfo:
+        azure_gpt4o_chat_engine._build_chat_messages([PromptRequestResponse(request_pieces=[entry])])
+    assert "Multimodal data type audio_path is not yet supported." in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_send_prompt_async_empty_response_adds_to_memory(
+    azure_openai_mock_return: ChatCompletion, azure_gpt4o_chat_engine: AzureOpenAIGPT4OChatTarget
+):
+    mock_memory = MagicMock()
+    mock_memory.get_conversation.return_value = []
+    mock_memory.add_request_response_to_memory = AsyncMock()
+    mock_memory.add_response_entries_to_memory = AsyncMock()
+
+    azure_gpt4o_chat_engine._memory = mock_memory
+
+    with NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
+        tmp_file_name = tmp_file.name
+    assert os.path.exists(tmp_file_name)
+    prompt_req_resp = PromptRequestResponse(
+        request_pieces=[
+            PromptRequestPiece(
+                role="user",
+                conversation_id="12345679",
+                original_value="hello",
+                converted_value="hello",
+                original_value_data_type="text",
+                converted_value_data_type="text",
+                prompt_target_identifier={"target": "target-identifier"},
+                orchestrator_identifier={"test": "test"},
+                labels={"test": "test"},
+            ),
+            PromptRequestPiece(
+                role="user",
+                conversation_id="12345679",
+                original_value=tmp_file_name,
+                converted_value=tmp_file_name,
+                original_value_data_type="image_path",
+                converted_value_data_type="image_path",
+                prompt_target_identifier={"target": "target-identifier"},
+                orchestrator_identifier={"test": "test"},
+                labels={"test": "test"},
+            ),
+        ]
+    )
+    # Make assistant response empty
+    azure_openai_mock_return.choices[0].message.content = ""
+    with patch.object(
+        azure_gpt4o_chat_engine,
+        "_convert_local_image_to_data_url",
+        return_value="data:image/jpeg;base64,encoded_string",
+    ):
+        with patch("openai.resources.chat.AsyncCompletions.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = azure_openai_mock_return
+            with pytest.raises(EmptyResponseException) as e:
+                await azure_gpt4o_chat_engine.send_prompt_async(prompt_request=prompt_req_resp)
+                azure_gpt4o_chat_engine._memory.get_conversation.assert_called_once_with(conversation_id="12345679")
+                azure_gpt4o_chat_engine._memory.add_request_response_to_memory.assert_called_once_with(
+                    request=prompt_req_resp
+                )
+                azure_gpt4o_chat_engine._memory.add_response_entries_to_memory.assert_called_once()
+            assert str(e.value) == "Status Code: 204, Message: The chat returned an empty response."
+
+
+@pytest.mark.asyncio
+async def test_send_prompt_async_rate_limit_exception_adds_to_memory(
+    azure_gpt4o_chat_engine: AzureOpenAIGPT4OChatTarget,
+):
+    mock_memory = MagicMock()
+    mock_memory.get_conversation.return_value = []
+    mock_memory.add_request_response_to_memory = AsyncMock()
+    mock_memory.add_response_entries_to_memory = AsyncMock()
+
+    azure_gpt4o_chat_engine._memory = mock_memory
+
+    response = MagicMock()
+    response.status_code = 429
+    mock_complete_chat_async = AsyncMock(
+        side_effect=RateLimitError("Rate Limit Reached", response=response, body="Rate limit reached")
+    )
+    setattr(azure_gpt4o_chat_engine, "_complete_chat_async", mock_complete_chat_async)
+    prompt_request = PromptRequestResponse(
+        request_pieces=[PromptRequestPiece(role="user", conversation_id="123", original_value="Hello")]
+    )
+
+    with pytest.raises(RateLimitError) as rle:
+        await azure_gpt4o_chat_engine.send_prompt_async(prompt_request=prompt_request)
+        azure_gpt4o_chat_engine._memory.get_conversation.assert_called_once_with(conversation_id="123")
+        azure_gpt4o_chat_engine._memory.add_request_response_to_memory.assert_called_once_with(request=prompt_request)
+        azure_gpt4o_chat_engine._memory.add_response_entries_to_memory.assert_called_once()
+
+    assert str(rle.value) == "Rate Limit Reached"
+
+
+@pytest.mark.asyncio
+async def test_send_prompt_async_bad_request_error_adds_to_memory(azure_gpt4o_chat_engine: AzureOpenAIGPT4OChatTarget):
+    mock_memory = MagicMock()
+    mock_memory.get_conversation.return_value = []
+    mock_memory.add_request_response_to_memory = AsyncMock()
+    mock_memory.add_response_entries_to_memory = AsyncMock()
+
+    azure_gpt4o_chat_engine._memory = mock_memory
+
+    response = MagicMock()
+    response.status_code = 400
+    mock_complete_chat_async = AsyncMock(
+        side_effect=BadRequestError("Bad Request", response=response, body="Bad Request")
+    )
+    setattr(azure_gpt4o_chat_engine, "_complete_chat_async", mock_complete_chat_async)
+    prompt_request = PromptRequestResponse(
+        request_pieces=[PromptRequestPiece(role="user", conversation_id="123", original_value="Hello")]
+    )
+
+    with pytest.raises(BadRequestError) as bre:
+        await azure_gpt4o_chat_engine.send_prompt_async(prompt_request=prompt_request)
+        azure_gpt4o_chat_engine._memory.get_conversation.assert_called_once_with(conversation_id="123")
+        azure_gpt4o_chat_engine._memory.add_request_response_to_memory.assert_called_once_with(request=prompt_request)
+        azure_gpt4o_chat_engine._memory.add_response_entries_to_memory.assert_called_once()
+
+    assert str(bre.value) == "Bad Request"
+
+
+@pytest.mark.asyncio
+async def test_send_prompt_async(
+    azure_openai_mock_return: ChatCompletion, azure_gpt4o_chat_engine: AzureOpenAIGPT4OChatTarget
+):
+    with NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
+        tmp_file_name = tmp_file.name
+    assert os.path.exists(tmp_file_name)
+    prompt_req_resp = PromptRequestResponse(
+        request_pieces=[
+            PromptRequestPiece(
+                role="user",
+                conversation_id="12345679",
+                original_value="hello",
+                converted_value="hello",
+                original_value_data_type="text",
+                converted_value_data_type="text",
+                prompt_target_identifier={"target": "target-identifier"},
+                orchestrator_identifier={"test": "test"},
+                labels={"test": "test"},
+            ),
+            PromptRequestPiece(
+                role="user",
+                conversation_id="12345679",
+                original_value=tmp_file_name,
+                converted_value=tmp_file_name,
+                original_value_data_type="image_path",
+                converted_value_data_type="image_path",
+                prompt_target_identifier={"target": "target-identifier"},
+                orchestrator_identifier={"test": "test"},
+                labels={"test": "test"},
+            ),
+        ]
+    )
+    with patch.object(
+        azure_gpt4o_chat_engine,
+        "_convert_local_image_to_data_url",
+        return_value="data:image/jpeg;base64,encoded_string",
+    ):
+        with patch("openai.resources.chat.AsyncCompletions.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = azure_openai_mock_return
+            response: PromptRequestResponse = await azure_gpt4o_chat_engine.send_prompt_async(
+                prompt_request=prompt_req_resp
+            )
+            assert len(response.request_pieces) == 1
+            assert response.request_pieces[0].converted_value == "hi"
+    os.remove(tmp_file_name)
+
+
+@pytest.mark.asyncio
+async def test_send_prompt_async_empty_response_retries(
+    azure_openai_mock_return: ChatCompletion, azure_gpt4o_chat_engine: AzureOpenAIGPT4OChatTarget
+):
+    with NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
+        tmp_file_name = tmp_file.name
+    assert os.path.exists(tmp_file_name)
+    prompt_req_resp = PromptRequestResponse(
+        request_pieces=[
+            PromptRequestPiece(
+                role="user",
+                conversation_id="12345679",
+                original_value="hello",
+                converted_value="hello",
+                original_value_data_type="text",
+                converted_value_data_type="text",
+                prompt_target_identifier={"target": "target-identifier"},
+                orchestrator_identifier={"test": "test"},
+                labels={"test": "test"},
+            ),
+            PromptRequestPiece(
+                role="user",
+                conversation_id="12345679",
+                original_value=tmp_file_name,
+                converted_value=tmp_file_name,
+                original_value_data_type="image_path",
+                converted_value_data_type="image_path",
+                prompt_target_identifier={"target": "target-identifier"},
+                orchestrator_identifier={"test": "test"},
+                labels={"test": "test"},
+            ),
+        ]
+    )
+    # Make assistant response empty
+    azure_openai_mock_return.choices[0].message.content = ""
+    with patch.object(
+        azure_gpt4o_chat_engine,
+        "_convert_local_image_to_data_url",
+        return_value="data:image/jpeg;base64,encoded_string",
+    ):
+        with patch("openai.resources.chat.AsyncCompletions.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = azure_openai_mock_return
+            constants.RETRY_MAX_NUM_ATTEMPTS = 5
+            azure_gpt4o_chat_engine._memory = MagicMock(MemoryInterface)
+
+            with pytest.raises(EmptyResponseException):
+                await azure_gpt4o_chat_engine.send_prompt_async(prompt_request=prompt_req_resp)
+
+            assert mock_create.call_count == constants.RETRY_MAX_NUM_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_send_prompt_async_rate_limit_exception_retries(azure_gpt4o_chat_engine: AzureOpenAIGPT4OChatTarget):
+
+    response = MagicMock()
+    response.status_code = 429
+    mock_complete_chat_async = AsyncMock(
+        side_effect=RateLimitError("Rate Limit Reached", response=response, body="Rate limit reached")
+    )
+    setattr(azure_gpt4o_chat_engine, "_complete_chat_async", mock_complete_chat_async)
+    prompt_request = PromptRequestResponse(
+        request_pieces=[PromptRequestPiece(role="user", conversation_id="12345", original_value="Hello")]
+    )
+
+    with pytest.raises(RateLimitError):
+        await azure_gpt4o_chat_engine.send_prompt_async(prompt_request=prompt_request)
+        assert mock_complete_chat_async.call_count == constants.RETRY_MAX_NUM_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_send_prompt_async_bad_request_error(azure_gpt4o_chat_engine: AzureOpenAIGPT4OChatTarget):
+
+    response = MagicMock()
+    response.status_code = 400
+    mock_complete_chat_async = AsyncMock(
+        side_effect=BadRequestError("Bad Request Error", response=response, body="Bad request")
+    )
+    setattr(azure_gpt4o_chat_engine, "_complete_chat_async", mock_complete_chat_async)
+
+    prompt_request = PromptRequestResponse(
+        request_pieces=[PromptRequestPiece(role="user", conversation_id="1236748", original_value="Hello")]
+    )
+    with pytest.raises(BadRequestError) as bre:
+        await azure_gpt4o_chat_engine.send_prompt_async(prompt_request=prompt_request)
+    assert str(bre.value) == "Bad Request Error"
+
+
+def test_parse_chat_completion_successful(azure_gpt4o_chat_engine: AzureOpenAIGPT4OChatTarget):
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message = MagicMock()
+    mock_response.choices[0].message.content = "Test response message"
+    result = azure_gpt4o_chat_engine._parse_chat_completion(mock_response)
+    assert result == "Test response message", "The response message was not parsed correctly"
+
+
+def test_validate_request_too_many_request_pieces(azure_gpt4o_chat_engine: AzureOpenAIGPT4OChatTarget):
+
+    prompt_request = PromptRequestResponse(
+        request_pieces=[
+            PromptRequestPiece(role="user", original_value="Hello", converted_value_data_type="text"),
+            PromptRequestPiece(role="user", original_value="Hello", converted_value_data_type="text"),
+            PromptRequestPiece(role="user", original_value="Hello", converted_value_data_type="text"),
+        ]
+    )
+    with pytest.raises(ValueError) as excinfo:
+        azure_gpt4o_chat_engine._validate_request(prompt_request=prompt_request)
+
+    assert "two prompt request pieces" in str(excinfo.value), "Error not raised for too many request pieces"
+
+
+def test_validate_request_unsupported_data_types(azure_gpt4o_chat_engine: AzureOpenAIGPT4OChatTarget):
+
+    image_piece = get_image_request_piece()
+    image_piece.converted_value_data_type = "new_unknown_type"  # type: ignore
+    prompt_request = PromptRequestResponse(
+        request_pieces=[
+            PromptRequestPiece(role="user", original_value="Hello", converted_value_data_type="text"),
+            image_piece,
+        ]
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        azure_gpt4o_chat_engine._validate_request(prompt_request=prompt_request)
+
+    assert "This target only supports text and image_path." in str(
+        excinfo.value
+    ), "Error not raised for unsupported data types"
+
+    os.remove(image_piece.original_value)


### PR DESCRIPTION
## Description
This PR adds new PyRit target for Open AI GPT-4o, along with tests, demos and environment configuration examples.
This PR is attached to #292 
Chat target has been added to: `pyrit/prompt_target/prompt_chat_target/azure_openai_gpto_chat_target.py`

## Tests and Documentation
Tests have been added to: `pyrit/tests/target/test_azure_openai_gpto_chat_target.py`

Demos have been added to:
1. `pyrit/doc/code/targets/gpt_4o_target.py`
2. `pyrit/doc/code/targets/gpt_4o_target.ipynb`
3. `pyrit/doc/demo/3_send_all_prompts.py`
4. `pyrit/doc/demo/3_send_all_prompts.ipynb`

Environment configuration examples have been added to: `./.env_example`
