### PR TITLE
FIX remove timezone info, pass timestamp around when retrieving data from DB

### DIFF
--- a/pyrit/auth/azure_storage_auth.py
+++ b/pyrit/auth/azure_storage_auth.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-import datetime
+from datetime import datetime, timedelta
 from urllib.parse import urlparse
 
 from azure.identity.aio import DefaultAzureCredential
@@ -27,8 +27,8 @@ class AzureStorageAuth:
         Returns:
             UserDelegationKey: A user delegation key valid for one day.
         """
-        delegation_key_start_time = datetime.datetime.now(datetime.timezone.utc)
-        delegation_key_expiry_time = delegation_key_start_time + datetime.timedelta(days=1)
+        delegation_key_start_time = datetime.now()
+        delegation_key_expiry_time = delegation_key_start_time + timedelta(days=1)
 
         user_delegation_key = await blob_service_client.get_user_delegation_key(
             key_start_time=delegation_key_start_time, key_expiry_time=delegation_key_expiry_time
@@ -75,8 +75,8 @@ class AzureStorageAuth:
                 storage_account_name = parsed_url.netloc.split(".")[0]
 
                 # Set start_time 5 minutes before the current time to account for any clock skew
-                start_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=5)
-                expiry_time = start_time + datetime.timedelta(days=1)
+                start_time = datetime.now() - timedelta(minutes=5)
+                expiry_time = start_time + timedelta(days=1)
 
                 sas_token = generate_container_sas(
                     account_name=storage_account_name,

--- a/pyrit/memory/memory_interface.py
+++ b/pyrit/memory/memory_interface.py
@@ -4,7 +4,7 @@
 import abc
 from collections import defaultdict
 import copy
-import datetime
+from datetime import datetime
 import logging
 from pathlib import Path
 from sqlalchemy import and_
@@ -605,7 +605,7 @@ class MemoryInterface(abc.ABC):
             added_by (str): The user who added the prompts.
         """
         entries: list[SeedPromptEntry] = []
-        current_time = datetime.datetime.now(datetime.timezone.utc)
+        current_time = datetime.now()
         for prompt in prompts:
             if added_by:
                 prompt.added_by = added_by

--- a/pyrit/memory/memory_models.py
+++ b/pyrit/memory/memory_models.py
@@ -122,6 +122,7 @@ class PromptMemoryEntry(Base):
             converted_value_data_type=self.converted_value_data_type,
             response_error=self.response_error,
             original_prompt_id=self.original_prompt_id,
+            timestamp=self.timestamp,
         )
 
     def __str__(self):

--- a/pyrit/models/prompt_request_piece.py
+++ b/pyrit/models/prompt_request_piece.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import abc
 import uuid
 
-import datetime
+from datetime import datetime
 from typing import Dict, List, Optional, Literal, get_args
 from uuid import uuid4
 
@@ -67,6 +67,7 @@ class PromptRequestPiece(abc.ABC):
         response_error: PromptResponseError = "none",
         originator: Originator = "undefined",
         original_prompt_id: Optional[uuid.UUID] = None,
+        timestamp: Optional[datetime] = None,
     ):
 
         self.id = id if id else uuid4()
@@ -82,7 +83,7 @@ class PromptRequestPiece(abc.ABC):
         self.conversation_id = conversation_id if conversation_id else str(uuid4())
         self.sequence = sequence
 
-        self.timestamp = datetime.datetime.now(datetime.timezone.utc)
+        self.timestamp = timestamp if timestamp else datetime.now()
         self.labels = labels
         self.prompt_metadata = prompt_metadata
 

--- a/pyrit/models/score.py
+++ b/pyrit/models/score.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 from dataclasses import dataclass
-import datetime
+from datetime import datetime
 from typing import Dict, Literal, Optional, get_args
 import uuid
 
@@ -43,7 +43,7 @@ class Score:
     prompt_request_response_id: uuid.UUID | str
 
     # Timestamp of when the score was created
-    timestamp: datetime.datetime
+    timestamp: datetime
 
     # The task based on which the text is scored (the original attacker model's objective).
     task: str
@@ -60,11 +60,11 @@ class Score:
         score_metadata: str,
         scorer_class_identifier: Dict[str, str] = None,
         prompt_request_response_id: str | uuid.UUID,
-        timestamp: Optional[datetime.datetime] = None,
+        timestamp: Optional[datetime] = None,
         task: Optional[str] = None,
     ):
         self.id = id if id else uuid.uuid4()
-        self.timestamp = timestamp if timestamp else datetime.datetime.now(datetime.timezone.utc)
+        self.timestamp = timestamp if timestamp else datetime.now()
 
         self.validate(score_type, score_value)
 
@@ -140,7 +140,7 @@ class UnvalidatedScore:
     prompt_request_response_id: uuid.UUID | str
     task: str
     id: Optional[uuid.UUID | str] = None
-    timestamp: Optional[datetime.datetime] = None
+    timestamp: Optional[datetime] = None
 
     def to_score(self, *, score_value: str):
         return Score(

--- a/pyrit/models/seed_prompt.py
+++ b/pyrit/models/seed_prompt.py
@@ -9,7 +9,7 @@ import yaml
 
 from copy import deepcopy
 from dataclasses import dataclass
-import datetime
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 from collections import defaultdict
 from jinja2 import Template, StrictUndefined
@@ -32,7 +32,7 @@ class SeedPrompt(YamlLoadable):
     authors: Optional[List[str]]
     groups: Optional[List[str]]
     source: Optional[str]
-    date_added: Optional[datetime.datetime]
+    date_added: Optional[datetime]
     added_by: Optional[str]
     metadata: Optional[Dict[str, str]]
     parameters: Optional[List[str]]
@@ -52,7 +52,7 @@ class SeedPrompt(YamlLoadable):
         authors: Optional[List[str]] = None,
         groups: Optional[List[str]] = None,
         source: Optional[str] = None,
-        date_added: Optional[datetime.datetime] = datetime.datetime.now(datetime.timezone.utc),
+        date_added: Optional[datetime] = datetime.now(),
         added_by: Optional[str] = None,
         metadata: Optional[Dict[str, str]] = None,
         parameters: Optional[List[str]] = None,

--- a/tests/memory/test_duckdb_memory.py
+++ b/tests/memory/test_duckdb_memory.py
@@ -357,7 +357,8 @@ def test_get_memories_with_json_properties(memory_interface):
         assert retrieved_entry.role == "user"
         assert retrieved_entry.original_value == "Test content"
         # For timestamp, you might want to check if it's close to the current time instead of an exact match
-        assert abs((retrieved_entry.timestamp - piece.timestamp).total_seconds()) < 10  # Assuming the test runs quickly
+        assert abs((retrieved_entry.timestamp - piece.timestamp).total_seconds()) < 0.1
+        assert abs((retrieved_entry.timestamp - entry.timestamp).total_seconds()) < 0.1
 
         converter_identifiers = retrieved_entry.converter_identifiers
         assert len(converter_identifiers) == 1

--- a/tests/test_azure_storage_auth.py
+++ b/tests/test_azure_storage_auth.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-import datetime
+from datetime import datetime, timedelta
 
 import pytest
 from unittest.mock import AsyncMock, patch
@@ -17,8 +17,8 @@ MOCK_CONTAINER_URL = "https://storageaccountname.blob.core.windows.net/container
 @pytest.mark.asyncio
 async def test_get_user_delegation_key():
     mock_blob_service_client = AsyncMock(spec=BlobServiceClient)
-    expected_start_time = datetime.datetime.now(datetime.timezone.utc)
-    expected_expiry_time = expected_start_time + datetime.timedelta(days=1)
+    expected_start_time = datetime.now()
+    expected_expiry_time = expected_start_time + timedelta(days=1)
 
     mock_user_delegation_key = UserDelegationKey()
     mock_user_delegation_key.signed_oid = "test_oid"

--- a/tests/test_prompt_request_piece.py
+++ b/tests/test_prompt_request_piece.py
@@ -7,7 +7,7 @@ import uuid
 import pytest
 import time
 
-import datetime
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 from pyrit.memory import CentralMemory
 from pyrit.models import PromptRequestPiece
@@ -48,7 +48,7 @@ def test_id_set():
 
 
 def test_datetime_set():
-    now = datetime.datetime.now(datetime.timezone.utc)
+    now = datetime.now()
     time.sleep(0.1)
     entry = PromptRequestPiece(
         role="user",


### PR DESCRIPTION
<!--- Please add one of the following as a prefix to the pull request title: -->
<!--- DOC for documentation changes -->
<!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
<!--- FIX for bug fixes -->
<!--- TEST for adding tests -->
<!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
<!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->
In #556 I standardized to use UTC as timezone everywhere but after consulting with @rdheekonda we decided not passing it at all is best. From what I could tell, the conversion from `datetime.datetime` to SqlAlchemy's `DateTime` stripped that info anyway, so this should be an improvement. While working through this, I discovered that we weren't actually preserving the timestamp when retrieving prompt memory entries from the DB. This is fixed here as well.
<!--- If you are considering making a contribution please open an issue first. -->
<!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
<!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->


## Tests and Documentation
All tests working, made a tiny update to the DuckDB tests.
<!--- Contributions require tests and documentation (if applicable). -->
<!--- Include a description of tests and documentation updated (if applicable) -->

<!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
<!--- Include how you/if ran JupyText here -->
<!--- This is described at: https://github.com/Azure/PyRIT/tree/main/doc  -->
