### PR TITLE
FEAT add seed prompt dataset loading function for legacy datasets

### DIFF
--- a/tests/memory/test_memory_interface.py
+++ b/tests/memory/test_memory_interface.py
@@ -1045,7 +1045,10 @@ def test_get_seed_prompt_dataset_names_multiple(memory: MemoryInterface):
 
 
 def test_add_seed_prompt_groups_to_memory_empty_list(memory: MemoryInterface):
-    prompt_group = SeedPromptGroup(prompts=[])
+    prompt_group = SeedPromptGroup(
+        prompts=[SeedPrompt(value="Test prompt", added_by="tester", data_type="text", sequence=0)]
+    )
+    prompt_group.prompts = []
     with pytest.raises(ValueError, match="Prompt group must have at least one prompt."):
         memory.add_seed_prompt_groups_to_memory(prompt_groups=[prompt_group])
 
@@ -1067,7 +1070,7 @@ def test_add_seed_prompt_groups_to_memory_multiple_elements(memory: MemoryInterf
 
 
 def test_add_seed_prompt_groups_to_memory_no_elements(memory: MemoryInterface):
-    with pytest.raises(ValueError, match="Prompt group must have at least one prompt."):
+    with pytest.raises(ValueError, match="SeedPromptGroup cannot be empty."):
         prompt_group = SeedPromptGroup(prompts=[])
         memory.add_seed_prompt_groups_to_memory(prompt_groups=[prompt_group])
 


### PR DESCRIPTION
<!--- Please add one of the following as a prefix to the pull request title: -->
<!--- DOC for documentation changes -->
<!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
<!--- FIX for bug fixes -->
<!--- TEST for adding tests -->
<!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
<!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->
Legacy datasets used to have all the metadata at the top-level rather than per-prompt. This function adds the capability to still load them without making changes to the datasets. 
<!--- If you are considering making a contribution please open an issue first. -->
<!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
<!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->


## Tests and Documentation

Tested with a few internal datasets.
<!--- Contributions require tests and documentation (if applicable). -->
<!--- Include a description of tests and documentation updated (if applicable) -->

<!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
<!--- Include how you/if ran JupyText here -->
<!--- This is described at: https://github.com/Azure/PyRIT/tree/main/doc  -->
