### PR TITLE
FEAT: Added memory config to scanner

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/devcontainers/anaconda:3
 RUN apt-get update && apt-get install -y \
     unixodbc \
     unixodbc-dev \
-    libgl1-mesa-glx \ 
+    libgl1-mesa-glx \
     curl \
     xdg-utils
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,4 +3,23 @@ FROM mcr.microsoft.com/devcontainers/anaconda:3
 RUN apt-get update && apt-get install -y \
     unixodbc \
     unixodbc-dev \
-    libgl1-mesa-glx
+    libgl1-mesa-glx \ 
+    curl \
+    xdg-utils
+
+# Download and install the DuckDB CLI.
+# Change this line if a newer version is available.
+RUN curl -Lo duckdb.gz https://github.com/duckdb/duckdb/releases/download/v1.2.1/duckdb_cli-linux-amd64.gz && \
+    gunzip duckdb.gz && \
+    mv duckdb /usr/local/bin/duckdb && \
+    chmod +x /usr/local/bin/duckdb
+
+# Install Azure CLI (Debian variant)
+RUN apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release && \
+    curl -sL https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -o packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb && \
+    rm packages-microsoft-prod.deb && \
+    apt-get update && \
+    apt-get install azure-cli -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
         }
     },
     "postCreateCommand": "/bin/bash -i .devcontainer/devcontainer_setup.sh",
-    "forwardPorts": [8888],
+    "forwardPorts": [4213, 8888],
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "workspaceFolder": "/workspace"
 }

--- a/pyrit/cli/__main__.py
+++ b/pyrit/cli/__main__.py
@@ -1,32 +1,18 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
-
 import asyncio
-import inspect
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, Namespace
-from copy import deepcopy
 from datetime import datetime
-from importlib import import_module
 from pathlib import Path
-from typing import Any, Dict, List, MutableSequence, Optional, Type
-from uuid import uuid4
-
-import yaml
+from typing import List
 
 from pyrit.common import initialize_pyrit
 from pyrit.memory import CentralMemory
 from pyrit.models import SeedPrompt, SeedPromptDataset
 from pyrit.models.seed_prompt import SeedPromptGroup
-from pyrit.orchestrator import Orchestrator
-from pyrit.prompt_converter import PromptConverter
 from pyrit.prompt_normalizer.normalizer_request import NormalizerRequest
-from pyrit.prompt_normalizer.prompt_converter_configuration import (
-    PromptConverterConfiguration,
-)
-from pyrit.prompt_target import PromptTarget
-from pyrit.prompt_target.common.prompt_chat_target import PromptChatTarget
-from pyrit.score.scorer import Scorer
+from pyrit.prompt_normalizer.prompt_converter_configuration import PromptConverterConfiguration
+from .scanner_config import ScannerConfig
 
+SCANNER_EXECUTION_START_TIME_MEMORY_LABEL: str = "scanner_execution_start_time"
 
 def parse_args(args=None) -> Namespace:
     parser = ArgumentParser(
@@ -37,245 +23,73 @@ def parse_args(args=None) -> Namespace:
     parser.add_argument(
         "--config-file",
         type=str,
-        help="The path to the configuration file.",
+        help="Path to the scanner YAML config file.",
         required=True,
     )
+    parser.add_argument(
+        "--db-type",
+        type=str,
+        default="DuckDB",
+        choices=["DuckDB", "AzureSQL"],
+        help="Which database to use (DuckDB or AzureSQL)."
+    )
+    return parser.parse_args(args)
 
-    parsed_args = parser.parse_args(args)
-    config_file = Path(parsed_args.config_file)
-    if not config_file.exists():
-        raise FileNotFoundError(f"Configuration file {config_file.absolute()} does not exist.")
-    return parsed_args
+def load_seed_prompts(dataset_paths: List[str]) -> List[SeedPrompt]:
+    """
+    loads each dataset file path into a list of SeedPrompt objects.
+    """
+    if not dataset_paths:
+        raise ValueError("No datasets provided in the configuration.")
+    
+    all_prompts: List[SeedPrompt] = []
+    for path_str in dataset_paths:
+        path = Path(path_str)
+        if not path.exists():
+            raise FileNotFoundError(f"Dataset file '{path}' does not exist.")
+        dataset = SeedPromptDataset.from_yaml_file(path)
+        all_prompts.extend(dataset.prompts)
+    return all_prompts
 
+async def run_scenarios_async(config: ScannerConfig) -> None:
+    """
+    Run scenarios
+    """
+    memory_labels = config.memory_labels or {}
+    memory_labels[SCANNER_EXECUTION_START_TIME_MEMORY_LABEL] = datetime.now().isoformat()
 
-def load_config(config_file: Path) -> Dict[str, Any]:
-    # Load the configuration YAML file
-    with open(config_file, "r") as file:
-        config = yaml.safe_load(file)
+    seed_prompts = load_seed_prompts(config.datasets)
+    prompt_converters = config.create_prompt_converters()
+    orchestrators = config.create_orchestrators(prompt_converters=prompt_converters)
 
-    if not config:
-        raise ValueError("Configuration file is empty.")
-
-    if not isinstance(config, dict):
-        raise TypeError("Configuration file must be a dictionary.")
-
-    return config
-
-
-async def validate_config_and_run_async(config: Dict[str, Any], memory_labels: Optional[Dict[str, str]] = None) -> None:
-    if "scenarios" not in config:
-        raise KeyError("Configuration file must contain a 'scenarios' key.")
-
-    scenarios = config["scenarios"]
-
-    if not scenarios:
-        raise ValueError("Scenarios list is empty.")
-
-    initialize_pyrit(memory_db_type="DuckDB")
-
-    seed_prompts = generate_datasets(config)
-    objective_target = validate_target(config, target_key="objective_target")
-    prompt_converters: list[PromptConverter] = []
-    # prompt_converters = validate_converters(config)
-    adversarial_chat: PromptChatTarget | None = None
-    if "adversarial_chat" in config:
-        adversarial_chat = validate_target(config, target_key="adversarial_chat")  # type: ignore
-    scoring_target = validate_scoring_target(config, adversarial_chat=adversarial_chat)  # type: ignore
-    objective_scorer = validate_objective_scorer(config, scoring_target=scoring_target)
-
-    orchestrators = []
-    for scenario_config in scenarios:
-        orchestrators.append(
-            validate_scenario(
-                scenario_config=scenario_config,
-                objective_target=objective_target,
-                adversarial_chat=adversarial_chat,
-                prompt_converters=prompt_converters,
-                scoring_target=scoring_target,
-                objective_scorer=objective_scorer,
-            )
-        )
-
-    # This is a separate loop because we want to validate all scenarios before starting execution.
     for orchestrator in orchestrators:
         if hasattr(orchestrator, "run_attack_async"):
-            for seed_prompt in seed_prompts:
-                await orchestrator.run_attack_async(objective=seed_prompt.value, memory_labels=memory_labels)
+            # Run attack for each seed prompt
+            for prompt in seed_prompts:
+                await orchestrator.run_attack_async(objective=prompt.value, memory_labels=memory_labels)
         elif hasattr(orchestrator, "send_normalizer_requests_async"):
-            converter_configurations = [
-                PromptConverterConfiguration(converters=prompt_converters if prompt_converters else [])
-            ]
-
-            normalizer_requests = [
-                NormalizerRequest(
-                    seed_prompt_group=SeedPromptGroup(prompts=[seed_prompt]),
-                    request_converter_configurations=converter_configurations,
-                    conversation_id=str(uuid4()),
-                )
-                for seed_prompt in seed_prompts
-            ]
+            converter_configurations = [PromptConverterConfiguration(converters=prompt_converters)]
+            normalizer_requests = []
+            for prompt in seed_prompts:
+                request = NormalizerRequest(
+                    seed_prompt_group=SeedPromptGroup(prompts=[prompt]),
+                    request_converter_configurations=converter_configurations,)
+                normalizer_requests.append(request)
+            
+            # Send normalizer requests to orchestrator
             await orchestrator.send_normalizer_requests_async(
                 prompt_request_list=normalizer_requests,
                 memory_labels=memory_labels,
             )
         else:
+            # If the orchestrator doesn't implement either method
             supported_methods = ["run_attack_async", "send_normalizer_requests_async"]
             raise ValueError(
-                f"The orchestrator of type {type(orchestrator).__name__} does not have a compatible "
-                f"method to execute its attack. The supported methods are {supported_methods}."
+                f"The orchestrator {type(orchestrator).__name__} does not have a supported method. "
+                f"Supported methods: {supported_methods}."
             )
-
-
-def validate_scenario(
-    scenario_config: Dict[str, Any],
-    objective_target: PromptTarget,
-    adversarial_chat: Optional[PromptChatTarget] = None,
-    prompt_converters: Optional[List[PromptConverter]] = None,
-    scoring_target: Optional[PromptChatTarget] = None,
-    objective_scorer: Optional[Scorer] = None,
-) -> Orchestrator:
-    if "type" not in scenario_config:
-        raise KeyError("Scenario must contain a 'type' key.")
-
-    scenario_type = scenario_config["type"]
-    scenario_args = deepcopy(scenario_config)
-    del scenario_args["type"]
-
-    orchestrator_class = load_class(
-        module_name="pyrit.orchestrator", class_name=scenario_type, error_context="scenario"
-    )
-
-    constructor_arg_names = [arg.name for arg in inspect.signature(orchestrator_class.__init__).parameters.values()]
-
-    # Some orchestrator arguments have their own configuration since they
-    # are more complex. They are passed in as args to this function.
-    complex_arg_names = [
-        "objective_target",
-        "adversarial_chat",
-        "prompt_converters",
-        "scoring_target",
-        "objective_scorer",
-    ]
-    for complex_arg_name in complex_arg_names:
-        if complex_arg_name in scenario_args:
-            raise ValueError(
-                f"{complex_arg_name} needs to be configured at the top level of the scanner configuration."
-                f"The scenario configuration cannot include {complex_arg_name}."
-            )
-
-        # Add complex args to the argument list.
-        local_vars = locals()
-        if complex_arg_name in constructor_arg_names:
-            arg_value = local_vars[complex_arg_name]
-            if arg_value:
-                scenario_args[complex_arg_name] = arg_value
-
-    try:
-        orchestrator = orchestrator_class(**scenario_args)
-    except Exception as ex:
-        raise ValueError(f"Failed to validate scenario {scenario_type}: {ex}") from ex
-    return orchestrator
-
-
-def generate_datasets(config: Dict[str, Any]) -> MutableSequence[SeedPrompt]:
-    datasets = config.get("datasets")
-
-    if not datasets:
-        raise KeyError("The configuration file must contain a 'datasets' key.")
-
-    loaded_dataset_prompts: MutableSequence[SeedPrompt] = []
-    for dataset_path in datasets:
-        dataset = SeedPromptDataset.from_yaml_file(dataset_path)
-        loaded_dataset_prompts.extend(dataset.prompts)
-
-    return loaded_dataset_prompts
-
-
-def validate_target(config: Dict[str, Any], target_key: str) -> PromptTarget:
-    if target_key not in config:
-        raise KeyError(f"Configuration file must contain a '{target_key}' key.")
-
-    if not config[target_key] or not config[target_key].get("type"):
-        raise KeyError(f"Target {target_key} must contain a 'type' key.")
-
-    target_config = deepcopy(config[target_key])
-    target_type = target_config.pop("type")
-
-    try:
-        target_module = import_module("pyrit.prompt_target")
-        target_class = getattr(target_module, target_type)
-    except Exception as ex:
-        raise RuntimeError(f"Failed to import target {target_type} from pyrit.prompt_target") from ex
-
-    target = target_class(**target_config)
-    return target
-
-
-def validate_scoring_target(
-    config: Dict[str, Any], adversarial_chat: Optional[PromptChatTarget]
-) -> PromptChatTarget | None:
-    if "scoring" not in config:
-        return None
-    scoring_config = config["scoring"]
-
-    # If a scoring_target has been configured use it.
-    # Otherwise, use the adversarial_chat target for scoring.
-    scoring_target = adversarial_chat
-    if "scoring_target" in scoring_config:
-        scoring_target = validate_target(scoring_config, target_key="scoring_target")  # type: ignore
-    return scoring_target
-
-
-def validate_objective_scorer(config: Dict[str, Any], scoring_target: Optional[PromptChatTarget]) -> Scorer | None:
-    if "scoring" not in config:
-        return None
-    scoring_config = config["scoring"]
-    if "objective_scorer" not in scoring_config:
-        return None
-
-    scorer_args = deepcopy(scoring_config["objective_scorer"])
-
-    if "type" not in scorer_args:
-        raise KeyError("Scorer definition must contain a 'type' key.")
-
-    scorer_type = scorer_args.pop("type")
-
-    scorer_class = load_class(module_name="pyrit.score", class_name=scorer_type, error_context="objective_scorer")
-
-    if "chat_target" in inspect.signature(scorer_class.__init__).parameters:
-        if scoring_target:
-            scorer_args["chat_target"] = scoring_target
-        else:
-            raise KeyError(
-                "Scorer requires a scoring_target to be defined. "
-                "Alternatively, the adversarial_target can be used "
-                "for scoring purposes, but none was provided."
-            )
-
-    return scorer_class(**scorer_args)
-
-
-def load_class(*, module_name: str, class_name: str, error_context: str) -> Type[Any]:
-    try:
-        mod = import_module(module_name)
-        cls = getattr(mod, class_name)
-        if not inspect.isclass(cls):
-            raise TypeError(f"The attribute {class_name} in module {module_name} is not a class.")
-    except Exception as ex:
-        raise RuntimeError(f"Failed to import {class_name} from {module_name} for {error_context}: {ex}") from ex
-    return cls
-
-
-def main(args=None):
-    parsed_args = parse_args(args)
-    config_file = parsed_args.config_file
-    config = load_config(config_file)
-    memory_labels = config.get("memory_labels", {})
-    # Add timestamp to distinguish between scanner runs with the same memory labels
-    memory_labels["scanner_execution_start_time"] = datetime.now().isoformat()
-
-    asyncio.run(validate_config_and_run_async(config, memory_labels))
-
+    
+    # Print conversation pieces from memory
     memory = CentralMemory.get_memory_instance()
     all_pieces = memory.get_prompt_request_pieces(labels=memory_labels)
     conversation_id = None
@@ -285,3 +99,18 @@ def main(args=None):
             print("===================================================")
             print(f"Conversation ID: {conversation_id}")
         print(f"{piece.role}: {piece.converted_value}")
+
+def main(args=None):
+    parsed_args = parse_args(args)
+
+    config_file = Path(parsed_args.config_file)
+    if not config_file.exists():
+        raise FileNotFoundError(f"Configuration file {config_file.absolute()} does not exist.")
+
+    config = ScannerConfig.from_yaml(str(config_file))
+    initialize_pyrit(memory_db_type=parsed_args.db_type)
+
+    asyncio.run(run_scenarios_async(config))
+
+if __name__ == "__main__":
+    main()

--- a/pyrit/cli/scanner_config.py
+++ b/pyrit/cli/scanner_config.py
@@ -9,10 +9,10 @@ from typing import Any, List, Literal, Optional, Type, get_args
 import yaml
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from pyrit.common.initialization import MemoryDatabaseType
 from pyrit.prompt_converter.prompt_converter import PromptConverter
 
 SupportedExecutionTypes = Literal["local"]
-SupportedDatabaseType = Literal["DuckDB", "AzureSQL"]
 
 
 def load_class(module_name: str, class_name: str, error_context: str) -> Type[Any]:
@@ -35,8 +35,10 @@ class DatabaseConfig(BaseModel):
     Configuration for the database used by the scanner.
     """
 
-    db_type: SupportedDatabaseType = Field(
-        "DuckDB", alias="type", description="Which database to use (DuckDB or AzureSQL)."
+    db_type: MemoryDatabaseType = Field(
+        ...,
+        alias="type",
+        description=f"Which database to use. Supported values: {list(get_args(MemoryDatabaseType))}",
     )
     memory_labels: dict = Field(default_factory=dict, description="Labels that will be stored in memory to tag runs.")
 
@@ -230,7 +232,7 @@ class ScannerConfig(BaseModel):
         description="Settings for how the scan is executed.",
     )
     database: DatabaseConfig = Field(
-        default_factory=lambda: DatabaseConfig.model_validate({}),
+        ...,
         description="Database configuration for storing memory or results, including memory_labels.",
     )
 

--- a/pyrit/cli/scanner_config.py
+++ b/pyrit/cli/scanner_config.py
@@ -1,0 +1,287 @@
+import inspect
+import yaml
+from typing import List, Optional, Literal, Any, Type
+from pydantic import BaseModel, Field, model_validator
+from copy import deepcopy
+from importlib import import_module
+
+def load_class(module_name: str, class_name: str, error_context: str) -> Type[Any]:
+    """
+    Dynamically import a class from a module by name.
+    """
+    try:
+        mod = import_module(module_name)
+        cls = getattr(mod, class_name)
+        if not inspect.isclass(cls):
+            raise TypeError(f"The attribute {class_name} in module {module_name} is not a class.")
+    except Exception as ex:
+        raise RuntimeError(f"Failed to import {class_name} from {module_name} for {error_context}: {ex}") from ex
+    
+    return cls
+
+class ScenarioConfig(BaseModel):
+    """
+    Configuration for a single scenario orchestrator.
+    """
+    scenario_type: str = Field(..., alias="type", description="Scenario orchestrator class/type (e.g. 'PromptSendingOrchestrator').")
+
+    @model_validator(mode="after")
+    def check_scenario_type(self) -> "ScenarioConfig":
+        """
+        Robustness check to ensure the user actually provided a scenario_type in the YAML.
+        Pydantic already enforces requiredness, but we are adding more checks here.
+        """
+        if not self.scenario_type:
+            raise ValueError("Scenario 'type' must not be empty.")
+        return self
+    
+    def create_orchestrator(
+        self,
+        objective_target: Any,
+        adversarial_chat: Optional[Any] = None,
+        prompt_converters: Optional[List[Any]] = None,
+        scoring_target: Optional[Any] = None,
+        objective_scorer: Optional[Any] = None,
+    ) -> Any:
+        """
+        Load and instantiate the orchestrator class, 
+        injecting top-level objects (targets, scorers) as needed.
+        """
+        # Loading the orchestrator class by name, e.g 'RedTeamingOrchestrator'
+        orchestrator_class = load_class(module_name="pyrit.orchestrator", class_name=self.scenario_type, error_context="scenario")
+
+        # Converting scenario fields into a dict for the orchestrator constructor
+        scenario_args = self.model_dump(exclude={"scenario_type"})
+        scenario_args = deepcopy(scenario_args)
+
+        # Inspecting the orchestrator constructor so we can inject the optional arguments if they exist
+        constructor_arg_names = [
+            param.name for param in inspect.signature(orchestrator_class.__init__).parameters.values()
+        ]
+
+        # Building a map of complex top-level objects that belong outside the scenario
+        complex_args = {
+            "objective_target": objective_target,
+            "adversarial_chat": adversarial_chat,
+            "prompt_converters": prompt_converters,
+            "scoring_target": scoring_target,
+            "objective_scorer": objective_scorer,
+        }
+
+        # Disallowing scenario-level overrides for these complex args
+        for key in complex_args:
+            if key in scenario_args:
+                raise ValueError(f"{key} must be configured at the top-level of the config, not inside a scenario.")
+
+        # If the orchestrator constructor expects any of these, inject them
+        for key, value in complex_args.items():
+            if key in constructor_arg_names and value is not None:
+                scenario_args[key] = value
+
+        # And the instantiation of the orchestrator
+        try:
+            return orchestrator_class(**scenario_args)
+        except Exception as ex:
+            raise ValueError(f"Failed to instantiate scenario '{self.scenario_type}': {ex}") from ex
+
+
+class TargetConfig(BaseModel):
+    """
+    Configuration for a prompt target (e.g. OpenAIChatTarget).
+    """
+    class_name: str = Field(..., alias="type", description="Prompt target class name (e.g. 'OpenAIChatTarget').")
+    
+    def create_instance(self) -> Any:
+        """
+        Dynamically instantiate the underlying target class.
+        """
+        target_class = load_class(module_name="pyrit.prompt_target", class_name=self.class_name, error_context="TargetConfig")
+
+        init_kwargs = self.model_dump(exclude={"class_name"})
+        return target_class(**init_kwargs)
+
+class ObjectiveScorerConfig(BaseModel):
+    """
+    Configuration for an objective scorer
+    """
+    type: str = Field(..., description="Scorer class (e.g. 'SelfAskRefusalScorer').")
+
+    def create_scorer(self, scoring_target_obj: Optional[Any]) -> Any:
+        """
+        Load and instantiate the scorer class.
+        """
+        scorer_class = load_class(module_name="pyrit.score", class_name=self.type, error_context="objective_scorer")
+
+        init_kwargs = self.model_dump(exclude={"type"})
+        signature = inspect.signature(scorer_class.__init__)
+
+        chat_target_key: str = "chat_target"
+        if chat_target_key in signature.parameters:
+            if scoring_target_obj is None:
+                raise ValueError(f"Scorer '{self.type}' requires a '{chat_target_key}', but none was provided.")
+            init_kwargs[chat_target_key] = scoring_target_obj
+
+        return scorer_class(**init_kwargs)
+
+
+class ScoringConfig(BaseModel):
+    """
+    Configuration for the scoring setup, including optional 
+    override of the default adversarial chat with a 'scoring_target'
+    and/or an 'objective_scorer'.
+    """
+    scoring_target: Optional[TargetConfig] = Field(
+        None,
+        description="If provided, use this target for scoring instead of 'adversarial_chat'."
+    )
+    objective_scorer: Optional[ObjectiveScorerConfig] = Field(
+        None,
+        description="Details for the objective scorer, if any."
+    )
+
+    def create_objective_scorer(self, scoring_target_obj: Optional[Any]) -> Optional[Any]:
+        # If the user did not provide an objective_scorer config block (meaning the YAML lacks that section), 
+        # we simply return None – no scorer to instantiate.
+        if not self.objective_scorer:
+            return None
+        
+        return self.objective_scorer.create_scorer(scoring_target_obj=scoring_target_obj)
+    
+class ConverterConfig(BaseModel):
+    """
+    Configuration for a single prompt converter, e.g. type: "Base64Converter"
+    """
+    class_name: str = Field(..., alias="type", description="The prompt converter class name (e.g. 'Base64Converter').")
+
+    def create_instance(self) -> Any:
+        """
+        Dynamically load and instantiate the converter class
+        """
+        converter_class = load_class(module_name="pyrit.prompt_converter", class_name=self.class_name, error_context="prompt_converter")
+        init_kwargs = self.model_dump(exclude={"class_name"})
+        return converter_class(**init_kwargs)
+
+
+class ExecutionSettings(BaseModel):
+    """
+    Configuration for how the scanner is executed (e.g. locally or via AzureML).
+    """
+    type: str = Field("local", description="Execution environment, e.g. 'local' or 'azureml'.")
+    parallel_nodes: Optional[int] = Field(None, description="How many scenarios to run in parallel.")
+
+
+class ScannerConfig(BaseModel):
+    """
+    Top-level configuration for the entire scanner.
+    """
+    datasets: List[str] = Field(
+        ...,
+        description="List of dataset YAML paths to load seed prompts from."
+    )
+    scenarios: List[ScenarioConfig] = Field(
+        ...,
+        description="List of scenario orchestrators to execute."
+    )
+    objective_target: TargetConfig = Field(
+        ...,
+        description="Configuration of the main (objective) chat target."
+    )
+    adversarial_chat: Optional[TargetConfig] = Field(
+        None,
+        description="Configuration of the adversarial chat target (if any)."
+    )
+    scoring: Optional[ScoringConfig] = Field(
+        None,
+        description="Scoring configuration (if any)."
+    )
+    converters: Optional[List[ConverterConfig]] = Field(
+        None,
+        description="List of prompt converters to apply."
+    )
+    memory_labels: dict = Field(
+        default_factory=dict,
+        description="Labels that will be stored in memory to tag runs."
+    )
+    execution_settings: ExecutionSettings = Field(
+        default_factory=ExecutionSettings,
+        description="Settings for how the scan is executed."
+    )
+
+    @model_validator(mode="after")
+    def fill_scoring_target(self) -> "ScannerConfig":
+        """
+        If config.scoring exists but doesn't explicitly define a scoring_target,
+        default it to the adversarial_chat
+        """
+        if self.scoring:
+            if self.scoring.scoring_target is None and self.adversarial_chat is not None:
+                self.scoring.scoring_target = self.adversarial_chat
+        return self
+
+    @classmethod
+    def from_yaml(cls, path: str) -> "ScannerConfig":
+        """
+        Loads configuration from a YAML file and validates it using Pydantic.
+        """
+        with open(path, "r", encoding="utf-8") as f:
+            raw_dict = yaml.safe_load(f)
+        return cls(**raw_dict)
+    
+    def create_objective_scorer(self) -> Optional[Any]:
+        """
+        if there's an objective scorer configured,
+        instantiate it using 'scoring_target' (which might be adversarial_chat).
+        """
+        if not self.scoring:
+            return None
+        
+        scoring_target = None
+        if self.scoring.scoring_target:
+            scoring_target = self.scoring.scoring_target.create_instance()
+        return self.scoring.create_objective_scorer(scoring_target_obj=scoring_target)
+    
+    def create_prompt_converters(self) -> List[Any]:
+        """
+        Instantiates each converter defined in 'self.converters' (if any).
+        Returns a list of converter objects.
+        """
+        if not self.converters:
+            return []
+        instances = []
+        for converter_cfg in self.converters:
+            instances.append(converter_cfg.create_instance())
+        return instances
+    
+    def create_orchestrators(self, prompt_converters: Optional[List[Any]] = None) -> List[Any]:
+        """
+        Helper method to instantiate all orchestrators from the scenario configs,
+        injecting objective_target, adversarial_chat, scoring_target, objective_scorer, etc.
+        """
+        # Instantiate the top-level targets
+        objective_target_obj = self.objective_target.create_instance()
+        adversarial_chat_obj = None
+        if self.adversarial_chat:
+            adversarial_chat_obj = self.adversarial_chat.create_instance()
+        
+        # If there is a scoring_target or an objective_scorer:
+        scoring_target_obj = None
+        objective_scorer_obj = None
+        if self.scoring:
+            # fill_scoring_target might have already assigned it to self.scoring.scoring_target
+            if self.scoring.scoring_target:
+                scoring_target_obj = self.scoring.scoring_target.create_instance()
+            # create the actual scorer
+            objective_scorer_obj = self.scoring.create_objective_scorer(scoring_target_obj=scoring_target_obj)
+        
+        # Now each scenario can create its orchestrator
+        orchestrators = []
+        for scenario in self.scenarios:
+            orch = scenario.create_orchestrator(
+                objective_target=objective_target_obj,
+                adversarial_chat=adversarial_chat_obj,
+                prompt_converters=prompt_converters,
+                scoring_target=scoring_target_obj,
+                objective_scorer=objective_scorer_obj,
+            )
+            orchestrators.append(orch)
+        return orchestrators

--- a/pyrit/cli/scanner_config.py
+++ b/pyrit/cli/scanner_config.py
@@ -1,6 +1,6 @@
 import inspect
 import yaml
-from typing import List, Optional, Literal, Any, Type
+from typing import List, Optional, Any, Type
 from pydantic import BaseModel, Field, model_validator
 from copy import deepcopy
 from importlib import import_module
@@ -19,7 +19,7 @@ def load_class(module_name: str, class_name: str, error_context: str) -> Type[An
     
     return cls
 
-class ScenarioConfig(BaseModel):
+class ScenarioConfig(BaseModel, extra='allow'):
     """
     Configuration for a single scenario orchestrator.
     """
@@ -118,7 +118,11 @@ class ObjectiveScorerConfig(BaseModel):
         chat_target_key: str = "chat_target"
         if chat_target_key in signature.parameters:
             if scoring_target_obj is None:
-                raise ValueError(f"Scorer '{self.type}' requires a '{chat_target_key}', but none was provided.")
+                raise KeyError(
+                    f"Scorer '{self.type}' requires a '{chat_target_key}', but none was provided. "
+                    "Alternatively, the adversarial_target can be used for scoring purposes, "
+                    "but none was provided."
+                )
             init_kwargs[chat_target_key] = scoring_target_obj
 
         return scorer_class(**init_kwargs)

--- a/scanner_configurations/basic_multi_turn_attack.yaml
+++ b/scanner_configurations/basic_multi_turn_attack.yaml
@@ -12,7 +12,6 @@ objective_target:
   # any arg for targets can be listed here:
   # deployment_name_env_variable:
   # headers:
-  is_azure_target: true
 # converters:
 #   - type: "Base64Converter"
 #   - type: "LeetspeakConverter"

--- a/scanner_configurations/basic_multi_turn_attack.yaml
+++ b/scanner_configurations/basic_multi_turn_attack.yaml
@@ -24,9 +24,10 @@ scoring:
   #   type: "OpenAIChatTarget"
   objective_scorer:
     type: "SelfAskRefusalScorer"
-memory_labels:
-  operator: roakey
-  operation: op_trash_panda
+database:
+  memory_labels:
+    operator: roakey
+    operation: op_trash_panda
 execution_settings:
   type: local # or "azureml"
   # parallel_nodes: 4 # how many scenarios to execute in parallel

--- a/scanner_configurations/basic_multi_turn_attack.yaml
+++ b/scanner_configurations/basic_multi_turn_attack.yaml
@@ -25,6 +25,7 @@ scoring:
   objective_scorer:
     type: "SelfAskRefusalScorer"
 database:
+  type: "DuckDB"
   memory_labels:
     operator: roakey
     operation: op_trash_panda

--- a/scanner_configurations/prompt_send.yaml
+++ b/scanner_configurations/prompt_send.yaml
@@ -15,6 +15,7 @@ objective_target:
 # scoring:
 #   objective_scorer: ...
 database:
+  type: "DuckDB"
   memory_labels:
     operator: roakey
     operation: op_trash_panda

--- a/scanner_configurations/prompt_send.yaml
+++ b/scanner_configurations/prompt_send.yaml
@@ -8,7 +8,6 @@ objective_target:
   # api_key_env_variable:
   # any arg for targets can be listed here:
   # deployment_name_env_variable:
-  is_azure_target: true
   # headers:
 # converters:
 #   - type: "Base64Converter"

--- a/scanner_configurations/prompt_send.yaml
+++ b/scanner_configurations/prompt_send.yaml
@@ -14,9 +14,10 @@ objective_target:
 #   - type: "LeetspeakConverter"
 # scoring:
 #   objective_scorer: ...
-memory_labels:
-  operator: roakey
-  operation: op_trash_panda
+database:
+  memory_labels:
+    operator: roakey
+    operation: op_trash_panda
 execution_settings:
   type: local # or "azureml"
   # parallel_nodes: 4 # how many scenarios to execute in parallel

--- a/tests/unit/cli/mixed_multiple_orchestrators_args_success.yaml
+++ b/tests/unit/cli/mixed_multiple_orchestrators_args_success.yaml
@@ -26,3 +26,5 @@ scoring:
     type: "OpenAIChatTarget"
   objective_scorer:
     type: "SelfAskRefusalScorer"
+database:
+  type: "DuckDB"

--- a/tests/unit/cli/multi_turn_crescendo_args_success.yaml
+++ b/tests/unit/cli/multi_turn_crescendo_args_success.yaml
@@ -11,3 +11,5 @@ adversarial_chat:
 scoring:
   scoring_target:
     type: "OpenAIChatTarget"
+database:
+  type: "DuckDB"

--- a/tests/unit/cli/multi_turn_crescendo_success.yaml
+++ b/tests/unit/cli/multi_turn_crescendo_success.yaml
@@ -9,3 +9,5 @@ adversarial_chat:
 scoring:
   scoring_target:
     type: "OpenAIChatTarget"
+database:
+  type: "DuckDB"

--- a/tests/unit/cli/multi_turn_crescendo_wrong_arg.yaml
+++ b/tests/unit/cli/multi_turn_crescendo_wrong_arg.yaml
@@ -11,3 +11,5 @@ adversarial_chat:
 scoring:
   scoring_target:
     type: "OpenAIChatTarget"
+database:
+  type: "DuckDB"

--- a/tests/unit/cli/multi_turn_multiple_orchestrators_args_success.yaml
+++ b/tests/unit/cli/multi_turn_multiple_orchestrators_args_success.yaml
@@ -25,3 +25,5 @@ scoring:
     type: "OpenAIChatTarget"
   objective_scorer:
     type: "SelfAskRefusalScorer"
+database:
+  type: "DuckDB"

--- a/tests/unit/cli/multi_turn_rto_args_success.yaml
+++ b/tests/unit/cli/multi_turn_rto_args_success.yaml
@@ -9,3 +9,5 @@ adversarial_chat:
 scoring:
   objective_scorer:
     type: "SelfAskRefusalScorer"
+database:
+  type: "DuckDB"

--- a/tests/unit/cli/multi_turn_rto_success.yaml
+++ b/tests/unit/cli/multi_turn_rto_success.yaml
@@ -9,3 +9,5 @@ adversarial_chat:
 scoring:
   objective_scorer:
     type: "SelfAskRefusalScorer"
+database:
+  type: "DuckDB"

--- a/tests/unit/cli/multi_turn_rto_wrong_arg.yaml
+++ b/tests/unit/cli/multi_turn_rto_wrong_arg.yaml
@@ -10,3 +10,5 @@ adversarial_chat:
 scoring:
   objective_scorer:
     type: "SelfAskRefusalScorer"
+database:
+  type: "DuckDB"

--- a/tests/unit/cli/multi_turn_tap_args_success.yaml
+++ b/tests/unit/cli/multi_turn_tap_args_success.yaml
@@ -12,3 +12,5 @@ adversarial_chat:
 scoring:
   scoring_target:
     type: "OpenAIChatTarget"
+database:
+  type: "DuckDB"

--- a/tests/unit/cli/multi_turn_tap_success.yaml
+++ b/tests/unit/cli/multi_turn_tap_success.yaml
@@ -9,3 +9,5 @@ adversarial_chat:
 scoring:
   scoring_target:
     type: "OpenAIChatTarget"
+database:
+  type: "DuckDB"

--- a/tests/unit/cli/multi_turn_tap_wrong_arg.yaml
+++ b/tests/unit/cli/multi_turn_tap_wrong_arg.yaml
@@ -12,3 +12,5 @@ adversarial_chat:
 scoring:
   scoring_target:
     type: "OpenAIChatTarget"
+database:
+  type: "DuckDB"

--- a/tests/unit/cli/prompt_send_bad_db_type.yaml
+++ b/tests/unit/cli/prompt_send_bad_db_type.yaml
@@ -1,0 +1,8 @@
+datasets:
+  - ./pyrit/datasets/seed_prompts/illegal.prompt
+objective_target:
+  type: "OpenAIChatTarget"
+scenarios:
+  - type: "PromptSendingOrchestrator"
+database:
+  type: "sqlite"

--- a/tests/unit/cli/prompt_send_db_with_no_type.yaml
+++ b/tests/unit/cli/prompt_send_db_with_no_type.yaml
@@ -4,8 +4,7 @@ objective_target:
   type: "OpenAIChatTarget"
 scenarios:
   - type: "PromptSendingOrchestrator"
-scoring:
-  objective_scorer:
-    type: "SelfAskRefusalScorer"
 database:
-  type: "DuckDB"
+  memory_labels:
+    operator: roakey
+    operation: op_trash_panda

--- a/tests/unit/cli/prompt_send_no_db.yaml
+++ b/tests/unit/cli/prompt_send_no_db.yaml
@@ -4,8 +4,3 @@ objective_target:
   type: "OpenAIChatTarget"
 scenarios:
   - type: "PromptSendingOrchestrator"
-scoring:
-  objective_scorer:
-    type: "SelfAskRefusalScorer"
-database:
-  type: "DuckDB"

--- a/tests/unit/cli/prompt_send_no_objective_target.yaml
+++ b/tests/unit/cli/prompt_send_no_objective_target.yaml
@@ -2,3 +2,5 @@ datasets:
   - ./pyrit/datasets/seed_prompts/illegal.prompt
 scenarios:
   - type: "PromptSendingOrchestrator"
+database:
+  type: "DuckDB"

--- a/tests/unit/cli/prompt_send_no_objective_target_type.yaml
+++ b/tests/unit/cli/prompt_send_no_objective_target_type.yaml
@@ -2,4 +2,6 @@ datasets:
   - ./pyrit/datasets/seed_prompts/illegal.prompt
 scenarios:
   - type: "PromptSendingOrchestrator"
+database:
+  type: "DuckDB"
 objective_target:

--- a/tests/unit/cli/prompt_send_no_scenario_type.yaml
+++ b/tests/unit/cli/prompt_send_no_scenario_type.yaml
@@ -4,3 +4,5 @@ objective_target:
   type: "OpenAIChatTarget"
 scenarios:
   - test: test-name
+database:
+  type: "DuckDB"

--- a/tests/unit/cli/prompt_send_no_scenarios.yaml
+++ b/tests/unit/cli/prompt_send_no_scenarios.yaml
@@ -2,4 +2,6 @@ datasets:
   - ./pyrit/datasets/seed_prompts/illegal.prompt
 objective_target:
   type: "OpenAIChatTarget"
+database:
+  type: "DuckDB"
 scenarios:

--- a/tests/unit/cli/prompt_send_no_scenarios_key.yaml
+++ b/tests/unit/cli/prompt_send_no_scenarios_key.yaml
@@ -2,3 +2,5 @@ datasets:
   - ./pyrit/datasets/seed_prompts/illegal.prompt
 objective_target:
   type: "OpenAIChatTarget"
+database:
+  type: "DuckDB"

--- a/tests/unit/cli/prompt_send_success.yaml
+++ b/tests/unit/cli/prompt_send_success.yaml
@@ -4,3 +4,5 @@ objective_target:
   type: "OpenAIChatTarget"
 scenarios:
   - type: "PromptSendingOrchestrator"
+database:
+  type: "DuckDB"

--- a/tests/unit/cli/prompt_send_success_invalid_exec.yaml
+++ b/tests/unit/cli/prompt_send_success_invalid_exec.yaml
@@ -1,0 +1,8 @@
+datasets:
+  - ./pyrit/datasets/seed_prompts/illegal.prompt
+objective_target:
+  type: "OpenAIChatTarget"
+scenarios:
+  - type: "PromptSendingOrchestrator"
+execution_settings:
+  type: "azureml"

--- a/tests/unit/cli/prompt_send_success_invalid_exec.yaml
+++ b/tests/unit/cli/prompt_send_success_invalid_exec.yaml
@@ -6,3 +6,5 @@ scenarios:
   - type: "PromptSendingOrchestrator"
 execution_settings:
   type: "azureml"
+database:
+  type: "DuckDB"

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -5,9 +5,9 @@ import contextlib
 import re
 import shlex
 from unittest.mock import patch
-from pydantic import ValidationError
 
 import pytest
+from pydantic import ValidationError
 
 from pyrit.cli.__main__ import main
 from pyrit.orchestrator import (
@@ -78,7 +78,8 @@ test_cases_error = [
     ),
     (
         "--config-file 'tests/unit/cli/prompt_send_no_objective_target_type.yaml'",
-        "objective_target\n  Value error, Field 'objective_target' must be a dictionary.\nExample:\n  objective_target:\n    type: OpenAIChatTarget",
+        "objective_target\n  Value error, Field 'objective_target' must be a dictionary.\n"
+        "Example:\n  objective_target:\n    type: OpenAIChatTarget",
         ValidationError,
     ),
     (
@@ -121,7 +122,18 @@ test_cases_error = [
         "got an unexpected keyword argument 'wrong_arg'",
         ValueError,
     ),
+    (
+        "--config-file 'tests/unit/cli/prompt_send_success_invalid_exec.yaml'",
+        "execution_settings.type\n  Input should be 'local' ",
+        ValidationError,
+    ),
+    (
+        "--config-file 'tests/unit/cli/prompt_send_bad_db_type.yaml'",
+        "database.type\n  Input should be 'DuckDB' or 'AzureSQL' ",
+        ValidationError,
+    ),
 ]
+#
 
 
 @pytest.mark.parametrize("command, orchestrator_classes, methods", test_cases_success)

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -78,7 +78,7 @@ test_cases_error = [
     ),
     (
         "--config-file 'tests/unit/cli/prompt_send_no_objective_target_type.yaml'",
-        "objective_target\n  Input should be a valid dictionary or instance of TargetConfig",
+        "objective_target\n  Value error, Field 'objective_target' must be a dictionary.\nExample:\n  objective_target:\n    type: OpenAIChatTarget",
         ValidationError,
     ),
     (
@@ -98,7 +98,7 @@ test_cases_error = [
     ),
     (
         "--config-file 'tests/unit/cli/prompt_send_no_scoring_target.yaml'",
-        "Scorer 'SelfAskRefusalScorer' requires a 'chat_target', but none was provided. "
+        "Scorer requires a scoring_target to be defined. "
         "Alternatively, the adversarial_target can be used for scoring purposes, but none was provided.",
         KeyError,
     ),

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -5,6 +5,7 @@ import contextlib
 import re
 import shlex
 from unittest.mock import patch
+from pydantic import ValidationError
 
 import pytest
 
@@ -72,50 +73,50 @@ test_cases_sys_exit = [
 test_cases_error = [
     (
         "--config-file 'tests/unit/cli/prompt_send_no_objective_target.yaml'",
-        "Configuration file must contain a 'objective_target' key.",
-        KeyError,
+        "objective_target\n  Field required",
+        ValidationError,
     ),
     (
         "--config-file 'tests/unit/cli/prompt_send_no_objective_target_type.yaml'",
-        "Target objective_target must contain a 'type' key.",
-        KeyError,
+        "objective_target\n  Input should be a valid dictionary or instance of TargetConfig",
+        ValidationError,
     ),
     (
         "--config-file 'tests/unit/cli/prompt_send_no_scenarios.yaml'",
-        "Scenarios list is empty.",
-        ValueError,
+        "scenarios\n  Input should be a valid list",
+        ValidationError,
     ),
     (
         "--config-file 'tests/unit/cli/prompt_send_no_scenarios_key.yaml'",
-        "Configuration file must contain a 'scenarios' key.",
-        KeyError,
+        "scenarios\n  Field required",
+        ValidationError,
     ),
     (
         "--config-file 'tests/unit/cli/prompt_send_no_scenario_type.yaml'",
-        "Scenario must contain a 'type' key.",
-        KeyError,
+        "scenarios.0.type\n  Field required",
+        ValidationError,
     ),
     (
         "--config-file 'tests/unit/cli/prompt_send_no_scoring_target.yaml'",
-        "'Scorer requires a scoring_target to be defined. "
+        "Scorer 'SelfAskRefusalScorer' requires a 'chat_target', but none was provided. "
         "Alternatively, the adversarial_target can be used for scoring purposes, but none was provided.",
         KeyError,
     ),
     (
         "--config-file 'tests/unit/cli/multi_turn_rto_wrong_arg.yaml'",
-        "Failed to validate scenario RedTeamingOrchestrator: RedTeamingOrchestrator.__init__() "
+        "Failed to instantiate scenario 'RedTeamingOrchestrator': RedTeamingOrchestrator.__init__() "
         "got an unexpected keyword argument 'wrong_arg'",
         ValueError,
     ),
     (
         "--config-file 'tests/unit/cli/multi_turn_crescendo_wrong_arg.yaml'",
-        "Failed to validate scenario CrescendoOrchestrator: CrescendoOrchestrator.__init__() "
+        "Failed to instantiate scenario 'CrescendoOrchestrator': CrescendoOrchestrator.__init__() "
         "got an unexpected keyword argument 'wrong_arg'",
         ValueError,
     ),
     (
         "--config-file 'tests/unit/cli/multi_turn_tap_wrong_arg.yaml'",
-        "Failed to validate scenario TreeOfAttacksWithPruningOrchestrator: "
+        "Failed to instantiate scenario 'TreeOfAttacksWithPruningOrchestrator': "
         "TreeOfAttacksWithPruningOrchestrator.__init__() "
         "got an unexpected keyword argument 'wrong_arg'",
         ValueError,

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -129,11 +129,20 @@ test_cases_error = [
     ),
     (
         "--config-file 'tests/unit/cli/prompt_send_bad_db_type.yaml'",
-        "database.type\n  Input should be 'DuckDB' or 'AzureSQL' ",
+        "database.type\n  Input should be 'InMemory', 'DuckDB' or 'AzureSQL' ",
+        ValidationError,
+    ),
+    (
+        "--config-file 'tests/unit/cli/prompt_send_db_with_no_type.yaml'",
+        "database.type\n  Field required",
+        ValidationError,
+    ),
+    (
+        "--config-file 'tests/unit/cli/prompt_send_no_db.yaml'",
+        "database\n  Field required",
         ValidationError,
     ),
 ]
-#
 
 
 @pytest.mark.parametrize("command, orchestrator_classes, methods", test_cases_success)


### PR DESCRIPTION
## Description
#### Moved Scanner configuration to `Pydantic`
- Replaced adhoc dictionary lookups and validation logic with Pydantic models
- Created dedicated config classes for scenarios, targets, scoring, and converters
#### Encapsulated validation and instantiation within the configuration for better code organization
- Each config section both validate and instantiate the corresponding Python classes
- By moving logic into the config classes, `main` is more readable and has fewer nested checks, makes it more flexible to extend 
#### Added support for memory configuration
- Added memory configuration to the scanner through cmd line arguments - this is more flexible than adding it directly to the configuration because it does not need changes to the yaml files
#### Updated DevContainer
- Added DuckDB CLI (FYI, this version has `-ui`, [DuckDB Announcement](https://duckdb.org/2025/03/12/duckdb-ui.html))
- Added Azure CLI 

## Tests and Documentation
Manually ran the scanner against both existing configurations and validated the db entries 

**PENDING PRE-COMMIT**