### PR TITLE
[FEAT] Separate `get_conversation()` method for `MultiTurnAttackResult`

### DIFF
--- a/pyrit/orchestrator/multi_turn/multi_turn_orchestrator.py
+++ b/pyrit/orchestrator/multi_turn/multi_turn_orchestrator.py
@@ -6,7 +6,7 @@ import logging
 import uuid
 from abc import abstractmethod
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, MutableSequence, Union
 
 from colorama import Fore, Style
 
@@ -31,13 +31,18 @@ class MultiTurnAttackResult:
         self.objective = objective
         self._memory = CentralMemory.get_memory_instance()
 
+    def get_conversation(self) -> MutableSequence[PromptRequestPiece]:
+        """Returns the conversation between the objective target and the adversarial chat."""
+        messages = self._memory.get_conversation(conversation_id=self.conversation_id)
+        return messages
+
     async def print_conversation_async(self):
         """Prints the conversation between the objective target and the adversarial chat, including the scores.
 
         Args:
             prompt_target_conversation_id (str): the conversation ID for the prompt target.
         """
-        target_messages = self._memory.get_conversation(conversation_id=self.conversation_id)
+        target_messages = self.get_conversation()
 
         if not target_messages or len(target_messages) == 0:
             print("No conversation with the target")

--- a/pyrit/orchestrator/multi_turn/multi_turn_orchestrator.py
+++ b/pyrit/orchestrator/multi_turn/multi_turn_orchestrator.py
@@ -6,7 +6,7 @@ import logging
 import uuid
 from abc import abstractmethod
 from pathlib import Path
-from typing import Optional, MutableSequence, Union
+from typing import MutableSequence, Optional, Union
 
 from colorama import Fore, Style
 

--- a/pyrit/orchestrator/multi_turn/multi_turn_orchestrator.py
+++ b/pyrit/orchestrator/multi_turn/multi_turn_orchestrator.py
@@ -31,7 +31,7 @@ class MultiTurnAttackResult:
         self.objective = objective
         self._memory = CentralMemory.get_memory_instance()
 
-    def get_conversation(self) -> MutableSequence[PromptRequestPiece]:
+    def get_conversation(self) -> MutableSequence[PromptRequestResponse]:
         """Returns the conversation between the objective target and the adversarial chat."""
         messages = self._memory.get_conversation(conversation_id=self.conversation_id)
         return messages


### PR DESCRIPTION
## Description

Refactor the `print_conversation_async()` method of `MultiTurnAttackResult` to expose a separate `get_conversation()` method. This is because I'd like to store the conversation elsewhere (in AzureML) and don't want all the pretty-printing.

## Tests and Documentation

Tested through existing tests.
