### PR TITLE
DOC: Clarifying PromptTargets from PromptChatTargets

### DIFF
--- a/doc/code/orchestrators/0_orchestrator.md
+++ b/doc/code/orchestrators/0_orchestrator.md
@@ -4,7 +4,7 @@ The Orchestrator is a top-level component that red team operators will interact 
 
 In general, a strategy for tackling a scenario will be:
 
-1. Creating/using a `PromptTarget`
+1. Creating/using a `PromptTarget` or `PromptChatTarget` (depending on if conversation history needs to be set)
 2. Creating/using a set of initial prompts
 3. Creating/using a `PromptConverter` (default is often to not transform)
 4. Creating/using a `Scorer` (this is often to self-ask)

--- a/doc/code/orchestrators/2_multi_turn_orchestrators.ipynb
+++ b/doc/code/orchestrators/2_multi_turn_orchestrators.ipynb
@@ -441,13 +441,13 @@
    "source": [
     "## Other Multi-Turn Orchestrators\n",
     "\n",
-    "The above attacks should work using other `MultiTurnOrchestrators` with minimal modification. If you want to use [PAIR](./pair_orchestrator.ipynb), [TAP](./tree_of_attacks_with_pruning.ipynb), or [Crescendo](./5_crescendo_orchestrator.ipynb) - this should be almost as easy as swapping out the orchestrator initialization."
+    "The above attacks should work using other `MultiTurnOrchestrators` with minimal modification. If you want to use [PAIR](./pair_orchestrator.ipynb), [TAP](./tree_of_attacks_with_pruning.ipynb), or [Crescendo](./5_crescendo_orchestrator.ipynb) - this should be almost as easy as swapping out the orchestrator initialization. These algorithms are always more effective than `RedTeamingOrchestrator`, which is a simiple algorithm. However, `RedTeamingOrchestrator` by its nature supports more targets - because it doesn't modify conversation history it can support any `PromptTarget` and not only `PromptChatTargets`."
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pyrit-dev",
+   "display_name": "pyrit-311",
    "language": "python",
    "name": "python3"
   },

--- a/doc/code/orchestrators/2_multi_turn_orchestrators.py
+++ b/doc/code/orchestrators/2_multi_turn_orchestrators.py
@@ -5,9 +5,9 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.16.4
+#       jupytext_version: 1.16.2
 #   kernelspec:
-#     display_name: pyrit-dev
+#     display_name: pyrit-311
 #     language: python
 #     name: python3
 # ---
@@ -241,4 +241,4 @@ memory.dispose_engine()
 # %% [markdown]
 # ## Other Multi-Turn Orchestrators
 #
-# The above attacks should work using other `MultiTurnOrchestrators` with minimal modification. If you want to use [PAIR](./pair_orchestrator.ipynb), [TAP](./tree_of_attacks_with_pruning.ipynb), or [Crescendo](./5_crescendo_orchestrator.ipynb) - this should be almost as easy as swapping out the orchestrator initialization.
+# The above attacks should work using other `MultiTurnOrchestrators` with minimal modification. If you want to use [PAIR](./pair_orchestrator.ipynb), [TAP](./tree_of_attacks_with_pruning.ipynb), or [Crescendo](./5_crescendo_orchestrator.ipynb) - this should be almost as easy as swapping out the orchestrator initialization. These algorithms are always more effective than `RedTeamingOrchestrator`, which is a simiple algorithm. However, `RedTeamingOrchestrator` by its nature supports more targets - because it doesn't modify conversation history it can support any `PromptTarget` and not only `PromptChatTargets`.

--- a/doc/code/targets/0_prompt_targets.md
+++ b/doc/code/targets/0_prompt_targets.md
@@ -21,14 +21,16 @@ A `PromptRequestResponse` object is a normalized object with all the information
 
 ## PromptChatTargets vs PromptTargets
 
-A `PromptTarget` is a generic place to send a prompt. With PyRIT, the idea is that it will eventually be consumed by an AI application, but that doesn't have to be immediate. For example, you could have a SharePoint target. Everything you send a prompt to is a `PromptTarget`.
+A `PromptTarget` is a generic place to send a prompt. With PyRIT, the idea is that it will eventually be consumed by an AI application, but that doesn't have to be immediate. For example, you could have a SharePoint target. Everything you send a prompt to is a `PromptTarget`. Many attacks work generically with any `PromptTarget` including `RedTeamingOrchestrator` and `PromptSendingOrchestrator`.
 
-With some algorithms, you want to send a prompt, set a system prompt, and modify conversation history. These often require a `PromptChatTarget`, which implies you can modify a conversation history. `PromptChatTarget` is a subclass of `PromptTarget`.
+With some algorithms, you want to send a prompt, set a system prompt, and modify conversation history (including PAIR, TAP, flip attack). These often require a `PromptChatTarget`, which implies you can modify a conversation history. `PromptChatTarget` is a subclass of `PromptTarget`.
 
 Here are some examples:
 
-- `OpenAIChatTarget` (e.g., GPT-4o) is a `PromptChatTarget`.
-- `OllamaChatTarget` (e.g., Llama3) is a `PromptChatTarget`.
-- `OpenAIDALLETarget` is NOT a `PromptChatTarget`.
-- `HTTPTarget` is currently NOT a `PromptChatTarget` because it is generic, even though in some cases the underlying application may allow you to set conversation history.
-- `AzureBlobStorageTarget` is NOT a `PromptChatTarget`.
+| Example                             | Is `PromptChatTarget`?               | Notes                                                                                           |
+|-------------------------------------|---------------------------------------|-------------------------------------------------------------------------------------------------|
+| **OpenAIChatTarget** (e.g., GPT-4)  | **Yes** (`PromptChatTarget`)         | Designed for conversational prompts (system messages, conversation history, etc.).               |
+| **OllamaChatTarget** (e.g., Llama3) | **Yes** (`PromptChatTarget`)         | Also handles conversation history similarly to OpenAIChatTarget.                                 |
+| **OpenAIDALLETarget**               | **No** (not a `PromptChatTarget`)    | Used for image generation; does not manage conversation history.                                 |
+| **HTTPTarget**                      | **No** (not a `PromptChatTarget`)    | Generic HTTP target. Some apps might allow conversation history, but this target doesn't handle it. |
+| **AzureBlobStorageTarget**          | **No** (not a `PromptChatTarget`)    | Used primarily for storage; not for conversation-based AI.                                       |

--- a/doc/code/targets/0_prompt_targets.md
+++ b/doc/code/targets/0_prompt_targets.md
@@ -8,10 +8,27 @@ Prompt Targets are endpoints for where to send prompts. For example, a target co
 
 Prompt targets are found [here](https://github.com/Azure/PyRIT/tree/main/pyrit/prompt_target/) in code.
 
+
+## Send_Prompt_Async
+
 The main entry method follow the following signature:
 
 ```
 async def send_prompt_async(self, *, prompt_request: PromptRequestResponse) -> PromptRequestResponse:
 ```
 
-A `PromptRequestResponse` object is a normalized object with all the information a target will need to send a prompt. This is discussed in more depth [here](../memory/3_prompt_request.md).
+A `PromptRequestResponse` object is a normalized object with all the information a target will need to send a prompt, including a way to get a history for that prompt (in the cases that also needs to be sent). This is discussed in more depth [here](../memory/3_prompt_request.md).
+
+## PromptChatTargets vs PromptTargets
+
+A `PromptTarget` is a generic place to send a prompt. With PyRIT, the idea is that it will eventually be consumed by an AI application, but that doesn't have to be immediate. For example, you could have a SharePoint target. Everything you send a prompt to is a `PromptTarget`.
+
+With some algorithms, you want to send a prompt, set a system prompt, and modify conversation history. These often require a `PromptChatTarget`, which implies you can modify a conversation history. `PromptChatTarget` is a subclass of `PromptTarget`.
+
+Here are some examples:
+
+- `OpenAIChatTarget` (e.g., GPT-4o) is a `PromptChatTarget`.
+- `OllamaChatTarget` (e.g., Llama3) is a `PromptChatTarget`.
+- `OpenAIDALLETarget` is NOT a `PromptChatTarget`.
+- `HTTPTarget` is currently NOT a `PromptChatTarget` because it is generic, even though in some cases the underlying application may allow you to set conversation history.
+- `AzureBlobStorageTarget` is NOT a `PromptChatTarget`.

--- a/doc/code/targets/1_openai_chat_target.ipynb
+++ b/doc/code/targets/1_openai_chat_target.ipynb
@@ -87,7 +87,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pyrit-dev",
+   "display_name": "pyrit-311",
    "language": "python",
    "name": "python3"
   },
@@ -101,7 +101,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/doc/code/targets/7_http_target.ipynb
+++ b/doc/code/targets/7_http_target.ipynb
@@ -294,7 +294,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pyrit-dev",
+   "display_name": "pyrit-311",
    "language": "python",
    "name": "python3"
   },

--- a/pyrit/orchestrator/multi_turn/crescendo_orchestrator.py
+++ b/pyrit/orchestrator/multi_turn/crescendo_orchestrator.py
@@ -21,7 +21,7 @@ from pyrit.prompt_normalizer import PromptNormalizer
 from pyrit.prompt_normalizer.prompt_converter_configuration import (
     PromptConverterConfiguration,
 )
-from pyrit.prompt_target import PromptChatTarget, PromptTarget
+from pyrit.prompt_target import PromptChatTarget
 from pyrit.score import (
     FloatScaleThresholdScorer,
     SelfAskRefusalScorer,
@@ -43,7 +43,7 @@ class CrescendoOrchestrator(MultiTurnOrchestrator):
     https://crescendo-the-multiturn-jailbreak.github.io/
 
     Args:
-        objective_target (PromptTarget): The target that prompts are sent to.
+        objective_target (PromptChatTarget): The target that prompts are sent to - must be a PromptChatTarget.
         adversarial_chat (PromptChatTarget): The chat target for red teaming.
         scoring_target (PromptChatTarget): The chat target for scoring.
         adversarial_chat_system_prompt_path (Optional[Path], Optional): The path to the red teaming chat's
@@ -60,7 +60,7 @@ class CrescendoOrchestrator(MultiTurnOrchestrator):
 
     def __init__(
         self,
-        objective_target: PromptTarget,
+        objective_target: PromptChatTarget,
         adversarial_chat: PromptChatTarget,
         scoring_target: PromptChatTarget,
         adversarial_chat_system_prompt_path: Optional[Path] = None,

--- a/pyrit/orchestrator/multi_turn/tree_of_attacks_node.py
+++ b/pyrit/orchestrator/multi_turn/tree_of_attacks_node.py
@@ -20,7 +20,7 @@ from pyrit.prompt_normalizer import PromptNormalizer
 from pyrit.prompt_normalizer.prompt_converter_configuration import (
     PromptConverterConfiguration,
 )
-from pyrit.prompt_target import PromptChatTarget, PromptTarget
+from pyrit.prompt_target import PromptChatTarget
 from pyrit.score.scorer import Scorer
 
 logger = logging.getLogger(__name__)
@@ -36,7 +36,7 @@ class TreeOfAttacksNode:
     def __init__(
         self,
         *,
-        objective_target: PromptTarget,
+        objective_target: PromptChatTarget,
         adversarial_chat: PromptChatTarget,
         adversarial_chat_seed_prompt: SeedPrompt,
         adversarial_chat_prompt_template: SeedPrompt,

--- a/pyrit/orchestrator/multi_turn/tree_of_attacks_with_pruning_orchestrator.py
+++ b/pyrit/orchestrator/multi_turn/tree_of_attacks_with_pruning_orchestrator.py
@@ -180,7 +180,7 @@ class TreeOfAttacksWithPruningOrchestrator(MultiTurnOrchestrator):
                 # Initialize branch nodes that execute a single branch of the attack
                 nodes = [
                     TreeOfAttacksNode(
-                        objective_target=self._objective_target,
+                        objective_target=self._objective_target,  # type: ignore
                         adversarial_chat=self._adversarial_chat,
                         adversarial_chat_seed_prompt=self._adversarial_chat_seed_prompt,
                         adversarial_chat_system_seed_prompt=self._adversarial_chat_system_seed_prompt,

--- a/pyrit/orchestrator/multi_turn/tree_of_attacks_with_pruning_orchestrator.py
+++ b/pyrit/orchestrator/multi_turn/tree_of_attacks_with_pruning_orchestrator.py
@@ -15,7 +15,7 @@ from pyrit.models import SeedPrompt
 from pyrit.orchestrator import MultiTurnAttackResult, MultiTurnOrchestrator
 from pyrit.orchestrator.multi_turn.tree_of_attacks_node import TreeOfAttacksNode
 from pyrit.prompt_converter import PromptConverter
-from pyrit.prompt_target import PromptChatTarget, PromptTarget
+from pyrit.prompt_target import PromptChatTarget
 from pyrit.score import SelfAskScaleScorer, SelfAskTrueFalseScorer, TrueFalseQuestion
 from pyrit.score.scorer import Scorer
 
@@ -42,12 +42,40 @@ class TAPAttackResult(MultiTurnAttackResult):
 
 
 class TreeOfAttacksWithPruningOrchestrator(MultiTurnOrchestrator):
+    """
+    TreeOfAttacksWithPruningOrchestrator follows the TAP alogrithm to attack a chat target.
+
+    Args:
+        objective_target (PromptChatTarget): The target for the objective prompt. Must be a PromptChatTarget.
+        adversarial_chat (PromptChatTarget): The target for the adversarial chat prompt.
+        scoring_target (PromptChatTarget): The target for scoring the responses.
+        adversarial_chat_seed_prompt (Optional[SeedPrompt], optional): The seed prompt for adversarial chat. Defaults
+        to None.
+        adversarial_chat_system_prompt_path (Optional[Path], optional): The path to the system prompt for adversarial
+        chat. Defaults to None.
+        width (int, optional): The width of the attack tree. Defaults to 3.
+        depth (int, optional): The depth of the attack tree. Defaults to 5.
+        branching_factor (int, optional): The branching factor of the attack tree. Defaults to 2.
+        on_topic_checking_enabled (bool, optional): Flag to enable on-topic checking. Defaults to True.
+        prompt_converters (Optional[list[PromptConverter]], optional): List of prompt converters. Defaults to None.
+        objective_achieved_score_threshold (float, optional): The score threshold to determine if the objective is
+        achieved. Defaults to 0.8.
+        desired_response_prefix (str, optional): The desired prefix for responses. Defaults to "Sure, here is".
+        verbose (bool, optional): Flag to enable verbose logging. Defaults to False.
+    Raises:
+        ValueError: If the adversarial seed prompt does not have a desired_prefix.
+            ValueError: If the width of the tree is less than 1.
+            ValueError: If the depth of the tree is less than 1.
+            ValueError: If the branching factor of the tree is less than 1.
+            ValueError: If the objective achieved score threshold is not between 0 and 1.
+    """
+
     _memory: MemoryInterface
 
     def __init__(
         self,
         *,
-        objective_target: PromptTarget,
+        objective_target: PromptChatTarget,
         adversarial_chat: PromptChatTarget,
         scoring_target: PromptChatTarget,
         adversarial_chat_seed_prompt: Optional[SeedPrompt] = None,

--- a/pyrit/orchestrator/single_turn/flip_attack_orchestrator.py
+++ b/pyrit/orchestrator/single_turn/flip_attack_orchestrator.py
@@ -10,7 +10,7 @@ from pyrit.models import PromptRequestResponse, SeedPrompt
 from pyrit.models.prompt_request_piece import PromptRequestPiece
 from pyrit.orchestrator import PromptSendingOrchestrator
 from pyrit.prompt_converter.flip_converter import FlipConverter
-from pyrit.prompt_target import PromptTarget
+from pyrit.prompt_target import PromptChatTarget
 from pyrit.score import Scorer
 
 logger = logging.getLogger(__name__)
@@ -26,20 +26,20 @@ class FlipAttackOrchestrator(PromptSendingOrchestrator):
 
     def __init__(
         self,
-        objective_target: PromptTarget,
+        objective_target: PromptChatTarget,
         scorers: Optional[list[Scorer]] = None,
         batch_size: int = 10,
         verbose: bool = False,
     ) -> None:
         """
         Args:
-            objective_target (PromptTarget): The target for sending prompts.
+            objective_target (PromptChatTarget): The target for sending prompts.
             prompt_converters (list[PromptConverter], Optional): List of prompt converters. These are stacked in
                 order.
             scorers (list[Scorer], Optional): List of scorers to use for each prompt request response, to be
                 scored immediately after receiving response. Default is None.
             batch_size (int, Optional): The (max) batch size for sending prompts. Defaults to 10.
-                Note: If providing max requests per minute on the prompt_target, this should be set to 1 to
+                Note: If providing max requests per minute on the objective_target, this should be set to 1 to
                 ensure proper rate limit management.\
             verbose (bool, Optional): Whether to log debug information. Defaults to False.
         """

--- a/pyrit/orchestrator/single_turn/prompt_sending_orchestrator.py
+++ b/pyrit/orchestrator/single_turn/prompt_sending_orchestrator.py
@@ -13,7 +13,7 @@ from pyrit.models import PromptDataType, PromptRequestResponse
 from pyrit.orchestrator import Orchestrator
 from pyrit.prompt_converter import PromptConverter
 from pyrit.prompt_normalizer import NormalizerRequest, PromptNormalizer
-from pyrit.prompt_target import PromptTarget
+from pyrit.prompt_target import PromptChatTarget, PromptTarget
 from pyrit.score import Scorer
 
 logger = logging.getLogger(__name__)
@@ -49,7 +49,7 @@ class PromptSendingOrchestrator(Orchestrator):
         self._prompt_normalizer = PromptNormalizer()
         self._scorers = scorers or []
 
-        self._prompt_target = objective_target
+        self._objective_target = objective_target
 
         self._batch_size = batch_size
         self._prepended_conversation: list[PromptRequestResponse] = None
@@ -58,6 +58,12 @@ class PromptSendingOrchestrator(Orchestrator):
         """
         Prepends a conversation to the prompt target.
         """
+        if prepended_conversation and not isinstance(self._objective_target, PromptChatTarget):
+            raise TypeError(
+                f"Only PromptChatTargets are able to modify conversation history. Instead objective_target is: "
+                f"{type(self._objective_target)}."
+            )
+
         self._prepended_conversation = prepended_conversation
 
     async def send_normalizer_requests_async(
@@ -74,7 +80,7 @@ class PromptSendingOrchestrator(Orchestrator):
         # The labels parameter may allow me to stash class information for each kind of prompt.
         responses: list[PromptRequestResponse] = await self._prompt_normalizer.send_prompt_batch_to_target_async(
             requests=prompt_request_list,
-            target=self._prompt_target,
+            target=self._objective_target,
             labels=combine_dict(existing_dict=self._global_memory_labels, new_dict=memory_labels),
             orchestrator_identifier=self.get_identifier(),
             batch_size=self._batch_size,

--- a/pyrit/prompt_target/common/prompt_chat_target.py
+++ b/pyrit/prompt_target/common/prompt_chat_target.py
@@ -9,6 +9,15 @@ from pyrit.prompt_target import PromptTarget
 
 
 class PromptChatTarget(PromptTarget):
+    """
+    A propmt chat target is a target where you can explicitly set the conversation history using memory.
+
+    Some algorithms require conversation to be modified (e.g. deleting the last message) or set explicitly.
+    These algorithms will require PromptChatTargets be used.
+
+    As a concrete example, OpenAI chat targets are PromptChatTargets. You can set made-up conversation history.
+    Realtime chat targets or OpenAI completions are NOT PromptChatTargets. You don't send the conversation history.
+    """
 
     def __init__(self, *, max_requests_per_minute: Optional[int] = None) -> None:
         super().__init__(max_requests_per_minute=max_requests_per_minute)

--- a/pyrit/prompt_target/common/prompt_chat_target.py
+++ b/pyrit/prompt_target/common/prompt_chat_target.py
@@ -10,7 +10,7 @@ from pyrit.prompt_target import PromptTarget
 
 class PromptChatTarget(PromptTarget):
     """
-    A propmt chat target is a target where you can explicitly set the conversation history using memory.
+    A prompt chat target is a target where you can explicitly set the conversation history using memory.
 
     Some algorithms require conversation to be modified (e.g. deleting the last message) or set explicitly.
     These algorithms will require PromptChatTargets be used.

--- a/tests/unit/orchestrator/test_flip_orchestrator.py
+++ b/tests/unit/orchestrator/test_flip_orchestrator.py
@@ -9,12 +9,12 @@ from pyrit.memory import MemoryInterface
 from pyrit.models import PromptRequestPiece, PromptRequestResponse
 from pyrit.orchestrator import FlipAttackOrchestrator, PromptSendingOrchestrator
 from pyrit.prompt_converter import FlipConverter
-from pyrit.prompt_target import PromptTarget
+from pyrit.prompt_target import PromptChatTarget
 
 
 @pytest.fixture
-def mock_objective_target():
-    return MagicMock(spec=PromptTarget)
+def mock_objective_target(patch_central_database):
+    return MagicMock(spec=PromptChatTarget)
 
 
 @pytest.fixture
@@ -44,7 +44,7 @@ async def test_send_prompts_async(flip_attack_orchestrator):
 
 
 def test_init(flip_attack_orchestrator):
-    assert isinstance(flip_attack_orchestrator._prompt_target, PromptTarget)
+    assert isinstance(flip_attack_orchestrator._objective_target, PromptChatTarget)
     assert isinstance(flip_attack_orchestrator._memory, MemoryInterface)
     assert flip_attack_orchestrator._batch_size == 5
     assert flip_attack_orchestrator._verbose is True

--- a/tests/unit/orchestrator/test_prompt_orchestrator.py
+++ b/tests/unit/orchestrator/test_prompt_orchestrator.py
@@ -14,6 +14,7 @@ from pyrit.models.seed_prompt import SeedPrompt, SeedPromptGroup
 from pyrit.orchestrator import PromptSendingOrchestrator
 from pyrit.prompt_converter import Base64Converter, StringJoinConverter
 from pyrit.prompt_normalizer import NormalizerRequest
+from pyrit.prompt_target import PromptChatTarget
 from pyrit.score import SubStringScorer
 
 
@@ -337,11 +338,11 @@ def test_orchestrator_unique_id(orchestrator_count: int):
     assert not duplicate_found
 
 
-def test_prepare_conversation_with_prepended_conversation():
+def test_prepare_conversation_with_prepended_conversation(patch_central_database):
     with patch("pyrit.orchestrator.single_turn.prompt_sending_orchestrator.uuid.uuid4") as mock_uuid:
 
         mock_uuid.return_value = "mocked-uuid"
-        objective_target_mock = MagicMock()
+        objective_target_mock = MagicMock(spec=PromptChatTarget)
         memory_mock = MagicMock()
         orchestrator = PromptSendingOrchestrator(objective_target=objective_target_mock)
         orchestrator._memory = memory_mock
@@ -356,6 +357,21 @@ def test_prepare_conversation_with_prepended_conversation():
                 assert piece.conversation_id == "mocked-uuid"
 
         memory_mock.add_request_response_to_memory.assert_called_with(request=prepended_conversation[0])
+
+
+def test_prepare_conversation_raises_non_chat_target(patch_central_database):
+    with patch("pyrit.orchestrator.single_turn.prompt_sending_orchestrator.uuid.uuid4") as mock_uuid:
+
+        mock_uuid.return_value = "mocked-uuid"
+        non_chat_target_mock = MagicMock()
+        memory_mock = MagicMock()
+        orchestrator = PromptSendingOrchestrator(objective_target=non_chat_target_mock)
+        orchestrator._memory = memory_mock
+        prepended_conversation = [PromptRequestResponse(request_pieces=[MagicMock(conversation_id=None)])]
+        with pytest.raises(TypeError) as exc:
+            orchestrator.set_prepended_conversation(prepended_conversation=prepended_conversation)
+
+        assert "Only PromptChatTargets are able to modify conversation history" in str(exc.value)
 
 
 def test_prepare_conversation_without_prepended_conversation():


### PR DESCRIPTION
A prompt chat target is a target where you can explicitly set the conversation history using memory.

This is not something we've explicitly said in the past, but as we're implementing new targets (like RealTimeTarget) which are a LOT like PromptChatTargets, it's important to clarify the difference between the two, because with RealTimeTarget we can't set the conversation history. And this has implications for which attacks will work. For example, PAIR won't work with RealTimeTarget (at least without modification) because you can't set the conversation history the same way.
