### PR TITLE
FIX: small edits to make integration tests pass

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
-recursive-include pyrit *.yaml
+recursive-include pyrit *.json
 recursive-include pyrit *.prompt
+recursive-include pyrit *.yaml
 recursive-include pyrit/datasets/seed_prompts *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ all = [
     "playwright>=1.49.0",
     "sentencepiece>=0.2.0",
     "torch>=2.3.0",
+    "opencv-python>=4.11.0.86",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ all = [
     "types-PyYAML>=6.0.12.9",
     "gradio>=5.16.0",
     "rpyc>=6.0.1",
-    "pywebview>=5.4"
+    "pywebview>=5.4",
     "opencv-python>=4.11.0.86",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,17 +129,17 @@ all = [
     "azure-ai-ml>=1.13.0",
     "azureml-mlflow>=1.57.0",
     "flask>=3.1.0",
+    "gradio>=5.16.0",
     "mlflow>=2.16.2",
     "ml-collections>=0.1.1",
     "ollama>=0.4.4",
+    "opencv-python>=4.11.0.86",
     "playwright>=1.49.0",
+    "pywebview>=5.4",
+    "rpyc>=6.0.1",
     "sentencepiece>=0.2.0",
     "torch>=2.3.0",
     "types-PyYAML>=6.0.12.9",
-    "gradio>=5.16.0",
-    "rpyc>=6.0.1",
-    "pywebview>=5.4",
-    "opencv-python>=4.11.0.86",
 ]
 
 [project.scripts]

--- a/pyrit/prompt_target/openai/openai_tts_target.py
+++ b/pyrit/prompt_target/openai/openai_tts_target.py
@@ -36,7 +36,7 @@ class OpenAITTSTarget(OpenAITarget):
         response_format: TTSResponseFormat = "mp3",
         language: Optional[str] = "en",
         speed: Optional[float] = None,
-        api_version: str = "2024-06-01",
+        api_version: str = "2025-02-01-preview",
         **kwargs,
     ):
         """
@@ -53,7 +53,7 @@ class OpenAITTSTarget(OpenAITarget):
                 https://cognitiveservices.azure.com/.default . Please run `az login` locally
                 to leverage user AuthN.
             api_version (str, Optional): The version of the Azure OpenAI API. Defaults to
-                "2024-06-01".
+                "2025-02-01-preview".
             max_requests_per_minute (int, Optional): Number of requests the target can handle per
                 minute before hitting a rate limit. The number of requests sent to the target
                 will be capped at the value provided.

--- a/tests/unit/target/test_tts_target.py
+++ b/tests/unit/target/test_tts_target.py
@@ -213,4 +213,4 @@ async def test_tts_target_default_api_version(sample_conversations: MutableSeque
         called_params = mock_request.call_args[1]["params"]
 
         assert "api-version" in called_params
-        assert called_params["api-version"] == "2024-06-01"
+        assert called_params["api-version"] == "2025-02-01-preview"


### PR DESCRIPTION
This PR addresses makes small changes to ensure integration tests pass:
- json files are automatically included in the source distribution via `MANIFEST`
- `opencv-python` is added to [all] dependencies in `pyproject.toml`
- tts default api_version is now `2025-02-01`

Associated notebooks, integration, and unit tests pass locally.