### PR TITLE
FIX handle empty exception message in validation

### DIFF
--- a/pyrit/prompt_normalizer/prompt_normalizer.py
+++ b/pyrit/prompt_normalizer/prompt_normalizer.py
@@ -4,6 +4,7 @@
 import abc
 import asyncio
 import logging
+import traceback
 from typing import Any, List, Optional
 from uuid import uuid4
 
@@ -110,7 +111,7 @@ class PromptNormalizer(abc.ABC):
 
             error_response = construct_response_from_request(
                 request=request.request_pieces[0],
-                response_text_pieces=[str(ex)],
+                response_text_pieces=[f"{ex}\n{repr(ex)}\n{traceback.format_exc()}"],
                 response_type="error",
                 error="processing",
             )

--- a/tests/unit/test_prompt_normalizer.py
+++ b/tests/unit/test_prompt_normalizer.py
@@ -523,7 +523,7 @@ async def test_send_prompt_async_exception_conv_id(mock_memory_instance, seed_pr
     )
     assert (
         "Test Exception"
-        == mock_memory_instance.add_request_response_to_memory.call_args_list[1][1]["request"]
+        in mock_memory_instance.add_request_response_to_memory.call_args_list[1][1]["request"]
         .request_pieces[0]
         .original_value
     )

--- a/tests/unit/test_prompt_normalizer.py
+++ b/tests/unit/test_prompt_normalizer.py
@@ -200,6 +200,17 @@ async def test_send_prompt_async_exception(mock_memory_instance, seed_prompt_gro
 
 
 @pytest.mark.asyncio
+async def test_send_prompt_async_empty_exception(mock_memory_instance, seed_prompt_group):
+    prompt_target = AsyncMock()
+    prompt_target.send_prompt_async = AsyncMock(side_effect=Exception(""))
+
+    normalizer = PromptNormalizer()
+
+    with pytest.raises(Exception, match="Error sending prompt with conversation ID") as ex:
+        await normalizer.send_prompt_async(seed_prompt_group=seed_prompt_group, target=prompt_target)
+
+
+@pytest.mark.asyncio
 async def test_send_prompt_async_adds_memory_twice(
     mock_memory_instance, seed_prompt_group, response: PromptRequestResponse
 ):

--- a/tests/unit/test_prompt_normalizer.py
+++ b/tests/unit/test_prompt_normalizer.py
@@ -206,7 +206,7 @@ async def test_send_prompt_async_empty_exception(mock_memory_instance, seed_prom
 
     normalizer = PromptNormalizer()
 
-    with pytest.raises(Exception, match="Error sending prompt with conversation ID") as ex:
+    with pytest.raises(Exception, match="Error sending prompt with conversation ID"):
         await normalizer.send_prompt_async(seed_prompt_group=seed_prompt_group, target=prompt_target)
 
 


### PR DESCRIPTION
<!--- Please add one of the following as a prefix to the pull request title: -->
<!--- DOC for documentation changes -->
<!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
<!--- FIX for bug fixes -->
<!--- TEST for adding tests -->
<!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
<!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->

<!--- Note on BREAKING changes: If your PR includes a change that will require users to make a corresponding
change (e.g. naming changes), please list [BREAKING] in front of the above prefix in the PR title.
For example, [BREAKING] FEAT or [BREAKING] MAINT -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->
Previously, we passed `str(ex)` as the content of a `PromptRequestPiece` but that can be empty causing exceptions. This PR addresses that so that we finally raise the exception properly from the root cause exception.
<!--- If you are considering making a contribution please open an issue first. -->
<!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
<!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->

<!--- If your change is BREAKING please include reasoning for why below. -->


## Tests and Documentation

<!--- Contributions require tests and documentation (if applicable). -->
<!--- Include a description of tests and documentation updated (if applicable) -->
add unit test
<!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
<!--- Include how you/if ran JupyText here -->
<!--- This is described at: https://github.com/Azure/PyRIT/tree/main/doc  -->
