### PR TITLE
FIX: bug with multi-modal image responses

### DIFF
--- a/doc/demo/6_multiturn_image_generation.py
+++ b/doc/demo/6_multiturn_image_generation.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.2
 #   kernelspec:
 #     display_name: pyrit-311
 #     language: python
@@ -81,8 +81,9 @@ with RedTeamingOrchestrator(
     use_score_as_feedback=True,
     verbose=True,
 ) as orchestrator:
-    score = await orchestrator.apply_attack_strategy_until_completion_async(max_turns=5)  # type: ignore
+    score = await orchestrator.apply_attack_strategy_until_completion_async(max_turns=3)  # type: ignore
     orchestrator.print_conversation()
+
 
 
 # %%

--- a/doc/demo/6_multiturn_image_generation.py
+++ b/doc/demo/6_multiturn_image_generation.py
@@ -85,5 +85,4 @@ with RedTeamingOrchestrator(
     orchestrator.print_conversation()
 
 
-
 # %%

--- a/pyrit/models/prompt_request_response.py
+++ b/pyrit/models/prompt_request_response.py
@@ -133,6 +133,7 @@ def construct_response_from_request(
                 prompt_target_identifier=request.prompt_target_identifier,
                 orchestrator_identifier=request.orchestrator_identifier,
                 original_value_data_type=response_type,
+                converted_value_data_type=response_type,
                 prompt_metadata=prompt_metadata,
                 response_error=error,
             )


### PR DESCRIPTION
Previously, demo 6 was broken due to a bug where RTO would interpret the image modality response as text. This fixes that bug and sets the content type of the response correctly.

To test, I reran demo 6 and it works as intended