### PR TITLE
FEAT Add export for conversations and scores

### DIFF
--- a/doc/code/memory/9_exporting_data.ipynb
+++ b/doc/code/memory/9_exporting_data.ipynb
@@ -1,0 +1,74 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exporting Data Example\n",
+    "\n",
+    "This notebook shows all the different ways to export data from memory. This first example exports all conversations from Azure SQL memory with their respective score values in a JSON format. Without using the database query editor, these export functions allow for a quick approach to exporting data from memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exported conversation with scores to JSON: conversation_and_scores_json_example\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyrit.memory.azure_sql_memory import AzureSQLMemory\n",
+    "from pyrit.common import default_values\n",
+    "from pathlib import Path\n",
+    "\n",
+    "default_values.load_default_env()\n",
+    "    \n",
+    "memory = AzureSQLMemory()\n",
+    "    \n",
+    "# Define file path for export\n",
+    "json_file_path = Path(\"conversation_and_scores_json_example\")\n",
+    "# csv_file_path = Path(\\\"conversation_and_scores_csv_example\\\")\n",
+    "\n",
+    "# Export the data to a JSON file\n",
+    "conversation_with_scores = memory.export_all_conversations_with_scores(file_path=json_file_path, export_type=\"json\")\n",
+    "print(f\"Exported conversation with scores to JSON: {json_file_path}\")\n",
+    "#conversation_with_scores = memory.export_all_conversations_with_scores(file_path=json_file_path, export_type=\"csv\")\n",
+    "#print(f\"Exported conversation with scores to CSV: {csv_file_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Importing Data as NumPy DataFrame\n",
+    "\n",
+    "You can use the exported JSON or CSV files to import the data as a NumPy DataFrame. This can be useful for various data manipulation and analysis tasks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd #type: ignore\n",
+    "\n",
+    "df = pd.read_json(json_file_path)\n",
+    "df.head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/doc/code/memory/9_exporting_data.ipynb
+++ b/doc/code/memory/9_exporting_data.ipynb
@@ -38,6 +38,8 @@
     "# Export the data to a JSON file\n",
     "conversation_with_scores = memory.export_all_conversations_with_scores(file_path=json_file_path, export_type=\"json\")\n",
     "print(f\"Exported conversation with scores to JSON: {json_file_path}\")\n",
+    "\n",
+    "# Export the data to a CSV file\n",
     "#conversation_with_scores = memory.export_all_conversations_with_scores(file_path=json_file_path, export_type=\"csv\")\n",
     "#print(f\"Exported conversation with scores to CSV: {csv_file_path}\")"
    ]

--- a/doc/code/memory/9_exporting_data.py
+++ b/doc/code/memory/9_exporting_data.py
@@ -1,0 +1,44 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.16.4
+# ---
+
+# %% [markdown]
+# ## Exporting Data Example
+#
+# This notebook shows all the different ways to export data from memory. This first example exports all conversations from Azure SQL memory with their respective score values in a JSON format. Without using the database query editor, these export functions allow for a quick approach to exporting data from memory.
+
+# %%
+from pyrit.memory.azure_sql_memory import AzureSQLMemory
+from pyrit.common import default_values
+from pathlib import Path
+
+default_values.load_default_env()
+    
+memory = AzureSQLMemory()
+    
+# Define file path for export
+json_file_path = Path("conversation_and_scores_json_example")
+# csv_file_path = Path(\"conversation_and_scores_csv_example\")
+
+# Export the data to a JSON file
+conversation_with_scores = memory.export_all_conversations_with_scores(file_path=json_file_path, export_type="json")
+print(f"Exported conversation with scores to JSON: {json_file_path}")
+#conversation_with_scores = memory.export_all_conversations_with_scores(file_path=json_file_path, export_type="csv")
+#print(f"Exported conversation with scores to CSV: {csv_file_path}")
+
+# %% [markdown]
+# ## Importing Data as NumPy DataFrame
+#
+# You can use the exported JSON or CSV files to import the data as a NumPy DataFrame. This can be useful for various data manipulation and analysis tasks.
+
+# %%
+import pandas as pd #type: ignore
+
+df = pd.read_json(json_file_path)
+df.head()

--- a/doc/code/memory/9_exporting_data.py
+++ b/doc/code/memory/9_exporting_data.py
@@ -29,6 +29,8 @@ json_file_path = Path("conversation_and_scores_json_example")
 # Export the data to a JSON file
 conversation_with_scores = memory.export_all_conversations_with_scores(file_path=json_file_path, export_type="json")
 print(f"Exported conversation with scores to JSON: {json_file_path}")
+
+# Export the data to a CSV file
 # conversation_with_scores = memory.export_all_conversations_with_scores(file_path=json_file_path, export_type="csv")
 # print(f"Exported conversation with scores to CSV: {csv_file_path}")
 

--- a/doc/code/memory/9_exporting_data.py
+++ b/doc/code/memory/9_exporting_data.py
@@ -19,9 +19,9 @@ from pyrit.common import default_values
 from pathlib import Path
 
 default_values.load_default_env()
-    
+
 memory = AzureSQLMemory()
-    
+
 # Define file path for export
 json_file_path = Path("conversation_and_scores_json_example")
 # csv_file_path = Path(\"conversation_and_scores_csv_example\")
@@ -29,8 +29,8 @@ json_file_path = Path("conversation_and_scores_json_example")
 # Export the data to a JSON file
 conversation_with_scores = memory.export_all_conversations_with_scores(file_path=json_file_path, export_type="json")
 print(f"Exported conversation with scores to JSON: {json_file_path}")
-#conversation_with_scores = memory.export_all_conversations_with_scores(file_path=json_file_path, export_type="csv")
-#print(f"Exported conversation with scores to CSV: {csv_file_path}")
+# conversation_with_scores = memory.export_all_conversations_with_scores(file_path=json_file_path, export_type="csv")
+# print(f"Exported conversation with scores to CSV: {csv_file_path}")
 
 # %% [markdown]
 # ## Importing Data as NumPy DataFrame
@@ -38,7 +38,7 @@ print(f"Exported conversation with scores to JSON: {json_file_path}")
 # You can use the exported JSON or CSV files to import the data as a NumPy DataFrame. This can be useful for various data manipulation and analysis tasks.
 
 # %%
-import pandas as pd #type: ignore
+import pandas as pd  # type: ignore
 
 df = pd.read_json(json_file_path)
 df.head()

--- a/pyrit/memory/memory_exporter.py
+++ b/pyrit/memory/memory_exporter.py
@@ -3,7 +3,7 @@
 
 import csv
 import json
-from typing import Any
+from typing import Any, Dict, List, Union
 import uuid
 from datetime import datetime
 from pathlib import Path
@@ -28,12 +28,15 @@ class MemoryExporter:
             # Future formats can be added here
         }
 
-    def export_data(self, data: list[Base], *, file_path: Path = None, export_type: str = "json"):  # type: ignore
+    def export_data(
+            self, data: Union[List[Base], List[Dict]], *, file_path: Path = None, export_type: str = "json"
+            ):  # type: ignore
         """
         Exports the provided data to a file in the specified format.
 
         Args:
-            data (list[Base]): The data to be exported, typically a list of SQLAlchemy model instances.
+            data (Union[List[Base], List[Dict]]): The data to be exported, typically a list of SQLAlchemy
+              model instances or as a list of dictionaries.
             file_path (str): The full path, including the file name, where the data will be exported.
             export_type (str, optional): The format for exporting data. Defaults to "json".
 
@@ -49,14 +52,15 @@ class MemoryExporter:
         else:
             raise ValueError(f"Unsupported export format: {export_type}")
 
-    def export_to_json(self, data: list[Base], file_path: Path = None) -> None:  # type: ignore
+    def export_to_json(self, data: Union[List[Base], List[Dict]], file_path: Path = None) -> None:  # type: ignore
         """
         Exports the provided data to a JSON file at the specified file path.
         Each item in the data list, representing a row from the table,
         is converted to a dictionary before being written to the file.
 
         Args:
-            data (list[Base]): The data to be exported, as a list of SQLAlchemy model instances.
+            data (Union[List[Base], List[Dict]]): The data to be exported, as a list of SQLAlchemy model instances
+              or as a list of dictionaries.
             file_path (Path): The full path, including the file name, where the data will be exported.
 
         Raises:
@@ -65,18 +69,19 @@ class MemoryExporter:
         if not file_path:
             raise ValueError("Please provide a valid file path for exporting data.")
 
-        export_data = [self.model_to_dict(instance) for instance in data]
+        export_data = [self.model_to_dict(instance) if isinstance(instance, Base) else instance for instance in data]
         with open(file_path, "w") as f:
             json.dump(export_data, f, indent=4)
 
-    def export_to_csv(self, data: list[Base], file_path: Path = None) -> None:  # type: ignore
+    def export_to_csv(self, data: Union[List[Base], List[Dict]], file_path: Path = None) -> None:  # type: ignore
         """
         Exports the provided data to a CSV file at the specified file path.
         Each item in the data list, representing a row from the table,
         is converted to a dictionary before being written to the file.
 
         Args:
-            data (list[Base]): The data to be exported, as a list of SQLAlchemy model instances.
+            data (Union[List[Base], List[Dict]]): The data to be exported, as a list of SQLAlchemy model instances
+              or as a list of dictionaries.
             file_path (Path): The full path, including the file name, where the data will be exported.
 
         Raises:
@@ -87,7 +92,10 @@ class MemoryExporter:
         if not data:
             raise ValueError("No data to export.")
 
-        export_data = [_flatten_dict(self.model_to_dict(instance)) for instance in data]
+        export_data = [
+            _flatten_dict(self.model_to_dict(instance)) if isinstance(instance, Base) else _flatten_dict(instance)
+            for instance in data
+        ]
         fieldnames = list(export_data[0].keys())
         with open(file_path, "w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=fieldnames)

--- a/pyrit/memory/memory_exporter.py
+++ b/pyrit/memory/memory_exporter.py
@@ -29,8 +29,8 @@ class MemoryExporter:
         }
 
     def export_data(
-            self, data: Union[List[Base], List[Dict]], *, file_path: Path = None, export_type: str = "json"
-            ):  # type: ignore
+        self, data: Union[List[Base], List[Dict]], *, file_path: Path = None, export_type: str = "json"
+    ):  # type: ignore
         """
         Exports the provided data to a file in the specified format.
 

--- a/pyrit/memory/memory_interface.py
+++ b/pyrit/memory/memory_interface.py
@@ -2,13 +2,14 @@
 # Licensed under the MIT license.
 
 import abc
+from collections import defaultdict
 import copy
 from datetime import datetime
 import logging
 from pathlib import Path
 from sqlalchemy import and_
 from sqlalchemy.orm.attributes import InstrumentedAttribute
-from typing import MutableSequence, Optional, Sequence
+from typing import MutableSequence, Optional, Sequence, Union
 import uuid
 
 from pyrit.common.path import RESULTS_PATH
@@ -684,3 +685,39 @@ class MemoryInterface(abc.ABC):
         seed_prompts = [memory_entry.get_seed_prompt() for memory_entry in memory_entries]
         seed_prompt_groups = SeedPromptDataset.group_seed_prompts_by_prompt_group_id(seed_prompts)
         return seed_prompt_groups
+
+    def export_all_conversations_with_scores(self, *, file_path: Optional[Path] = None, export_type: str = "json"):
+        """
+        Exports all conversations with scores to a specified file.
+        Args:
+            file_path (str): The path to the file where the data will be exported.
+            If not provided, a default path using RESULTS_PATH will be constructed.
+            export_type (str): The format of the export. Defaults to "json".
+        """
+        all_prompt_pieces = self.get_all_prompt_pieces()
+
+        # Group pieces by original prompt ID
+        grouped_pieces: defaultdict[Union[uuid.UUID, str], list[str]] = defaultdict(list)
+        for piece in all_prompt_pieces:
+            grouped_pieces[piece.original_prompt_id].append(piece.converted_value)
+
+        all_scores = self.get_scores_by_prompt_ids(
+            prompt_request_response_ids=[str(key) for key in list(grouped_pieces.keys())]
+        )
+
+        # Combine data for export
+        combined_data = [
+            {
+                "prompt_request_response_id": str(score.prompt_request_response_id),
+                "conversation": grouped_pieces[score.prompt_request_response_id],
+                "score_value": score.score_value,
+            }
+            for score in all_scores
+        ]
+
+        # If file_path is not provided, construct a default using the exporter's results_path
+        if not file_path:
+            file_name = f"conversations_and_scores.{export_type}"
+            file_path = RESULTS_PATH / file_name
+
+        self.exporter.export_data(combined_data, file_path=file_path, export_type=export_type)

--- a/tests/memory/test_memory_interface.py
+++ b/tests/memory/test_memory_interface.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import tempfile
 from typing import Generator, Literal
 from unittest.mock import MagicMock, patch
 from pathlib import Path
@@ -1252,3 +1253,65 @@ def test_get_seed_prompt_groups_multiple_groups_with_unique_ids(memory: MemoryIn
     assert len(groups) == 2
     # Check that each group has a unique prompt_group_id
     assert groups[0].prompts[0].prompt_group_id != groups[1].prompts[0].prompt_group_id
+
+
+def test_export_all_conversations_with_scores_file_created(memory: MemoryInterface):
+    memory.exporter = MemoryExporter()
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".json") as temp_file:
+        with (
+            patch("pyrit.memory.duckdb_memory.DuckDBMemory.get_all_prompt_pieces") as mock_get_pieces,
+            patch("pyrit.memory.duckdb_memory.DuckDBMemory.get_scores_by_prompt_ids") as mock_get_scores,
+        ):
+            file_path = Path(temp_file.name)
+
+            mock_get_pieces.return_value = [MagicMock(original_prompt_id="1234", converted_value="sample piece")]
+            mock_get_scores.return_value = [MagicMock(prompt_request_response_id="1234", score_value=10)]
+            memory.export_all_conversations_with_scores(file_path=file_path)
+
+            assert file_path.exists()
+
+
+def test_export_all_conversations_with_scores_correct_data(memory: MemoryInterface):
+    memory.exporter = MemoryExporter()
+    expected_data = [
+        {
+            "prompt_request_response_id": "1234",
+            "conversation": ["sample piece"],
+            "score_value": 10,
+        }
+    ]
+
+    with tempfile.NamedTemporaryFile(delete=True, suffix=".json") as temp_file:
+        with (
+            patch("pyrit.memory.duckdb_memory.DuckDBMemory.get_all_prompt_pieces") as mock_get_pieces,
+            patch("pyrit.memory.duckdb_memory.DuckDBMemory.get_scores_by_prompt_ids") as mock_get_scores,
+            patch.object(memory.exporter, "export_data") as mock_export_data,
+        ):
+            file_path = Path(temp_file.name)
+
+            mock_get_pieces.return_value = [MagicMock(original_prompt_id="1234", converted_value="sample piece")]
+            mock_get_scores.return_value = [MagicMock(prompt_request_response_id="1234", score_value=10)]
+
+            memory.export_all_conversations_with_scores(file_path=file_path)
+
+            mock_export_data.assert_called_once_with(expected_data, file_path=file_path, export_type="json")
+            assert mock_export_data.call_args[0][0] == expected_data
+
+
+def test_export_all_conversations_with_scores_empty_data(memory: MemoryInterface):
+    memory.exporter = MemoryExporter()
+    expected_data: list = []
+    with tempfile.NamedTemporaryFile(delete=True, suffix=".json") as temp_file:
+        with (
+            patch("pyrit.memory.duckdb_memory.DuckDBMemory.get_all_prompt_pieces") as mock_get_pieces,
+            patch("pyrit.memory.duckdb_memory.DuckDBMemory.get_scores_by_prompt_ids") as mock_get_scores,
+            patch.object(memory.exporter, "export_data") as mock_export_data,
+        ):
+            file_path = Path(temp_file.name)
+
+            mock_get_pieces.return_value = []
+            mock_get_scores.return_value = []
+
+            memory.export_all_conversations_with_scores(file_path=file_path)
+            mock_export_data.assert_called_once_with(expected_data, file_path=file_path, export_type="json")


### PR DESCRIPTION
## Description
To make export functionality easier to use, this PR adds in work from [#432 ](https://github.com/Azure/PyRIT/pull/432) with added unit tests and export notebook to document all use cases of data export in PyRIT. This is an initial PR to set up a following PR to refactor memory schema to also include scores with conversation data.
