### PR TITLE
FEAT Add SQL Entra Auth for Azure SQL Server

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -128,3 +128,6 @@ AZURE_SQL_SERVER_CONNECTION_STRING="<Provide DB Azure SQL Server connection stri
 
 # Crucible API Key. You can get yours at: https://crucible.dreadnode.io/login
 CRUCIBLE_API_KEY = "<Provide Crucible API key here>"
+
+# Azure SQL Server Connection String
+AZURE_SQL_DB_CONNECTION_STRING = "<Provide Azure SQL DB connection string here in SQLAlchemy format>"

--- a/doc/setup/use_sql_server.md
+++ b/doc/setup/use_sql_server.md
@@ -5,9 +5,10 @@
 In order to connect PyRIT with Azure SQL Server, an Azure SQL Server instance with username & password
 authentication enabled is required. If you are creating a new Azure SQL Server resource, be sure to note the password for your "Server Admin." Otherwise, if you have an existing Azure SQL Server resource, you can reset the password from the "Overview" page.
 
-PyRIT does not yet support Microsoft Entra ID (formerly known as Azure Active Directory) when accessing Azure SQL Server. Therefore, ensure your server is configured to take non-Entra connections. To do that, navigate in the Azure Portal to Settings -&gt; Microsoft Entra ID. Under the heading "Microsoft Entra authentication only", uncheck the box reading "Support only Microsoft Entra authentication for this server." Then save the configuration.
+SQL Server requires Microsoft Entra authentication (formerly known as Azure Active Directory). To ensure this works, be
+sure to install the `az` utility and have it availble on PATH for Python to access.
 
-Finally, firewall rules can prevent you or your team from accessing SQL Server. To ensure you and your team have access, collect any public IP addresses of anyone who may need access to Azure SQL Server while running PyRIT. Once these are collected, navigate in the Azure Portal to Security -&gt; Networking. Under the heading "Firewall rules," click "+ Add a firewall rule" for each IP address that must be granted access. If the rule has only one IP address, copy the vame value into "Start IPv4 Address" and "End IPv4 Address." Then save this configuration.
+Firewall rules can prevent you or your team from accessing SQL Server. To ensure you and your team have access, collect any public IP addresses of anyone who may need access to Azure SQL Server while running PyRIT. Once these are collected, navigate in the Azure Portal to Security -&gt; Networking. Under the heading "Firewall rules," click "+ Add a firewall rule" for each IP address that must be granted access. If the rule has only one IP address, copy the vame value into "Start IPv4 Address" and "End IPv4 Address." Then save this configuration.
 
 ## Configure SQL Database
 
@@ -21,7 +22,7 @@ Connecting PyRIT to an Azure SQL Server database requires ODBC, PyODBC and Micro
 
 Once ODBC and the SQL Server driver have been configured, you must use the `AzureSQLMemory` implementation of `MemoryInterface` from the `pyrit.memory.azure_sql_server` module to connect PyRIT to an Azure SQL Server database.
 
-The constructor for `AzureSQLMemory` requires a URL connection string of the form: `mssql+pyodbc://<username>:<password>@<serverName>.database.windows.net/<databaseName>?driver=<driver string>`, where `<username>` and `<password>` are the SQL Server username and password configured above, `<serverName>` is the "Server name" as specified on the Azure SQL Server "Overview" page, `<databaseName>` is the name of the database instance created above, and `<driver string>` is the driver identifier (likely `ODBC+Driver+18+for+SQL+Server` if you installed the latest version of Microsoft's ODBC driver).
+The constructor for `AzureSQLMemory` requires a URL connection string of the form: `mssql+pyodbc://@<serverName>.database.windows.net/<databaseName>?driver=<driver string>`, where `<serverName>` is the "Server name" as specified on the Azure SQL Server "Overview" page, `<databaseName>` is the name of the database instance created above, and `<driver string>` is the driver identifier (likely `ODBC+Driver+18+for+SQL+Server` if you installed the latest version of Microsoft's ODBC driver).
 
 ## Use PyRIT with Azure SQL Server
 
@@ -35,9 +36,7 @@ from pyrit.memory import AzureSQLServer
 
 default_values.load_default_env()
 
-conn_str = os.environ.get('AZURE_SQL_SERVER_CONNECTION_STRING')
-
-azure_memory = AzureSQLServer(connection_string=conn_str)
+azure_memory = AzureSQLServer()
 ```
 
 Once you have created an instance of `AzureSQLServer`, the code will ensure that your Azure SQL Server database is properly configured with the appropriate tables.

--- a/pyrit/memory/azure_sql_memory.py
+++ b/pyrit/memory/azure_sql_memory.py
@@ -8,6 +8,7 @@ from contextlib import closing
 from typing import Optional, Sequence
 
 from azure.identity import DefaultAzureCredential
+from azure.core.credentials import AccessToken
 
 from sqlalchemy import create_engine, func, and_, event
 from sqlalchemy.engine.base import Engine
@@ -43,13 +44,13 @@ class AzureSQLMemory(MemoryInterface, metaclass=Singleton):
 
         self.engine = self._create_engine(has_echo=verbose)
 
-        self._auth_token = self._create_azure_token()
+        self._auth_token = self._create_auth_token()
         self._enable_azure_authorization()
 
         self.SessionFactory = sessionmaker(bind=self.engine)
         self._create_tables_if_not_exist()
 
-    def _create_auth_token(self) -> str:
+    def _create_auth_token(self) -> AccessToken:
         azure_credentials = DefaultAzureCredential()
         return azure_credentials.get_token(self.TOKEN_URL)
 

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -141,10 +141,17 @@ def get_azure_sql_memory() -> Generator[AzureSQLMemory, None, None]:
         connection_string="mssql+pyodbc://test:test@test/test?driver=ODBC+Driver+18+for+SQL+Server"
     )
 
-    with patch("pyrit.memory.AzureSQLMemory.get_session") as get_session_mock:
+    with (
+        patch("pyrit.memory.AzureSQLMemory.get_session") as get_session_mock,
+        patch("pyrit.memory.AzureSQLMemory._create_auth_token") as create_auth_token_mock,
+        patch("pyrit.memory.AzureSQLMemory._enable_azure_authorization") as enable_azure_authorization_mock,
+    ):
         session_mock = UnifiedAlchemyMagicMock()
         session_mock.__enter__.return_value = session_mock
         get_session_mock.return_value = session_mock
+
+        create_auth_token_mock.return_value = "token"
+        enable_azure_authorization_mock.return_value = None
 
         azure_sql_memory.disable_embedding()
 

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -137,15 +137,15 @@ def get_duckdb_memory() -> Generator[DuckDBMemory, None, None]:
 
 def get_azure_sql_memory() -> Generator[AzureSQLMemory, None, None]:
     # Create a test Azure SQL Server DB
-    azure_sql_memory = AzureSQLMemory(
-        connection_string="mssql+pyodbc://test:test@test/test?driver=ODBC+Driver+18+for+SQL+Server"
-    )
-
     with (
         patch("pyrit.memory.AzureSQLMemory.get_session") as get_session_mock,
         patch("pyrit.memory.AzureSQLMemory._create_auth_token") as create_auth_token_mock,
         patch("pyrit.memory.AzureSQLMemory._enable_azure_authorization") as enable_azure_authorization_mock,
     ):
+        azure_sql_memory = AzureSQLMemory(
+            connection_string="mssql+pyodbc://test:test@test/test?driver=ODBC+Driver+18+for+SQL+Server"
+        )
+
         session_mock = UnifiedAlchemyMagicMock()
         session_mock.__enter__.return_value = session_mock
         get_session_mock.return_value = session_mock


### PR DESCRIPTION
## Description

In order to use PyRIT with Azure SQL Server, we use username & password authentication. Such authentication has been deprecated in favor of the more secure Microsoft Entra authentication (formerly known as Azure Active Directory). This PR implements that change.

CC: @rdheekonda 

## Tests and Documentation

All tests pass

NOTE: to test this module, you will need the Azure CLI utility `az` as well as a SQL Server ODBC Driver (`ODBC Driver 18 for SQL Server` is recommended). Additionally, on Linux or macOS systems, `unixODBC` is required for ODBC-based connections to work.