### PR TITLE
DOC: clarify OpenAITarget targets httpx_client_kwargs timeout settings

### DIFF
--- a/pyrit/prompt_target/openai/openai_chat_target.py
+++ b/pyrit/prompt_target/openai/openai_chat_target.py
@@ -93,6 +93,9 @@ class OpenAIChatTarget(OpenAITarget):
                 such that repeated requests with the same seed and parameters should return the same result.
             n (int, Optional): The number of completions to generate for each prompt.
             extra_body_parameters (dict, Optional): Additional parameters to be included in the request body.
+            httpx_client_kwargs (dict, Optional): Additional kwargs to be passed to the
+                httpx.AsyncClient() constructor.
+                For example, to specify a 3 minutes timeout: httpx_client_kwargs={"timeout": 180}
         """
         super().__init__(**kwargs)
 

--- a/pyrit/prompt_target/openai/openai_completion_target.py
+++ b/pyrit/prompt_target/openai/openai_completion_target.py
@@ -64,6 +64,9 @@ class OpenAICompletionTarget(OpenAITarget):
                 tokens based on whether they appear in the text so far, increasing the model's likelihood to
                 talk about new topics.
             n (int, Optional): How many completions to generate for each prompt.
+            httpx_client_kwargs (dict, Optional): Additional kwargs to be passed to the
+                httpx.AsyncClient() constructor.
+                For example, to specify a 3 minutes timeout: httpx_client_kwargs={"timeout": 180}
         """
 
         super().__init__(*args, **kwargs)

--- a/pyrit/prompt_target/openai/openai_dall_e_target.py
+++ b/pyrit/prompt_target/openai/openai_dall_e_target.py
@@ -70,6 +70,9 @@ class OpenAIDALLETarget(OpenAITarget):
                 DALL-E-3. Defaults to "natural".
             *args: Additional positional arguments to be passed to AzureOpenAITarget.
             **kwargs: Additional keyword arguments to be passed to AzureOpenAITarget.
+            httpx_client_kwargs (dict, Optional): Additional kwargs to be passed to the
+                httpx.AsyncClient() constructor.
+                For example, to specify a 3 minutes timeout: httpx_client_kwargs={"timeout": 180}
 
         Raises:
             ValueError: If `num_images` is not 1 for DALL-E-3.

--- a/pyrit/prompt_target/openai/openai_realtime_target.py
+++ b/pyrit/prompt_target/openai/openai_realtime_target.py
@@ -56,6 +56,9 @@ class RealtimeTarget(OpenAITarget):
             voice (literal str, Optional): The voice to use. Defaults to None.
                 the only supported voices by the AzureOpenAI Realtime API are "alloy", "echo", and "shimmer".
             existing_convo (dict[str, websockets.WebSocketClientProtocol], Optional): Existing conversations.
+            httpx_client_kwargs (dict, Optional): Additional kwargs to be passed to the
+                httpx.AsyncClient() constructor.
+                For example, to specify a 3 minutes timeout: httpx_client_kwargs={"timeout": 180}
         """
 
         super().__init__(api_version=api_version, **kwargs)

--- a/pyrit/prompt_target/openai/openai_tts_target.py
+++ b/pyrit/prompt_target/openai/openai_tts_target.py
@@ -63,6 +63,9 @@ class OpenAITTSTarget(OpenAITarget):
             response_format (str, Optional): The format of the audio response. Defaults to "mp3".
             language (str, Optional): The language for TTS. Defaults to "en".
             speed (float, Optional): The speed of the TTS. Select a value from 0.25 to 4.0. 1.0 is normal.
+            httpx_client_kwargs (dict, Optional): Additional kwargs to be passed to the
+                httpx.AsyncClient() constructor.
+                For example, to specify a 3 minutes timeout: httpx_client_kwargs={"timeout": 180}
         """
 
         super().__init__(**kwargs)


### PR DESCRIPTION
### Summary
________________________________

Added details on how to change the default 60 seconds timeout for the Open AI targets by passing the `httpx_client_kwargs` dict argument, for example:

```python
OpenAIChatTarget(
   httpx_client_kwargs={"timeout": 300}
)
```