### PR TITLE
FIX catch content_filter with 200s instead of 500s

### DIFF
--- a/tests/unit/target/test_openai_chat_target.py
+++ b/tests/unit/target/test_openai_chat_target.py
@@ -558,11 +558,10 @@ async def test_send_prompt_async_content_filter(target: OpenAIChatTarget):
     )
 
     mock_response = MagicMock()
-    mock_response.status_code = 500
+    mock_response.status_code = 200
     mock_response.text = response_body
-    side_effect = httpx.HTTPStatusError("Content Filter Error", response=mock_response, request=MagicMock())
 
-    with patch("pyrit.common.net_utility.make_request_and_raise_if_error_async", side_effect=side_effect):
+    with patch("pyrit.common.net_utility.make_request_and_raise_if_error_async", return_value=mock_response):
         response = await target.send_prompt_async(prompt_request=prompt_request)
         assert len(response.request_pieces) == 1
         assert response.request_pieces[0].response_error == "blocked"


### PR DESCRIPTION
<!--- Please add one of the following as a prefix to the pull request title: -->
<!--- DOC for documentation changes -->
<!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
<!--- FIX for bug fixes -->
<!--- TEST for adding tests -->
<!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
<!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->

<!--- Note on BREAKING changes: If your PR includes a change that will require users to make a corresponding
change (e.g. naming changes), please list [BREAKING] in front of the above prefix in the PR title.
For example, [BREAKING] FEAT or [BREAKING] MAINT -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->
In PR #825 we addressed the issue of returned 500s for triggered content filters. As it turns out, the status code is not actually a 500, but a 200. The error just looks like a 500 because PyRIT assigns default 500 for errors and that got printed. Clearly, that should have been caught during validation but somehow didn't. I suspect I missed it because the responses aren't deterministic (?) Difficult to say in hindsight, but could have been handled better.

The new behavior is that we catch the "old" 400s which probably still exist (unclear) and the new 200s which we catch and mark as content filter error responses.
<!--- If you are considering making a contribution please open an issue first. -->
<!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
<!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->

<!--- If your change is BREAKING please include reasoning for why below. -->


## Tests and Documentation

<!--- Contributions require tests and documentation (if applicable). -->
<!--- Include a description of tests and documentation updated (if applicable) -->
Updated unit test accordingly.
<!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
<!--- Include how you/if ran JupyText here -->
<!--- This is described at: https://github.com/Azure/PyRIT/tree/main/doc  -->
