### PR TITLE
MAINT: Fixing data serializer ability to properly raise errors

### DIFF
--- a/pyrit/models/data_type_serializer.py
+++ b/pyrit/models/data_type_serializer.py
@@ -34,7 +34,7 @@ def data_serializer_factory(*, data_type: PromptDataType, value: str = None, ext
         elif data_type == "audio_path":
             return AudioPathDataTypeSerializer(extension=extension)
         elif data_type == "error":
-            value = ""
+            return ErrorDataTypeSerializer(prompt_text="")
         else:
             raise ValueError(f"Data type {data_type} without prompt text not supported")
 

--- a/pyrit/models/data_type_serializer.py
+++ b/pyrit/models/data_type_serializer.py
@@ -33,6 +33,8 @@ def data_serializer_factory(*, data_type: PromptDataType, value: str = None, ext
             return ImagePathDataTypeSerializer(extension=extension)
         elif data_type == "audio_path":
             return AudioPathDataTypeSerializer(extension=extension)
+        elif data_type == "error":
+            value = ""
         else:
             raise ValueError(f"Data type {data_type} without prompt text not supported")
 


### PR DESCRIPTION
There are situations when we want to raise errors in multi-modal, but when exception handling, this error is raised in the exception handling code.

This pr allows us to add multi-modal errors to memory and raise appropriate exceptions.