### PR TITLE
[FIX][Issue #302] update language version enforcement to fix black-pre-commit installation incompatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     rev: 24.2.0
     hooks:
       - id: black
-        language_version: python3.10
+        language_version: python3
 
   - repo: https://github.com/PyCQA/flake8
     rev: 7.0.0


### PR DESCRIPTION
#### Describe the bug
Black-pre-commit hook language-version binding is enforced for Python v3.10. However, PyRIT supports both Python - v3.10 and v3.11.
When installing PyRit pre-commit hooks on Python v3.11, there is an error:
![image](https://github.com/user-attachments/assets/087b8ffb-d408-4a40-9fda-3cdc8a9ec4b7)

#### Steps/Code to Reproduce
1. Create PyRit dev environment with Python v3.11.
2. Make sure that `./pre-commit-config.yaml` has `language_version: python3.10` for black-pre-commit.
3. Run pre-commit hooks with `pre-commit run --all-files` to see the error.

#### Actual Results
Actual stack-trace:
```
[INFO] Installing environment for https://github.com/psf/black-pre-commit-mirror.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('...\\.conda\\envs\\pyrit-dev\\python.exe', '-mvirtualenv', '...\\.cache\\pre-commit\\repozdb7lsoe\\py_env-python3.10', '-p', 'python3.10')
return code: 1
stdout:
    RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.10'
stderr: (none)
Check the log at ...\.cache\pre-commit\pre-commit.log
```

#### Screenshots
Bug screenshot:
![image](https://github.com/user-attachments/assets/087b8ffb-d408-4a40-9fda-3cdc8a9ec4b7)

Resolution screenshot:
![image](https://github.com/user-attachments/assets/738562b3-1a2b-40dc-8693-8cf1ec8c92a2)


#### Versions
Python 3.10/3.11



## Tests and Documentation
#### Resolution:
Only specifying major language version for the hook would solve the issue:
![image](https://github.com/user-attachments/assets/a2933bde-85d3-4e64-80bd-4c5781bb7b5a)

#### Expected Results
Expected result should be a successful installation:
![image](https://github.com/user-attachments/assets/1f0b5e73-ab97-4f8f-8e3e-2de7457aa3f8)

