### PR TITLE
FEAT responses only scoring option

### DIFF
--- a/pyrit/orchestrator/scoring_orchestrator.py
+++ b/pyrit/orchestrator/scoring_orchestrator.py
@@ -85,6 +85,7 @@ class ScoringOrchestrator(Orchestrator):
         data_type: Optional[str] = None,
         not_data_type: Optional[str] = None,
         converted_value_sha256: Optional[list[str]] = None,
+        responses_only: bool = True,
     ) -> list[Score]:
         """
         Scores the responses that match the specified filters.
@@ -103,6 +104,8 @@ class ScoringOrchestrator(Orchestrator):
             not_data_type (Optional[str], optional): The data type to exclude. Defaults to None.
             converted_value_sha256 (Optional[list[str]], optional): A list of SHA256 hashes of converted values.
                 Defaults to None.
+            responses_only (bool, optional): If True, only the responses (messages with role "assistant") are
+                scored. Defaults to True.
         Returns:
             list[Score]: A list of Score objects for responses that match the specified filters.
         Raises:
@@ -125,6 +128,9 @@ class ScoringOrchestrator(Orchestrator):
         )
 
         request_pieces = self._remove_duplicates(request_pieces)
+
+        if responses_only:
+            request_pieces = self._extract_responses_only(request_pieces)
 
         if not request_pieces:
             raise ValueError("No entries match the provided filters. Please check your filters.")


### PR DESCRIPTION
<!--- Please add one of the following as a prefix to the pull request title: -->
<!--- DOC for documentation changes -->
<!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
<!--- FIX for bug fixes -->
<!--- TEST for adding tests -->
<!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
<!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->

<!--- Note on BREAKING changes: If your PR includes a change that will require users to make a corresponding
change (e.g. naming changes), please list [BREAKING] in front of the above prefix in the PR title.
For example, [BREAKING] FEAT or [BREAKING] MAINT -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->
Adding "responses_only" option in `ScoringOrchestrator`
<!--- If you are considering making a contribution please open an issue first. -->
<!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
<!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->

<!--- If your change is BREAKING please include reasoning for why below. -->


## Tests and Documentation

<!--- Contributions require tests and documentation (if applicable). -->
<!--- Include a description of tests and documentation updated (if applicable) -->

<!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
<!--- Include how you/if ran JupyText here -->
<!--- This is described at: https://github.com/Azure/PyRIT/tree/main/doc  -->
