### PR TITLE
[MAINT] Fix typos in OllamaChatTarget

### DIFF
--- a/pyrit/prompt_target/prompt_chat_target/ollama_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/ollama_chat_target.py
@@ -73,11 +73,11 @@ class OllamaChatTarget(PromptChatTarget):
         self,
         messages: list[ChatMessage],
     ) -> dict:
-        squased_messages = self.chat_message_normalizer.normalize(messages)
-        messages_dict = [message.model_dump(exclude_none=True) for message in squased_messages]
+        squashed_messages = self.chat_message_normalizer.normalize(messages)
+        messages_list = [message.model_dump(exclude_none=True) for message in squashed_messages]
         data = {
             "model": self.model_name,
-            "messages": messages_dict,
+            "messages": messages_list,
             "stream": False,
         }
         return data


### PR DESCRIPTION
## Description

Fixes two small typos in `OllamaChatTarget._construct_http_body`:
- `squashed_messages` was missing the `h`
- `messages_dict` is actually a list

## Tests and Documentation

N/A