### PR TITLE
FEAT: Export Conversations and Scores in the same JSON file

### DIFF
--- a/pyrit/memory/memory_exporter.py
+++ b/pyrit/memory/memory_exporter.py
@@ -28,7 +28,7 @@ class MemoryExporter:
             # Future formats can be added here
         }
 
-    def export_data(self, data: list[Base], *, file_path: Path = None, export_type: str = "json"):  # type: ignore
+    def export_data(self, data: list[dict], *, file_path: Path = None, export_type: str = "json"):  # type: ignore
         """
         Exports the provided data to a file in the specified format.
 


### PR DESCRIPTION
## FEAT: Add Function to Export Conversations and Scores to JSON

### Description
This pull request introduces a new feature to the `memory_interface` that allows for exporting both conversations and their associated scores into a JSON file. The `export_conversations_and_scores` function groups conversations by their original prompt IDs and attaches corresponding scores to each conversation, exporting the combined data to a JSON file.

- Resolves issue: #422 

### Changes
- Added `export_conversations_and_scores` function to export conversations and their scores.
- Updated relevant code areas to support the feature.
  