### PR TITLE
FEAT: Adding true_false inverter scorer

### DIFF
--- a/pyrit/score/__init__.py
+++ b/pyrit/score/__init__.py
@@ -14,6 +14,7 @@ from pyrit.score.self_ask_likert_scorer import SelfAskLikertScorer, LikertScaleP
 from pyrit.score.self_ask_scale_scorer import SelfAskScaleScorer, ScalePaths
 from pyrit.score.self_ask_true_false_scorer import SelfAskTrueFalseScorer, TrueFalseQuestionPaths
 from pyrit.score.substring_scorer import SubStringScorer
+from pyrit.score.true_false_inverter_scorer import TrueFalseInverterScorer
 
 
 __all__ = [
@@ -35,5 +36,6 @@ __all__ = [
     "SelfAskScaleScorer",
     "SelfAskTrueFalseScorer",
     "SubStringScorer",
+    "TrueFalseInverterScorer",
     "TrueFalseQuestionPaths",
 ]

--- a/pyrit/score/float_scale_threshold_scorer.py
+++ b/pyrit/score/float_scale_threshold_scorer.py
@@ -10,7 +10,7 @@ from pyrit.score.scorer import Scorer
 
 
 class FloatScaleThresholdScorer(Scorer):
-    """A scorer that pplies a threshold to a float scale score to make it a true/false score."""
+    """A scorer that applies a threshold to a float scale score to make it a true/false score."""
 
     def __init__(self, *, memory: MemoryInterface, scorer: Scorer, threshold: float) -> None:
         self._scorer = scorer
@@ -51,6 +51,8 @@ class FloatScaleThresholdScorer(Scorer):
             )
             score.score_type = self.scorer_type
             score.id = uuid.uuid4()
+            score.scorer_class_identifier = self.get_identifier()
+            score.scorer_class_identifier["sub_identifier"] = self._scorer.get_identifier()
         self._memory.add_scores_to_memory(scores=scores)
         return scores
 

--- a/pyrit/score/scorer.py
+++ b/pyrit/score/scorer.py
@@ -112,4 +112,5 @@ class Scorer(abc.ABC):
         identifier = {}
         identifier["__type__"] = self.__class__.__name__
         identifier["__module__"] = self.__class__.__module__
+        identifier["sub_identifier"] = None
         return identifier

--- a/pyrit/score/true_false_inverter_scorer.py
+++ b/pyrit/score/true_false_inverter_scorer.py
@@ -34,7 +34,7 @@ class TrueFalseInverterScorer(Scorer):
         """
         scores = await self._scorer.score_async(request_response, task=task)
         for score in scores:
-            score.score_value = not score.get_value()
+            score.score_value = str(True) if not score.get_value() else str(False)
             score.score_value_description = "Inverted score: " + str(score.score_value_description)
             score.score_rationale = f"Inverted score: {score.score_value}\n{score.score_rationale}"
 

--- a/pyrit/score/true_false_inverter_scorer.py
+++ b/pyrit/score/true_false_inverter_scorer.py
@@ -1,0 +1,51 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from typing import Optional
+import uuid
+
+from pyrit.memory import MemoryInterface
+from pyrit.models import PromptRequestPiece, Score
+from pyrit.score.scorer import Scorer
+
+
+class TrueFalseInverterScorer(Scorer):
+    """A scorer that inverts a true false score."""
+
+    def __init__(self, *, memory: MemoryInterface, scorer: Scorer, threshold: float) -> None:
+        self._scorer = scorer
+        self._threshold = threshold
+        self._memory = memory
+
+        if not scorer.scorer_type == "true_false":
+            raise ValueError("The scorer must be a true false scorer")
+
+        self.scorer_type = "true_false"
+
+    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
+        """Scores the piece using the underlying true-false scorer and returns the opposite score.
+
+        Args:
+            request_response (PromptRequestPiece): The piece to score.
+            task (str): The task based on which the text should be scored.
+
+        Returns:
+            list[Score]: The scores.
+        """
+        scores = await self._scorer.score_async(request_response, task=task)
+        for score in scores:
+            score.score_value = not score.get_value()
+            score.score_value_description = "Inverted score: " + str(score.score_value_description)
+            score.score_rationale = f"Inverted score: {score.score_value}\n{score.score_rationale}"
+
+            score.id = uuid.uuid4()
+
+            score.scorer_class_identifier = self.get_identifier()
+            score.scorer_class_identifier["sub_identifier"] = self._scorer.get_identifier()
+
+        self._memory.add_scores_to_memory(scores=scores)
+        return scores
+
+    def validate(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> None:
+        """Validates the request response for scoring."""
+        self._scorer.validate(request_response, task=task)

--- a/tests/score/test_true_false_inverter.py
+++ b/tests/score/test_true_false_inverter.py
@@ -1,0 +1,67 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import os
+import pytest
+
+from typing import Generator
+from unittest.mock import MagicMock
+
+
+from pyrit.memory.memory_interface import MemoryInterface
+from pyrit.models.prompt_request_piece import PromptRequestPiece
+
+
+from pyrit.score import SubStringScorer, TrueFalseInverterScorer
+from tests.mocks import get_image_request_piece, get_memory_interface
+
+
+@pytest.fixture
+def image_request_piece() -> PromptRequestPiece:
+    return get_image_request_piece()
+
+
+@pytest.fixture
+def memory() -> Generator[MemoryInterface, None, None]:
+    yield from get_memory_interface()
+
+
+@pytest.mark.asyncio
+async def test_inverter_scorer_validate(image_request_piece: PromptRequestPiece):
+    sub_scorer = SubStringScorer(substring="test", category="new_category")
+    scorer = TrueFalseInverterScorer(memory=memory, scorer=sub_scorer, threshold=0.5)
+
+    with pytest.raises(ValueError, match="Expected text data type"):
+        await scorer.score_async(image_request_piece)
+
+    os.remove(image_request_piece.converted_value)
+
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sub_string", ["I can't answer", "Not present"])
+async def test_substring_scorer_score(sub_string: str, memory: MemoryInterface):
+    full_text = "blah I can't answer that too"
+
+    sub_scorer = SubStringScorer(substring=sub_string, category="new_category", memory=memory)
+    scorer = TrueFalseInverterScorer(memory=memory, scorer=sub_scorer, threshold=0.5)
+
+    score = await scorer.score_text_async(full_text)
+
+    assert len(score) == 1
+
+    # score_value should be the opposite of substring scorer since results are inverted
+    assert score[0].score_value != str(sub_string in full_text)
+    assert score[0].score_type == "true_false"
+    assert score[0].score_category == "new_category"
+    assert score[0].prompt_request_response_id is None
+
+
+@pytest.mark.asyncio
+async def test_substring_scorer_adds_to_memory():
+    memory = MagicMock(MemoryInterface)
+
+    scorer = SubStringScorer(substring="string", category="new_category", memory=memory)
+    await scorer.score_text_async(text="string")
+
+    memory.add_scores_to_memory.assert_called_once()

--- a/tests/score/test_true_false_inverter.py
+++ b/tests/score/test_true_false_inverter.py
@@ -27,15 +27,14 @@ def memory() -> Generator[MemoryInterface, None, None]:
 
 
 @pytest.mark.asyncio
-async def test_inverter_scorer_validate(image_request_piece: PromptRequestPiece):
-    sub_scorer = SubStringScorer(substring="test", category="new_category")
+async def test_inverter_scorer_validate(image_request_piece: PromptRequestPiece, memory: MemoryInterface):
+    sub_scorer = SubStringScorer(substring="test", category="new_category", memory=memory)
     scorer = TrueFalseInverterScorer(memory=memory, scorer=sub_scorer, threshold=0.5)
 
     with pytest.raises(ValueError, match="Expected text data type"):
         await scorer.score_async(image_request_piece)
 
     os.remove(image_request_piece.converted_value)
-
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
It can often be useful to invert true_false values. This came up most recently in Victor's PromptShield scorer.

To handle this in a generic way, this PR adds an InverterScorer, that inverts any true_false scorer.


## Tests and Documentation

Unit tests added. No documentation yet, but potentially we should add a new page with this and the float_scale_threshhold
