### PR TITLE
FIX: Update `re.split` calls to use `maxsplit` keyword argument

### DIFF
--- a/pyrit/prompt_converter/repeat_token_converter.py
+++ b/pyrit/prompt_converter/repeat_token_converter.py
@@ -43,7 +43,7 @@ class RepeatTokenConverter(PromptConverter):
             case "split":
                 # function to split prompt on first punctuation (.?! only), preserve punctuation, 2 parts max.
                 def insert(text: str) -> list:
-                    parts = re.split(r"(\?|\.|\!)", text, 1)
+                    parts = re.split(r"(\?|\.|\!)", text, maxsplit=1)
                     if len(parts) == 3:  # if split mode with no punctuation
                         return [parts[0] + parts[1], parts[2]]
                     return ["", text]


### PR DESCRIPTION
## Description
Starting from Python 3.13, using `maxsplit` as a positional argument in `re.split` is deprecated and will become keyword-only in future Python versions. Currently, this triggers the following warning:
> DeprecationWarning: 'maxsplit' is passed as a positional argument

This small PR updates the codebase to explicitly use `maxsplit` as a keyword argument. See relevant warning in the [CI logs](https://github.com/Azure/PyRIT/actions/runs/14539113535/job/40793408887#step:7:161):
```python
D:\a\PyRIT\PyRIT\pyrit\prompt_converter\repeat_token_converter.py:46: DeprecationWarning: 'maxsplit' is passed as positional argument
    parts = re.split(r"(\?|\.|\!)", text, 1)
```

For more information see the [official Python docs](https://docs.python.org/3/library/re.html#re.split).


## Tests and Documentation
