### PR TITLE
MAINT: Stripping json in llm scorers

### DIFF
--- a/pyrit/score/scorer.py
+++ b/pyrit/score/scorer.py
@@ -8,7 +8,7 @@ from typing import Optional, Sequence
 import uuid
 
 from pyrit.common.batch_helper import batch_task_async
-from pyrit.exceptions.exception_classes import InvalidJsonException, pyrit_json_retry
+from pyrit.exceptions.exception_classes import InvalidJsonException, pyrit_json_retry, remove_markdown_json
 from pyrit.models import PromptRequestResponse, PromptRequestPiece
 from pyrit.models.literals import PromptDataType
 from pyrit.prompt_target import PromptChatTarget
@@ -205,6 +205,8 @@ class Scorer(abc.ABC):
 
         try:
             response_json = response.request_pieces[0].converted_value
+
+            response_json = remove_markdown_json(response_json)
             parsed_response = json.loads(response_json)
 
             category_response = parsed_response.get("category")

--- a/tests/score/test_scorer.py
+++ b/tests/score/test_scorer.py
@@ -4,11 +4,11 @@
 import os
 from textwrap import dedent
 from typing import Optional
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from pyrit.exceptions.exception_classes import InvalidJsonException
+from pyrit.exceptions.exception_classes import InvalidJsonException, remove_markdown_json
 from pyrit.models import PromptRequestPiece
 from pyrit.models import PromptRequestResponse, Score
 from pyrit.prompt_target import PromptChatTarget
@@ -21,6 +21,20 @@ class MockScorer(Scorer):
 
     def validate(self, request_response: PromptRequestPiece, *, task: Optional[str] = None):
         pass
+
+
+@pytest.fixture
+def good_json():
+    return (
+        dedent(
+            """
+            {"score_value": "1",
+            "rationale": "The message does not contain any code or instructions that could be used to cause harm"}
+            """
+        )
+        .strip()
+        .replace("\n", " ")
+    )
 
 
 BAD_JSON = "this is not json"
@@ -77,18 +91,7 @@ async def test_scorer_send_chat_target_async_bad_json_exception_retries(bad_json
 
 
 @pytest.mark.asyncio
-async def test_scorer_send_chat_target_async_good_response():
-
-    good_json = (
-        dedent(
-            """
-            {"score_value": "1",
-            "rationale": "The message does not contain any code or instructions that could be used to cause harm"}
-            """
-        )
-        .strip()
-        .replace("\n", " ")
-    )
+async def test_scorer_send_chat_target_async_good_response(good_json):
 
     chat_target = MagicMock(PromptChatTarget)
 
@@ -111,3 +114,29 @@ async def test_scorer_send_chat_target_async_good_response():
     )
 
     assert chat_target.send_prompt_async.call_count == int(1)
+
+
+@pytest.mark.asyncio
+async def test_scorer_remove_markdown_json_called(good_json):
+
+    chat_target = MagicMock(PromptChatTarget)
+    good_json_resp = PromptRequestResponse(
+        request_pieces=[PromptRequestPiece(role="assistant", original_value=good_json)]
+    )
+    chat_target.send_prompt_async = AsyncMock(return_value=good_json_resp)
+
+    scorer = MockScorer()
+    scorer.scorer_type = "true_false"
+
+    with patch("pyrit.score.scorer.remove_markdown_json", wraps=remove_markdown_json) as mock_remove_markdown_json:
+        await scorer._score_value_with_llm(
+            prompt_target=chat_target,
+            system_prompt="system_prompt",
+            prompt_request_value="prompt_request_value",
+            prompt_request_data_type="text",
+            scored_prompt_id="123",
+            category="category",
+            task="task",
+        )
+
+        mock_remove_markdown_json.assert_called_once()


### PR DESCRIPTION
This change makes scoring using SelfAskLLM scorers more reliable because JSON tags are stripped (this is a known weird response and we handle it centrally for our JSON converters)