### PR TITLE
MAINT Update gcg_attack.py

### DIFF
--- a/pyrit/auxiliary_attacks/gcg/attack/gcg/gcg_attack.py
+++ b/pyrit/auxiliary_attacks/gcg/attack/gcg/gcg_attack.py
@@ -86,7 +86,7 @@ class GCGPromptManager(PromptManager):
     def sample_control(self, grad, batch_size, topk=256, temp=1, allow_non_ascii=True):
 
         if not allow_non_ascii:
-            grad[:, self._nonascii_toks.to(grad.device)] = np.infty
+            grad[:, self._nonascii_toks.to(grad.device)] = np.inf
         top_indices = (-grad).topk(topk, dim=1).indices
         control_toks = self.control_toks.to(grad.device)
         original_control_toks = control_toks.repeat(batch_size, 1)


### PR DESCRIPTION
<!--- Please add one of the following as a prefix to the pull request title: -->
<!--- DOC for documentation changes -->
<!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
<!--- FIX for bug fixes -->
<!--- TEST for adding tests -->
<!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
<!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

<!--- If you are considering making a contribution please open an issue first. -->
<!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
<!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->

I noticed that `np.infty` is used in `gcg_attack.py`.

However, `np.infty` was deprecated as an alias of `np.inf` in NumPy 2.0.0 (https://numpy.org/devdocs/release/2.0.0-notes.html).

Since PyRIT uses NumPy 1.26.4 at the moment, it still works!

However, 2.0.0 is the release right after 1.26.4, so it might be good to change ahead of time since `np.inf` works either way.

This might be of relevance to Issue #532 since Python 3.13 is supported only by NumPy 2.1.0+.

## Tests and Documentation

<!--- Contributions require tests and documentation (if applicable). -->
<!--- Include a description of tests and documentation updated (if applicable) -->

<!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
<!--- Include how you/if ran JupyText here -->
<!--- This is described at: https://github.com/Azure/PyRIT/tree/main/doc  -->
