### PR TITLE
FEAT: adding hex code converter (#666)

### DIFF
--- a/pyrit/prompt_converter/__init__.py
+++ b/pyrit/prompt_converter/__init__.py
@@ -43,6 +43,7 @@ from pyrit.prompt_converter.search_replace_converter import SearchReplaceConvert
 from pyrit.prompt_converter.string_join_converter import StringJoinConverter
 from pyrit.prompt_converter.suffix_append_converter import SuffixAppendConverter
 from pyrit.prompt_converter.tense_converter import TenseConverter
+from pyrit.prompt_converter.text_to_hex_converter import TextToHexConverter
 from pyrit.prompt_converter.tone_converter import ToneConverter
 from pyrit.prompt_converter.translation_converter import TranslationConverter
 from pyrit.prompt_converter.unicode_confusable_converter import UnicodeConfusableConverter
@@ -90,6 +91,7 @@ __all__ = [
     "SearchReplaceConverter",
     "StringJoinConverter",
     "SuffixAppendConverter",
+    "TextToHexConverter",
     "TenseConverter",
     "ToneConverter",
     "TranslationConverter",

--- a/pyrit/prompt_converter/text_to_hex_converter.py
+++ b/pyrit/prompt_converter/text_to_hex_converter.py
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import base64
+
+from pyrit.models import PromptDataType
+from pyrit.prompt_converter import ConverterResult, PromptConverter
+
+
+class TextToHexConverter(PromptConverter):
+
+    async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
+        """
+        Converts text to a hexadecimal encoded utf-8 string.
+        """
+        hex_representation = ""
+
+        if not self.input_supported(input_type):
+            raise ValueError("Input type not supported")
+
+        hex_representation += prompt.encode("utf-8").hex().upper()
+
+        return ConverterResult(output_text=hex_representation, output_type="text")
+
+    def input_supported(self, input_type: PromptDataType) -> bool:
+        return input_type == "text"
+

--- a/tests/unit/converter/test_text_to_hex_converter.py
+++ b/tests/unit/converter/test_text_to_hex_converter.py
@@ -1,0 +1,60 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import pytest
+
+from pyrit.prompt_converter import TextToHexConverter, ConverterResult
+
+
+@pytest.mark.asyncio
+async def test_text_to_hex_converter_ascii():
+    converter = TextToHexConverter()
+    prompt = "Test random string[#$!; > 18% \n" # String of ascii characters
+    expected_output = "546573742072616E646F6D20737472696E675B2324213B203E20313825200A" # hex representation of prompt
+    result = await converter.convert_async(prompt=prompt, input_type="text")
+    assert isinstance(result, ConverterResult)
+    assert result.output_text == expected_output
+    assert result.output_type == "text"
+
+
+@pytest.mark.asyncio
+async def test_text_to_hex_converter_extended_ascii():
+    converter = TextToHexConverter()
+    prompt = "éÄ§æ" # String of extended ascii characters
+    expected_output = "C3A9C384C2A7C3A6" # hex representation of extended ascii characters
+    result = await converter.convert_async(prompt=prompt, input_type="text")
+    assert isinstance(result, ConverterResult)
+    assert result.output_text == expected_output
+    assert result.output_type == "text"
+
+
+@pytest.mark.asyncio
+async def test_text_to_hex_converter_empty_string():
+    converter = TextToHexConverter()
+    prompt = ""  # Empty input string
+    expected_output = ""  # Empty output string
+    result = await converter.convert_async(prompt=prompt, input_type="text")
+    assert result.output_text == expected_output
+    assert result.output_type == "text"
+
+
+@pytest.mark.asyncio
+async def test_text_to_hex_converter_multilingual():
+    converter = TextToHexConverter()
+    prompt = "বাংলা 日本語 ᬅᬓ᭄ᬱᬭᬩᬮᬶ"  # Bengali, Japanese, Balinese 
+    expected_output = "E0A6ACE0A6BEE0A682E0A6B2E0A6BE20E697A5E69CACE8AA9E20E1AC85E1AC93E1" \
+                      "AD84E1ACB1E1ACADE1ACA9E1ACAEE1ACB6"  # hex representation of multilingual string
+    result = await converter.convert_async(prompt=prompt, input_type="text")
+    assert result.output_text == expected_output
+    assert result.output_type == "text"
+
+
+@pytest.mark.asyncio
+async def test_text_to_hex_converter_emoji():
+    converter = TextToHexConverter()
+    prompt = "😊"  # Emoji character with code point U+1F60A
+    expected_output = "F09F988A"  # hex representation of '😊'
+    result = await converter.convert_async(prompt=prompt, input_type="text")
+    assert isinstance(result, ConverterResult)
+    assert result.output_text == expected_output
+    assert result.output_type == "text"


### PR DESCRIPTION
## Description

Added a new function to the `pyrit.prompt_converter` module that converts text to a hexadecimal encoded utf-8 string.
This address the issue: https://github.com/Azure/PyRIT/issues/666

## Tests and Documentation

Added unit testing in the `tests/unit/converter` directory.

Tagging @rdheekonda for review.