### PR TITLE
FIX: sort_request_pieces bug

### DIFF
--- a/pyrit/models/prompt_request_piece.py
+++ b/pyrit/models/prompt_request_piece.py
@@ -208,4 +208,4 @@ def sort_request_pieces(prompt_pieces: list[PromptRequestPiece]) -> list[PromptR
     }
 
     # Sort using the precomputed timestamp values, then by sequence
-    return sorted(prompt_pieces, key=lambda x: (earliest_timestamps[x.conversation_id], x.sequence))
+    return sorted(prompt_pieces, key=lambda x: (earliest_timestamps[x.conversation_id], x.conversation_id, x.sequence))

--- a/tests/unit/test_prompt_request_piece.py
+++ b/tests/unit/test_prompt_request_piece.py
@@ -369,6 +369,7 @@ def test_order_request_pieces_by_conversation_multiple_conversations():
 
     assert sort_request_pieces(pieces) == expected
 
+
 def test_order_request_pieces_by_conversation_same_timestamp():
     timestamp = datetime.now()
 

--- a/tests/unit/test_prompt_request_piece.py
+++ b/tests/unit/test_prompt_request_piece.py
@@ -369,6 +369,82 @@ def test_order_request_pieces_by_conversation_multiple_conversations():
 
     assert sort_request_pieces(pieces) == expected
 
+def test_order_request_pieces_by_conversation_same_timestamp():
+    timestamp = datetime.now()
+
+    pieces = [
+        PromptRequestPiece(
+            role="user",
+            original_value="Hello 4",
+            conversation_id="conv2",
+            timestamp=timestamp,
+            sequence=2,
+            id="4",
+        ),
+        PromptRequestPiece(
+            role="user",
+            original_value="Hello 1",
+            conversation_id="conv1",
+            timestamp=timestamp,
+            sequence=1,
+            id="1",
+        ),
+        PromptRequestPiece(
+            role="user",
+            original_value="Hello 3",
+            conversation_id="conv2",
+            timestamp=timestamp,
+            sequence=1,
+            id="3",
+        ),
+        PromptRequestPiece(
+            role="user",
+            original_value="Hello 2",
+            conversation_id="conv1",
+            timestamp=timestamp,
+            sequence=2,
+            id="2",
+        ),
+    ]
+
+    expected = [
+        PromptRequestPiece(
+            role="user",
+            original_value="Hello 1",
+            conversation_id="conv1",
+            timestamp=pieces[1].timestamp,
+            sequence=1,
+            id="1",
+        ),
+        PromptRequestPiece(
+            role="user",
+            original_value="Hello 2",
+            conversation_id="conv1",
+            timestamp=pieces[3].timestamp,
+            sequence=2,
+            id="2",
+        ),
+        PromptRequestPiece(
+            role="user",
+            original_value="Hello 3",
+            conversation_id="conv2",
+            timestamp=pieces[2].timestamp,
+            sequence=1,
+            id="3",
+        ),
+        PromptRequestPiece(
+            role="user",
+            original_value="Hello 4",
+            conversation_id="conv2",
+            timestamp=pieces[0].timestamp,
+            sequence=2,
+            id="4",
+        ),
+    ]
+
+    sorted = sort_request_pieces(pieces)
+    assert sorted == expected
+
 
 def test_order_request_pieces_by_conversation_empty_list():
     pieces = []


### PR DESCRIPTION
When the timestamps of prompts were the same, the `sort_request_pieces` function would NOT group by conversation id. This fix adds conversation_id to the sort criteria so that the conversations are grouped properly. A new test is also added that reproduced the issue (it was failing before the fix, but passing now).