### PR TITLE
MAINT: Make integration tests run outside of repository and various fixes

### DIFF
--- a/integration-tests.yml
+++ b/integration-tests.yml
@@ -44,6 +44,7 @@ jobs:
     name: install_tkinter
   - bash: pip install .[dev,all] -v
     name: install_PyRIT
+  # This step ensures that integration tests are run outside of the PyRIT directory to test that .env files are accessed correctly.
   - bash: |
       PyRIT_DIR=$(pwd)
       NEW_DIR="integration_test_directory"

--- a/integration-tests.yml
+++ b/integration-tests.yml
@@ -44,6 +44,18 @@ jobs:
     name: install_tkinter
   - bash: pip install .[dev,all] -v
     name: install_PyRIT
+  - bash: |
+      PyRIT_DIR=$(pwd)
+      NEW_DIR="integration_test_directory"
+      cd ..
+      mkdir -p $NEW_DIR/tests
+      cp $PyRIT_DIR/.env $NEW_DIR
+      cp $PyRIT_DIR/.env.local $NEW_DIR
+      cp -r $PyRIT_DIR/doc $NEW_DIR
+      cp -r $PyRIT_DIR/assets $NEW_DIR
+      cp -r $PyRIT_DIR/tests/integration $NEW_DIR/tests
+      cd $NEW_DIR
+    displayName: "Create and switch to new integration test directory"
   - bash: make integration-test
     name: run_integration_tests
   - bash: rm -f .env

--- a/integration-tests.yml
+++ b/integration-tests.yml
@@ -44,7 +44,7 @@ jobs:
     name: install_tkinter
   - bash: pip install .[dev,all] -v
     name: install_PyRIT
-  # This step ensures that integration tests are run outside of the PyRIT directory to test that .env files are accessed correctly.
+  # This step ensures that integration tests are run outside of the PyRIT repository to test that .env files are accessed correctly.
   - bash: |
       PyRIT_DIR=$(pwd)
       NEW_DIR="integration_test_directory"

--- a/pyrit/datasets/darkbench_dataset.py
+++ b/pyrit/datasets/darkbench_dataset.py
@@ -20,7 +20,7 @@ def fetch_darkbench_dataset() -> SeedPromptDataset:
         - https://darkbench.ai/ \n
         - https://openreview.net/forum?id=odjMSBSWRt
     """
-    data = load_dataset("apart/darkbench", "default")
+    data = load_dataset("apart/darkbench", "default", split="train", data_files="darkbench.tsv")
 
     seed_prompts = [
         SeedPrompt(
@@ -46,7 +46,7 @@ def fetch_darkbench_dataset() -> SeedPromptDataset:
                 "Mateusz Maria Jurewicz",
             ],
         )
-        for item in data["train"]
+        for item in data
     ]
 
     seed_prompt_dataset = SeedPromptDataset(prompts=seed_prompts)

--- a/tests/integration/cli/mixed_multiple_orchestrators_args_success.yaml
+++ b/tests/integration/cli/mixed_multiple_orchestrators_args_success.yaml
@@ -1,5 +1,5 @@
 datasets:
-  - ./pyrit/tests/integration/cli/illegal_integration_test.prompt
+  - ./tests/integration/cli/illegal_integration_test.prompt
 scenarios:
   - type: "PromptSendingOrchestrator"
   - type: "RedTeamingOrchestrator"
@@ -22,3 +22,5 @@ scoring:
     type: "OpenAIChatTarget"
   objective_scorer:
     type: "SelfAskRefusalScorer"
+database:
+  type: "DuckDB"

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -15,7 +15,7 @@ from pyrit.orchestrator import (
 
 test_cases_success = [
     (
-        "--config-file 'tests/unit/cli/mixed_multiple_orchestrators_args_success.yaml'",
+        "--config-file 'tests/integration/cli/mixed_multiple_orchestrators_args_success.yaml'",
         [
             PromptSendingOrchestrator,
             TreeOfAttacksWithPruningOrchestrator,

--- a/tests/integration/orchestrators/test_orchestrator_notebooks.py
+++ b/tests/integration/orchestrators/test_orchestrator_notebooks.py
@@ -27,7 +27,7 @@ def test_execute_notebooks(file_name):
     with open(nb_path, encoding="utf-8") as f:
         nb = nbformat.read(f, as_version=4)
 
-    ep = ExecutePreprocessor(timeout=600)
+    ep = ExecutePreprocessor(timeout=900)
 
     # Execute notebook, test will throw exception if any cell fails
     ep.preprocess(nb, {"metadata": {"path": nb_path.parent}})

--- a/tests/integration/test_notebooks_cookbooks.py
+++ b/tests/integration/test_notebooks_cookbooks.py
@@ -24,7 +24,7 @@ def test_execute_notebooks(file_name):
     with open(nb_path, encoding="utf-8") as f:
         nb = nbformat.read(f, as_version=4)
 
-    ep = ExecutePreprocessor(timeout=600)
+    ep = ExecutePreprocessor(timeout=900)
 
     # Execute notebook, test will throw exception if any cell fails
     ep.preprocess(nb, {"metadata": {"path": nb_path.parent}})


### PR DESCRIPTION
## Description
This PR mainly amends integration-tests.yml by adding bash commands to create an integration test directory outside the PyRIT repository in order to ensure env files are picked up correctly. It also extends timeout in some notebook integration tests and fixes error in fetching darkbench dataset. 

This also fixes a previous bug where we were using `mixed_multiple_orchestrators_args_success.yaml` from the unit test directory instead of the integration test directory for our scanner integration tests. 


## Tests and Documentation
Relevant integration tests pass.
