### PR TITLE
FIX: fixing check links

### DIFF
--- a/.github/check_links.py
+++ b/.github/check_links.py
@@ -4,6 +4,13 @@ import os
 import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+
+skipped_urls = [
+    "https://cognitiveservices.azure.com/.default",
+    "https://gandalf.lakera.ai/api/send-message",
+    "https://code.visualstudio.com/Download",  # This will block python requests
+]
+
 # Updated regex pattern to capture URLs from Markdown and HTML
 URL_PATTERN = re.compile(r'\[.*?\]\((.*?)\)|href="([^"]+)"|src="([^"]+)"')
 
@@ -26,7 +33,7 @@ def resolve_relative_url(base_path, url):
 def check_url(url):
     if (
         "http://localhost:" in url
-        or url in ["https://cognitiveservices.azure.com/.default", "https://gandalf.lakera.ai/api/send-message"]
+        or url in skipped_urls
         or os.path.isfile(url)
         or os.path.isdir(url)
         or url.startswith("mailto:")


### PR DESCRIPTION
https://code.visualstudio.com/Download started blocking python requests, and the only way I was able to make that request was to mimic browser requests. Let's skip checking that link