### PR TITLE
MAINT add support for Python 3.12 and fix tests that started breaking

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10", "3.11"]
+        python: ["3.10", "3.11", "3.12"]
         package_name: ["pyrit"]
     runs-on: ${{ matrix.os }}
     # EnricoMi/publish-unit-test-result-action@v2 requires the following permissions

--- a/doc/contributing/installation.md
+++ b/doc/contributing/installation.md
@@ -15,7 +15,7 @@ This is a list of the prerequisites needed to run this library.
     git clone https://github.com/Azure/PyRIT
     ```
 
-Note: PyRIT requires Python version 3.11. If using Conda, you'll set the environment to use this version. If running PyRIT outside of a python environment, make sure you have this version installed.
+Note: PyRIT requires Python version 3.10, 3.11, or 3.12. If using Conda, you'll set the environment to use this version. If running PyRIT outside of a python environment, make sure you have this version installed.
 
 ## Installation
 

--- a/doc/setup/install_pyrit.md
+++ b/doc/setup/install_pyrit.md
@@ -1,6 +1,6 @@
 # Install PyRIT
 
-To install PyRIT using pip, make sure you have Python 3.11 installed using `python --version`.
+To install PyRIT using pip, make sure you have Python 3.10, 3.11, or 3.12 installed using `python --version`.
 Alternatively, create a conda environment as follows
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,9 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.10, <3.12"
+requires-python = ">=3.10, <3.13"
 dependencies = [
     "aioconsole>=0.7.1",
     "appdirs>=1.4.0",


### PR DESCRIPTION
<!--- Please add one of the following as a prefix to the pull request title: -->
<!--- DOC for documentation changes -->
<!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
<!--- FIX for bug fixes -->
<!--- TEST for adding tests -->
<!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
<!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->
Added support for Python 3.12. In the process a few tests started failing. It turns out `called_once` doesn't seem to work the way we had been using it. Also, we were deliberately adding mocks to not use them and then asserting that they were called which makes little sense. I'm fixing this issue with this PR.
<!--- If you are considering making a contribution please open an issue first. -->
<!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
<!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->


## Tests and Documentation

<!--- Contributions require tests and documentation (if applicable). -->
<!--- Include a description of tests and documentation updated (if applicable) -->

<!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
<!--- Include how you/if ran JupyText here -->
<!--- This is described at: https://github.com/Azure/PyRIT/tree/main/doc  -->
