### PR TITLE
FEAT: set favicon for the website

### DIFF
--- a/doc/_config.yml
+++ b/doc/_config.yml
@@ -29,6 +29,7 @@ repository:
 # Add GitHub buttons to your book
 # See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository
 html:
+  favicon: 'roakey.jpg'
   use_issues_button: true
   use_repository_button: true
   use_edit_page_button: true


### PR DESCRIPTION
## Description

Just made a really tiny update to the PyRIT website by adding a favicon.
I simply changed the Jupyter Book config to use the existing `roakey.jpg` file.

From now on, you'll see this cute icon in your browser tab instead of the default blank one :)

![image](https://github.com/user-attachments/assets/c95e1855-9f6c-4eb2-bca6-b8b0e92e1384)


