### PR TITLE
FEAT - Adding optional kwargs to huggingface chat target

### DIFF
--- a/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
+++ b/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
@@ -21,9 +21,10 @@ logger = logging.getLogger(__name__)
 
 try:
     import torch
-except ModuleNotFoundError as e:
+except ModuleNotFoundError:
     logger.warning("Torch is not installed. Some functionalities may not work.")
     torch = None
+
 
 class HuggingFaceChatTarget(PromptChatTarget):
     """The HuggingFaceChatTarget interacts with HuggingFace models, specifically for conducting red teaming activities.
@@ -55,10 +56,9 @@ class HuggingFaceChatTarget(PromptChatTarget):
         top_p: float = 1.0,
         skip_special_tokens: bool = True,
         trust_remote_code: bool = False,
-        device_map: Optional[str] = None, 
+        device_map: Optional[str] = None,
         torch_dtype: Optional["torch.dtype"] = None,
         attn_implementation: Optional[str] = None,
-
     ) -> None:
         super().__init__()
 
@@ -152,7 +152,6 @@ class HuggingFaceChatTarget(PromptChatTarget):
                 if value is not None
             }
 
-
             # Check if the model is already cached
             if HuggingFaceChatTarget._cache_enabled and HuggingFaceChatTarget._cached_model_id == model_identifier:
                 logger.info(f"Using cached model and tokenizer for {model_identifier}.")
@@ -191,10 +190,10 @@ class HuggingFaceChatTarget(PromptChatTarget):
                     self.model_id, cache_dir=cache_dir, trust_remote_code=self.trust_remote_code
                 )
                 self.model = AutoModelForCausalLM.from_pretrained(
-                    self.model_id, 
-                    cache_dir=cache_dir, 
+                    self.model_id,
+                    cache_dir=cache_dir,
                     trust_remote_code=self.trust_remote_code,
-                    **optional_model_kwargs
+                    **optional_model_kwargs,
                 )
 
             # Move the model to the correct device

--- a/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
+++ b/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 from typing import Optional
+from typing import TYPE_CHECKING
 
 from transformers import AutoModelForCausalLM, AutoTokenizer, PretrainedConfig
 
@@ -15,15 +16,10 @@ from pyrit.models.prompt_request_response import PromptRequestResponse, construc
 from pyrit.exceptions import EmptyResponseException, pyrit_target_retry
 from pyrit.common import default_values
 
-
 logger = logging.getLogger(__name__)
 
-
-try:
+if TYPE_CHECKING:
     import torch
-except ModuleNotFoundError:
-    logger.warning("Torch is not installed. Some functionalities may not work.")
-    torch = None
 
 
 class HuggingFaceChatTarget(PromptChatTarget):
@@ -57,7 +53,7 @@ class HuggingFaceChatTarget(PromptChatTarget):
         skip_special_tokens: bool = True,
         trust_remote_code: bool = False,
         device_map: Optional[str] = None,
-        torch_dtype: Optional["torch.dtype"] = None,
+        torch_dtype: Optional[torch.dtype] = None,
         attn_implementation: Optional[str] = None,
     ) -> None:
         super().__init__()

--- a/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
+++ b/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
@@ -23,6 +23,7 @@ try:
     import torch
 except ModuleNotFoundError as e:
     logger.warning("Torch is not installed. Some functionalities may not work.")
+    torch = None
 
 class HuggingFaceChatTarget(PromptChatTarget):
     """The HuggingFaceChatTarget interacts with HuggingFace models, specifically for conducting red teaming activities.
@@ -55,7 +56,7 @@ class HuggingFaceChatTarget(PromptChatTarget):
         skip_special_tokens: bool = True,
         trust_remote_code: bool = False,
         device_map: Optional[str] = None, 
-        torch_dtype: Optional[torch.dtype] = None,
+        torch_dtype: Optional["torch.dtype"] = None,
         attn_implementation: Optional[str] = None,
 
     ) -> None:

--- a/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
+++ b/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
@@ -19,6 +19,11 @@ from pyrit.common import default_values
 logger = logging.getLogger(__name__)
 
 
+try:
+    import torch
+except ModuleNotFoundError as e:
+    logger.warning("Torch is not installed. Some functionalities may not work.")
+
 class HuggingFaceChatTarget(PromptChatTarget):
     """The HuggingFaceChatTarget interacts with HuggingFace models, specifically for conducting red teaming activities.
     Inherits from PromptTarget to comply with the current design standards.
@@ -50,7 +55,7 @@ class HuggingFaceChatTarget(PromptChatTarget):
         skip_special_tokens: bool = True,
         trust_remote_code: bool = False,
         device_map: Optional[str] = None, 
-        torch_dtype: Optional["torch.dtype"] = None,
+        torch_dtype: Optional[torch.dtype] = None,
         attn_implementation: Optional[str] = None,
 
     ) -> None:

--- a/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
+++ b/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
@@ -53,7 +53,7 @@ class HuggingFaceChatTarget(PromptChatTarget):
         skip_special_tokens: bool = True,
         trust_remote_code: bool = False,
         device_map: Optional[str] = None,
-        torch_dtype: Optional[torch.dtype] = None,
+        torch_dtype: Optional["torch.dtype"] = None,
         attn_implementation: Optional[str] = None,
     ) -> None:
         super().__init__()

--- a/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
+++ b/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
@@ -49,6 +49,10 @@ class HuggingFaceChatTarget(PromptChatTarget):
         top_p: float = 1.0,
         skip_special_tokens: bool = True,
         trust_remote_code: bool = False,
+        device_map: Optional[str] = None, 
+        torch_dtype: Optional["torch.dtype"] = None,
+        attn_implementation: Optional[str] = None,
+
     ) -> None:
         super().__init__()
 
@@ -62,6 +66,9 @@ class HuggingFaceChatTarget(PromptChatTarget):
         self.use_cuda = use_cuda
         self.tensor_format = tensor_format
         self.trust_remote_code = trust_remote_code
+        self.device_map = device_map
+        self.torch_dtype = torch_dtype
+        self.attn_implementation = attn_implementation
 
         # Only get the Hugging Face token if a model ID is provided
         if model_id:
@@ -95,13 +102,13 @@ class HuggingFaceChatTarget(PromptChatTarget):
 
         self.load_model_and_tokenizer_task = asyncio.create_task(self.load_model_and_tokenizer())
 
-    def _load_from_path(self, path: str):
+    def _load_from_path(self, path: str, **kwargs):
         """
         Helper function to load the model and tokenizer from a given path.
         """
         logger.info(f"Loading model and tokenizer from path: {path}...")
         self.tokenizer = AutoTokenizer.from_pretrained(path, trust_remote_code=self.trust_remote_code)
-        self.model = AutoModelForCausalLM.from_pretrained(path, trust_remote_code=self.trust_remote_code)
+        self.model = AutoModelForCausalLM.from_pretrained(path, trust_remote_code=self.trust_remote_code, **kwargs)
 
     def is_model_id_valid(self) -> bool:
         """
@@ -129,6 +136,17 @@ class HuggingFaceChatTarget(PromptChatTarget):
             # Determine the identifier for caching purposes
             model_identifier = self.model_path or self.model_id
 
+            optional_model_kwargs = {
+                key: value
+                for key, value in {
+                    "device_map": self.device_map,
+                    "torch_dtype": self.torch_dtype,
+                    "attn_implementation": self.attn_implementation,
+                }.items()
+                if value is not None
+            }
+
+
             # Check if the model is already cached
             if HuggingFaceChatTarget._cache_enabled and HuggingFaceChatTarget._cached_model_id == model_identifier:
                 logger.info(f"Using cached model and tokenizer for {model_identifier}.")
@@ -139,7 +157,7 @@ class HuggingFaceChatTarget(PromptChatTarget):
             if self.model_path:
                 # Load the tokenizer and model from the local directory
                 logger.info(f"Loading model from local path: {self.model_path}...")
-                self._load_from_path(self.model_path)
+                self._load_from_path(self.model_path, **optional_model_kwargs)
             else:
                 # Define the default Hugging Face cache directory
                 cache_dir = os.path.join(
@@ -167,7 +185,10 @@ class HuggingFaceChatTarget(PromptChatTarget):
                     self.model_id, cache_dir=cache_dir, trust_remote_code=self.trust_remote_code
                 )
                 self.model = AutoModelForCausalLM.from_pretrained(
-                    self.model_id, cache_dir=cache_dir, trust_remote_code=self.trust_remote_code
+                    self.model_id, 
+                    cache_dir=cache_dir, 
+                    trust_remote_code=self.trust_remote_code,
+                    **optional_model_kwargs
                 )
 
             # Move the model to the correct device

--- a/tests/target/test_huggingface_chat_target.py
+++ b/tests/target/test_huggingface_chat_target.py
@@ -272,7 +272,7 @@ async def test_optional_kwargs_args_passed_when_loading_model(mock_transformers)
     mock_tokenizer_from_pretrained, mock_model_from_pretrained = mock_transformers
     hf_chat = HuggingFaceChatTarget(
         model_path="./mock_local_model_path",
-        use_cuda=True,
+        use_cuda=False,
         device_map='auto',
         torch_dtype='float16',
         attn_implementation='flash_attention_2',

--- a/tests/target/test_huggingface_chat_target.py
+++ b/tests/target/test_huggingface_chat_target.py
@@ -273,14 +273,14 @@ async def test_optional_kwargs_args_passed_when_loading_model(mock_transformers)
     hf_chat = HuggingFaceChatTarget(
         model_path="./mock_local_model_path",
         use_cuda=False,
-        device_map='auto',
-        torch_dtype='float16',
-        attn_implementation='flash_attention_2',
+        device_map="auto",
+        torch_dtype="float16",
+        attn_implementation="flash_attention_2",
     )
     await hf_chat.load_model_and_tokenizer()
     # Assert that from_pretrained was called with expected kwargs
     assert mock_model_from_pretrained.called
     call_args = mock_model_from_pretrained.call_args[1]  # Get the kwargs of the most recent call
-    assert call_args.get('device_map') == 'auto'
-    assert call_args.get('torch_dtype') == 'float16'
-    assert call_args.get('attn_implementation') == 'flash_attention_2'
+    assert call_args.get("device_map") == "auto"
+    assert call_args.get("torch_dtype") == "float16"
+    assert call_args.get("attn_implementation") == "flash_attention_2"

--- a/tests/target/test_huggingface_chat_target.py
+++ b/tests/target/test_huggingface_chat_target.py
@@ -263,3 +263,24 @@ def test_load_model_without_model_id_or_path():
     with pytest.raises(ValueError) as excinfo:
         HuggingFaceChatTarget(use_cuda=False)
     assert "Either `model_id` or `model_path` must be provided." in str(excinfo.value)
+
+
+@pytest.mark.skipif(not is_torch_installed(), reason="torch is not installed")
+@pytest.mark.asyncio
+async def test_optional_kwargs_args_passed_when_loading_model(mock_transformers):
+    """Test loading a model from a local directory (`model_path`) with optional keyword arguments."""
+    mock_tokenizer_from_pretrained, mock_model_from_pretrained = mock_transformers
+    hf_chat = HuggingFaceChatTarget(
+        model_path="./mock_local_model_path",
+        use_cuda=True,
+        device_map='auto',
+        torch_dtype='float16',
+        attn_implementation='flash_attention_2',
+    )
+    await hf_chat.load_model_and_tokenizer()
+    # Assert that from_pretrained was called with expected kwargs
+    assert mock_model_from_pretrained.called
+    call_args = mock_model_from_pretrained.call_args[1]  # Get the kwargs of the most recent call
+    assert call_args.get('device_map') == 'auto'
+    assert call_args.get('torch_dtype') == 'float16'
+    assert call_args.get('attn_implementation') == 'flash_attention_2'


### PR DESCRIPTION
## Description
This feature adds the optional keywords `device_map`, `torch_dtype`, and `attn_implementation` to the `HuggingFaceChatTarget` class. This PR addresses the Issue #601 I recently opened. I often have to specify these parameters when loading intermediate development models of the `Phi` family, as well as other open source models from Huggingface of similar size.

## Tests and Documentation
I added a test to check whether optional arguments are loaded correctly when loading a HuggingFace model. I have also successfully ran this code in my local branch. 

Hi haven't run JupyText yet. 
