### PR TITLE
FIX: Amended dockerfile and requirements.txt to unblock ADO pipelines

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,8 +28,10 @@ WORKDIR /app
 # Copy requirements file
 COPY requirements.txt /app/
 
+# Install torch, torchvision, torchaudio from PyTorch with CUDA 11.8 support
+RUN pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cu118 torch==2.6.0+cu118 torchvision==0.21.0+cu118 torchaudio==2.6.0+cu118
 # Install all Python dependencies at once with pinned versions
-RUN pip install --no-cache-dir -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu118
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Install PyRIT from PyPI (the official way)
 RUN pip install --no-cache-dir pyrit[dev,all]

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,8 +1,3 @@
-# PyTorch ecosystem with specific versions
-torch==2.6.0+cu118
-torchvision==0.21.0+cu118
-torchaudio==2.6.0+cu118
-
 # JupyterLab and related packages
 jupyterlab==4.3.5
 notebook==7.3.2


### PR DESCRIPTION
## Description
The use of the --extra-index-url flag was causing our ADO pipelines to not run properly (namely Secure Supply Chain Analysis). This PR gets rid of this flag and uses --index-url and amends the Dockerfile and requirements.txt files accordingly. 


## Tests and Documentation

Component Governance runs successfully in pipeline.
