### PR TITLE
FIX: correct type of the top_p argument in various PromptTarget classes

### DIFF
--- a/pyrit/prompt_target/azure_openai_completion_target.py
+++ b/pyrit/prompt_target/azure_openai_completion_target.py
@@ -33,7 +33,7 @@ class AzureOpenAICompletionTarget(PromptTarget):
         api_version: str = "2024-02-01",
         max_tokens: int = 1024,
         temperature: float = 1.0,
-        top_p: int = 1,
+        top_p: float = 1.0,
         frequency_penalty: float = 0.5,
         presence_penalty: float = 0.5,
         max_requests_per_minute: Optional[int] = None,
@@ -62,8 +62,8 @@ class AzureOpenAICompletionTarget(PromptTarget):
                 Defaults to 1024.
             temperature (float, optional): The temperature parameter for controlling the
                 randomness of the response. Defaults to 1.0.
-            top_p (int, optional): The top-p parameter for controlling the diversity of the
-                response. Defaults to 1.
+            top_p (float, optional): The top-p parameter for controlling the diversity of the
+                response. Defaults to 1.0.
             frequency_penalty (float, optional): The frequency penalty parameter for penalizing
                 frequently generated tokens. Defaults to 0.5.
             presence_penalty (float, optional): The presence penalty parameter for penalizing

--- a/pyrit/prompt_target/prompt_chat_target/azure_ml_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/azure_ml_chat_target.py
@@ -31,7 +31,7 @@ class AzureMLChatTarget(PromptChatTarget):
         memory: MemoryInterface = None,
         max_tokens: int = 400,
         temperature: float = 1.0,
-        top_p: int = 1,
+        top_p: float = 1.0,
         repetition_penalty: float = 1.2,
         max_requests_per_minute: Optional[int] = None,
     ) -> None:
@@ -51,8 +51,8 @@ class AzureMLChatTarget(PromptChatTarget):
                 Defaults to 400.
             temperature (float, optional): The temperature for generating diverse responses.
                 Defaults to 1.0.
-            top_p (int, optional): The top-p value for generating diverse responses.
-                Defaults to 1.
+            top_p (float, optional): The top-p value for generating diverse responses.
+                Defaults to 1.0.
             repetition_penalty (float, optional): The repetition penalty for generating diverse responses.
                 Defaults to 1.2.
             max_requests_per_minute (int, optional): Number of requests the target can handle per
@@ -119,7 +119,7 @@ class AzureMLChatTarget(PromptChatTarget):
         messages: list[ChatMessage],
         max_tokens: int = 400,
         temperature: float = 1.0,
-        top_p: int = 1,
+        top_p: float = 1.0,
         repetition_penalty: float = 1.2,
     ) -> str:
         """
@@ -132,7 +132,7 @@ class AzureMLChatTarget(PromptChatTarget):
             max_tokens (int, optional): The maximum number of tokens to generate. Defaults to 400.
             temperature (float, optional): Controls randomness in the response generation. Defaults to 1.0.
                 1 is more random, 0 is less.
-            top_p (int, optional): Controls diversity of the response generation. Defaults to 1.
+            top_p (float, optional): Controls diversity of the response generation. Defaults to 1.0.
                 1 is more random, 0 is less.
             repetition_penalty (float, optional): Controls repetition in the response generation.
                 Defaults to 1.2.
@@ -157,7 +157,7 @@ class AzureMLChatTarget(PromptChatTarget):
         messages: list[ChatMessage],
         max_tokens: int,
         temperature: float,
-        top_p: int,
+        top_p: float,
         repetition_penalty: float,
     ) -> dict:
         """Constructs the HTTP request body for the AML online endpoint."""

--- a/pyrit/prompt_target/prompt_chat_target/azure_openai_gpto_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/azure_openai_gpto_chat_target.py
@@ -47,7 +47,7 @@ class AzureOpenAIGPT4OChatTarget(PromptChatTarget):
         api_version: str = "2024-02-01",
         max_tokens: int = 1024,
         temperature: float = 1.0,
-        top_p: int = 1,
+        top_p: float = 1.0,
         frequency_penalty: float = 0.5,
         presence_penalty: float = 0.5,
         max_requests_per_minute: Optional[int] = None,
@@ -75,8 +75,8 @@ class AzureOpenAIGPT4OChatTarget(PromptChatTarget):
                 Defaults to 1024.
             temperature (float, optional): The temperature parameter for controlling the
                 randomness of the response. Defaults to 1.0.
-            top_p (int, optional): The top-p parameter for controlling the diversity of the
-                response. Defaults to 1.
+            top_p (float, optional): The top-p parameter for controlling the diversity of the
+                response. Defaults to 1.0.
             frequency_penalty (float, optional): The frequency penalty parameter for penalizing
                 frequently generated tokens. Defaults to 0.5.
             presence_penalty (float, optional): The presence penalty parameter for penalizing
@@ -261,7 +261,7 @@ class AzureOpenAIGPT4OChatTarget(PromptChatTarget):
         messages: list[ChatMessageListDictContent],
         max_tokens: int = 1024,
         temperature: float = 1.0,
-        top_p: int = 1,
+        top_p: float = 1.0,
         frequency_penalty: float = 0.5,
         presence_penalty: float = 0.5,
     ) -> str:
@@ -276,8 +276,8 @@ class AzureOpenAIGPT4OChatTarget(PromptChatTarget):
                 Defaults to 1024.
             temperature (float, optional): Controls randomness in the response generation.
                 Defaults to 1.0.
-            top_p (int, optional): Controls diversity of the response generation.
-                Defaults to 1.
+            top_p (float, optional): Controls diversity of the response generation.
+                Defaults to 1.0.
             frequency_penalty (float, optional): Controls the frequency of generating the same lines of text.
                 Defaults to 0.5.
             presence_penalty (float, optional): Controls the likelihood to talk about new topics.

--- a/pyrit/prompt_target/prompt_chat_target/azure_openai_gptv_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/azure_openai_gptv_chat_target.py
@@ -46,7 +46,7 @@ class AzureOpenAIGPTVChatTarget(PromptChatTarget):
         api_version: str = "2024-02-01",
         max_tokens: int = 1024,
         temperature: float = 1.0,
-        top_p: int = 1,
+        top_p: float = 1.0,
         frequency_penalty: float = 0.5,
         presence_penalty: float = 0.5,
         max_requests_per_minute: Optional[int] = None,
@@ -74,8 +74,8 @@ class AzureOpenAIGPTVChatTarget(PromptChatTarget):
                 Defaults to 1024.
             temperature (float, optional): The temperature parameter for controlling the
                 randomness of the response. Defaults to 1.0.
-            top_p (int, optional): The top-p parameter for controlling the diversity of the
-                response. Defaults to 1.
+            top_p (float, optional): The top-p parameter for controlling the diversity of the
+                response. Defaults to 1.0.
             frequency_penalty (float, optional): The frequency penalty parameter for penalizing
                 frequently generated tokens. Defaults to 0.5.
             presence_penalty (float, optional): The presence penalty parameter for penalizing
@@ -256,7 +256,7 @@ class AzureOpenAIGPTVChatTarget(PromptChatTarget):
         messages: list[ChatMessageListContent],
         max_tokens: int = 1024,
         temperature: float = 1.0,
-        top_p: int = 1,
+        top_p: float = 1.0,
         frequency_penalty: float = 0.5,
         presence_penalty: float = 0.5,
     ) -> str:
@@ -271,8 +271,8 @@ class AzureOpenAIGPTVChatTarget(PromptChatTarget):
                 Defaults to 1024.
             temperature (float, optional): Controls randomness in the response generation.
                 Defaults to 1.0.
-            top_p (int, optional): Controls diversity of the response generation.
-                Defaults to 1.
+            top_p (float, optional): Controls diversity of the response generation.
+                Defaults to 1.0.
             frequency_penalty (float, optional): Controls the frequency of generating the same lines of text.
                 Defaults to 0.5.
             presence_penalty (float, optional): Controls the likelihood to talk about new topics.

--- a/pyrit/prompt_target/prompt_chat_target/openai_chat_target.py
+++ b/pyrit/prompt_target/prompt_chat_target/openai_chat_target.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 class OpenAIChatInterface(PromptChatTarget):
 
-    _top_p: int
+    _top_p: float
     _deployment_name: str
     _temperature: float
     _frequency_penalty: float
@@ -83,7 +83,7 @@ class OpenAIChatInterface(PromptChatTarget):
         messages: list[ChatMessage],
         max_tokens: int = 1024,
         temperature: float = 1.0,
-        top_p: int = 1,
+        top_p: float = 1.0,
         frequency_penalty: float = 0.5,
         presence_penalty: float = 0.5,
     ) -> str:
@@ -98,8 +98,13 @@ class OpenAIChatInterface(PromptChatTarget):
                 Defaults to 1024.
             temperature (float, optional): Controls randomness in the response generation.
                 Defaults to 1.0.
-            top_p (int, optional): Controls diversity of the response generation.
-                Defaults to 1.
+            top_p (float, optional): Probability mass for nucleus sampling (an alternative to
+                temperature). Tokens are sampled from the rescaled output probability distribution
+                whose support is the smallest set of tokens whose cumulative probability mass exceeds
+                top_p. So, with top_p = 0.1 only the top 10% of the tokens will be considered.
+                This technique helps increase output diversity and fluency.
+                It is recommended to set top_p or temperature, but not both.
+                Defaults to 1.0.
             frequency_penalty (float, optional): Controls the frequency of generating the same lines of text.
                 Defaults to 0.5.
             presence_penalty (float, optional): Controls the likelihood to talk about new topics.
@@ -157,7 +162,7 @@ class AzureOpenAITextChatTarget(OpenAIChatInterface):
         api_version: str = "2024-02-01",
         max_tokens: int = 1024,
         temperature: float = 1.0,
-        top_p: int = 1,
+        top_p: float = 1.0,
         frequency_penalty: float = 0.5,
         presence_penalty: float = 0.5,
         max_requests_per_minute: Optional[int] = None,
@@ -190,8 +195,8 @@ class AzureOpenAITextChatTarget(OpenAIChatInterface):
                 Defaults to 1024.
             temperature (float, optional): The temperature parameter for controlling the
                 randomness of the response. Defaults to 1.0.
-            top_p (int, optional): The top-p parameter for controlling the diversity of the
-                response. Defaults to 1.
+            top_p (float, optional): The top-p parameter for controlling the diversity of the
+                response. Defaults to 1.0.
             frequency_penalty (float, optional): The frequency penalty parameter for penalizing
                 frequently generated tokens. Defaults to 0.5.
             presence_penalty (float, optional): The presence penalty parameter for penalizing
@@ -260,7 +265,7 @@ class OpenAIChatTarget(OpenAIChatInterface):
         memory: MemoryInterface = None,
         max_tokens: int = 1024,
         temperature: float = 1.0,
-        top_p: int = 1,
+        top_p: float = 1.0,
         frequency_penalty: float = 0.5,
         presence_penalty: float = 0.5,
         headers: Optional[dict[str, str]] = None,
@@ -282,8 +287,8 @@ class OpenAIChatTarget(OpenAIChatInterface):
                 Defaults to 1024.
             temperature (float, optional): The temperature parameter for controlling the
                 randomness of the response. Defaults to 1.0.
-            top_p (int, optional): The top-p parameter for controlling the diversity of the
-                response. Defaults to 1.
+            top_p (float, optional): The top-p parameter for controlling the diversity of the
+                response. Defaults to 1.0.
             frequency_penalty (float, optional): The frequency penalty parameter for penalizing
                 frequently generated tokens. Defaults to 0.5.
             presence_penalty (float, optional): The presence penalty parameter for penalizing


### PR DESCRIPTION
## Description

The `top_p` argument for nucleus sampling that stands for the cumulative mass probability of the tokens considered for sampling was wrongly annotated as having type `int` (see e.g. https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p). This PR changes the type to `float`.

## Tests and Documentation

Modified the docstrings accordingly.
Found no regressions in existing tests. 
