### PR TITLE
FEAT: CBT-Bench Dataset

### DIFF
--- a/pyrit/datasets/__init__.py
+++ b/pyrit/datasets/__init__.py
@@ -22,6 +22,7 @@ from pyrit.datasets.seclists_bias_testing_dataset import fetch_seclists_bias_tes
 from pyrit.datasets.tdc23_redteaming_dataset import fetch_tdc23_redteaming_dataset
 from pyrit.datasets.wmdp_dataset import fetch_wmdp_dataset
 from pyrit.datasets.xstest_dataset import fetch_xstest_dataset
+from pyrit.datasets.cbt_bench import fetch_cbt_bench_dataset
 
 __all__ = [
     "fetch_adv_bench_dataset",
@@ -43,4 +44,5 @@ __all__ = [
     "fetch_tdc23_redteaming_dataset",
     "fetch_wmdp_dataset",
     "fetch_xstest_dataset",
+    "fetch_cbt_bench_dataset",
 ]

--- a/pyrit/datasets/cbt_bench_dataset.py
+++ b/pyrit/datasets/cbt_bench_dataset.py
@@ -1,0 +1,67 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from datasets import load_dataset
+
+from pyrit.models import SeedPromptDataset
+from pyrit.models.seed_prompt import SeedPrompt
+
+
+def fetch_cbt_bench_dataset(config_name: str = "core_fine_seed") -> SeedPromptDataset:
+    """
+    Fetch CBT-Bench examples for a specific configuration and create a SeedPromptDataset.
+
+    Args:
+        config_name (str): The configuration name to load (default is "core_fine_seed").
+
+    Returns:
+        SeedPromptDataset: A SeedPromptDataset containing the examples.
+
+    Note:
+        For more information about the dataset and related materials, visit: \n
+        - https://huggingface.co/datasets/Psychotherapy-LLM/CBT-Bench \n
+        - Related to Cognitive Behavioral Therapy benchmarking and psychological safety tasks.
+
+    Citation:
+        Zhang, M., Yang, X., Zhang, X., Labrum, T., Chiu, J. C., Eack, S. M., Fang, F., Wang, W. Y., & Chen, Z. Z. (2024).
+        CBT-Bench: Evaluating Large Language Models on Assisting Cognitive Behavior Therapy. 
+        arXiv preprint arXiv:2410.13218.
+
+    Authors:
+        Mian Zhang, Xianjun Yang, Xinlu Zhang, Travis Labrum, Jamie C. Chiu, Shaun M. Eack, 
+        Fei Fang, William Yang Wang, Zhiyu Zoey Chen
+    """
+    try:
+        # Load the dataset with the specified configuration
+        data = load_dataset("Psychotherapy-LLM/CBT-Bench", config_name, split="train")
+    except Exception as e:
+        raise ValueError(f"Error loading CBT-Bench dataset with config '{config_name}': {e}")
+
+    seed_prompts = [
+        SeedPrompt(
+            value=item["situation"],  # Use 'situation' as the main prompt text
+            data_type="text",
+            name=f"CBT-Bench-{item['id']}",
+            dataset_name="CBT-Bench",
+            harm_categories=item.get("core_belief_fine_grained", []),
+            description=(
+                "CBT-Bench is a benchmark dataset designed to evaluate the alignment and therapeutic safety of "
+                "Large Language Models (LLMs) in the context of Cognitive Behavioral Therapy (CBT)."
+            ),
+            source="https://huggingface.co/datasets/Psychotherapy-LLM/CBT-Bench",
+            authors=[
+                "Mian Zhang",
+                "Xianjun Yang",
+                "Xinlu Zhang",
+                "Travis Labrum",
+                "Jamie C. Chiu",
+                "Shaun M. Eack",
+                "Fei Fang",
+                "William Yang Wang",
+                "Zhiyu Zoey Chen"
+            ],
+        )
+        for item in data
+    ]
+
+    return SeedPromptDataset(prompts=seed_prompts)

--- a/pyrit/datasets/cbt_bench_dataset.py
+++ b/pyrit/datasets/cbt_bench_dataset.py
@@ -19,8 +19,8 @@ def fetch_cbt_bench_dataset(config_name: str = "core_fine_seed") -> SeedPromptDa
 
     Note:
         For more information about the dataset and related materials, visit: \n
-        - https://huggingface.co/datasets/Psychotherapy-LLM/CBT-Bench \n
-        - Related to Cognitive Behavioral Therapy benchmarking and psychological safety tasks.
+        https://huggingface.co/datasets/Psychotherapy-LLM/CBT-Bench \n
+        Related to Cognitive Behavioral Therapy benchmarking and psychological safety tasks.
 
     Citation:
         Zhang, M., Yang, X., Zhang, X., Labrum, T., Chiu, J. C., Eack, S. M., Fang, F., Wang, W. Y., & Chen, Z. Z. (2024).


### PR DESCRIPTION
# CBT-Bench Dataset Integration for PyRIT

This pull request introduces support for the CBT-Bench dataset in PyRIT. The CBT-Bench dataset is a benchmark designed to evaluate the alignment and therapeutic safety of Large Language Models (LLMs) in the context of Cognitive Behavioral Therapy (CBT). By integrating this dataset, PyRIT can analyze psychotherapy-related prompts and identify potential risks, including cognitive distortions, harmful self-beliefs, and other vulnerabilities.

## Key Changes

- Added a new function `fetch_cbt_bench_dataset` to fetch and process the dataset.
- Mapped dataset fields (`situation`, `core_belief_fine_grained`) to PyRIT's `SeedPrompt` model.
- Included default configuration (`core_fine_seed`) with support for other configurations.
- Updated documentation and comments to explain the purpose and usage of the dataset.

## Related Issue

Closes: #865   
Tagging @romanlutz  for review.

## Tests and Documentation

- **Tests**: Unit tests have not been added. They can be included in a subsequent commit within the same pull request if requested by the reviewer.
- **Documentation**: Inline documentation has been updated. The README has not been updated yet but will be addressed if deemed necessary.
- **JupyText**: Not applicable, as this contribution focuses on dataset integration rather than API or documentation changes.

## References

- [CBT-Bench Dataset on Hugging Face](https://huggingface.co/datasets/Psychotherapy-LLM/CBT-Bench)

### Citation

```bibtex
@article{zhang2024cbt,
  title={CBT-Bench: Evaluating Large Language Models on Assisting Cognitive Behavior Therapy},
  author={Zhang, Mian and Yang, Xianjun and Zhang, Xinlu and Labrum, Travis and Chiu, Jamie C and Eack, Shaun M and Fang, Fei and Wang, William Yang and Chen, Zhiyu Zoey},
  journal={arXiv preprint arXiv:2410.13218},
  year={2024}
}