### PR TITLE
FEAT Passing HTTP client kwargs from OllamaChatTarget

### DIFF
--- a/.github/check_links.py
+++ b/.github/check_links.py
@@ -12,6 +12,7 @@ skipped_urls = [
     "https://gandalf.lakera.ai/api/send-message",
     "https://code.visualstudio.com/Download",  # This will block python requests
     "https://platform.openai.com/docs/api-reference/introduction",  # blocks python requests
+    "https://www.anthropic.com/research/many-shot-jailbreaking/",  # blocks python requests
 ]
 
 custom_myst_references = ["notebook_tests"]

--- a/.github/check_links.py
+++ b/.github/check_links.py
@@ -12,7 +12,7 @@ skipped_urls = [
     "https://gandalf.lakera.ai/api/send-message",
     "https://code.visualstudio.com/Download",  # This will block python requests
     "https://platform.openai.com/docs/api-reference/introduction",  # blocks python requests
-    "https://www.anthropic.com/research/many-shot-jailbreaking/",  # blocks python requests
+    "https://www.anthropic.com/research/many-shot-jailbreaking",  # blocks python requests
 ]
 
 custom_myst_references = ["notebook_tests"]

--- a/pyrit/common/net_utility.py
+++ b/pyrit/common/net_utility.py
@@ -1,20 +1,23 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from typing import Literal
+from typing import Literal, Optional, Any
 import httpx
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 
-def get_httpx_client(use_async: bool = False, debug: bool = False):
+def get_httpx_client(use_async: bool = False, debug: bool = False, **client_kwargs: Optional[Any]):
     """Get the httpx client for making requests."""
 
     client_class = httpx.AsyncClient if use_async else httpx.Client
     proxy = "http://localhost:8080" if debug else None
-    verify_certs = not debug
 
+    proxy = client_kwargs.pop('proxy', proxy)
+    verify_certs = client_kwargs.pop('verify', not debug)
     # fun notes; httpx default is 5 seconds, httpclient is 100, urllib in indefinite
-    return client_class(proxy=proxy, verify=verify_certs, timeout=60.0)
+    timeout = client_kwargs.pop('timeout', 60.0)
+
+    return client_class(proxy=proxy, verify=verify_certs, timeout=timeout, **client_kwargs)
 
 
 PostType = Literal["json", "data"]
@@ -29,6 +32,7 @@ async def make_request_and_raise_if_error_async(
     headers: dict[str, str] = None,
     post_type: PostType = "json",
     debug: bool = False,
+    **client_kwargs: Optional[Any],
 ) -> httpx.Response:
     """Make a request and raise an exception if it fails."""
     headers = headers or {}
@@ -36,7 +40,7 @@ async def make_request_and_raise_if_error_async(
 
     params = params or {}
 
-    async with get_httpx_client(debug=debug, use_async=True) as async_client:
+    async with get_httpx_client(debug=debug, use_async=True, **client_kwargs) as async_client:
         response = await async_client.request(
             method=method,
             params=params,

--- a/pyrit/common/net_utility.py
+++ b/pyrit/common/net_utility.py
@@ -6,18 +6,18 @@ import httpx
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 
-def get_httpx_client(use_async: bool = False, debug: bool = False, **client_kwargs: Optional[Any]):
+def get_httpx_client(use_async: bool = False, debug: bool = False, **httpx_client_kwargs: Optional[Any]):
     """Get the httpx client for making requests."""
 
     client_class = httpx.AsyncClient if use_async else httpx.Client
     proxy = "http://localhost:8080" if debug else None
 
-    proxy = client_kwargs.pop('proxy', proxy)
-    verify_certs = client_kwargs.pop('verify', not debug)
+    proxy = httpx_client_kwargs.pop('proxy', proxy)
+    verify_certs = httpx_client_kwargs.pop('verify', not debug)
     # fun notes; httpx default is 5 seconds, httpclient is 100, urllib in indefinite
-    timeout = client_kwargs.pop('timeout', 60.0)
+    timeout = httpx_client_kwargs.pop('timeout', 60.0)
 
-    return client_class(proxy=proxy, verify=verify_certs, timeout=timeout, **client_kwargs)
+    return client_class(proxy=proxy, verify=verify_certs, timeout=timeout, **httpx_client_kwargs)
 
 
 PostType = Literal["json", "data"]
@@ -32,7 +32,7 @@ async def make_request_and_raise_if_error_async(
     headers: dict[str, str] = None,
     post_type: PostType = "json",
     debug: bool = False,
-    **client_kwargs: Optional[Any],
+    **httpx_client_kwargs: Optional[Any],
 ) -> httpx.Response:
     """Make a request and raise an exception if it fails."""
     headers = headers or {}
@@ -40,7 +40,7 @@ async def make_request_and_raise_if_error_async(
 
     params = params or {}
 
-    async with get_httpx_client(debug=debug, use_async=True, **client_kwargs) as async_client:
+    async with get_httpx_client(debug=debug, use_async=True, **httpx_client_kwargs) as async_client:
         response = await async_client.request(
             method=method,
             params=params,

--- a/pyrit/common/net_utility.py
+++ b/pyrit/common/net_utility.py
@@ -12,10 +12,10 @@ def get_httpx_client(use_async: bool = False, debug: bool = False, **httpx_clien
     client_class = httpx.AsyncClient if use_async else httpx.Client
     proxy = "http://localhost:8080" if debug else None
 
-    proxy = httpx_client_kwargs.pop('proxy', proxy)
-    verify_certs = httpx_client_kwargs.pop('verify', not debug)
+    proxy = httpx_client_kwargs.pop("proxy", proxy)
+    verify_certs = httpx_client_kwargs.pop("verify", not debug)
     # fun notes; httpx default is 5 seconds, httpclient is 100, urllib in indefinite
-    timeout = httpx_client_kwargs.pop('timeout', 60.0)
+    timeout = httpx_client_kwargs.pop("timeout", 60.0)
 
     return client_class(proxy=proxy, verify=verify_certs, timeout=timeout, **httpx_client_kwargs)
 

--- a/pyrit/prompt_target/http_target/http_target.py
+++ b/pyrit/prompt_target/http_target/http_target.py
@@ -26,7 +26,7 @@ class HTTPTarget(PromptTarget):
         use_tls: (bool): whether to use TLS or not. Default is True
         callback_function (function): function to parse HTTP response.
             These are the customizable functions which determine how to parse the output
-        client_kwargs: (dict): additional keyword arguments to pass to the HTTP client
+        httpx_client_kwargs: (dict): additional keyword arguments to pass to the HTTP client
     """
 
     def __init__(
@@ -36,14 +36,14 @@ class HTTPTarget(PromptTarget):
         use_tls: bool = True,
         callback_function: Callable = None,
         max_requests_per_minute: Optional[int] = None,
-        **client_kwargs: Optional[Any],
+        **httpx_client_kwargs: Optional[Any],
     ) -> None:
         super().__init__(max_requests_per_minute=max_requests_per_minute)
         self.http_request = http_request
         self.callback_function = callback_function
         self.prompt_regex_string = prompt_regex_string
         self.use_tls = use_tls
-        self.client_kwargs = client_kwargs or {}
+        self.httpx_client_kwargs = httpx_client_kwargs or {}
 
     async def send_prompt_async(self, *, prompt_request: PromptRequestResponse) -> PromptRequestResponse:
         """
@@ -70,7 +70,7 @@ class HTTPTarget(PromptTarget):
         if http_version and "HTTP/2" in http_version:
             http2_version = True
 
-        async with httpx.AsyncClient(http2=http2_version, **self.client_kwargs) as client:
+        async with httpx.AsyncClient(http2=http2_version, **self.httpx_client_kwargs) as client:
             response = await client.request(
                 method=http_method,
                 url=url,

--- a/pyrit/prompt_target/ollama_chat_target.py
+++ b/pyrit/prompt_target/ollama_chat_target.py
@@ -26,7 +26,7 @@ class OllamaChatTarget(PromptChatTarget):
         model_name: str = None,
         chat_message_normalizer: ChatMessageNormalizer = ChatMessageNop(),
         max_requests_per_minute: Optional[int] = None,
-        **client_kwargs: Optional[Any],
+        **httpx_client_kwargs: Optional[Any],
     ) -> None:
         PromptChatTarget.__init__(self, max_requests_per_minute=max_requests_per_minute)
 
@@ -37,7 +37,7 @@ class OllamaChatTarget(PromptChatTarget):
             env_var_name=self.MODEL_NAME_ENVIRONMENT_VARIABLE, passed_value=model_name
         )
         self.chat_message_normalizer = chat_message_normalizer
-        self.client_kwargs = client_kwargs or {}
+        self.httpx_client_kwargs = httpx_client_kwargs or {}
 
     @limit_requests_per_minute
     async def send_prompt_async(self, *, prompt_request: PromptRequestResponse) -> PromptRequestResponse:
@@ -67,7 +67,7 @@ class OllamaChatTarget(PromptChatTarget):
         payload = self._construct_http_body(messages)
 
         response = await net_utility.make_request_and_raise_if_error_async(
-            endpoint_uri=self.endpoint, method="POST", request_body=payload, headers=headers, **self.client_kwargs
+            endpoint_uri=self.endpoint, method="POST", request_body=payload, headers=headers, **self.httpx_client_kwargs
         )
 
         return response.json()["message"]["content"]

--- a/pyrit/prompt_target/ollama_chat_target.py
+++ b/pyrit/prompt_target/ollama_chat_target.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 import logging
-from typing import Optional
+from typing import Optional, Any
 
 from pyrit.chat_message_normalizer import ChatMessageNop, ChatMessageNormalizer
 from pyrit.common import default_values, net_utility
@@ -26,6 +26,7 @@ class OllamaChatTarget(PromptChatTarget):
         model_name: str = None,
         chat_message_normalizer: ChatMessageNormalizer = ChatMessageNop(),
         max_requests_per_minute: Optional[int] = None,
+        **client_kwargs: Optional[Any],
     ) -> None:
         PromptChatTarget.__init__(self, max_requests_per_minute=max_requests_per_minute)
 
@@ -36,6 +37,7 @@ class OllamaChatTarget(PromptChatTarget):
             env_var_name=self.MODEL_NAME_ENVIRONMENT_VARIABLE, passed_value=model_name
         )
         self.chat_message_normalizer = chat_message_normalizer
+        self.client_kwargs = client_kwargs or {}
 
     @limit_requests_per_minute
     async def send_prompt_async(self, *, prompt_request: PromptRequestResponse) -> PromptRequestResponse:
@@ -65,7 +67,7 @@ class OllamaChatTarget(PromptChatTarget):
         payload = self._construct_http_body(messages)
 
         response = await net_utility.make_request_and_raise_if_error_async(
-            endpoint_uri=self.endpoint, method="POST", request_body=payload, headers=headers
+            endpoint_uri=self.endpoint, method="POST", request_body=payload, headers=headers, **self.client_kwargs
         )
 
         return response.json()["message"]["content"]

--- a/tests/target/test_http_target.py
+++ b/tests/target/test_http_target.py
@@ -66,12 +66,12 @@ async def test_send_prompt_async(mock_request, mock_http_target, mock_http_respo
 @pytest.mark.asyncio
 @patch("httpx.AsyncClient")
 async def test_send_prompt_async_client_kwargs(mock_async_client):
-    # Create client_kwargs to test
-    client_kwargs = {"timeout": 10, "verify": False}
+    # Create httpx_client_kwargs to test
+    httpx_client_kwargs = {"timeout": 10, "verify": False}
     sample_request = "GET /test HTTP/1.1\nHost: example.com\n\n"
-    # Create instance of HTTPTarget with client_kwargs
-    # Use **client_kwargs to pass them as keyword arguments
-    http_target = HTTPTarget(http_request=sample_request, **client_kwargs)
+    # Create instance of HTTPTarget with httpx_client_kwargs
+    # Use **httpx_client_kwargs to pass them as keyword arguments
+    http_target = HTTPTarget(http_request=sample_request, **httpx_client_kwargs)
     prompt_request = MagicMock()
     prompt_request.request_pieces = [MagicMock(converted_value="")]
     mock_response = MagicMock()


### PR DESCRIPTION
## Description

Note original PR here by https://github.com/jselvi but github closed his pr and wouldn't let me reopen :(

This is approved by me and only push is pre-commit.

The OllamaChatTarget class did not implement a way to forward custom parameters directly to the HTTP client, as it happens in other implemented targets. I found this necessary when using Ollama through a proxy implementing non built-in features, such as encryption (HTTPS) or authentication.

I have updated the `OllamaChatTarget` class to handled those additional parameters via `kwargs`, and a couple of methods in file `net_utility.py` so those parameters are used when making the HTTP request.

## Tests and Documentation

I haven't seen this feature being tested or documented in other prompt targets, so not sure if it is required.
If I missed it, please point me to an example and I'll be happy to replicate it for `OllamaChatTarget`.