### PR TITLE
FIX: Not raising exceptions on None responses

### DIFF
--- a/pyrit/models/literals.py
+++ b/pyrit/models/literals.py
@@ -13,6 +13,6 @@ none: no exception is raised
 processing: there is an exception thrown unrelated to the query
 unknown: the type of error is unknown
 """
-PromptResponseError = Literal["blocked", "none", "processing", "unknown"]
+PromptResponseError = Literal["blocked", "none", "processing", "empty", "unknown"]
 
 ChatMessageRole = Literal["system", "user", "assistant"]

--- a/tests/test_prompt_normalizer.py
+++ b/tests/test_prompt_normalizer.py
@@ -93,12 +93,13 @@ async def test_send_prompt_async_no_response_adds_memory(
 
     assert mock_memory_instance.add_request_response_to_memory.call_count == 1
 
+
 @pytest.mark.asyncio
 async def test_send_prompt_async_empty_response_exception_handled(
     mock_memory_instance, normalizer_piece: NormalizerRequestPiece
 ):
     prompt_target = AsyncMock()
-    prompt_target.send_prompt_async = AsyncMock(side_effect=EmptyResponseException("Empty response"))
+    prompt_target.send_prompt_async = AsyncMock(side_effect=EmptyResponseException(message="Empty response"))
 
     normalizer = PromptNormalizer()
     request = NormalizerRequest([normalizer_piece])

--- a/tests/test_prompt_normalizer.py
+++ b/tests/test_prompt_normalizer.py
@@ -13,6 +13,8 @@ from pyrit.models import PromptRequestResponse
 from pyrit.prompt_converter import Base64Converter, StringJoinConverter
 from pyrit.prompt_normalizer import NormalizerRequestPiece, NormalizerRequest, PromptNormalizer
 from pyrit.prompt_converter import PromptConverter, ConverterResult
+from pyrit.exceptions import EmptyResponseException
+
 
 from pyrit.prompt_normalizer.prompt_response_converter_configuration import PromptResponseConverterConfiguration
 from pyrit.prompt_target import PromptTarget
@@ -90,6 +92,24 @@ async def test_send_prompt_async_no_response_adds_memory(
     await normalizer.send_prompt_async(normalizer_request=NormalizerRequest([normalizer_piece]), target=prompt_target)
 
     assert mock_memory_instance.add_request_response_to_memory.call_count == 1
+
+@pytest.mark.asyncio
+async def test_send_prompt_async_empty_response_exception_handled(
+    mock_memory_instance, normalizer_piece: NormalizerRequestPiece
+):
+    prompt_target = AsyncMock()
+    prompt_target.send_prompt_async = AsyncMock(side_effect=EmptyResponseException("Empty response"))
+
+    normalizer = PromptNormalizer()
+    request = NormalizerRequest([normalizer_piece])
+
+    response = await normalizer.send_prompt_async(normalizer_request=request, target=prompt_target)
+
+    assert mock_memory_instance.add_request_response_to_memory.call_count == 2
+
+    assert response.request_pieces[0].response_error == "empty"
+    assert response.request_pieces[0].original_value == ""
+    assert response.request_pieces[0].original_value_data_type == "text"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`EmptyResponseException`s are raised when a target expects a response but only an empty string is returned.

Right now, PyRIT retries these. This is probably correct. However, previously, this error would re-raise. There are some models operators were testing that had this re-raise, and we don't want to stop execution.

This change makes is so EmptyResponseException are not re-raised

## Tests and Documentation

- Checked that self-ask scorers are fine with empty content
- Added a test so that the normalizer returns the proper content