### PR TITLE
[FEAT] Add "task" to the scoring memory entry

### DIFF
--- a/doc/code/memory/1_memory.ipynb
+++ b/doc/code/memory/1_memory.ipynb
@@ -29,9 +29,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\rlundeen\\AppData\\Local\\anaconda3\\envs\\pyrit-311\\Lib\\site-packages\\duckdb_engine\\__init__.py:565: SAWarning: Did not recognize type 'list' of column 'embedding'\n",
+      "c:\\Users\\songjustin\\AppData\\Local\\anaconda3\\envs\\pyrit-dev\\Lib\\site-packages\\duckdb_engine\\__init__.py:565: SAWarning: Did not recognize type 'list' of column 'embedding'\n",
       "  columns = self._get_columns_info(rows, domains, enums, schema)  # type: ignore[attr-defined]\n",
-      "C:\\Users\\rlundeen\\AppData\\Local\\anaconda3\\envs\\pyrit-311\\Lib\\site-packages\\duckdb_engine\\__init__.py:180: DuckDBEngineWarning: duckdb-engine doesn't yet support reflection on indices\n",
+      "c:\\Users\\songjustin\\AppData\\Local\\anaconda3\\envs\\pyrit-dev\\Lib\\site-packages\\duckdb_engine\\__init__.py:180: DuckDBEngineWarning: duckdb-engine doesn't yet support reflection on indices\n",
       "  warnings.warn(\n"
      ]
     },
@@ -71,7 +71,8 @@
       "  Column score_metadata (VARCHAR)\n",
       "  Column scorer_class_identifier (VARCHAR)\n",
       "  Column prompt_request_response_id (UUID)\n",
-      "  Column date_time (TIMESTAMP)\n"
+      "  Column date_time (TIMESTAMP)\n",
+      "  Column task (VARCHAR)\n"
      ]
     }
    ],

--- a/pyrit/memory/memory_models.py
+++ b/pyrit/memory/memory_models.py
@@ -166,6 +166,7 @@ class ScoreEntry(Base):  # type: ignore
     scorer_class_identifier: Mapped[dict[str, str]] = Column(JSON)
     prompt_request_response_id = Column(Uuid(as_uuid=True), ForeignKey(f"{PromptMemoryEntry.__tablename__}.id"))
     date_time = Column(DateTime, nullable=False)
+    task = Column(String, nullable=True)
 
     def __init__(self, *, entry: Score):
         self.id = entry.id
@@ -178,6 +179,7 @@ class ScoreEntry(Base):  # type: ignore
         self.scorer_class_identifier = entry.scorer_class_identifier
         self.prompt_request_response_id = entry.prompt_request_response_id if entry.prompt_request_response_id else None
         self.date_time = entry.date_time
+        self.task = entry.task
 
     def get_score(self) -> Score:
         return Score(
@@ -191,6 +193,7 @@ class ScoreEntry(Base):  # type: ignore
             scorer_class_identifier=self.scorer_class_identifier,
             prompt_request_response_id=self.prompt_request_response_id,
             date_time=self.date_time,
+            task=self.task,
         )
 
 

--- a/pyrit/models/score.py
+++ b/pyrit/models/score.py
@@ -44,6 +44,9 @@ class Score:
     # Timestamp of when the score was created
     timestamp: datetime
 
+    # The task based on which the text was scored
+    task: str
+
     def __init__(
         self,
         *,
@@ -57,6 +60,7 @@ class Score:
         scorer_class_identifier: Dict[str, str] = None,
         prompt_request_response_id: str | uuid.UUID,
         date_time: Optional[datetime] = datetime.now(),
+        task: Optional[str] = None,
     ):
         self.id = id if id else uuid.uuid4()
 
@@ -75,6 +79,7 @@ class Score:
         self.scorer_class_identifier = scorer_class_identifier
         self.prompt_request_response_id = prompt_request_response_id
         self.date_time = date_time
+        self.task = task
 
     def get_value(self):
         """

--- a/pyrit/models/score.py
+++ b/pyrit/models/score.py
@@ -44,7 +44,7 @@ class Score:
     # Timestamp of when the score was created
     timestamp: datetime
 
-    # The task based on which the text was scored
+    # The original objective that the attacker model aimed to achieve
     task: str
 
     def __init__(

--- a/pyrit/models/score.py
+++ b/pyrit/models/score.py
@@ -44,7 +44,7 @@ class Score:
     # Timestamp of when the score was created
     timestamp: datetime
 
-    # The original objective that the attacker model aimed to achieve
+    # The task based on which the text is scored (the original attacker model's objective).
     task: str
 
     def __init__(

--- a/pyrit/score/azure_content_filter_scorer.py
+++ b/pyrit/score/azure_content_filter_scorer.py
@@ -129,6 +129,7 @@ class AzureContentFilterScorer(Scorer):
                 score_rationale=None,
                 scorer_class_identifier=self.get_identifier(),
                 prompt_request_response_id=request_response.id,
+                task=task,
             )
             self._memory.add_scores_to_memory(scores=[score])
             scores.append(score)

--- a/pyrit/score/azure_content_filter_scorer.py
+++ b/pyrit/score/azure_content_filter_scorer.py
@@ -82,7 +82,8 @@ class AzureContentFilterScorer(Scorer):
                 In case of an image, the image size needs to less than image size is 2048 x 2048 pixels,
                 but more than 50x50 pixels. The data size should not exceed exceed 4 MB. Image must be
                 of type JPEG, PNG, GIF, BMP, TIFF, or WEBP.
-            task (str): The task based on which the text should be scored. Currently not supported for this scorer.
+            task (str): The task based on which the text should be scored (the original attacker model's objective).
+                Currently not supported for this scorer.
         Returns:
             A Score object with the score value mapping to severity utilizing the get_azure_severity function.
             The value will be on a 0-7 scale with 0 being least and 7 being most harmful for text or image.

--- a/pyrit/score/float_scale_threshold_scorer.py
+++ b/pyrit/score/float_scale_threshold_scorer.py
@@ -30,7 +30,7 @@ class FloatScaleThresholdScorer(Scorer):
 
         Args:
             request_response (PromptRequestPiece): The piece to score.
-            task (str): The task based on which the text should be scored.
+            task (str): The task based on which the text should be scored (the original attacker model's objective).
 
         Returns:
             list[Score]: The scores.

--- a/pyrit/score/gandalf_scorer.py
+++ b/pyrit/score/gandalf_scorer.py
@@ -116,6 +116,7 @@ class GandalfScorer(Scorer):
                 score_metadata=None,
                 prompt_request_response_id=request_response.id,
                 scorer_class_identifier=self.get_identifier(),
+                task=task,
             )
         else:
             # Step 2. Check for correct password via API
@@ -140,6 +141,7 @@ class GandalfScorer(Scorer):
                     score_metadata=None,
                     prompt_request_response_id=request_response.id,
                     scorer_class_identifier=self.get_identifier(),
+                    task=task,
                 )
             else:
                 score = Score(
@@ -151,6 +153,7 @@ class GandalfScorer(Scorer):
                     score_metadata=None,
                     prompt_request_response_id=request_response.id,
                     scorer_class_identifier=self.get_identifier(),
+                    task=task,
                 )
 
         self._memory.add_scores_to_memory(scores=[score])

--- a/pyrit/score/gandalf_scorer.py
+++ b/pyrit/score/gandalf_scorer.py
@@ -92,7 +92,8 @@ class GandalfScorer(Scorer):
 
         Args:
             text (str): The text to be scored.
-            task (str): The task based on which the text should be scored. Currently not supported for this scorer.
+            task (str): The task based on which the text should be scored (the original attacker model's objective).
+                Currently not supported for this scorer.
 
         Returns:
             The score is the password if found in text, else empty.

--- a/pyrit/score/human_in_the_loop_scorer.py
+++ b/pyrit/score/human_in_the_loop_scorer.py
@@ -34,6 +34,7 @@ class HumanInTheLoopScorer(Scorer):
                     score_metadata=row.get("score_metadata", None),
                     scorer_class_identifier=self.get_identifier(),
                     prompt_request_response_id=row["prompt_request_response_id"],
+                    task=row.get("task", None),
                 )
                 scores.append(score)
 
@@ -75,6 +76,7 @@ class HumanInTheLoopScorer(Scorer):
             score_metadata=score_metadata,
             scorer_class_identifier=self.get_identifier(),
             prompt_request_response_id=request_response.id,
+            task=task,
         )
 
         self._memory.add_scores_to_memory(scores=[score])

--- a/pyrit/score/markdown_injection.py
+++ b/pyrit/score/markdown_injection.py
@@ -52,6 +52,7 @@ class MarkdownInjectionScorer(Scorer):
                 score_rationale=None,
                 scorer_class_identifier=self.get_identifier(),
                 prompt_request_response_id=request_response.id,
+                task=task,
             )
         ]
 

--- a/pyrit/score/markdown_injection.py
+++ b/pyrit/score/markdown_injection.py
@@ -24,7 +24,8 @@ class MarkdownInjectionScorer(Scorer):
         Args:
             request_response (PromptRequestPiece): The PromptRequestPiece object containing the text to check for
                 markdown injection.
-            task (str): The task based on which the text should be scored. Currently not supported for this scorer.
+            task (str): The task based on which the text should be scored (the original attacker model's objective).
+                Currently not supported for this scorer.
 
         Returns:
             list[Score]: A list of Score objects with the score value as True if markdown injection is detected,

--- a/pyrit/score/prompt_shield_scorer.py
+++ b/pyrit/score/prompt_shield_scorer.py
@@ -73,6 +73,7 @@ class PromptShieldScorer(Scorer):
             score_rationale=None,
             scorer_class_identifier=self.get_identifier(),
             prompt_request_response_id=request_response.id,
+            task=task,
         )
 
         self._memory.add_scores_to_memory(scores=[score])

--- a/pyrit/score/scorer.py
+++ b/pyrit/score/scorer.py
@@ -24,7 +24,7 @@ class Scorer(abc.ABC):
 
         Args:
             request_response (PromptRequestPiece): The request response to be scored.
-            task (str): The task based on which the text should be scored.
+            task (str): The task based on which the text should be scored (the original attacker model's objective).
 
         Returns:
             list[Score]: A list of Score objects representing the results.
@@ -39,7 +39,7 @@ class Scorer(abc.ABC):
 
         Args:
             request_response (PromptRequestPiece): The request response to be validated.
-            task (str): The task based on which the text should be scored.
+            task (str): The task based on which the text should be scored (the original attacker model's objective).
         """
         raise NotImplementedError("score_async method not implemented")
 
@@ -49,7 +49,7 @@ class Scorer(abc.ABC):
 
         Args:
             text (str): The text to be scored.
-            task (str): The task based on which the text should be scored.
+            task (str): The task based on which the text should be scored (the original attacker model's objective).
 
         Returns:
             list[Score]: A list of Score objects representing the results.
@@ -68,7 +68,7 @@ class Scorer(abc.ABC):
 
         Args:
             text (str): The image to be scored.
-            task (str): The task based on which the text should be scored.
+            task (str): The task based on which the text should be scored (the original attacker model's objective).
 
         Returns:
             list[Score]: A list of Score objects representing the results.

--- a/pyrit/score/self_ask_category_scorer.py
+++ b/pyrit/score/self_ask_category_scorer.py
@@ -96,7 +96,8 @@ class SelfAskCategoryScorer(Scorer):
 
         Args:
             request_response (PromptRequestPiece): The prompt request piece to score.
-            task (str): The task based on which the text should be scored. Currently not supported for this scorer.
+            task (str): The task based on which the text should be scored (the original attacker model's objective).
+                Currently not supported for this scorer.
 
         Returns:
             list[Score]: The request_response scored.

--- a/pyrit/score/self_ask_category_scorer.py
+++ b/pyrit/score/self_ask_category_scorer.py
@@ -126,6 +126,7 @@ class SelfAskCategoryScorer(Scorer):
         )
 
         score = await self._send_chat_target_async(request, request_response.id)
+        score.task = task
         self._memory.add_scores_to_memory(scores=[score])
         return [score]
 

--- a/pyrit/score/self_ask_likert_scorer.py
+++ b/pyrit/score/self_ask_likert_scorer.py
@@ -92,7 +92,8 @@ class SelfAskLikertScorer(Scorer):
 
         Args:
             request_response (PromptRequestPiece): The prompt request piece containing the text to be scored.
-            task (str): The task based on which the text should be scored. Currently not supported for this scorer.
+            task (str): The task based on which the text should be scored (the original attacker model's objective).
+                Currently not supported for this scorer.
 
         Returns:
             list[Score]: The request_response scored.

--- a/pyrit/score/self_ask_likert_scorer.py
+++ b/pyrit/score/self_ask_likert_scorer.py
@@ -46,7 +46,7 @@ class SelfAskLikertScorer(Scorer):
         if likert_scale["category"]:
             self._score_category = likert_scale["category"]
         else:
-            raise ValueError(f"Impropoerly formated likert scale yaml file. Missing category in {likert_scale_path}.")
+            raise ValueError(f"Improperly formatted likert scale yaml file. Missing category in {likert_scale_path}.")
 
         likert_scale = self._likert_scale_description_to_string(likert_scale["scale_descriptions"])
 
@@ -120,7 +120,7 @@ class SelfAskLikertScorer(Scorer):
         )
 
         score = await self._send_chat_target_async(request, request_response.id)
-
+        score.task = task
         self._memory.add_scores_to_memory(scores=[score])
         return [score]
 

--- a/pyrit/score/self_ask_scale_scorer.py
+++ b/pyrit/score/self_ask_scale_scorer.py
@@ -129,7 +129,7 @@ class SelfAskScaleScorer(Scorer):
 
         Args:
             request_response (PromptRequestPiece): The prompt request piece containing the text to be scored.
-            task (str): The task to be scored.
+            task (str): The task based on which the text should be scored (the original attacker model's objective).
 
         Returns:
             list[Score]: The request_response scored.

--- a/pyrit/score/self_ask_scale_scorer.py
+++ b/pyrit/score/self_ask_scale_scorer.py
@@ -159,7 +159,7 @@ class SelfAskScaleScorer(Scorer):
         )
 
         score = await self._send_chat_target_async(request, request_response.id)
-
+        score.task = task
         self._memory.add_scores_to_memory(scores=[score])
         return [score]
 

--- a/pyrit/score/self_ask_true_false_scorer.py
+++ b/pyrit/score/self_ask_true_false_scorer.py
@@ -80,7 +80,8 @@ class SelfAskTrueFalseScorer(Scorer):
 
         Args:
             request_response (PromptRequestPiece): The prompt request piece containing the text to be scored.
-            task (str): The task based on which the text should be scored. Currently not supported for this scorer.
+            task (str): The task based on which the text should be scored (the original attacker model's objective).
+                Currently not supported for this scorer.
 
         Returns:
             list[Score]: The request_response scored.

--- a/pyrit/score/self_ask_true_false_scorer.py
+++ b/pyrit/score/self_ask_true_false_scorer.py
@@ -114,6 +114,7 @@ class SelfAskTrueFalseScorer(Scorer):
         )
 
         score = await self._send_chat_target_async(request, request_response.id)
+        score.task = task
         self._memory.add_scores_to_memory(scores=[score])
         return [score]
 

--- a/pyrit/score/substring_scorer.py
+++ b/pyrit/score/substring_scorer.py
@@ -36,6 +36,7 @@ class SubStringScorer(Scorer):
                 score_rationale=None,
                 scorer_class_identifier=self.get_identifier(),
                 prompt_request_response_id=request_response.id,
+                task=task,
             )
         ]
 

--- a/pyrit/score/true_false_inverter_scorer.py
+++ b/pyrit/score/true_false_inverter_scorer.py
@@ -27,7 +27,7 @@ class TrueFalseInverterScorer(Scorer):
 
         Args:
             request_response (PromptRequestPiece): The piece to score.
-            task (str): The task based on which the text should be scored.
+            task (str): The task based on which the text should be scored (the original attacker model's objective).
 
         Returns:
             list[Score]: The scores.

--- a/tests/score/test_self_ask_scale.py
+++ b/tests/score/test_self_ask_scale.py
@@ -174,6 +174,7 @@ async def test_scale_scorer_score(memory: MemoryInterface, scorer_scale_response
     assert score[0].score_type == "float_scale"
     assert score[0].score_category == "jailbreak"
     assert score[0].prompt_request_response_id is None
+    assert score[0].task == "task"
 
 
 @pytest.mark.asyncio
@@ -222,6 +223,7 @@ async def test_scale_scorer_score_custom_scale(memory: MemoryInterface, scorer_s
     assert score[0].score_type == "float_scale"
     assert score[0].score_category == "jailbreak"
     assert score[0].prompt_request_response_id is None
+    assert score[0].task == "task"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Added task as arg for `Score` initialization (provided through `score_async` functions) and added column in `ScoreEntries` db so that memory keeps track of task. 

I re-ran 1_memory notebook to ensure the column exists in `ScoreEntries` schema and re-ran all score unit tests (after adjusting a couple of the tests in `test_self_ask_scale` to test task initialization)
