### PR TITLE
FIX: Remove Duplicate Import Statement in Documentation Examples

### DIFF
--- a/doc/how_to_guide.ipynb
+++ b/doc/how_to_guide.ipynb
@@ -61,7 +61,6 @@
     "from pyrit.common import default_values\n",
     "from pyrit.models import PromptRequestPiece\n",
     "from pyrit.prompt_target import OpenAIChatTarget\n",
-    "from pyrit.models import PromptRequestPiece\n",
     "\n",
     "default_values.load_default_env()\n",
     "\n",

--- a/doc/how_to_guide.py
+++ b/doc/how_to_guide.py
@@ -55,7 +55,6 @@ from pathlib import Path
 from pyrit.common import default_values
 from pyrit.models import PromptRequestPiece
 from pyrit.prompt_target import OpenAIChatTarget
-from pyrit.models import PromptRequestPiece
 
 default_values.load_default_env()
 


### PR DESCRIPTION
## Description

This pull request addresses a documentation issue identified in the `how_to_guide.ipynb` and `how_to_guide.py` files where a duplicate import statement:

```python
from pyrit.models import PromptRequestPiece
```

was redundantly present. This duplication could potentially lead to confusion for new contributors and clutter the codebase. By removing this duplicate line, the documentation becomes cleaner and more accessible, improving the onboarding experience for new users. This fix directly relates to issue #483.

## Tests and Documentation

No new tests were needed for this documentation fix as it involves a simple removal of a redundant import statement. The existing documentation and examples were verified to ensure they function correctly without the import statement.