### PR TITLE
FIX: adding hashes to retrieved PromptRequestPiece

### DIFF
--- a/pyrit/memory/memory_models.py
+++ b/pyrit/memory/memory_models.py
@@ -127,7 +127,9 @@ class PromptMemoryEntry(Base):
         prompt_request_piece = PromptRequestPiece(
             role=self.role,
             original_value=self.original_value,
+            original_value_sha256=self.original_value_sha256,
             converted_value=self.converted_value,
+            converted_value_sha256=self.converted_value_sha256,
             id=self.id,
             conversation_id=self.conversation_id,
             sequence=self.sequence,

--- a/pyrit/models/prompt_request_piece.py
+++ b/pyrit/models/prompt_request_piece.py
@@ -53,7 +53,9 @@ class PromptRequestPiece(abc.ABC):
         *,
         role: ChatMessageRole,
         original_value: str,
+        original_value_sha256: Optional[str] = None,
         converted_value: Optional[str] = None,
+        converted_value_sha256: Optional[str] = None,
         id: Optional[uuid.UUID | str] = None,
         conversation_id: Optional[str] = None,
         sequence: int = -1,
@@ -103,7 +105,7 @@ class PromptRequestPiece(abc.ABC):
 
         self.original_value_data_type = original_value_data_type
 
-        self.original_value_sha256 = None
+        self.original_value_sha256 = original_value_sha256
 
         self.converted_value = converted_value
 
@@ -112,7 +114,7 @@ class PromptRequestPiece(abc.ABC):
 
         self.converted_value_data_type = converted_value_data_type
 
-        self.converted_value_sha256 = None
+        self.converted_value_sha256 = converted_value_sha256
 
         if response_error not in get_args(PromptResponseError):
             raise ValueError(f"response_error {response_error} is not a valid response error.")

--- a/tests/unit/memory/test_memory_interface.py
+++ b/tests/unit/memory/test_memory_interface.py
@@ -1865,3 +1865,28 @@ def test_prompt_piece_scores_duplicate_piece(duckdb_instance: MemoryInterface):
     # Check that the duplicate piece has the same score as the original
     assert len(retrieved_pieces[1].scores) == 1
     assert retrieved_pieces[1].scores[0].score_value == "0.8"
+
+
+@pytest.mark.asyncio
+async def test_prompt_piece_hash_stored_and_retrieved(duckdb_instance: MemoryInterface):
+    entries = [
+        PromptRequestPiece(
+            role="user",
+            original_value="Hello 1",
+        ),
+        PromptRequestPiece(
+            role="assistant",
+            original_value="Hello 2",
+        ),
+    ]
+
+    for entry in entries:
+        await entry.set_sha256_values_async()
+
+    duckdb_instance.add_request_pieces_to_memory(request_pieces=entries)
+    retrieved_entries = duckdb_instance.get_prompt_request_pieces()
+
+    assert len(retrieved_entries) == 2
+    for prompt in retrieved_entries:
+        assert prompt.converted_value_sha256
+        assert prompt.original_value_sha256


### PR DESCRIPTION
Previously if you set the hashes (which you need to do manually due to async stuff) and retrieved the prompts from memory, these would be empty. This fixes that so it retrieves hashes from retrieved pieces.


## Tests and Documentation

See the added test, it was failing previous to this PR.
