### PR TITLE
FIX: httpx proxy arg fix, pinned httpx version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "datasets>=3.0.0",
     "duckdb==0.10.0",
     "duckdb-engine==0.11.2",
-    "httpx[http2]>=0.27.2",
+    "httpx[http2]==0.27.2",
     "jupyter>=1.0.0",
     "ipykernel>=6.29.4",
     "numpy>=1.26.4",

--- a/pyrit/common/net_utility.py
+++ b/pyrit/common/net_utility.py
@@ -10,11 +10,11 @@ def get_httpx_client(use_async: bool = False, debug: bool = False):
     """Get the httpx client for making requests."""
 
     client_class = httpx.AsyncClient if use_async else httpx.Client
-    proxies = "http://localhost:8080" if debug else None
+    proxy = "http://localhost:8080" if debug else None
     verify_certs = not debug
 
     # fun notes; httpx default is 5 seconds, httpclient is 100, urllib in indefinite
-    return client_class(proxies=proxies, verify=verify_certs, timeout=60.0)
+    return client_class(proxt=proxy, verify=verify_certs, timeout=60.0)
 
 
 PostType = Literal["json", "data"]

--- a/pyrit/common/net_utility.py
+++ b/pyrit/common/net_utility.py
@@ -14,7 +14,7 @@ def get_httpx_client(use_async: bool = False, debug: bool = False):
     verify_certs = not debug
 
     # fun notes; httpx default is 5 seconds, httpclient is 100, urllib in indefinite
-    return client_class(proxt=proxy, verify=verify_certs, timeout=60.0)
+    return client_class(proxy=proxy, verify=verify_certs, timeout=60.0)
 
 
 PostType = Literal["json", "data"]


### PR DESCRIPTION
`proxies` arg removed --> changed to `proxy`

httpx version pinned to 0.27.2 until RESPX fix is merged: https://github.com/lundberg/respx/pull/278