### PR TITLE
FIX: Integration Test Pipeline

### DIFF
--- a/pyrit/datasets/seed_prompts/illegal-multimodal.prompt
+++ b/pyrit/datasets/seed_prompts/illegal-multimodal.prompt
@@ -10,20 +10,20 @@ prompts:
     harm_categories:
       - illegal
     source: AI Red Team
-    value: ..\..\..\assets\pyrit_architecture.png
+    value: ../../../assets/pyrit_architecture.png
     data_type: image_path
     sequence: 1
   - dataset_name: TestMultimodalTextImageAudioVideo
     harm_categories:
       - illegal
     source: AI Red Team
-    value: ..\..\..\assets\molotov.wav
+    value: ../../../assets\molotov.wav
     data_type: audio_path
     sequence: 2
   - dataset_name: TestMultimodalTextImageAudioVideo
     harm_categories:
       - illegal
     source: AI Red Team
-    value: ..\..\..\assets\kinetics_0107.mp4
+    value: ../../../assets/kinetics_0107.mp4
     data_type: video_path
     sequence: 3

--- a/pyrit/prompt_target/openai/openai_tts_target.py
+++ b/pyrit/prompt_target/openai/openai_tts_target.py
@@ -69,11 +69,13 @@ class OpenAITTSTarget(OpenAITarget):
         self._extra_headers["api-key"] = self._api_key
 
         response_entry = None
+        endpoint_uri = (
+            f"{self._endpoint}/openai/deployments/{self._deployment_name}/audio/speech?api-version={self._api_version}"
+        )
         try:
             # Note the openai client doesn't work here, potentially due to a mismatch
             response = await net_utility.make_request_and_raise_if_error_async(
-                endpoint_uri=f"{self._endpoint}/openai/deployments/{self._deployment_name}/"
-                f"audio/speech?api-version={self._api_version}",
+                endpoint_uri=endpoint_uri,
                 method="POST",
                 headers=self._extra_headers,
                 request_body=body,

--- a/tests/integration/orchestrators/test_orchestrator_notebooks.py
+++ b/tests/integration/orchestrators/test_orchestrator_notebooks.py
@@ -12,7 +12,7 @@ from pyrit.common import path
 
 nb_directory_path = pathlib.Path(path.DOCS_CODE_PATH, "orchestrators").resolve()
 
-skipped_files = ["HITL_Scoring_Orchestrator.ipynb", "3_XPIA_Orchestrator.ipynb"]
+skipped_files = ["HITL_Scoring_Orchestrator.ipynb", "3_xpia_orchestrator.ipynb"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Integration tests working locally but failing in pipeline: fixing the orchestrator failure (skipping 3_xpia), making the file location for pyrit_architecture.png findable for linux and windows by swapping the "\" to "/" in the path. Also fixing TTS uri formation



## Tests and Documentation
Reran locally