### PR TITLE
MAINT: Making JSON support configurable with OpenAIChatTargets

### DIFF
--- a/pyrit/prompt_target/openai/openai_chat_target.py
+++ b/pyrit/prompt_target/openai/openai_chat_target.py
@@ -51,6 +51,7 @@ class OpenAIChatTarget(OpenAITarget):
         presence_penalty: Optional[float] = None,
         seed: Optional[int] = None,
         n: Optional[int] = None,
+        is_json_supported: bool = True,
         extra_body_parameters: Optional[dict[str, Any]] = None,
         **kwargs,
     ):
@@ -92,6 +93,8 @@ class OpenAIChatTarget(OpenAITarget):
             seed (int, Optional): If specified, openAI will make a best effort to sample deterministically,
                 such that repeated requests with the same seed and parameters should return the same result.
             n (int, Optional): The number of completions to generate for each prompt.
+            is_json_supported (bool, Optional): If True, the target will support JSON responses and send
+                the response_format header.
             extra_body_parameters (dict, Optional): Additional parameters to be included in the request body.
             httpx_client_kwargs (dict, Optional): Additional kwargs to be passed to the
                 httpx.AsyncClient() constructor.
@@ -110,6 +113,7 @@ class OpenAIChatTarget(OpenAITarget):
         self._presence_penalty = presence_penalty
         self._seed = seed
         self._n = n
+        self._is_json_supported = is_json_supported
         self._extra_body_parameters = extra_body_parameters
 
     def _set_openai_env_configuration_vars(self) -> None:
@@ -388,4 +392,4 @@ class OpenAIChatTarget(OpenAITarget):
 
     def is_json_response_supported(self) -> bool:
         """Indicates that this target supports JSON response format."""
-        return True
+        return self._is_json_supported

--- a/pyrit/prompt_target/openai/openai_chat_target.py
+++ b/pyrit/prompt_target/openai/openai_chat_target.py
@@ -93,7 +93,7 @@ class OpenAIChatTarget(OpenAITarget):
             seed (int, Optional): If specified, openAI will make a best effort to sample deterministically,
                 such that repeated requests with the same seed and parameters should return the same result.
             n (int, Optional): The number of completions to generate for each prompt.
-            is_json_supported (bool, Optional): If True, the target will supports formatting resposnes as JSON by
+            is_json_supported (bool, Optional): If True, the target will supports formatting responses as JSON by
                 setting the response_format header. Official OpenAI models all support this, but if you are using
                 this target with different models, is_json_supported should be set correctly to avoid issues when
                 using adversarial infrastructure (e.g. Crescendo scorers will set this flag).

--- a/pyrit/prompt_target/openai/openai_chat_target.py
+++ b/pyrit/prompt_target/openai/openai_chat_target.py
@@ -93,8 +93,10 @@ class OpenAIChatTarget(OpenAITarget):
             seed (int, Optional): If specified, openAI will make a best effort to sample deterministically,
                 such that repeated requests with the same seed and parameters should return the same result.
             n (int, Optional): The number of completions to generate for each prompt.
-            is_json_supported (bool, Optional): If True, the target will support JSON responses and send
-                the response_format header.
+            is_json_supported (bool, Optional): If True, the target will supports formatting resposnes as JSON by
+                setting the response_format header. Official OpenAI models all support this, but if you are using
+                this target with different models, is_json_supported should be set correctly to avoid issues when
+                using adversarial infrastructure (e.g. Crescendo scorers will set this flag).
             extra_body_parameters (dict, Optional): Additional parameters to be included in the request body.
             httpx_client_kwargs (dict, Optional): Additional kwargs to be passed to the
                 httpx.AsyncClient() constructor.


### PR DESCRIPTION
Likely not all OpenAIChatTargets support JSON output. This could potentially break in scenarios where you're using an OpenAIChatTarget that doesn't support JSON output for something like Crescendo that sets it for the scorer. 

This change allows users to configure those targets
