### PR TITLE
FEAT: Add Diacritics Converter

### DIFF
--- a/pyrit/prompt_converter/diacritic_converter.py
+++ b/pyrit/prompt_converter/diacritic_converter.py
@@ -21,11 +21,23 @@ class DiacriticConverter(PromptConverter):
         Args:
             target_chars (str): Characters to apply the diacritic to. Defaults to "aeiou".
             accent (str): Type of diacritic to apply (default is 'acute').
+
+             Available options are:
+            - 'acute': ´
+            - 'grave': `
+            - 'tilde': ˜
+            - 'umlaut': ¨
+
+        Raises:
+            ValueError: If `target_chars` is empty.
         """
         super().__init__()
 
-        self.target_chars = target_chars
-        self.accent = accent
+        if not target_chars:
+            raise ValueError("target_chars cannot be empty.")
+
+        self._target_chars = set(target_chars)
+        self._accent = accent
 
     def input_supported(self, input_type: PromptDataType) -> bool:
         """
@@ -51,10 +63,10 @@ class DiacriticConverter(PromptConverter):
             # Add other accents as needed
         }
 
-        if self.accent not in diacritics:
-            raise ValueError(f"Accent '{self.accent}' not recognized. Choose from {list(diacritics.keys())}.")
+        if self._accent not in diacritics:
+            raise ValueError(f"Accent '{self._accent}' not recognized. Choose from {list(diacritics.keys())}.")
 
-        return diacritics[self.accent]
+        return diacritics[self._accent]
 
     def _add_diacritic(self, text: str) -> str:
         """
@@ -70,7 +82,7 @@ class DiacriticConverter(PromptConverter):
 
         # Apply accent to each target character in the string
         return "".join(
-            unicodedata.normalize("NFC", char + accent_mark) if char in self.target_chars else char for char in text
+            unicodedata.normalize("NFC", char + accent_mark) if char in self._target_chars else char for char in text
         )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:

--- a/pyrit/prompt_converter/diacritic_converter.py
+++ b/pyrit/prompt_converter/diacritic_converter.py
@@ -1,0 +1,92 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import unicodedata
+import logging
+from pyrit.prompt_converter import PromptConverter, ConverterResult
+from pyrit.models import PromptDataType
+
+logger = logging.getLogger(__name__)
+
+
+class DiacriticConverter(PromptConverter):
+    """
+    A PromptConverter that applies diacritics to specified characters in a string.
+    """
+
+    def __init__(self, target_chars: str = "aeiou", accent: str = "acute"):
+        """
+        Initializes the DiacriticConverter.
+
+        Args:
+            target_chars (str): Characters to apply the diacritic to. Defaults to "aeiou".
+            accent (str): Type of diacritic to apply (default is 'acute').
+        """
+        super().__init__()
+
+        self.target_chars = target_chars
+        self.accent = accent
+
+    def input_supported(self, input_type: PromptDataType) -> bool:
+        """
+        Checks if the input type is supported by this converter.
+
+        Args:
+            input_type (PromptDataType): The type of input to check (e.g., "text").
+
+        Returns:
+            bool: True if the input type is "text", otherwise False.
+        """
+        return input_type == "text"
+
+    def _get_accent_mark(self) -> str:
+        """
+        Retrieves the Unicode character for the specified diacritic accent.
+        """
+        diacritics = {
+            "acute": "\u0301",  # Acute accent
+            "grave": "\u0300",  # Grave accent
+            "tilde": "\u0303",  # Tilde
+            "umlaut": "\u0308",  # Umlaut/Diaeresis
+            # Add other accents as needed
+        }
+
+        if self.accent not in diacritics:
+            raise ValueError(f"Accent '{self.accent}' not recognized. Choose from {list(diacritics.keys())}.")
+
+        return diacritics[self.accent]
+
+    def _add_diacritic(self, text: str) -> str:
+        """
+        Applies the diacritic to each specified target character in the text.
+
+        Args:
+            text (str): The input text in which diacritics will be added.
+
+        Returns:
+            str: The text with diacritical marks applied to specified characters.
+        """
+        accent_mark = self._get_accent_mark()
+
+        # Apply accent to each target character in the string
+        return "".join(
+            unicodedata.normalize("NFC", char + accent_mark) if char in self.target_chars else char for char in text
+        )
+
+    async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
+        """
+        Converts the given prompt by applying diacritics to target characters.
+
+        Args:
+            prompt (str): The prompt to be converted.
+
+        Returns:
+            ConverterResult: The result containing the modified prompt.
+        """
+        if not self.input_supported(input_type):
+            raise ValueError("Only 'text' input type is supported.")
+
+        # Apply diacritic transformation to the entire string
+        modified_text = self._add_diacritic(prompt)
+
+        return ConverterResult(output_text=modified_text, output_type="text")

--- a/tests/converter/test_diacritics_converter.py
+++ b/tests/converter/test_diacritics_converter.py
@@ -1,0 +1,80 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import pytest
+from pyrit.prompt_converter import ConverterResult
+from pyrit.prompt_converter.diacritic_converter import DiacriticConverter
+
+
+@pytest.mark.asyncio
+async def test_convert_async_default_target_chars():
+    converter = DiacriticConverter()
+    text = "Hello, world!"
+    result = await converter.convert_async(prompt=text)
+    assert isinstance(result, ConverterResult)
+    assert result.output_text == "Hélló, wórld!"  # Accents on every 'e', 'o' instance
+
+
+@pytest.mark.asyncio
+async def test_convert_async_custom_target_chars():
+    converter = DiacriticConverter(target_chars="l")
+    text = "Hello, world!"
+    result = await converter.convert_async(prompt=text)
+    assert result.output_text == "Heĺĺo, worĺd!"  # Accents on every 'l'
+
+
+@pytest.mark.asyncio
+async def test_convert_async_empty_target_chars():
+    converter = DiacriticConverter(target_chars="")
+    text = "Hello, world!"
+    result = await converter.convert_async(prompt=text)
+    assert result.output_text == text  # No modifications should occur
+
+
+@pytest.mark.asyncio
+async def test_convert_async_no_matching_chars():
+    converter = DiacriticConverter(target_chars="xyz")
+    text = "Hello, world!"
+    result = await converter.convert_async(prompt=text)
+    assert result.output_text == text  # No characters matched in "Hello, world!"
+
+
+@pytest.mark.asyncio
+async def test_convert_async_grave_accent():
+    converter = DiacriticConverter(target_chars="aeiou", accent="grave")
+    text = "Hello, world!"
+    result = await converter.convert_async(prompt=text)
+    assert result.output_text == "Hèllò, wòrld!"  # Grave accents on every 'e' and 'o'
+
+
+@pytest.mark.asyncio
+async def test_convert_async_invalid_accent():
+    with pytest.raises(ValueError) as excinfo:
+        converter = DiacriticConverter(accent="invalid")
+        await converter.convert_async(prompt="Hello, world!")
+    assert "Accent 'invalid' not recognized" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_convert_async_non_text_input_type():
+    converter = DiacriticConverter()
+    with pytest.raises(ValueError) as excinfo:
+        await converter.convert_async(prompt="Hello, world!", input_type="non-text")
+    assert "Only 'text' input type is supported" in str(excinfo.value)
+
+
+def test_get_accent_mark_valid():
+    converter = DiacriticConverter(accent="tilde")
+    assert converter._get_accent_mark() == "\u0303"  # Tilde mark
+
+
+def test_get_accent_mark_invalid():
+    converter = DiacriticConverter(accent="invalid")
+    with pytest.raises(ValueError) as excinfo:
+        converter._get_accent_mark()
+    assert "Accent 'invalid' not recognized" in str(excinfo.value)
+
+
+def test_default_target_chars():
+    converter = DiacriticConverter(target_chars="")
+    assert converter.target_chars == ""  # target_chars should remain empty if explicitly set to ""

--- a/tests/converter/test_diacritics_converter.py
+++ b/tests/converter/test_diacritics_converter.py
@@ -24,14 +24,6 @@ async def test_convert_async_custom_target_chars():
 
 
 @pytest.mark.asyncio
-async def test_convert_async_empty_target_chars():
-    converter = DiacriticConverter(target_chars="")
-    text = "Hello, world!"
-    result = await converter.convert_async(prompt=text)
-    assert result.output_text == text  # No modifications should occur
-
-
-@pytest.mark.asyncio
 async def test_convert_async_no_matching_chars():
     converter = DiacriticConverter(target_chars="xyz")
     text = "Hello, world!"
@@ -75,6 +67,31 @@ def test_get_accent_mark_invalid():
     assert "Accent 'invalid' not recognized" in str(excinfo.value)
 
 
-def test_default_target_chars():
-    converter = DiacriticConverter(target_chars="")
-    assert converter.target_chars == ""  # target_chars should remain empty if explicitly set to ""
+@pytest.mark.asyncio
+async def test_convert_async_single_character():
+    converter = DiacriticConverter()
+    text = "o"
+    result = await converter.convert_async(prompt=text)
+    assert result.output_text == "ó"  # 'o' with acute accent
+
+
+@pytest.mark.asyncio
+async def test_convert_async_whitespace_handling():
+    converter = DiacriticConverter()
+    text = "     "
+    result = await converter.convert_async(prompt=text)
+    assert result.output_text == text  # Whitespace should remain unchanged
+
+
+@pytest.mark.asyncio
+async def test_convert_async_empty_prompt():
+    converter = DiacriticConverter()
+    text = ""
+    result = await converter.convert_async(prompt=text)
+    assert result.output_text == ""  # Output should be empty if input is empty
+
+
+def test_empty_target_chars():
+    with pytest.raises(ValueError) as excinfo:
+        DiacriticConverter(target_chars="")
+    assert "target_chars cannot be empty." in str(excinfo.value)


### PR DESCRIPTION
### **Overview**

This PR introduces a new `DiacriticConverter` class under `pyrit.prompt_converter` to enable transformations using diacritical marks on specified characters. This converter is inspired by techniques outlined in resources such as [Bypassing Azure AI Content Safety Guardrails](https://mindgard.ai/resources/bypassing-azure-ai-content-safety-guardrails), where diacritical marks can be applied to bypass content filters. The converter provides an effective tool for testing the resilience of AI content safety mechanisms against such techniques.

### **Work Completed**
1. **Implemented `DiacriticConverter`**: 
   - Located in `pyrit.prompt_converter`.
   - Transforms text by applying specified diacritical marks (e.g., acute, grave) to target characters, supporting content safety testing.

2. **Edge Case Handling**:
   - Leaves text unmodified if `target_chars` is empty.
   - Defaults to `"aeiou"` for `target_chars` if unspecified.

3. **Test Suite**:
   - Added `pytest` tests covering default and custom targets, empty `target_chars`, and invalid accent handling.

### **Related Issue**
Resolves [FEAT add diacritics converter #515](https://github.com/Azure/PyRIT/issues/515)