### PR TITLE
FIX changed OpenAIChatTarget default values

### DIFF
--- a/pyrit/prompt_target/openai/openai_chat_target.py
+++ b/pyrit/prompt_target/openai/openai_chat_target.py
@@ -169,8 +169,8 @@ class OpenAIChatTarget(OpenAITarget):
         max_tokens: int = 1024,
         temperature: float = 1.0,
         top_p: float = 1.0,
-        frequency_penalty: float = 0.5,
-        presence_penalty: float = 0.5,
+        frequency_penalty: float = 0.,
+        presence_penalty: float = 0.,
     ) -> str:
         """
         Completes asynchronous chat request.
@@ -186,9 +186,9 @@ class OpenAIChatTarget(OpenAITarget):
             top_p (float, optional): Controls diversity of the response generation.
                 Defaults to 1.0.
             frequency_penalty (float, optional): Controls the frequency of generating the same lines of text.
-                Defaults to 0.5.
+                Defaults to 0.
             presence_penalty (float, optional): Controls the likelihood to talk about new topics.
-                Defaults to 0.5.
+                Defaults to 0.
 
         Returns:
             str: The generated response message.
@@ -196,7 +196,7 @@ class OpenAIChatTarget(OpenAITarget):
 
         response: ChatCompletion = await self._async_client.chat.completions.create(
             model=self._deployment_name,
-            max_tokens=max_tokens,
+            max_completion_tokens=max_tokens,
             temperature=temperature,
             top_p=top_p,
             frequency_penalty=frequency_penalty,

--- a/pyrit/prompt_target/openai/openai_chat_target.py
+++ b/pyrit/prompt_target/openai/openai_chat_target.py
@@ -169,8 +169,8 @@ class OpenAIChatTarget(OpenAITarget):
         max_tokens: int = 1024,
         temperature: float = 1.0,
         top_p: float = 1.0,
-        frequency_penalty: float = 0.,
-        presence_penalty: float = 0.,
+        frequency_penalty: float = 0.0,
+        presence_penalty: float = 0.0,
     ) -> str:
         """
         Completes asynchronous chat request.

--- a/pyrit/prompt_target/openai/openai_target.py
+++ b/pyrit/prompt_target/openai/openai_target.py
@@ -38,8 +38,8 @@ class OpenAITarget(PromptChatTarget):
         max_tokens: int = 2048,
         temperature: float = 1.0,
         top_p: float = 1.0,
-        frequency_penalty: float = 0.,
-        presence_penalty: float = 0.,
+        frequency_penalty: float = 0.0,
+        presence_penalty: float = 0.0,
         max_requests_per_minute: Optional[int] = None,
     ) -> None:
         """

--- a/pyrit/prompt_target/openai/openai_target.py
+++ b/pyrit/prompt_target/openai/openai_target.py
@@ -38,8 +38,8 @@ class OpenAITarget(PromptChatTarget):
         max_tokens: int = 2048,
         temperature: float = 1.0,
         top_p: float = 1.0,
-        frequency_penalty: float = 0.5,
-        presence_penalty: float = 0.5,
+        frequency_penalty: float = 0.,
+        presence_penalty: float = 0.,
         max_requests_per_minute: Optional[int] = None,
     ) -> None:
         """
@@ -73,9 +73,9 @@ class OpenAITarget(PromptChatTarget):
             top_p (float, optional): The top-p parameter for controlling the diversity of the
                 response. Defaults to 1.0.
             frequency_penalty (float, optional): The frequency penalty parameter for penalizing
-                frequently generated tokens. Defaults to 0.5.
+                frequently generated tokens. Defaults to 0.
             presence_penalty (float, optional): The presence penalty parameter for penalizing
-                tokens that are already present in the conversation history. Defaults to 0.5.
+                tokens that are already present in the conversation history. Defaults to 0.
             max_requests_per_minute (int, optional): Number of requests the target can handle per
                 minute before hitting a rate limit. The number of requests sent to the target
                 will be capped at the value provided.


### PR DESCRIPTION
## Description
This PR makes three small changes to fix an error with the `OpenAIChatTarget`:
- `max_tokens` --> `max_completion_tokens` in the OAI chat completion client
- `frequency_penalty` default value 0.5 --> 0.
- `presence_penalty` default value 0.5 --> 0.

Thanks @nina-msft for the help!

## Tests and Documentation
Tests are passing.