### PR TITLE
FEAT: Improve prompts reference to objectives for offline results analysis

### DIFF
--- a/pyrit/orchestrator/multi_turn/crescendo_orchestrator.py
+++ b/pyrit/orchestrator/multi_turn/crescendo_orchestrator.py
@@ -196,7 +196,7 @@ class CrescendoOrchestrator(MultiTurnOrchestrator):
         self._adversarial_chat.set_system_prompt(
             system_prompt=adversarial_chat_system_prompt,
             conversation_id=adversarial_chat_conversation_id,
-            orchestrator_identifier=self.get_identifier(),
+            orchestrator_identifier=self.get_identifier_with_objective(objective),
             labels=updated_memory_labels,
         )
 

--- a/pyrit/orchestrator/multi_turn/crescendo_orchestrator.py
+++ b/pyrit/orchestrator/multi_turn/crescendo_orchestrator.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
-
+import base64
+import hashlib
 import json
 import logging
 from pathlib import Path
@@ -232,6 +233,7 @@ class CrescendoOrchestrator(MultiTurnOrchestrator):
 
             last_response = await self._send_prompt_to_target_async(
                 attack_prompt=attack_prompt,
+                objective=objective,
                 objective_target_conversation_id=objective_target_conversation_id,
                 memory_labels=updated_memory_labels,
             )
@@ -354,7 +356,7 @@ class CrescendoOrchestrator(MultiTurnOrchestrator):
                     seed_prompt_group=seed_prompt_group,
                     conversation_id=adversarial_chat_conversation_id,
                     target=self._adversarial_chat,
-                    orchestrator_identifier=self.get_identifier(),
+                    orchestrator_identifier=self.get_identifier_with_objective(objective),
                     labels=memory_labels,
                 )
             )
@@ -386,6 +388,7 @@ class CrescendoOrchestrator(MultiTurnOrchestrator):
         self,
         *,
         attack_prompt: str,
+        objective: str,
         objective_target_conversation_id: str = None,
         memory_labels: Optional[dict[str, str]] = None,
     ) -> PromptRequestPiece:
@@ -402,7 +405,7 @@ class CrescendoOrchestrator(MultiTurnOrchestrator):
                 target=self._objective_target,
                 conversation_id=objective_target_conversation_id,
                 request_converter_configurations=[converter_configuration],
-                orchestrator_identifier=self.get_identifier(),
+                orchestrator_identifier=self.get_identifier_with_objective(objective),
                 labels=memory_labels,
             )
         ).request_pieces[0]

--- a/pyrit/orchestrator/multi_turn/red_teaming_orchestrator.py
+++ b/pyrit/orchestrator/multi_turn/red_teaming_orchestrator.py
@@ -258,7 +258,7 @@ class RedTeamingOrchestrator(MultiTurnOrchestrator):
                 request_converter_configurations=[converter_configurations],
                 target=self._objective_target,
                 labels=memory_labels,
-                orchestrator_identifier=self.get_identifier(),
+                orchestrator_identifier=self.get_identifier_with_objective(objective),
             )
         ).request_pieces[0]
 
@@ -412,7 +412,7 @@ class RedTeamingOrchestrator(MultiTurnOrchestrator):
                     seed_prompt_group=seed_prompt_group,
                     conversation_id=adversarial_chat_conversation_id,
                     target=self._adversarial_chat,
-                    orchestrator_identifier=self.get_identifier(),
+                    orchestrator_identifier=self.get_identifier_with_objective(objective),
                     labels=memory_labels,
                 )
             )

--- a/pyrit/orchestrator/multi_turn/red_teaming_orchestrator.py
+++ b/pyrit/orchestrator/multi_turn/red_teaming_orchestrator.py
@@ -398,7 +398,7 @@ class RedTeamingOrchestrator(MultiTurnOrchestrator):
             self._adversarial_chat.set_system_prompt(
                 system_prompt=str(system_prompt),
                 conversation_id=adversarial_chat_conversation_id,
-                orchestrator_identifier=self.get_identifier(),
+                orchestrator_identifier=self.get_identifier_with_objective(objective=objective),
                 labels=memory_labels,
             )
 

--- a/pyrit/orchestrator/multi_turn/tree_of_attacks_with_pruning_orchestrator.py
+++ b/pyrit/orchestrator/multi_turn/tree_of_attacks_with_pruning_orchestrator.py
@@ -188,7 +188,7 @@ class TreeOfAttacksWithPruningOrchestrator(MultiTurnOrchestrator):
                         objective_scorer=self._objective_scorer,
                         on_topic_scorer=self._get_on_topic_scorer(objective),
                         prompt_converters=self._prompt_converters,
-                        orchestrator_id=self.get_identifier(),
+                        orchestrator_id=self.get_identifier_with_objective(objective),
                         memory_labels=updated_memory_labels,
                         desired_response_prefix=self._desired_response_prefix,
                     )

--- a/tests/unit/orchestrator/test_multi_turn_orchestrator.py
+++ b/tests/unit/orchestrator/test_multi_turn_orchestrator.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
-
+import base64
+import hashlib
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -300,3 +301,20 @@ async def test_print_conversation_with_messages():
             mock_memory.get_conversation.assert_called_once_with(conversation_id="conversation_id_123")
             assert mock_display_image_response.call_count == 2
             assert mock_memory.get_scores_by_prompt_ids.call_count == 2
+
+
+def test_get_identifier_with_objective(orchestrator):
+    target_objective = 'the objective to test for'
+    orchestrator_identifier = orchestrator.get_identifier_with_objective(target_objective)
+    assert orchestrator_identifier["id"] == str(orchestrator._id)
+    assert orchestrator_identifier["__type__"] == orchestrator.__class__.__name__
+    assert orchestrator_identifier["__module__"] == orchestrator.__class__.__module__
+    assert orchestrator_identifier["objective_base64"] == str(base64.b64encode(target_objective.encode('utf-8')), encoding='utf-8')
+    assert orchestrator_identifier["objective_id"] == hashlib.md5(target_objective.encode('utf-8')).hexdigest()
+
+
+def test_get_identifier_with_objective_for_empty_objective(orchestrator):
+    with pytest.raises(ValueError) as identifier_exception:
+        orchestrator.get_identifier_with_objective('')
+
+    assert 'objective is required' in str(identifier_exception.value)

--- a/tests/unit/orchestrator/test_orchestrator_class.py
+++ b/tests/unit/orchestrator/test_orchestrator_class.py
@@ -1,0 +1,11 @@
+
+from pyrit.orchestrator import Orchestrator
+
+
+def test_get_identifier():
+    orchestrator = Orchestrator()
+    orchestrator_identifier = orchestrator.get_identifier()
+
+    assert orchestrator_identifier["id"] == str(orchestrator._id)
+    assert orchestrator_identifier["__type__"] == orchestrator.__class__.__name__
+    assert orchestrator_identifier["__module__"] == orchestrator.__class__.__module__

--- a/tests/unit/orchestrator/test_red_teaming_orchestrator.py
+++ b/tests/unit/orchestrator/test_red_teaming_orchestrator.py
@@ -350,6 +350,103 @@ def test_handle_last_prepended_assistant_message_with_no_matching_score():
     objective_score = orchestrator._handle_last_prepended_assistant_message()
     assert objective_score is None
 
+@pytest.mark.asyncio
+async def test_get_prompt_from_adversarial_chat_does_not_call_system_prompt(patch_central_database):
+    scorer = MagicMock(Scorer)
+    scorer.scorer_type = "true_false"
+    orchestrator = RedTeamingOrchestrator(
+        adversarial_chat=MagicMock(),
+        objective_target=MagicMock(),
+        objective_scorer=scorer,
+    )
+
+    prompt_request_response = PromptRequestResponse(request_pieces=[
+        PromptRequestPiece(role="user", original_value="message", converted_value="message",
+                           original_value_data_type="text", converted_value_data_type="text", )])
+    conversations = [
+        prompt_request_response
+    ]
+
+    with (
+        patch.object(
+            orchestrator, "_get_prompt_for_adversarial_chat", MagicMock(return_value="prompt_text")
+        ),
+        patch.object(
+            orchestrator._memory, "get_conversation", MagicMock(return_value=conversations)
+        ),
+        patch.object(
+            orchestrator._prompt_normalizer, "send_prompt_async", AsyncMock(return_value=prompt_request_response)
+        ),
+        patch.object(
+            orchestrator._adversarial_chat, "set_system_prompt", AsyncMock()
+        ) as mock_set_system_prompt,
+    ):
+        objective = "objective"
+        memory_labels = {"username": "user"}
+        objective_target_conversation_id = str(uuid4())
+        adversarial_chat_conversation_id = str(uuid4())
+
+        await orchestrator._get_prompt_from_adversarial_chat(
+            objective=objective,
+            objective_target_conversation_id=objective_target_conversation_id,
+            adversarial_chat_conversation_id=adversarial_chat_conversation_id,
+            memory_labels=memory_labels
+        )
+
+        mock_set_system_prompt.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_get_prompt_from_adversarial_chat_does_call_system_prompt(patch_central_database):
+    scorer = MagicMock(Scorer)
+    scorer.scorer_type = "true_false"
+    orchestrator = RedTeamingOrchestrator(
+        adversarial_chat=MagicMock(),
+        objective_target=MagicMock(),
+        objective_scorer=scorer,
+    )
+
+    prompt_request_response = PromptRequestResponse(request_pieces=[
+        PromptRequestPiece(role="user", original_value="message", converted_value="message",
+                           original_value_data_type="text", converted_value_data_type="text", )])
+
+    with (
+        patch.object(
+            orchestrator, "_get_prompt_for_adversarial_chat", MagicMock(return_value="prompt_text")
+        ),
+        patch.object(
+            orchestrator._memory, "get_conversation", MagicMock(return_value=[])
+        ),
+        patch.object(
+            orchestrator._prompt_normalizer, "send_prompt_async", AsyncMock(return_value=prompt_request_response)
+        ),
+        patch.object(
+            orchestrator._adversarial_chat, "set_system_prompt", AsyncMock()
+        ) as mock_set_system_prompt,
+    ):
+        objective = "objective"
+        memory_labels = {"username": "user"}
+        objective_target_conversation_id = str(uuid4())
+        adversarial_chat_conversation_id = str(uuid4())
+
+        await orchestrator._get_prompt_from_adversarial_chat(
+            objective=objective,
+            objective_target_conversation_id=objective_target_conversation_id,
+            adversarial_chat_conversation_id=adversarial_chat_conversation_id,
+            memory_labels=memory_labels
+        )
+
+        expected_system_prompt = orchestrator._adversarial_chat_system_seed_prompt.render_template_value(
+            objective=objective,
+            max_turns=orchestrator._max_turns,
+        )
+
+        mock_set_system_prompt.assert_called_once()
+
+        _, adv_chat_system_prompt_args = mock_set_system_prompt.call_args
+        assert adv_chat_system_prompt_args["system_prompt"] == expected_system_prompt
+        assert adv_chat_system_prompt_args["conversation_id"] == adversarial_chat_conversation_id
+        assert adv_chat_system_prompt_args["orchestrator_identifier"] == orchestrator.get_identifier_with_objective(objective=objective)
+        assert adv_chat_system_prompt_args["labels"].items() == memory_labels.items()
 
 @pytest.mark.asyncio
 async def test_get_prompt_from_adversarial_chat_sends_prompt(patch_central_database):


### PR DESCRIPTION

## Description
When analysing results of a set of attacks, we loose the reference to the objectives (when multiple objectives are provided in a multi-turn attack) within the prompts. This pull request attempts to capture the objective on each prompt using the `orchestrator_identifier` of the persisted PromptEntry.

Links to the discussion on discord - https://discord.com/channels/1311106595429548142/1311106596159623261/1339989315618607145

CC: @romanlutz @rlundeen2 

## Changes in this PR:

[FEAT: Enhance attack result data](https://github.com/Azure/PyRIT/commit/67fc6389319f737b387ccc14d33f6a2078b73530) 

* The prompt entries stored for the multi-turn attacks loose the link to the objective
  for which the prompt is applicable to. This makes it hard or impossible to map the
  prompt entries to the objective when pulling the data out for further analysis.
* This change captures the objective with the orchestrator identifier.
* The `orchestrator_identifier` json blob is enriched with a base64 encoded objective and
  an id derived from the objective string.
  The reason for the base64 encoding is to address any encoding issues when capturing
  the content in the json file. And the hash is to provide a fixed length ID for the objective

[FEAT: Enrich orchestrator_identifier for system prompts](https://github.com/Azure/PyRIT/commit/64c5cd315d9fe29c3706b80b3feea56c1b692f98) 

* When there are many objectives, the systems prompts used within
  an orchestrator doesn't have a reference to the objective they were
  applicable to. Having a reference to the objective helps with understanding
  the system prompts used during the attack. This change adds the link to the
  objective within the orchestrator_identifier.