### PR TITLE
FEAT PyRIT to not upload duplicate seed-prompts

### DIFF
--- a/doc/code/datasets/0_dataset.md
+++ b/doc/code/datasets/0_dataset.md
@@ -9,3 +9,10 @@ By using `SeedPrompts` through loading from a YAML file or loading them via syst
 **Loading Datasets**:
 
 We also show examples of common methods to fetch datasets into PyRIT from different sources. Most datasets will be loaded as a `SeedPromptDataset`. Outside of these examples, the fetch functions which are currently available can be found in `fetch_example_datasets.py` and are organized by similar method type. There is a wide range of datasets which are included and can be used as example to also load in other datasets. As these datasets are the first component of building an attack in PyRIT, the following notebooks also continue to demonstrate how these prompts can be used in the process.
+
+**Datasets Loading Process: Seed Prompt De-duplication**:
+PyRIT checks for existence of duplicate seed prompts using hashes to make sure it is not uploading duplicate seed prompts in the memory. The feature follows following decision-tree:
+
+1. If PyRIT receives duplicate seed-prompt within the same dataset, it doesn't upload the seed-prompt
+2. But if it receives a new seed-prompt in the same dataset with even a slight modification and having a different hash, it accepts it.
+3. If PyRIT receives a duplicate seed-prompt in a different dataset, it accepts it.

--- a/pyrit/memory/memory_interface.py
+++ b/pyrit/memory/memory_interface.py
@@ -693,7 +693,7 @@ class MemoryInterface(abc.ABC):
 
             await prompt.set_sha256_value_async()
 
-            if not self.get_seed_prompts(value_sha256=[prompt.value_sha256]):
+            if not self.get_seed_prompts(value_sha256=[prompt.value_sha256], dataset_name=prompt.dataset_name):
                 entries.append(SeedPromptEntry(entry=prompt))
 
         self._insert_entries(entries=entries)

--- a/pyrit/memory/memory_interface.py
+++ b/pyrit/memory/memory_interface.py
@@ -693,7 +693,8 @@ class MemoryInterface(abc.ABC):
 
             await prompt.set_sha256_value_async()
 
-            entries.append(SeedPromptEntry(entry=prompt))
+            if not self.get_seed_prompts(value_sha256=[prompt.value_sha256]):
+                entries.append(SeedPromptEntry(entry=prompt))
 
         self._insert_entries(entries=entries)
 

--- a/tests/unit/memory/test_memory_interface.py
+++ b/tests/unit/memory/test_memory_interface.py
@@ -1104,6 +1104,28 @@ async def test_add_seed_prompts_to_memory_empty_list(duckdb_instance: MemoryInte
     assert len(stored_prompts) == 0
 
 
+@pytest.mark.asyncio
+async def test_add_seed_prompts_duplicate_entries(duckdb_instance: MemoryInterface):
+    prompts: list[SeedPrompt] = [
+        SeedPrompt(value="prompt1", dataset_name="test_dataset", data_type="text"),
+        SeedPrompt(value="prompt2", dataset_name="test_dataset", data_type="text"),
+    ]
+    await duckdb_instance.add_seed_prompts_to_memory_async(prompts=prompts, added_by="tester")
+    stored_prompts = duckdb_instance.get_seed_prompts(dataset_name="test_dataset")
+    assert len(stored_prompts) == 2
+
+    # Try to add prompt list with one duplicate prompt and one new prompt
+    duplicate_prompts: list[SeedPrompt] = [
+        SeedPrompt(value="prompt1", dataset_name="test_dataset", data_type="text"),
+        SeedPrompt(value="prompt3", dataset_name="test_dataset", data_type="text"),
+    ]
+    await duckdb_instance.add_seed_prompts_to_memory_async(prompts=duplicate_prompts, added_by="tester")
+
+    # Validate that only new prompt is added and the total prompt count is 3
+    stored_prompts = duckdb_instance.get_seed_prompts(dataset_name="test_dataset")
+    assert len(stored_prompts) == 3
+
+
 def test_get_seed_prompt_dataset_names_empty(duckdb_instance: MemoryInterface):
     assert duckdb_instance.get_seed_prompt_dataset_names() == []
 

--- a/tests/unit/memory/test_memory_interface.py
+++ b/tests/unit/memory/test_memory_interface.py
@@ -1105,7 +1105,7 @@ async def test_add_seed_prompts_to_memory_empty_list(duckdb_instance: MemoryInte
 
 
 @pytest.mark.asyncio
-async def test_add_seed_prompts_duplicate_entries(duckdb_instance: MemoryInterface):
+async def test_add_seed_prompts_duplicate_entries_same_dataset(duckdb_instance: MemoryInterface):
     prompts: list[SeedPrompt] = [
         SeedPrompt(value="prompt1", dataset_name="test_dataset", data_type="text"),
         SeedPrompt(value="prompt2", dataset_name="test_dataset", data_type="text"),
@@ -1124,6 +1124,28 @@ async def test_add_seed_prompts_duplicate_entries(duckdb_instance: MemoryInterfa
     # Validate that only new prompt is added and the total prompt count is 3
     stored_prompts = duckdb_instance.get_seed_prompts(dataset_name="test_dataset")
     assert len(stored_prompts) == 3
+
+
+@pytest.mark.asyncio
+async def test_add_seed_prompts_duplicate_entries_different_datasets(duckdb_instance: MemoryInterface):
+    prompts: list[SeedPrompt] = [
+        SeedPrompt(value="prompt1", dataset_name="test_dataset", data_type="text"),
+        SeedPrompt(value="prompt2", dataset_name="test_dataset", data_type="text"),
+    ]
+    await duckdb_instance.add_seed_prompts_to_memory_async(prompts=prompts, added_by="tester")
+    stored_prompts = duckdb_instance.get_seed_prompts(dataset_name="test_dataset")
+    assert len(stored_prompts) == 2
+
+    # Try to add prompt list with one duplicate prompt and one new prompt
+    duplicate_prompts: list[SeedPrompt] = [
+        SeedPrompt(value="prompt1", dataset_name="test_dataset2", data_type="text"),
+        SeedPrompt(value="prompt3", dataset_name="test_dataset2", data_type="text"),
+    ]
+    await duckdb_instance.add_seed_prompts_to_memory_async(prompts=duplicate_prompts, added_by="tester")
+
+    # Validate that only new prompt is added and the total prompt count is 3
+    stored_prompts = duckdb_instance.get_seed_prompts(dataset_name="test_dataset")
+    assert len(stored_prompts) == 4
 
 
 def test_get_seed_prompt_dataset_names_empty(duckdb_instance: MemoryInterface):

--- a/tests/unit/memory/test_memory_interface.py
+++ b/tests/unit/memory/test_memory_interface.py
@@ -1144,7 +1144,7 @@ async def test_add_seed_prompts_duplicate_entries_different_datasets(duckdb_inst
     await duckdb_instance.add_seed_prompts_to_memory_async(prompts=duplicate_prompts, added_by="tester")
 
     # Validate that only new prompt is added and the total prompt count is 3
-    stored_prompts = duckdb_instance.get_seed_prompts(dataset_name="test_dataset")
+    stored_prompts = duckdb_instance.get_seed_prompts()
     assert len(stored_prompts) == 4
 
 


### PR DESCRIPTION
## Description
This PR is aimed to resolve #739. Objective of this issue is to:
1. Enable PyRIT to check for existence of duplicate seed prompts using hashes to make sure we are not uploading duplicate seed prompts in the memory.
2. Follow-up: to figure out what actions we can take once we find a duplicate seed-prompt and can create story about what would help red-teamers if there is a need for uploading duplicate seed prompts.

## Technical Specification:
The feature follows following decision-tree:
1. If PyRIT receives duplicate seed-prompt within the same dataset, it doesn't upload the seed-prompt
2. But if it receives a new seed-prompt in the same dataset with even a slight modification and having a different hash, it accepts it.
3. If PyRIT receives a duplicate seed-prompt in a different dataset, it accepts it.