### PR TITLE
FEAT: Add Zero-Width-Converter

### DIFF
--- a/doc/code/orchestrators/violent_durian.ipynb
+++ b/doc/code/orchestrators/violent_durian.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Violent Duran attack strategy\n",
+    "# Violent Durian attack strategy\n",
     "This update integrates the Violent Durian attack strategy from Project Moonshot into the PyRIT system. \n",
     "The strategy revolves around an attacker LLM manipulating the Target LLM into adopting a criminal persona and\n",
     "providing illegal advice or dangerous suggestions. The criminal persona is chosen randomly from a predefined list, \n",

--- a/doc/code/orchestrators/violent_durian.py
+++ b/doc/code/orchestrators/violent_durian.py
@@ -13,7 +13,7 @@
 # ---
 
 # %% [markdown]
-# # Violent Duran attack strategy
+# # Violent Durian attack strategy
 # This update integrates the Violent Durian attack strategy from Project Moonshot into the PyRIT system.
 # The strategy revolves around an attacker LLM manipulating the Target LLM into adopting a criminal persona and
 # providing illegal advice or dangerous suggestions. The criminal persona is chosen randomly from a predefined list,

--- a/pyrit/prompt_converter/zero_width_converter.py
+++ b/pyrit/prompt_converter/zero_width_converter.py
@@ -1,0 +1,45 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from pyrit.prompt_converter import PromptConverter, ConverterResult
+from pyrit.models import PromptDataType
+
+
+class ZeroWidthConverter(PromptConverter):
+    """
+    A PromptConverter that injects zero-width spaces between characters
+    in the provided text to bypass content safety mechanisms.
+    """
+
+    ZERO_WIDTH_SPACE = "\u200B"
+
+    def input_supported(self, input_type: PromptDataType) -> bool:
+        """
+        Checks if the input type is supported by this converter.
+        Supports only 'text' input type.
+
+        Args:
+            input_type (PromptDataType): The type of input to check (e.g., "text").
+
+        Returns:
+            bool: True if the input type is "text", otherwise False.
+        """
+        return input_type == "text"
+
+    async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
+        """
+        Converts the given prompt by injecting zero-width spaces between each character.
+
+        Args:
+            prompt (str): The prompt to be converted.
+
+        Returns:
+            ConverterResult: The result containing the modified prompt.
+        """
+        if not self.input_supported(input_type):
+            raise ValueError("Only 'text' input type is supported.")
+
+        # Insert zero-width spaces between each character
+        modified_text = self.ZERO_WIDTH_SPACE.join(prompt)
+
+        return ConverterResult(output_text=modified_text, output_type="text")

--- a/tests/converter/test_zero_width_converter.py
+++ b/tests/converter/test_zero_width_converter.py
@@ -1,0 +1,56 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import pytest
+from pyrit.prompt_converter import ConverterResult
+from pyrit.prompt_converter.zero_width_converter import ZeroWidthConverter
+
+
+@pytest.mark.asyncio
+async def test_convert_async_injects_zero_width_spaces():
+    converter = ZeroWidthConverter()
+    text = "Hello"
+    expected_output = "H\u200Be\u200Bl\u200Bl\u200Bo"  # Zero-width spaces between each character
+    result = await converter.convert_async(prompt=text)
+    assert isinstance(result, ConverterResult)
+    assert result.output_text == expected_output  # Check if output matches expected result with zero-width spaces
+
+
+@pytest.mark.asyncio
+async def test_convert_async_long_text():
+    converter = ZeroWidthConverter()
+    text = "This is a longer text used to test the ZeroWidthConverter."
+    # Expected output has a zero-width space between every character in `text`
+    expected_output = "\u200B".join(text)
+
+    result = await converter.convert_async(prompt=text)
+
+    assert result.output_text == expected_output
+    # Verify that the output length is as expected: original length + (number of characters - 1) for zero-width spaces
+    assert len(result.output_text) == len(text) + len(text) - 1
+
+
+@pytest.mark.asyncio
+async def test_convert_async_handles_empty_string():
+    converter = ZeroWidthConverter()
+    text = ""
+    result = await converter.convert_async(prompt=text)
+    assert result.output_text == ""  # Output should be empty if input is empty
+
+
+@pytest.mark.asyncio
+async def test_convert_async_non_text_input_type():
+    converter = ZeroWidthConverter()
+    with pytest.raises(ValueError) as excinfo:
+        await converter.convert_async(prompt="Hello", input_type="non-text")
+    assert "Only 'text' input type is supported" in str(excinfo.value)
+
+
+def test_input_supported_text():
+    converter = ZeroWidthConverter()
+    assert converter.input_supported("text") is True  # Should support 'text' input type
+
+
+def test_input_supported_non_text():
+    converter = ZeroWidthConverter()
+    assert converter.input_supported("non-text") is False  # Should not support non-'text' input types

--- a/tests/converter/test_zero_width_converter.py
+++ b/tests/converter/test_zero_width_converter.py
@@ -54,3 +54,26 @@ def test_input_supported_text():
 def test_input_supported_non_text():
     converter = ZeroWidthConverter()
     assert converter.input_supported("non-text") is False  # Should not support non-'text' input types
+
+
+@pytest.mark.asyncio
+async def test_convert_async_single_character():
+    converter = ZeroWidthConverter()
+    text = "A"  # Single character input
+    expected_output = "A"  # Should remain unchanged without zero-width spaces
+    result = await converter.convert_async(prompt=text)
+    assert result.output_text == expected_output
+
+
+@pytest.mark.asyncio
+async def test_convert_async_multiple_whitespace():
+    converter = ZeroWidthConverter()
+    text = "   "  # Input with multiple whitespace characters
+
+    # Converter Behavior: The ZeroWidthConverter inserts zero-width spaces between each character,
+    # resulting in N - 1 zero-width spaces for an input of length N.
+    # For three spaces, there will be two zero-width spaces between them.
+    expected_output = " \u200B \u200B "
+
+    result = await converter.convert_async(prompt=text)
+    assert result.output_text == expected_output, f"Unexpected output: {result.output_text}"


### PR DESCRIPTION
### **Overview**

This PR introduces a `ZeroWidthConverter` class under `pyrit.prompt_converter`, designed to inject zero-width spaces between characters in a given text. The primary purpose of this converter is to support testing of content safety mechanisms by creating transformed text that may bypass certain filters while appearing unchanged to the human eye.

### **Work Completed**

1. **Implemented `ZeroWidthConverter` Class**:
   - **Functionality**: Injects zero-width spaces (Unicode `U+200B`) between each character in the input text to create an unaltered visual appearance that may circumvent content safety filters.

2. **Testing**:
   - **Basic Functionality**: Confirms that zero-width spaces are correctly inserted between each character.

### **Related Issue**

Resolves [Add Zero-Width Converter for Text Transformation #516](https://github.com/Azure/PyRIT/issues/516)