### PR TITLE
DOC: Fixing title

### DIFF
--- a/doc/blog/2024_12_3.md
+++ b/doc/blog/2024_12_3.md
@@ -1,6 +1,6 @@
 # Multi-Turn orchestrators
 
-<small>03 Dec 2024</small>
+<small>03 Dec 2024 - Rich Lundeen</small>
 
 In PyRIT, orchestrators are typically seen as the top-level component. This is where your attack logic is implemented, while notebooks should primarily be used to configure orchestrators.
 

--- a/doc/code/orchestrators/2_multi_turn_orchestrators.py
+++ b/doc/code/orchestrators/2_multi_turn_orchestrators.py
@@ -13,7 +13,7 @@
 # ---
 
 # %% [markdown]
-# # Multi-Turn Orchestrator
+# # 2. Multi-Turn Orchestrator
 #
 # `MultiTurnOrchestrators` are orchestrators that sets up an attacker LLM (called `adveresarial_chat` to communicate with an objective target (called `objective_target`).
 #


### PR DESCRIPTION
Didn't realize the docs get the toc from the title, but this fixes it. Also, unlike docs, let's add authors to blog posts
