### PR TITLE
FIX: AAD Auth refresh bug with OpenAITargets

### DIFF
--- a/pyrit/common/print.py
+++ b/pyrit/common/print.py
@@ -55,4 +55,4 @@ def print_chat_messages_with_color(
                 subsequent_indent=left_padding,
             )
         print("Message with role: " + message.role)
-        termcolor.cprint(output_message, color=role_to_color[message.role])
+        termcolor.cprint(output_message, color=role_to_color[message.role])  # type: ignore[arg-type]

--- a/pyrit/prompt_target/openai/openai_chat_target.py
+++ b/pyrit/prompt_target/openai/openai_chat_target.py
@@ -136,6 +136,8 @@ class OpenAIChatTarget(OpenAITarget):
         """
 
         self._validate_request(prompt_request=prompt_request)
+        self.refresh_auth_headers()
+
         request_piece: PromptRequestPiece = prompt_request.request_pieces[0]
 
         is_json_response = self.is_response_format_json(request_piece)

--- a/pyrit/prompt_target/openai/openai_completion_target.py
+++ b/pyrit/prompt_target/openai/openai_completion_target.py
@@ -92,6 +92,9 @@ class OpenAICompletionTarget(OpenAITarget):
 
         logger.info(f"Sending the following prompt to the prompt target: {request_piece}")
 
+        # Refresh auth headers if using AAD
+        self.refresh_auth_headers()
+
         body = await self._construct_request_body(request=request_piece)
 
         params = {}

--- a/pyrit/prompt_target/openai/openai_completion_target.py
+++ b/pyrit/prompt_target/openai/openai_completion_target.py
@@ -92,7 +92,6 @@ class OpenAICompletionTarget(OpenAITarget):
 
         logger.info(f"Sending the following prompt to the prompt target: {request_piece}")
 
-        # Refresh auth headers if using AAD
         self.refresh_auth_headers()
 
         body = await self._construct_request_body(request=request_piece)

--- a/pyrit/prompt_target/openai/openai_dall_e_target.py
+++ b/pyrit/prompt_target/openai/openai_dall_e_target.py
@@ -107,19 +107,23 @@ class OpenAIDALLETarget(OpenAITarget):
         prompt_request: PromptRequestResponse,
     ) -> PromptRequestResponse:
         """
-        (Async) Sends prompt to image target and returns response
+        Send a prompt to the DALL-E target and return the response.
 
         Args:
-            prompt_request (PromptRequestResponse): the prompt to send formatted as an object
+            prompt_request (PromptRequestResponse): The prompt request to send.
 
-        Returns: response from target model formatted as an object
+        Returns:
+            PromptRequestResponse: The response from the DALL-E target.
         """
-
         self._validate_request(prompt_request=prompt_request)
         request = prompt_request.request_pieces[0]
-        prompt = request.converted_value
 
-        request_body = self._construct_request_body(prompt=prompt)
+        logger.info(f"Sending the following prompt to the prompt target: {request}")
+
+        # Refresh auth headers if using AAD
+        self.refresh_auth_headers()
+
+        body = self._construct_request_body(prompt=request.converted_value)
 
         params = {}
         if self._api_version is not None:
@@ -130,7 +134,7 @@ class OpenAIDALLETarget(OpenAITarget):
                 endpoint_uri=self._endpoint,
                 method="POST",
                 headers=self._headers,
-                request_body=request_body,
+                request_body=body,
                 params=params,
                 **self._httpx_client_kwargs,
             )

--- a/pyrit/prompt_target/openai/openai_realtime_target.py
+++ b/pyrit/prompt_target/openai/openai_realtime_target.py
@@ -11,7 +11,6 @@ from urllib.parse import urlencode
 
 import websockets
 
-from pyrit.common.utils import combine_dict
 from pyrit.models import PromptRequestResponse
 from pyrit.models.data_type_serializer import data_serializer_factory
 from pyrit.models.prompt_request_response import construct_response_from_request

--- a/pyrit/prompt_target/openai/openai_realtime_target.py
+++ b/pyrit/prompt_target/openai/openai_realtime_target.py
@@ -80,6 +80,9 @@ class RealtimeTarget(OpenAITarget):
 
         logger.info(f"Connecting to WebSocket: {self._endpoint}")
 
+        # Refresh auth headers if using AAD
+        self.refresh_auth_headers()
+
         query_params = {
             "deployment": self._model_name,
             "api-key": self._api_key,

--- a/pyrit/prompt_target/openai/openai_realtime_target.py
+++ b/pyrit/prompt_target/openai/openai_realtime_target.py
@@ -11,11 +11,11 @@ from urllib.parse import urlencode
 
 import websockets
 
+from pyrit.common.utils import combine_dict
 from pyrit.models import PromptRequestResponse
 from pyrit.models.data_type_serializer import data_serializer_factory
 from pyrit.models.prompt_request_response import construct_response_from_request
 from pyrit.prompt_target import OpenAITarget, limit_requests_per_minute
-from pyrit.common.utils import combine_dict
 
 logger = logging.getLogger(__name__)
 
@@ -110,7 +110,6 @@ class RealtimeTarget(OpenAITarget):
 
         if self._azure_auth:
             query_params["access_token"] = self._azure_auth.refresh_token()
-
 
     def _set_system_prompt_and_config_vars(self):
 

--- a/pyrit/prompt_target/openai/openai_target.py
+++ b/pyrit/prompt_target/openai/openai_target.py
@@ -7,9 +7,9 @@ from abc import abstractmethod
 from typing import Callable, Optional
 
 from pyrit.auth.azure_auth import (
+    AzureAuth,
     get_default_scope,
     get_token_provider_from_default_azure_credential,
-    AzureAuth,
 )
 from pyrit.common import default_values
 from pyrit.prompt_target import PromptChatTarget

--- a/pyrit/prompt_target/openai/openai_target.py
+++ b/pyrit/prompt_target/openai/openai_target.py
@@ -9,6 +9,7 @@ from typing import Callable, Optional
 from pyrit.auth.azure_auth import (
     get_default_scope,
     get_token_provider_from_default_azure_credential,
+    AzureAuth,
 )
 from pyrit.common import default_values
 from pyrit.prompt_target import PromptChatTarget
@@ -25,6 +26,7 @@ class OpenAITarget(PromptChatTarget):
     api_key_environment_variable: str
 
     _model_name: Optional[str]
+    _azure_auth: Optional[AzureAuth] = None
 
     def __init__(
         self,
@@ -87,12 +89,10 @@ class OpenAITarget(PromptChatTarget):
         ).rstrip("/")
 
         self._api_key = api_key
-        self._token_provider: Optional[Callable[[], str]] = None
 
         self._set_auth_headers(use_aad_auth=use_aad_auth, passed_api_key=api_key)
 
     def _set_auth_headers(self, use_aad_auth, passed_api_key) -> None:
-
         self._api_key = default_values.get_non_required_value(
             env_var_name=self.api_key_environment_variable, passed_value=passed_api_key
         )
@@ -105,12 +105,16 @@ class OpenAITarget(PromptChatTarget):
             self._headers["Authorization"] = f"Bearer {self._api_key}"
 
         if use_aad_auth:
-            logger.info("Authenticating with DefaultAzureCredential()")
-
+            logger.info("Authenticating with AzureAuth")
             scope = get_default_scope(self._endpoint)
-            self._token_provider = get_token_provider_from_default_azure_credential(scope=scope)
+            self._azure_auth = AzureAuth(token_scope=scope)
+            self._headers["Authorization"] = f"Bearer {self._azure_auth.get_token()}"
 
-            self._headers["Authorization"] = f"Bearer {self._token_provider()}"
+    def refresh_auth_headers(self) -> None:
+        """Refresh the authentication headers. This is particularly useful for AAD authentication
+        where tokens need to be refreshed periodically."""
+        if self._azure_auth:
+            self._headers["Authorization"] = f"Bearer {self._azure_auth.refresh_token()}"
 
     @abstractmethod
     def _set_openai_env_configuration_vars(self) -> None:

--- a/pyrit/prompt_target/openai/openai_target.py
+++ b/pyrit/prompt_target/openai/openai_target.py
@@ -4,12 +4,11 @@
 import json
 import logging
 from abc import abstractmethod
-from typing import Callable, Optional
+from typing import Optional
 
 from pyrit.auth.azure_auth import (
     AzureAuth,
     get_default_scope,
-    get_token_provider_from_default_azure_credential,
 )
 from pyrit.common import default_values
 from pyrit.prompt_target import PromptChatTarget

--- a/pyrit/prompt_target/openai/openai_tts_target.py
+++ b/pyrit/prompt_target/openai/openai_tts_target.py
@@ -157,7 +157,7 @@ class OpenAITTSTarget(OpenAITarget):
             raise ValueError("This target only supports text prompt input.")
 
         request = prompt_request.request_pieces[0]
-        messages = self._memory.get_chat_messages_with_conversation_id(conversation_id=request.conversation_id)
+        messages = self._memory.get_conversation(conversation_id=request.conversation_id)
 
         if len(messages) > 0:
             raise ValueError("This target only supports a single turn conversation.")

--- a/pyrit/prompt_target/openai/openai_tts_target.py
+++ b/pyrit/prompt_target/openai/openai_tts_target.py
@@ -92,6 +92,9 @@ class OpenAITTSTarget(OpenAITarget):
 
         logger.info(f"Sending the following prompt to the prompt target: {request}")
 
+        # Refresh auth headers if using AAD
+        self.refresh_auth_headers()
+
         body = self._construct_request_body(request=request)
 
         params = {}

--- a/tests/integration/targets/test_aad_auth.py
+++ b/tests/integration/targets/test_aad_auth.py
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import os
+
+import pytest
+
+from pyrit.orchestrator import PromptSendingOrchestrator
+from pyrit.prompt_target import OpenAIChatTarget, RealtimeTarget
+
+
+@pytest.mark.asyncio
+@pytest.mark.run_only_if_all_tests
+@pytest.mark.parametrize(
+    ("endpoint", "model_name"),
+    [
+        ("AZURE_OPENAI_GPT4O_AAD_ENDPOINT", ""),
+    ],
+)
+async def test_openai_chat_target_aad_auth(duckdb_instance, endpoint, model_name):
+    args = {
+        "endpoint": os.getenv(endpoint),
+        "temperature": 0.0,
+        "seed": 42,
+        "use_aad_auth": True,
+        "model_name": model_name
+    }
+
+    # These endpoints should have AAD authentication enabled in the current context
+    # e.g. Cognitive Services OpenAI Contributor role
+    target = OpenAIChatTarget(**args)
+
+
+    orchestrator = PromptSendingOrchestrator(objective_target=target)
+    result = await orchestrator.send_prompts_async(prompt_list=["Hello, how are you?"])
+    assert result is not None
+    assert result[0].request_pieces[0].converted_value is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.run_only_if_all_tests
+@pytest.mark.parametrize(
+    ("endpoint", "model_name"),
+    [
+        ("OPENAI_REALTIME_ENDPOINT", ""),
+    ],
+)
+async def test_openai_realtime_target_aad_auth(duckdb_instance, endpoint, model_name):
+    args = {
+        "endpoint": os.getenv(endpoint),
+        "model_name": model_name
+    }
+
+    # These endpoints should have AAD authentication enabled in the current context
+    # e.g.  Cognitive Services OpenAI Contributor role
+    target = RealtimeTarget(**args)
+
+    orchestrator = PromptSendingOrchestrator(objective_target=target)
+    result = await orchestrator.send_prompts_async(prompt_list=["Hello, how are you?"])
+    assert result is not None
+    assert result[0].request_pieces[0].converted_value is not None

--- a/tests/integration/targets/test_aad_auth.py
+++ b/tests/integration/targets/test_aad_auth.py
@@ -23,13 +23,12 @@ async def test_openai_chat_target_aad_auth(duckdb_instance, endpoint, model_name
         "temperature": 0.0,
         "seed": 42,
         "use_aad_auth": True,
-        "model_name": model_name
+        "model_name": model_name,
     }
 
     # These endpoints should have AAD authentication enabled in the current context
     # e.g. Cognitive Services OpenAI Contributor role
     target = OpenAIChatTarget(**args)
-
 
     orchestrator = PromptSendingOrchestrator(objective_target=target)
     result = await orchestrator.send_prompts_async(prompt_list=["Hello, how are you?"])
@@ -46,10 +45,7 @@ async def test_openai_chat_target_aad_auth(duckdb_instance, endpoint, model_name
     ],
 )
 async def test_openai_realtime_target_aad_auth(duckdb_instance, endpoint, model_name):
-    args = {
-        "endpoint": os.getenv(endpoint),
-        "model_name": model_name
-    }
+    args = {"endpoint": os.getenv(endpoint), "model_name": model_name}
 
     # These endpoints should have AAD authentication enabled in the current context
     # e.g.  Cognitive Services OpenAI Contributor role

--- a/tests/unit/target/test_azure_openai_completion_target.py
+++ b/tests/unit/target/test_azure_openai_completion_target.py
@@ -12,6 +12,7 @@ from unit.mocks import get_sample_conversations
 from pyrit.memory.central_memory import CentralMemory
 from pyrit.models import PromptRequestPiece, PromptRequestResponse
 from pyrit.prompt_target import OpenAICompletionTarget
+from pyrit.memory.memory_interface import MemoryInterface
 
 
 @pytest.fixture
@@ -159,11 +160,14 @@ async def test_openai_completion_target_default_api_version(sample_conversations
 
 @pytest.mark.asyncio
 async def test_send_prompt_async_calls_refresh_auth_headers(azure_completion_target: OpenAICompletionTarget):
+    mock_memory = MagicMock(spec=MemoryInterface)
+    mock_memory.get_conversation.return_value = []
+    mock_memory.add_request_response_to_memory = AsyncMock()
+
+    azure_completion_target._memory = mock_memory
+
     azure_completion_target.refresh_auth_headers = MagicMock()
-
     azure_completion_target._validate_request = MagicMock()
-
-    azure_completion_target._memory.get_chat_messages_with_conversation_id = MagicMock(return_value=[])
     azure_completion_target._construct_request_body = AsyncMock(return_value={})
 
     with patch("pyrit.common.net_utility.make_request_and_raise_if_error_async") as mock_make_request:

--- a/tests/unit/target/test_azure_openai_completion_target.py
+++ b/tests/unit/target/test_azure_openai_completion_target.py
@@ -10,9 +10,9 @@ import pytest
 from unit.mocks import get_sample_conversations
 
 from pyrit.memory.central_memory import CentralMemory
+from pyrit.memory.memory_interface import MemoryInterface
 from pyrit.models import PromptRequestPiece, PromptRequestResponse
 from pyrit.prompt_target import OpenAICompletionTarget
-from pyrit.memory.memory_interface import MemoryInterface
 
 
 @pytest.fixture
@@ -179,7 +179,7 @@ async def test_send_prompt_async_calls_refresh_auth_headers(azure_completion_tar
                     role="user",
                     original_value="test prompt",
                     converted_value="test prompt",
-                    converted_value_data_type="text"
+                    converted_value_data_type="text",
                 )
             ]
         )

--- a/tests/unit/target/test_dall_e_target.py
+++ b/tests/unit/target/test_dall_e_target.py
@@ -17,6 +17,7 @@ from pyrit.exceptions.exception_classes import (
 )
 from pyrit.models import PromptRequestPiece, PromptRequestResponse
 from pyrit.prompt_target import OpenAIDALLETarget
+from pyrit.memory.memory_interface import MemoryInterface
 
 
 @pytest.fixture
@@ -319,6 +320,12 @@ async def test_dalle_target_default_api_version(
 
 @pytest.mark.asyncio
 async def test_send_prompt_async_calls_refresh_auth_headers(dalle_target):
+    mock_memory = MagicMock(spec=MemoryInterface)
+    mock_memory.get_conversation.return_value = []
+    mock_memory.add_request_response_to_memory = AsyncMock()
+
+    dalle_target._memory = mock_memory
+
     dalle_target.refresh_auth_headers = MagicMock()
     dalle_target._validate_request = MagicMock()
     dalle_target._construct_request_body = AsyncMock(return_value={})

--- a/tests/unit/target/test_dall_e_target.py
+++ b/tests/unit/target/test_dall_e_target.py
@@ -15,9 +15,9 @@ from pyrit.exceptions.exception_classes import (
     EmptyResponseException,
     RateLimitException,
 )
+from pyrit.memory.memory_interface import MemoryInterface
 from pyrit.models import PromptRequestPiece, PromptRequestResponse
 from pyrit.prompt_target import OpenAIDALLETarget
-from pyrit.memory.memory_interface import MemoryInterface
 
 
 @pytest.fixture
@@ -332,11 +332,7 @@ async def test_send_prompt_async_calls_refresh_auth_headers(dalle_target):
 
     with patch("pyrit.common.net_utility.make_request_and_raise_if_error_async") as mock_make_request:
         mock_response = MagicMock()
-        mock_response.text = json.dumps({
-            "data": [{
-                "b64_json": "aGVsbG8="  # Base64 encoded "hello"
-            }]
-        })
+        mock_response.text = json.dumps({"data": [{"b64_json": "aGVsbG8="}]})  # Base64 encoded "hello"
         mock_make_request.return_value = mock_response
 
         prompt_request = PromptRequestResponse(
@@ -345,7 +341,7 @@ async def test_send_prompt_async_calls_refresh_auth_headers(dalle_target):
                     role="user",
                     original_value="test prompt",
                     converted_value="test prompt",
-                    converted_value_data_type="text"
+                    converted_value_data_type="text",
                 )
             ]
         )

--- a/tests/unit/target/test_openai_chat_target.py
+++ b/tests/unit/target/test_openai_chat_target.py
@@ -58,7 +58,7 @@ def target(patch_central_database) -> OpenAIChatTarget:
         endpoint="https://mock.azure.com/",
         api_key="mock-api-key",
         api_version="some_version",
-        use_aad_auth=True
+        use_aad_auth=True,
     )
 
 
@@ -718,7 +718,9 @@ async def test_send_prompt_async_calls_refresh_auth_headers(target: OpenAIChatTa
     target._construct_request_body = AsyncMock(return_value={})
 
     with patch("pyrit.common.net_utility.make_request_and_raise_if_error_async") as mock_make_request:
-        mock_make_request.return_value = MagicMock(text='{"choices": [{"finish_reason": "stop", "message": {"content": "test response"}}]}')
+        mock_make_request.return_value = MagicMock(
+            text='{"choices": [{"finish_reason": "stop", "message": {"content": "test response"}}]}'
+        )
 
         prompt_request = PromptRequestResponse(
             request_pieces=[
@@ -726,7 +728,7 @@ async def test_send_prompt_async_calls_refresh_auth_headers(target: OpenAIChatTa
                     role="user",
                     original_value="test prompt",
                     converted_value="test prompt",
-                    converted_value_data_type="text"
+                    converted_value_data_type="text",
                 )
             ]
         )

--- a/tests/unit/target/test_openai_chat_target.py
+++ b/tests/unit/target/test_openai_chat_target.py
@@ -58,7 +58,6 @@ def target(patch_central_database) -> OpenAIChatTarget:
         endpoint="https://mock.azure.com/",
         api_key="mock-api-key",
         api_version="some_version",
-        use_aad_auth=True,
     )
 
 
@@ -711,6 +710,7 @@ async def test_send_prompt_async_calls_refresh_auth_headers(target: OpenAIChatTa
     mock_memory.get_conversation.return_value = []
     mock_memory.add_request_response_to_memory = AsyncMock()
 
+    target._azure_auth = MagicMock()
     target._memory = mock_memory
 
     with (

--- a/tests/unit/target/test_openai_chat_target.py
+++ b/tests/unit/target/test_openai_chat_target.py
@@ -707,12 +707,14 @@ async def test_openai_chat_target_default_api_version(sample_conversations: Muta
 
 @pytest.mark.asyncio
 async def test_send_prompt_async_calls_refresh_auth_headers(target: OpenAIChatTarget):
+    mock_memory = MagicMock(spec=MemoryInterface)
+    mock_memory.get_conversation.return_value = []
+    mock_memory.add_request_response_to_memory = AsyncMock()
+
+    target._memory = mock_memory
+
     target.refresh_auth_headers = MagicMock()
-
     target._validate_request = MagicMock()
-
-    target._memory.get_conversation = MagicMock(return_value=[])
-
     target._construct_request_body = AsyncMock(return_value={})
 
     with patch("pyrit.common.net_utility.make_request_and_raise_if_error_async") as mock_make_request:

--- a/tests/unit/target/test_realtime_target.py
+++ b/tests/unit/target/test_realtime_target.py
@@ -17,7 +17,7 @@ def target(duckdb_instance):
 
 @pytest.fixture
 def target_with_aad(duckdb_instance):
-    target = RealtimeTarget(endpoint="wss://test_url", api_key="test_api_key", use_aad_auth=True)
+    target = RealtimeTarget(endpoint="wss://test_url", api_key="test_api_key")
     target._azure_auth = MagicMock()
     target._azure_auth.refresh_token = MagicMock(return_value="test_access_token")
     return target

--- a/tests/unit/target/test_realtime_target.py
+++ b/tests/unit/target/test_realtime_target.py
@@ -6,7 +6,6 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 
-from pyrit.memory import MemoryInterface
 from pyrit.models import PromptRequestPiece, PromptRequestResponse
 from pyrit.prompt_target import RealtimeTarget
 

--- a/tests/unit/target/test_realtime_target.py
+++ b/tests/unit/target/test_realtime_target.py
@@ -6,14 +6,15 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 
+from pyrit.memory import MemoryInterface
 from pyrit.models import PromptRequestPiece, PromptRequestResponse
 from pyrit.prompt_target import RealtimeTarget
-from pyrit.memory import MemoryInterface
 
 
 @pytest.fixture
 def target(duckdb_instance):
     return RealtimeTarget(api_key="test_key", endpoint="wss://test_url", model_name="test", api_version="v1")
+
 
 @pytest.fixture
 def target_with_aad(duckdb_instance):
@@ -21,6 +22,7 @@ def target_with_aad(duckdb_instance):
     target._azure_auth = MagicMock()
     target._azure_auth.refresh_token = MagicMock(return_value="test_access_token")
     return target
+
 
 @pytest.mark.asyncio
 async def test_connect_success(target):
@@ -256,10 +258,12 @@ def test_add_auth_param_to_query_params_with_api_key(target_with_aad):
     target_with_aad._add_auth_param_to_query_params(query_params)
     assert query_params["api-key"] == "test_api_key"
 
+
 def test_add_auth_param_to_query_params_with_azure_auth(target_with_aad):
     query_params = {}
     target_with_aad._add_auth_param_to_query_params(query_params)
     assert query_params["access_token"] == "test_access_token"
+
 
 def test_add_auth_param_to_query_params_with_both_auth_methods(target_with_aad):
     query_params = {}

--- a/tests/unit/target/test_realtime_target.py
+++ b/tests/unit/target/test_realtime_target.py
@@ -17,7 +17,7 @@ def target(duckdb_instance):
 
 @pytest.fixture
 def target_with_aad(duckdb_instance):
-    target = RealtimeTarget(api_key="test_api_key", use_aad_auth=True)
+    target = RealtimeTarget(endpoint="wss://test_url", api_key="test_api_key", use_aad_auth=True)
     target._azure_auth = MagicMock()
     target._azure_auth.refresh_token = MagicMock(return_value="test_access_token")
     return target

--- a/tests/unit/target/test_tts_target.py
+++ b/tests/unit/target/test_tts_target.py
@@ -13,10 +13,10 @@ from unit.mocks import get_sample_conversations
 
 from pyrit.common import net_utility
 from pyrit.exceptions import RateLimitException
+from pyrit.memory import MemoryInterface
 from pyrit.models import PromptRequestPiece, PromptRequestResponse
 from pyrit.prompt_target import OpenAITTSTarget
 from pyrit.prompt_target.openai.openai_tts_target import TTSResponseFormat
-from pyrit.memory import MemoryInterface
 
 
 @pytest.fixture
@@ -69,7 +69,9 @@ async def test_tts_validate_prompt_type(
 
 
 @pytest.mark.asyncio
-async def test_tts_validate_previous_conversations(tts_target: OpenAITTSTarget, sample_conversations: MutableSequence[PromptRequestPiece]):
+async def test_tts_validate_previous_conversations(
+    tts_target: OpenAITTSTarget, sample_conversations: MutableSequence[PromptRequestPiece]
+):
     request_piece = sample_conversations[0]
 
     mock_memory = MagicMock()
@@ -246,7 +248,7 @@ async def test_send_prompt_async_calls_refresh_auth_headers(tts_target):
                     role="user",
                     original_value="test prompt",
                     converted_value="test prompt",
-                    converted_value_data_type="text"
+                    converted_value_data_type="text",
                 )
             ]
         )


### PR DESCRIPTION
- Added refresh logic to all openAI targets. 
- Added AAD auth to Realtime, which turns out is a unique butterfly.
- Added unit tests to verify refresh is called
- Added integration tests to verify it works, but these are manual and not run in our pipeline yet (we need to onboard an MSI to our pipeline/infra)