### PR TITLE
FIX: small edits to populate_prompt_piece_scores

### DIFF
--- a/doc/_toc.yml
+++ b/doc/_toc.yml
@@ -69,6 +69,7 @@ chapters:
         - file: code/converters/ansi_attack_converter
         - file: code/converters/char_swap_attack_generator
         - file: code/converters/math_prompt_converter
+        - file: code/converters/pdf_converter
     - file: code/scoring/0_scoring
       sections:
       - file: code/scoring/1_azure_content_safety_scorers

--- a/doc/code/converters/pdf_converter.ipynb
+++ b/doc/code/converters/pdf_converter.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "The `PromptSendingOrchestrator` is used to handle the interaction with the `PDFConverter` and the mock `TextTarget` target system.\n",
     "\n",
-    "### Key Features\n",
+    "## Key Features\n",
     "\n",
     "1. **Template-Based Generation**:\n",
     "   - Populate placeholders in a YAML-based template using dynamic data.\n",
@@ -115,6 +115,8 @@
     }
    ],
    "source": [
+    "# Direct Prompt PDF Generation (No Template)\n",
+    "\n",
     "# Define a simple string prompt (no templates)\n",
     "prompt = \"This is a simple test string for PDF generation. No templates here!\"\n",
     "\n",

--- a/doc/code/converters/pdf_converter.ipynb
+++ b/doc/code/converters/pdf_converter.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "**PDF Converter with Multiple Modes**\n",
+    "# PDF Converter with Multiple Modes:\n",
     "\n",
     "This script demonstrates the use of the `PDFConverter` for generating PDFs in two different modes:\n",
     "\n",

--- a/doc/code/converters/pdf_converter.py
+++ b/doc/code/converters/pdf_converter.py
@@ -8,7 +8,7 @@
 #
 # The `PromptSendingOrchestrator` is used to handle the interaction with the `PDFConverter` and the mock `TextTarget` target system.
 #
-# ### Key Features
+# ## Key Features
 #
 # 1. **Template-Based Generation**:
 #    - Populate placeholders in a YAML-based template using dynamic data.
@@ -74,7 +74,9 @@ with PromptSendingOrchestrator(
 
     await orchestrator.print_conversations_async()  # type: ignore
 
-# %% Direct Prompt PDF Generation (No Template)
+# %%
+# Direct Prompt PDF Generation (No Template)
+
 # Define a simple string prompt (no templates)
 prompt = "This is a simple test string for PDF generation. No templates here!"
 

--- a/doc/code/converters/pdf_converter.py
+++ b/doc/code/converters/pdf_converter.py
@@ -1,5 +1,5 @@
 # %% [markdown]
-# **PDF Converter with Multiple Modes**
+# # PDF Converter with Multiple Modes:
 #
 # This script demonstrates the use of the `PDFConverter` for generating PDFs in two different modes:
 #

--- a/pyrit/memory/memory_interface.py
+++ b/pyrit/memory/memory_interface.py
@@ -230,18 +230,16 @@ class MemoryInterface(abc.ABC):
             prompt_request_pieces (list[PromptRequestPiece]): The list of PromptRequestPieces to add scores to.
 
         Returns:
-            list[PromptRequestPiece]: A list of PromptRequestPiece objects with their associated scores.
+            None
         """
-        result: list[PromptRequestPiece] = []
         for prompt_request_piece in prompt_request_pieces:
             score_entries = self._query_entries(
                 ScoreEntry, conditions=ScoreEntry.prompt_request_response_id == prompt_request_piece.original_prompt_id
             )
             scores = [score_entry.get_score() for score_entry in score_entries]
             prompt_request_piece.scores = scores
-            result.append(prompt_request_piece)
 
-        return result
+        return None
 
     def get_prompt_request_pieces(
         self,

--- a/pyrit/memory/memory_interface.py
+++ b/pyrit/memory/memory_interface.py
@@ -227,7 +227,7 @@ class MemoryInterface(abc.ABC):
         Adds scores in the database to prompt request piece objects
 
         Args:
-            entries (list[PromptMemoryEntry]): The list of promptRequestPieces to add
+            prompt_request_pieces (list[PromptRequestPiece]): The list of PromptRequestPieces to add scores to.
 
         Returns:
             list[PromptRequestPiece]: A list of PromptRequestPiece objects with their associated scores.
@@ -235,10 +235,11 @@ class MemoryInterface(abc.ABC):
         result: list[PromptRequestPiece] = []
         for prompt_request_piece in prompt_request_pieces:
             score_entries = self._query_entries(
-                ScoreEntry, conditions=ScoreEntry.prompt_request_response_id == prompt_request_piece.id
+                ScoreEntry, conditions=ScoreEntry.prompt_request_response_id == prompt_request_piece.original_prompt_id
             )
             scores = [score_entry.get_score() for score_entry in score_entries]
             prompt_request_piece.scores = scores
+            result.append(prompt_request_piece)
 
         return result
 


### PR DESCRIPTION
This PR amends `id` to `original_prompt_id` when querying for scores within `populate_prompt_piece_scores` as well as updates the docstring to match params. 
`result` is also updated so that it contains all the pieces with their scores. 
pdf converter notebook headers and _toc.yml amended to resolve build-book error.