### PR TITLE
[MAINT] Delete output_filename arg in image/text and text/image converters

### DIFF
--- a/pyrit/prompt_converter/add_image_text_converter.py
+++ b/pyrit/prompt_converter/add_image_text_converter.py
@@ -24,13 +24,12 @@ class AddImageTextConverter(PromptConverter):
     we pass in an image file path as an argument to the constructor as opposed to text.
 
     Args:
-        img_to_add (str): file path of image to add text to
-        font_name (str, optional): path of font to use. Must be a TrueType font (.ttf). Defaults to "arial.ttf".
-        color (tuple, optional): color to print text in, using RGB values. Defaults to (0, 0, 0).
-        font_size (optional, float): size of font to use. Defaults to 15.
-        x_pos (int, optional): x coordinate to place text in (0 is left most). Defaults to 10.
-        y_pos (int, optional): y coordinate to place text in (0 is upper most). Defaults to 10.
-        output_filename (optional, str): filename to store converted image. If not provided a unique UUID will be used
+        img_to_add (str): File path of image to add text to
+        font_name (str, optional): Path of font to use. Must be a TrueType font (.ttf). Defaults to "arial.ttf".
+        color (tuple, optional): Color to print text in, using RGB values. Defaults to (0, 0, 0).
+        font_size (float, optional): Size of font to use. Defaults to 15.
+        x_pos (int, optional): X coordinate to place text in (0 is left most). Defaults to 10.
+        y_pos (int, optional): Y coordinate to place text in (0 is upper most). Defaults to 10.
     """
 
     def __init__(
@@ -41,7 +40,6 @@ class AddImageTextConverter(PromptConverter):
         font_size: Optional[int] = 15,
         x_pos: Optional[int] = 10,
         y_pos: Optional[int] = 10,
-        output_filename: Optional[str] = None,
     ):
         if not img_to_add:
             raise ValueError("Please provide valid image path")
@@ -54,7 +52,6 @@ class AddImageTextConverter(PromptConverter):
         self._color = color
         self._x_pos = x_pos
         self._y_pos = y_pos
-        self._output_name = output_filename
 
     def _load_font(self):
         """
@@ -137,7 +134,8 @@ class AddImageTextConverter(PromptConverter):
         image_type = mime_type.split("/")[-1]
         updated_img.save(image_bytes, format=image_type)
         image_str = base64.b64encode(image_bytes.getvalue())
-        img_serializer.save_b64_image(data=image_str, output_filename=self._output_name)
+        # Save image as generated UUID filename
+        img_serializer.save_b64_image(data=image_str)
         return ConverterResult(output_text=img_serializer.value, output_type="image_path")
 
     def input_supported(self, input_type: PromptDataType) -> bool:

--- a/pyrit/prompt_converter/add_text_image_converter.py
+++ b/pyrit/prompt_converter/add_text_image_converter.py
@@ -22,13 +22,12 @@ class AddTextImageConverter(PromptConverter):
     Adds a string to an image and wraps the text into multiple lines if necessary.
 
     Args:
-        text_to_add (str): text to add to an image. Defaults to empty string.
-        font_name (str, optional): path of font to use. Must be a TrueType font (.ttf). Defaults to "arial.ttf".
-        color (tuple, optional): color to print text in, using RGB values. Defaults to (0, 0, 0).
-        font_size (optional, float): size of font to use. Defaults to 15.
-        x_pos (int, optional): x coordinate to place text in (0 is left most). Defaults to 10.
-        y_pos (int, optional): y coordinate to place text in (0 is upper most). Defaults to 10.
-        output_filename (optional, str): filename to store converted image. If not provided a unique UUID will be used
+        text_to_add (str): Text to add to an image. Defaults to empty string.
+        font_name (str, optional): Path of font to use. Must be a TrueType font (.ttf). Defaults to "arial.ttf".
+        color (tuple, optional): Color to print text in, using RGB values. Defaults to (0, 0, 0).
+        font_size (float, optional): Size of font to use. Defaults to 15.
+        x_pos (int, optional): X coordinate to place text in (0 is left most). Defaults to 10.
+        y_pos (int, optional): Y coordinate to place text in (0 is upper most). Defaults to 10.
     """
 
     def __init__(
@@ -39,9 +38,8 @@ class AddTextImageConverter(PromptConverter):
         font_size: Optional[int] = 15,
         x_pos: Optional[int] = 10,
         y_pos: Optional[int] = 10,
-        output_filename: Optional[str] = None,
     ):
-        if not text_to_add:
+        if text_to_add.strip() == "":
             raise ValueError("Please provide valid text_to_add value")
         if not font_name.endswith(".ttf"):
             raise ValueError("The specified font must be a TrueType font with a .ttf extension")
@@ -52,7 +50,6 @@ class AddTextImageConverter(PromptConverter):
         self._color = color
         self._x_pos = x_pos
         self._y_pos = y_pos
-        self._output_name = output_filename
 
     def _load_font(self):
         """
@@ -135,7 +132,8 @@ class AddTextImageConverter(PromptConverter):
         image_type = mime_type.split("/")[-1]
         updated_img.save(image_bytes, format=image_type)
         image_str = base64.b64encode(image_bytes.getvalue())
-        img_serializer.save_b64_image(data=image_str, output_filename=self._output_name)
+        # Save image as generated UUID filename
+        img_serializer.save_b64_image(data=image_str)
         return ConverterResult(output_text=img_serializer.value, output_type="image_path")
 
     def input_supported(self, input_type: PromptDataType) -> bool:

--- a/tests/converter/test_add_image_text_converter.py
+++ b/tests/converter/test_add_image_text_converter.py
@@ -25,7 +25,6 @@ def test_add_image_text_converter_initialization(image_text_converter_sample_ima
         font_size=20,
         x_pos=10,
         y_pos=10,
-        output_filename="sample_conv_image.png",
     )
     assert converter._img_to_add == "test.png"
     assert converter._font_name == "arial.ttf"
@@ -35,7 +34,6 @@ def test_add_image_text_converter_initialization(image_text_converter_sample_ima
     assert converter._y_pos == 10
     assert converter._font is not None
     assert type(converter._font) is ImageFont.FreeTypeFont
-    assert converter._output_name == "sample_conv_image.png"
     os.remove("test.png")
 
 
@@ -98,12 +96,10 @@ async def test_add_image_text_converter_invalid_file_path():
 
 @pytest.mark.asyncio
 async def test_add_image_text_converter_convert_async(image_text_converter_sample_image) -> None:
-    converter = AddImageTextConverter(
-        img_to_add=image_text_converter_sample_image, output_filename="sample_conv_image.png"
-    )
+    converter = AddImageTextConverter(img_to_add=image_text_converter_sample_image)
     converted_image = await converter.convert_async(prompt="Sample Text!", input_type="text")
     assert converted_image
-    assert converted_image.output_text == "sample_conv_image.png"
+    assert converted_image.output_text
     assert converted_image.output_type == "image_path"
     assert os.path.exists(converted_image.output_text)
     os.remove(converted_image.output_text)


### PR DESCRIPTION
Deleted output_filename arg in add_image_text_converter and add_text_image_converter, UUID is used instead. 

Adjusted unit tests accordingly and re-ran them. 