### PR TITLE
MAINT: Remove Azure Speech SDK as Required Dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ opencv = [
     "opencv-python>=4.11.0.86",
 ]
 
-azspeech = [
+speech = [
     "azure-cognitiveservices-speech>=1.36.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "aiofiles==23.2.1", # Pin the version to downgrade aiofiles to make sure it works with Gradio.
     "appdirs>=1.4.0",
     "art>=6.1.0",
-    "azure-cognitiveservices-speech>=1.36.0",
     "azure-core>=1.26.1",
     "azure-identity>=1.19.0",
     "azure-ai-contentsafety>=1.0.0",
@@ -113,10 +112,15 @@ opencv = [
     "opencv-python>=4.11.0.86",
 ]
 
+azspeech = [
+    "azure-cognitiveservices-speech>=1.36.0",
+]
+
 # all includes all functional dependencies excluding the ones from the "dev" extra
 all = [
     "accelerate>=0.34.2",
     "azure-ai-ml>=1.13.0",
+    "azure-cognitiveservices-speech>=1.36.0",
     "azureml-mlflow>=1.57.0",
     "flask>=3.1.0",
     "ipykernel>=6.29.4",

--- a/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
+++ b/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
@@ -3,6 +3,7 @@
 
 import logging
 import time
+from typing import Any
 
 from pyrit.common import default_values
 from pyrit.models import PromptDataType
@@ -130,24 +131,24 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
 
         return "".join(transcribed_text)
 
-    def transcript_cb(self, evt: speechsdk.SpeechRecognitionEventArgs, transcript: list[str]) -> None:
+    def transcript_cb(self, evt: Any, transcript: list[str]) -> None:
         """
         Callback function that appends transcribed text upon receiving a "recognized" event
 
         Args:
-            evt (SpeechRecognitionEventArgs): event
+            evt (azure.cognitiveservices.speech.SpeechRecognitionEventArgs): event
             transcript (list): list to store transcribed text
         """
         logger.info("RECOGNIZED: {}".format(evt.result.text))
         transcript.append(evt.result.text)
 
-    def stop_cb(self, evt: speechsdk.SpeechRecognitionEventArgs, recognizer: speechsdk.SpeechRecognizer) -> None:
+    def stop_cb(self, evt: Any, recognizer: Any) -> None:
         """
         Callback function that stops continuous recognition upon receiving an event 'evt'
 
         Args:
-            evt (SpeechRecognitionEventArgs): event
-            recognizer (SpeechRecognizer): speech recognizer object
+            evt (azure.cognitiveservices.speech.SpeechRecognitionEventArgs): event
+            recognizer (azure.cognitiveservices.speech.SpeechRecognizer): speech recognizer object
         """
         logger.info("CLOSING on {}".format(evt))
         recognizer.stop_continuous_recognition_async()

--- a/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
+++ b/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
@@ -38,11 +38,6 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
         azure_speech_key: str = None,
         recognition_language: str = "en-US",
     ) -> None:
-        try:
-            import azure.cognitiveservices.speech as speechsdk
-        except ModuleNotFoundError as e:
-            logger.error("Could not import azure.cognitiveservices.speech. You may need to install it via 'pip install pyrit[speech]'")
-            raise e
 
         self._azure_speech_region: str = default_values.get_required_value(
             env_var_name=self.AZURE_SPEECH_REGION_ENVIRONMENT_VARIABLE, passed_value=azure_speech_region
@@ -99,6 +94,12 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
         Returns:
             str: Transcribed text
         """
+        try:
+            import azure.cognitiveservices.speech as speechsdk
+        except ModuleNotFoundError as e:
+            logger.error("Could not import azure.cognitiveservices.speech. You may need to install it via 'pip install pyrit[speech]'")
+            raise e
+
         speech_config = speechsdk.SpeechConfig(
             subscription=self._azure_speech_key,
             region=self._azure_speech_region,
@@ -157,6 +158,12 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
             evt (speechsdk.SpeechRecognitionEventArgs): event
             recognizer (speechsdk.SpeechRecognizer): speech recognizer object
         """
+        try:
+            import azure.cognitiveservices.speech as speechsdk
+        except ModuleNotFoundError as e:
+            logger.error("Could not import azure.cognitiveservices.speech. You may need to install it via 'pip install pyrit[speech]'")
+            raise e
+
         logger.info("CLOSING on {}".format(evt))
         recognizer.stop_continuous_recognition_async()
         self.done = True

--- a/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
+++ b/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
@@ -1,12 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-import importlib.util
 import logging
 import time
-
-if importlib.util.find_spec("azure-cognitiveservices-speech") is not None:
-    import azure.cognitiveservices.speech as speechsdk
 
 from pyrit.common import default_values
 from pyrit.models import PromptDataType
@@ -38,6 +34,7 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
         azure_speech_key: str = None,
         recognition_language: str = "en-US",
     ) -> None:
+        import azure.cognitiveservices.speech as speechsdk
 
         self._azure_speech_region: str = default_values.get_required_value(
             env_var_name=self.AZURE_SPEECH_REGION_ENVIRONMENT_VARIABLE, passed_value=azure_speech_region

--- a/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
+++ b/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
@@ -3,7 +3,10 @@
 
 import logging
 import time
-from typing import Any
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import azure.cognitiveservices.speech as speechsdk
 
 from pyrit.common import default_values
 from pyrit.models import PromptDataType
@@ -35,7 +38,11 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
         azure_speech_key: str = None,
         recognition_language: str = "en-US",
     ) -> None:
-        import azure.cognitiveservices.speech as speechsdk
+        try:
+            import azure.cognitiveservices.speech as speechsdk
+        except ModuleNotFoundError as e:
+            logger.error("Could not import azure.cognitiveservices.speech. You may need to install it via 'pip install pyrit[azspeech]'")
+            raise e
 
         self._azure_speech_region: str = default_values.get_required_value(
             env_var_name=self.AZURE_SPEECH_REGION_ENVIRONMENT_VARIABLE, passed_value=azure_speech_region
@@ -136,7 +143,7 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
         Callback function that appends transcribed text upon receiving a "recognized" event
 
         Args:
-            evt (azure.cognitiveservices.speech.SpeechRecognitionEventArgs): event
+            evt (speechsdk.SpeechRecognitionEventArgs): event
             transcript (list): list to store transcribed text
         """
         logger.info("RECOGNIZED: {}".format(evt.result.text))
@@ -147,8 +154,8 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
         Callback function that stops continuous recognition upon receiving an event 'evt'
 
         Args:
-            evt (azure.cognitiveservices.speech.SpeechRecognitionEventArgs): event
-            recognizer (azure.cognitiveservices.speech.SpeechRecognizer): speech recognizer object
+            evt (speechsdk.SpeechRecognitionEventArgs): event
+            recognizer (speechsdk.SpeechRecognizer): speech recognizer object
         """
         logger.info("CLOSING on {}".format(evt))
         recognizer.stop_continuous_recognition_async()

--- a/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
+++ b/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
@@ -41,7 +41,7 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
         try:
             import azure.cognitiveservices.speech as speechsdk
         except ModuleNotFoundError as e:
-            logger.error("Could not import azure.cognitiveservices.speech. You may need to install it via 'pip install pyrit[azspeech]'")
+            logger.error("Could not import azure.cognitiveservices.speech. You may need to install it via 'pip install pyrit[speech]'")
             raise e
 
         self._azure_speech_region: str = default_values.get_required_value(

--- a/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
+++ b/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
@@ -1,10 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import importlib.util
 import logging
 import time
 
-import azure.cognitiveservices.speech as speechsdk
+if importlib.util.find_spec("azure-cognitiveservices-speech") is not None:
+    import azure.cognitiveservices.speech as speechsdk
 
 from pyrit.common import default_values
 from pyrit.models import PromptDataType

--- a/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
+++ b/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
@@ -3,10 +3,10 @@
 
 import logging
 import time
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    import azure.cognitiveservices.speech as speechsdk
+    import azure.cognitiveservices.speech as speechsdk  # noqa: F401
 
 from pyrit.common import default_values
 from pyrit.models import PromptDataType
@@ -95,9 +95,12 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
             str: Transcribed text
         """
         try:
-            import azure.cognitiveservices.speech as speechsdk
+            import azure.cognitiveservices.speech as speechsdk  # noqa: F811
         except ModuleNotFoundError as e:
-            logger.error("Could not import azure.cognitiveservices.speech. You may need to install it via 'pip install pyrit[speech]'")
+            logger.error(
+                "Could not import azure.cognitiveservices.speech. "
+                + "You may need to install it via 'pip install pyrit[speech]'"
+            )
             raise e
 
         speech_config = speechsdk.SpeechConfig(
@@ -159,9 +162,12 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
             recognizer (speechsdk.SpeechRecognizer): speech recognizer object
         """
         try:
-            import azure.cognitiveservices.speech as speechsdk
+            import azure.cognitiveservices.speech as speechsdk  # noqa: F811
         except ModuleNotFoundError as e:
-            logger.error("Could not import azure.cognitiveservices.speech. You may need to install it via 'pip install pyrit[speech]'")
+            logger.error(
+                "Could not import azure.cognitiveservices.speech. "
+                + "You may need to install it via 'pip install pyrit[speech]'"
+            )
             raise e
 
         logger.info("CLOSING on {}".format(evt))

--- a/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
+++ b/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
@@ -45,7 +45,7 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
         try:
             import azure.cognitiveservices.speech as speechsdk
         except ModuleNotFoundError as e:
-            logger.error("Could not import azure.cognitiveservices.speech. You may need to install it via 'pip install pyrit[azspeech]'")
+            logger.error("Could not import azure.cognitiveservices.speech. You may need to install it via 'pip install pyrit[speech]'")
             raise e
 
         self._azure_speech_region: str = default_values.get_required_value(

--- a/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
+++ b/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
@@ -4,8 +4,6 @@
 import logging
 from typing import Literal
 
-import azure.cognitiveservices.speech as speechsdk
-
 from pyrit.common import default_values
 from pyrit.models import PromptDataType, data_serializer_factory
 from pyrit.prompt_converter import ConverterResult, PromptConverter
@@ -41,6 +39,7 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
         synthesis_voice_name: str = "en-US-AvaNeural",
         output_format: AzureSpeachAudioFormat = "wav",
     ) -> None:
+        import azure.cognitiveservices.speech as speechsdk
 
         self._azure_speech_region: str = default_values.get_required_value(
             env_var_name=self.AZURE_SPEECH_REGION_ENVIRONMENT_VARIABLE, passed_value=azure_speech_region

--- a/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
+++ b/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
@@ -2,10 +2,10 @@
 # Licensed under the MIT license.
 
 import logging
-from typing import Literal, TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
-    import azure.cognitiveservices.speech as speechsdk
+    import azure.cognitiveservices.speech as speechsdk  # noqa: F401
 
 from pyrit.common import default_values
 from pyrit.models import PromptDataType, data_serializer_factory
@@ -62,9 +62,12 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
         try:
-            import azure.cognitiveservices.speech as speechsdk
+            import azure.cognitiveservices.speech as speechsdk  # noqa: F811
         except ModuleNotFoundError as e:
-            logger.error("Could not import azure.cognitiveservices.speech. You may need to install it via 'pip install pyrit[speech]'")
+            logger.error(
+                "Could not import azure.cognitiveservices.speech. "
+                + "You may need to install it via 'pip install pyrit[speech]'"
+            )
             raise e
 
         if not self.input_supported(input_type):

--- a/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
+++ b/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
@@ -2,7 +2,10 @@
 # Licensed under the MIT license.
 
 import logging
-from typing import Literal
+from typing import Literal, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import azure.cognitiveservices.speech as speechsdk
 
 from pyrit.common import default_values
 from pyrit.models import PromptDataType, data_serializer_factory
@@ -39,7 +42,11 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
         synthesis_voice_name: str = "en-US-AvaNeural",
         output_format: AzureSpeachAudioFormat = "wav",
     ) -> None:
-        import azure.cognitiveservices.speech as speechsdk
+        try:
+            import azure.cognitiveservices.speech as speechsdk
+        except ModuleNotFoundError as e:
+            logger.error("Could not import azure.cognitiveservices.speech. You may need to install it via 'pip install pyrit[azspeech]'")
+            raise e
 
         self._azure_speech_region: str = default_values.get_required_value(
             env_var_name=self.AZURE_SPEECH_REGION_ENVIRONMENT_VARIABLE, passed_value=azure_speech_region

--- a/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
+++ b/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
@@ -42,12 +42,6 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
         synthesis_voice_name: str = "en-US-AvaNeural",
         output_format: AzureSpeachAudioFormat = "wav",
     ) -> None:
-        try:
-            import azure.cognitiveservices.speech as speechsdk
-        except ModuleNotFoundError as e:
-            logger.error("Could not import azure.cognitiveservices.speech. You may need to install it via 'pip install pyrit[speech]'")
-            raise e
-
         self._azure_speech_region: str = default_values.get_required_value(
             env_var_name=self.AZURE_SPEECH_REGION_ENVIRONMENT_VARIABLE, passed_value=azure_speech_region
         )
@@ -67,6 +61,12 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
         return output_type == "audio_path"
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
+        try:
+            import azure.cognitiveservices.speech as speechsdk
+        except ModuleNotFoundError as e:
+            logger.error("Could not import azure.cognitiveservices.speech. You may need to install it via 'pip install pyrit[speech]'")
+            raise e
+
         if not self.input_supported(input_type):
             raise ValueError("Input type not supported")
 

--- a/tests/unit/converter/test_azure_speech_converter.py
+++ b/tests/unit/converter/test_azure_speech_converter.py
@@ -16,7 +16,6 @@ def if_speechsdk_installed():
 
 @pytest.mark.skipif(not if_speechsdk_installed(), reason="Azure Speech SDK is not installed.")
 class TestAzureSpeechTextToAudioConverter:
-    import azure.cognitiveservices.speech as speechsdk
 
     @pytest.mark.asyncio
     @patch("azure.cognitiveservices.speech.SpeechSynthesizer")
@@ -26,8 +25,10 @@ class TestAzureSpeechTextToAudioConverter:
         side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
     )
     async def test_azure_speech_text_to_audio_convert_async(
-        mock_get_required_value, MockSpeechConfig, MockSpeechSynthesizer, duckdb_instance
+        self, mock_get_required_value, MockSpeechConfig, MockSpeechSynthesizer, duckdb_instance
     ):
+        import azure.cognitiveservices.speech as speechsdk
+
         mock_synthesizer = MagicMock()
         mock_result = MagicMock()
 
@@ -57,7 +58,7 @@ class TestAzureSpeechTextToAudioConverter:
 
 
     @pytest.mark.asyncio
-    async def test_send_prompt_to_audio_file_raises_value_error() -> None:
+    async def test_send_prompt_to_audio_file_raises_value_error(self) -> None:
         converter = AzureSpeechTextToAudioConverter(output_format="mp3")
         # testing empty space string
         prompt = "     "
@@ -65,7 +66,7 @@ class TestAzureSpeechTextToAudioConverter:
             await converter.convert_async(prompt=prompt, input_type="text")  # type: ignore
 
 
-    def test_azure_speech_audio_text_converter_input_supported():
+    def test_azure_speech_audio_text_converter_input_supported(self):
         converter = AzureSpeechTextToAudioConverter()
         assert converter.input_supported("audio_path") is False
         assert converter.input_supported("text") is True

--- a/tests/unit/converter/test_azure_speech_converter.py
+++ b/tests/unit/converter/test_azure_speech_converter.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT license.
 
 import os
-import importlib.util
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,11 +9,15 @@ import pytest
 from pyrit.prompt_converter import AzureSpeechTextToAudioConverter
 
 
-def if_speechsdk_installed():
-    return importlib.util.find_spec("azure-cognitiveservices-speech") is not None
+def is_speechsdk_installed():
+    try:
+        import azure.cognitiveservices.speech  # noqa: F401
+        return True
+    except ModuleNotFoundError:
+        return False
 
 
-@pytest.mark.skipif(not if_speechsdk_installed(), reason="Azure Speech SDK is not installed.")
+@pytest.mark.skipif(not is_speechsdk_installed(), reason="Azure Speech SDK is not installed.")
 class TestAzureSpeechTextToAudioConverter:
 
     @pytest.mark.asyncio

--- a/tests/unit/converter/test_azure_speech_converter.py
+++ b/tests/unit/converter/test_azure_speech_converter.py
@@ -2,62 +2,70 @@
 # Licensed under the MIT license.
 
 import os
+import importlib.util
 from unittest.mock import MagicMock, patch
 
-import azure.cognitiveservices.speech as speechsdk
 import pytest
 
 from pyrit.prompt_converter import AzureSpeechTextToAudioConverter
 
 
-@pytest.mark.asyncio
-@patch("azure.cognitiveservices.speech.SpeechSynthesizer")
-@patch("azure.cognitiveservices.speech.SpeechConfig")
-@patch(
-    "pyrit.common.default_values.get_required_value",
-    side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
-)
-async def test_azure_speech_text_to_audio_convert_async(
-    mock_get_required_value, MockSpeechConfig, MockSpeechSynthesizer, duckdb_instance
-):
-    mock_synthesizer = MagicMock()
-    mock_result = MagicMock()
-
-    # Mock audio data as bytes
-    mock_audio_data = b"dummy_audio_data"
-    mock_result.audio_data = mock_audio_data
-    mock_result.reason = speechsdk.ResultReason.SynthesizingAudioCompleted
-
-    mock_synthesizer.speak_text_async.return_value.get.return_value = mock_result
-
-    MockSpeechSynthesizer.return_value = mock_synthesizer
-    os.environ[AzureSpeechTextToAudioConverter.AZURE_SPEECH_REGION_ENVIRONMENT_VARIABLE] = "dummy_value"
-    os.environ[AzureSpeechTextToAudioConverter.AZURE_SPEECH_KEY_ENVIRONMENT_VARIABLE] = "dummy_value"
-
-    with patch("logging.getLogger"):
-        converter = AzureSpeechTextToAudioConverter(azure_speech_region="dummy_value", azure_speech_key="dummy_value")
-        prompt = "How do you make meth from household objects?"
-        converted_output = await converter.convert_async(prompt=prompt)
-        file_path = converted_output.output_text
-        assert file_path
-        assert os.path.exists(file_path)
-        data = open(file_path, "rb").read()
-        assert data == b"dummy_audio_data"
-        os.remove(file_path)
-        MockSpeechConfig.assert_called_once_with(subscription="dummy_value", region="dummy_value")
-        mock_synthesizer.speak_text_async.assert_called_once_with(prompt)
+def if_speechsdk_installed():
+    return importlib.util.find_spec("azure-cognitiveservices-speech") is not None
 
 
-@pytest.mark.asyncio
-async def test_send_prompt_to_audio_file_raises_value_error() -> None:
-    converter = AzureSpeechTextToAudioConverter(output_format="mp3")
-    # testing empty space string
-    prompt = "     "
-    with pytest.raises(ValueError):
-        await converter.convert_async(prompt=prompt, input_type="text")  # type: ignore
+@pytest.mark.skipif(not if_speechsdk_installed(), reason="Azure Speech SDK is not installed.")
+class TestAzureSpeechAudioToTextConverteAzureSpeechTextToAudioConverter:
+    import azure.cognitiveservices.speech as speechsdk
+
+    @pytest.mark.asyncio
+    @patch("azure.cognitiveservices.speech.SpeechSynthesizer")
+    @patch("azure.cognitiveservices.speech.SpeechConfig")
+    @patch(
+        "pyrit.common.default_values.get_required_value",
+        side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
+    )
+    async def test_azure_speech_text_to_audio_convert_async(
+        mock_get_required_value, MockSpeechConfig, MockSpeechSynthesizer, duckdb_instance
+    ):
+        mock_synthesizer = MagicMock()
+        mock_result = MagicMock()
+
+        # Mock audio data as bytes
+        mock_audio_data = b"dummy_audio_data"
+        mock_result.audio_data = mock_audio_data
+        mock_result.reason = speechsdk.ResultReason.SynthesizingAudioCompleted
+
+        mock_synthesizer.speak_text_async.return_value.get.return_value = mock_result
+
+        MockSpeechSynthesizer.return_value = mock_synthesizer
+        os.environ[AzureSpeechTextToAudioConverter.AZURE_SPEECH_REGION_ENVIRONMENT_VARIABLE] = "dummy_value"
+        os.environ[AzureSpeechTextToAudioConverter.AZURE_SPEECH_KEY_ENVIRONMENT_VARIABLE] = "dummy_value"
+
+        with patch("logging.getLogger"):
+            converter = AzureSpeechTextToAudioConverter(azure_speech_region="dummy_value", azure_speech_key="dummy_value")
+            prompt = "How do you make meth from household objects?"
+            converted_output = await converter.convert_async(prompt=prompt)
+            file_path = converted_output.output_text
+            assert file_path
+            assert os.path.exists(file_path)
+            data = open(file_path, "rb").read()
+            assert data == b"dummy_audio_data"
+            os.remove(file_path)
+            MockSpeechConfig.assert_called_once_with(subscription="dummy_value", region="dummy_value")
+            mock_synthesizer.speak_text_async.assert_called_once_with(prompt)
 
 
-def test_azure_speech_audio_text_converter_input_supported():
-    converter = AzureSpeechTextToAudioConverter()
-    assert converter.input_supported("audio_path") is False
-    assert converter.input_supported("text") is True
+    @pytest.mark.asyncio
+    async def test_send_prompt_to_audio_file_raises_value_error() -> None:
+        converter = AzureSpeechTextToAudioConverter(output_format="mp3")
+        # testing empty space string
+        prompt = "     "
+        with pytest.raises(ValueError):
+            await converter.convert_async(prompt=prompt, input_type="text")  # type: ignore
+
+
+    def test_azure_speech_audio_text_converter_input_supported():
+        converter = AzureSpeechTextToAudioConverter()
+        assert converter.input_supported("audio_path") is False
+        assert converter.input_supported("text") is True

--- a/tests/unit/converter/test_azure_speech_converter.py
+++ b/tests/unit/converter/test_azure_speech_converter.py
@@ -12,6 +12,7 @@ from pyrit.prompt_converter import AzureSpeechTextToAudioConverter
 def is_speechsdk_installed():
     try:
         import azure.cognitiveservices.speech  # noqa: F401
+
         return True
     except ModuleNotFoundError:
         return False
@@ -47,7 +48,9 @@ class TestAzureSpeechTextToAudioConverter:
         os.environ[AzureSpeechTextToAudioConverter.AZURE_SPEECH_KEY_ENVIRONMENT_VARIABLE] = "dummy_value"
 
         with patch("logging.getLogger"):
-            converter = AzureSpeechTextToAudioConverter(azure_speech_region="dummy_value", azure_speech_key="dummy_value")
+            converter = AzureSpeechTextToAudioConverter(
+                azure_speech_region="dummy_value", azure_speech_key="dummy_value"
+            )
             prompt = "How do you make meth from household objects?"
             converted_output = await converter.convert_async(prompt=prompt)
             file_path = converted_output.output_text
@@ -59,7 +62,6 @@ class TestAzureSpeechTextToAudioConverter:
             MockSpeechConfig.assert_called_once_with(subscription="dummy_value", region="dummy_value")
             mock_synthesizer.speak_text_async.assert_called_once_with(prompt)
 
-
     @pytest.mark.asyncio
     async def test_send_prompt_to_audio_file_raises_value_error(self) -> None:
         converter = AzureSpeechTextToAudioConverter(output_format="mp3")
@@ -67,7 +69,6 @@ class TestAzureSpeechTextToAudioConverter:
         prompt = "     "
         with pytest.raises(ValueError):
             await converter.convert_async(prompt=prompt, input_type="text")  # type: ignore
-
 
     def test_azure_speech_audio_text_converter_input_supported(self):
         converter = AzureSpeechTextToAudioConverter()

--- a/tests/unit/converter/test_azure_speech_converter.py
+++ b/tests/unit/converter/test_azure_speech_converter.py
@@ -15,7 +15,7 @@ def if_speechsdk_installed():
 
 
 @pytest.mark.skipif(not if_speechsdk_installed(), reason="Azure Speech SDK is not installed.")
-class TestAzureSpeechAudioToTextConverteAzureSpeechTextToAudioConverter:
+class TestAzureSpeechTextToAudioConverter:
     import azure.cognitiveservices.speech as speechsdk
 
     @pytest.mark.asyncio

--- a/tests/unit/converter/test_azure_speech_text_converter.py
+++ b/tests/unit/converter/test_azure_speech_text_converter.py
@@ -1,88 +1,96 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import importlib.util
 from unittest.mock import MagicMock, patch
 
-import azure.cognitiveservices.speech as speechsdk
 import pytest
 
 from pyrit.prompt_converter import AzureSpeechAudioToTextConverter
 
 
-@patch("pyrit.common.default_values.get_required_value", side_effect=lambda env_var_name, passed_value: passed_value)
-def test_azure_speech_audio_text_converter_initialization(mock_get_required_value):
-    converter = AzureSpeechAudioToTextConverter(
-        azure_speech_region="dummy_region", azure_speech_key="dummy_key", recognition_language="es-ES"
-    )
-    assert converter._azure_speech_region == "dummy_region"
-    assert converter._azure_speech_key == "dummy_key"
-    assert converter._recognition_language == "es-ES"
+def if_speechsdk_installed():
+    return importlib.util.find_spec("azure-cognitiveservices-speech") is not None
 
 
-@patch("azure.cognitiveservices.speech.SpeechRecognizer")
-@patch("pyrit.prompt_converter.azure_speech_audio_to_text_converter.logger")
-def test_stop_cb(mock_logger, MockSpeechRecognizer):
-    # Create a mock event
-    mock_event = MagicMock()
-    mock_event.result.reason = speechsdk.ResultReason.Canceled
-    mock_event.result.cancellation_details.reason = speechsdk.CancellationReason.EndOfStream
-    mock_event.result.cancellation_details.error_details = "Mock error details"
+@pytest.mark.skipif(not if_speechsdk_installed(), reason="Azure Speech SDK is not installed.")
+class TestAzureSpeechAudioToTextConverter:
+    import azure.cognitiveservices.speech as speechsdk
 
-    MockSpeechRecognizer.return_value = MagicMock()
-
-    mock_logger.return_value = MagicMock()
-
-    # Call the stop_cb function with the mock event
-    converter = AzureSpeechAudioToTextConverter()
-    converter.stop_cb(evt=mock_event, recognizer=MockSpeechRecognizer)
-
-    # Check if the callback function worked as expected
-    MockSpeechRecognizer.stop_continuous_recognition_async.assert_called_once()
-    mock_logger.info.assert_any_call("CLOSING on {}".format(mock_event))
-    mock_logger.info.assert_any_call("Speech recognition canceled: {}".format(speechsdk.CancellationReason.EndOfStream))
-    mock_logger.info.assert_called_with("End of audio stream detected.")
+    @patch("pyrit.common.default_values.get_required_value", side_effect=lambda env_var_name, passed_value: passed_value)
+    def test_azure_speech_audio_text_converter_initialization(mock_get_required_value):
+        converter = AzureSpeechAudioToTextConverter(
+            azure_speech_region="dummy_region", azure_speech_key="dummy_key", recognition_language="es-ES"
+        )
+        assert converter._azure_speech_region == "dummy_region"
+        assert converter._azure_speech_key == "dummy_key"
+        assert converter._recognition_language == "es-ES"
 
 
-@patch("azure.cognitiveservices.speech.SpeechRecognizer")
-@patch("pyrit.prompt_converter.azure_speech_audio_to_text_converter.logger")
-def test_transcript_cb(mock_logger, MockSpeechRecognizer):
-    # Create a mock event
-    mock_event = MagicMock()
-    mock_event.result.reason = speechsdk.ResultReason.RecognizedSpeech
-    mock_event.result.text = "Mock transcribed text"
+    @patch("azure.cognitiveservices.speech.SpeechRecognizer")
+    @patch("pyrit.prompt_converter.azure_speech_audio_to_text_converter.logger")
+    def test_stop_cb(mock_logger, MockSpeechRecognizer):
+        # Create a mock event
+        mock_event = MagicMock()
+        mock_event.result.reason = speechsdk.ResultReason.Canceled
+        mock_event.result.cancellation_details.reason = speechsdk.CancellationReason.EndOfStream
+        mock_event.result.cancellation_details.error_details = "Mock error details"
 
-    MockSpeechRecognizer.return_value = MagicMock()
+        MockSpeechRecognizer.return_value = MagicMock()
 
-    mock_logger.return_value = MagicMock()
+        mock_logger.return_value = MagicMock()
 
-    # Call the transcript_cb function with the mock event
-    converter = AzureSpeechAudioToTextConverter()
-    transcript = ["sample", "transcript"]
-    converter.transcript_cb(evt=mock_event, transcript=transcript)
+        # Call the stop_cb function with the mock event
+        converter = AzureSpeechAudioToTextConverter()
+        converter.stop_cb(evt=mock_event, recognizer=MockSpeechRecognizer)
 
-    # Check if the callback function worked as expected
-    mock_logger.info.assert_called_once_with("RECOGNIZED: {}".format(mock_event.result.text))
-    assert mock_event.result.text in transcript
-
-
-def test_azure_speech_audio_text_converter_input_supported():
-    converter = AzureSpeechAudioToTextConverter()
-    assert converter.input_supported("image_path") is False
-    assert converter.input_supported("audio_path") is True
+        # Check if the callback function worked as expected
+        MockSpeechRecognizer.stop_continuous_recognition_async.assert_called_once()
+        mock_logger.info.assert_any_call("CLOSING on {}".format(mock_event))
+        mock_logger.info.assert_any_call("Speech recognition canceled: {}".format(speechsdk.CancellationReason.EndOfStream))
+        mock_logger.info.assert_called_with("End of audio stream detected.")
 
 
-@pytest.mark.asyncio
-async def test_azure_speech_audio_text_converter_nonexistent_path():
-    converter = AzureSpeechAudioToTextConverter()
-    prompt = "nonexistent_path2.wav"
-    with pytest.raises(FileNotFoundError):
-        assert await converter.convert_async(prompt=prompt, input_type="audio_path")
+    @patch("azure.cognitiveservices.speech.SpeechRecognizer")
+    @patch("pyrit.prompt_converter.azure_speech_audio_to_text_converter.logger")
+    def test_transcript_cb(mock_logger, MockSpeechRecognizer):
+        # Create a mock event
+        mock_event = MagicMock()
+        mock_event.result.reason = speechsdk.ResultReason.RecognizedSpeech
+        mock_event.result.text = "Mock transcribed text"
+
+        MockSpeechRecognizer.return_value = MagicMock()
+
+        mock_logger.return_value = MagicMock()
+
+        # Call the transcript_cb function with the mock event
+        converter = AzureSpeechAudioToTextConverter()
+        transcript = ["sample", "transcript"]
+        converter.transcript_cb(evt=mock_event, transcript=transcript)
+
+        # Check if the callback function worked as expected
+        mock_logger.info.assert_called_once_with("RECOGNIZED: {}".format(mock_event.result.text))
+        assert mock_event.result.text in transcript
 
 
-@pytest.mark.asyncio
-@patch("os.path.exists", return_value=True)
-async def test_azure_speech_audio_text_converter_non_wav_file(mock_path_exists):
-    converter = AzureSpeechAudioToTextConverter()
-    prompt = "dummy_audio.mp3"
-    with pytest.raises(ValueError):
-        assert await converter.convert_async(prompt=prompt, input_type="audio_path")
+    def test_azure_speech_audio_text_converter_input_supported():
+        converter = AzureSpeechAudioToTextConverter()
+        assert converter.input_supported("image_path") is False
+        assert converter.input_supported("audio_path") is True
+
+
+    @pytest.mark.asyncio
+    async def test_azure_speech_audio_text_converter_nonexistent_path():
+        converter = AzureSpeechAudioToTextConverter()
+        prompt = "nonexistent_path2.wav"
+        with pytest.raises(FileNotFoundError):
+            assert await converter.convert_async(prompt=prompt, input_type="audio_path")
+
+
+    @pytest.mark.asyncio
+    @patch("os.path.exists", return_value=True)
+    async def test_azure_speech_audio_text_converter_non_wav_file(mock_path_exists):
+        converter = AzureSpeechAudioToTextConverter()
+        prompt = "dummy_audio.mp3"
+        with pytest.raises(ValueError):
+            assert await converter.convert_async(prompt=prompt, input_type="audio_path")

--- a/tests/unit/converter/test_azure_speech_text_converter.py
+++ b/tests/unit/converter/test_azure_speech_text_converter.py
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-import importlib.util
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,11 +8,15 @@ import pytest
 from pyrit.prompt_converter import AzureSpeechAudioToTextConverter
 
 
-def if_speechsdk_installed():
-    return importlib.util.find_spec("azure-cognitiveservices-speech") is not None
+def is_speechsdk_installed():
+    try:
+        import azure.cognitiveservices.speech  # noqa: F401
+        return True
+    except ModuleNotFoundError:
+        return False
 
 
-@pytest.mark.skipif(not if_speechsdk_installed(), reason="Azure Speech SDK is not installed.")
+@pytest.mark.skipif(not is_speechsdk_installed(), reason="Azure Speech SDK is not installed.")
 class TestAzureSpeechAudioToTextConverter:
 
     @patch("pyrit.common.default_values.get_required_value", side_effect=lambda env_var_name, passed_value: passed_value)

--- a/tests/unit/converter/test_azure_speech_text_converter.py
+++ b/tests/unit/converter/test_azure_speech_text_converter.py
@@ -15,10 +15,9 @@ def if_speechsdk_installed():
 
 @pytest.mark.skipif(not if_speechsdk_installed(), reason="Azure Speech SDK is not installed.")
 class TestAzureSpeechAudioToTextConverter:
-    import azure.cognitiveservices.speech as speechsdk
 
     @patch("pyrit.common.default_values.get_required_value", side_effect=lambda env_var_name, passed_value: passed_value)
-    def test_azure_speech_audio_text_converter_initialization(mock_get_required_value):
+    def test_azure_speech_audio_text_converter_initialization(self, mock_get_required_value):
         converter = AzureSpeechAudioToTextConverter(
             azure_speech_region="dummy_region", azure_speech_key="dummy_key", recognition_language="es-ES"
         )
@@ -29,7 +28,9 @@ class TestAzureSpeechAudioToTextConverter:
 
     @patch("azure.cognitiveservices.speech.SpeechRecognizer")
     @patch("pyrit.prompt_converter.azure_speech_audio_to_text_converter.logger")
-    def test_stop_cb(mock_logger, MockSpeechRecognizer):
+    def test_stop_cb(self, mock_logger, MockSpeechRecognizer):
+        import azure.cognitiveservices.speech as speechsdk
+
         # Create a mock event
         mock_event = MagicMock()
         mock_event.result.reason = speechsdk.ResultReason.Canceled
@@ -53,7 +54,9 @@ class TestAzureSpeechAudioToTextConverter:
 
     @patch("azure.cognitiveservices.speech.SpeechRecognizer")
     @patch("pyrit.prompt_converter.azure_speech_audio_to_text_converter.logger")
-    def test_transcript_cb(mock_logger, MockSpeechRecognizer):
+    def test_transcript_cb(self, mock_logger, MockSpeechRecognizer):
+        import azure.cognitiveservices.speech as speechsdk
+
         # Create a mock event
         mock_event = MagicMock()
         mock_event.result.reason = speechsdk.ResultReason.RecognizedSpeech
@@ -73,14 +76,14 @@ class TestAzureSpeechAudioToTextConverter:
         assert mock_event.result.text in transcript
 
 
-    def test_azure_speech_audio_text_converter_input_supported():
+    def test_azure_speech_audio_text_converter_input_supported(self):
         converter = AzureSpeechAudioToTextConverter()
         assert converter.input_supported("image_path") is False
         assert converter.input_supported("audio_path") is True
 
 
     @pytest.mark.asyncio
-    async def test_azure_speech_audio_text_converter_nonexistent_path():
+    async def test_azure_speech_audio_text_converter_nonexistent_path(self):
         converter = AzureSpeechAudioToTextConverter()
         prompt = "nonexistent_path2.wav"
         with pytest.raises(FileNotFoundError):
@@ -89,7 +92,7 @@ class TestAzureSpeechAudioToTextConverter:
 
     @pytest.mark.asyncio
     @patch("os.path.exists", return_value=True)
-    async def test_azure_speech_audio_text_converter_non_wav_file(mock_path_exists):
+    async def test_azure_speech_audio_text_converter_non_wav_file(self, mock_path_exists):
         converter = AzureSpeechAudioToTextConverter()
         prompt = "dummy_audio.mp3"
         with pytest.raises(ValueError):

--- a/tests/unit/converter/test_azure_speech_text_converter.py
+++ b/tests/unit/converter/test_azure_speech_text_converter.py
@@ -11,6 +11,7 @@ from pyrit.prompt_converter import AzureSpeechAudioToTextConverter
 def is_speechsdk_installed():
     try:
         import azure.cognitiveservices.speech  # noqa: F401
+
         return True
     except ModuleNotFoundError:
         return False
@@ -19,7 +20,9 @@ def is_speechsdk_installed():
 @pytest.mark.skipif(not is_speechsdk_installed(), reason="Azure Speech SDK is not installed.")
 class TestAzureSpeechAudioToTextConverter:
 
-    @patch("pyrit.common.default_values.get_required_value", side_effect=lambda env_var_name, passed_value: passed_value)
+    @patch(
+        "pyrit.common.default_values.get_required_value", side_effect=lambda env_var_name, passed_value: passed_value
+    )
     def test_azure_speech_audio_text_converter_initialization(self, mock_get_required_value):
         converter = AzureSpeechAudioToTextConverter(
             azure_speech_region="dummy_region", azure_speech_key="dummy_key", recognition_language="es-ES"
@@ -27,7 +30,6 @@ class TestAzureSpeechAudioToTextConverter:
         assert converter._azure_speech_region == "dummy_region"
         assert converter._azure_speech_key == "dummy_key"
         assert converter._recognition_language == "es-ES"
-
 
     @patch("azure.cognitiveservices.speech.SpeechRecognizer")
     @patch("pyrit.prompt_converter.azure_speech_audio_to_text_converter.logger")
@@ -51,9 +53,10 @@ class TestAzureSpeechAudioToTextConverter:
         # Check if the callback function worked as expected
         MockSpeechRecognizer.stop_continuous_recognition_async.assert_called_once()
         mock_logger.info.assert_any_call("CLOSING on {}".format(mock_event))
-        mock_logger.info.assert_any_call("Speech recognition canceled: {}".format(speechsdk.CancellationReason.EndOfStream))
+        mock_logger.info.assert_any_call(
+            "Speech recognition canceled: {}".format(speechsdk.CancellationReason.EndOfStream)
+        )
         mock_logger.info.assert_called_with("End of audio stream detected.")
-
 
     @patch("azure.cognitiveservices.speech.SpeechRecognizer")
     @patch("pyrit.prompt_converter.azure_speech_audio_to_text_converter.logger")
@@ -78,12 +81,10 @@ class TestAzureSpeechAudioToTextConverter:
         mock_logger.info.assert_called_once_with("RECOGNIZED: {}".format(mock_event.result.text))
         assert mock_event.result.text in transcript
 
-
     def test_azure_speech_audio_text_converter_input_supported(self):
         converter = AzureSpeechAudioToTextConverter()
         assert converter.input_supported("image_path") is False
         assert converter.input_supported("audio_path") is True
-
 
     @pytest.mark.asyncio
     async def test_azure_speech_audio_text_converter_nonexistent_path(self):
@@ -91,7 +92,6 @@ class TestAzureSpeechAudioToTextConverter:
         prompt = "nonexistent_path2.wav"
         with pytest.raises(FileNotFoundError):
             assert await converter.convert_async(prompt=prompt, input_type="audio_path")
-
 
     @pytest.mark.asyncio
     @patch("os.path.exists", return_value=True)

--- a/tests/unit/converter/test_prompt_converter.py
+++ b/tests/unit/converter/test_prompt_converter.py
@@ -463,9 +463,12 @@ def setup_memory():
     CentralMemory.set_memory_instance(None)
 
 
-def if_speechsdk_installed():
-    import importlib.util
-    return importlib.util.find_spec("azure-cognitiveservices-speech") is not None
+def is_speechsdk_installed():
+    try:
+        import azure.cognitiveservices.speech  # noqa: F401
+        return True
+    except ModuleNotFoundError:
+        return False
 
 
 @pytest.mark.parametrize(
@@ -482,13 +485,13 @@ def if_speechsdk_installed():
             AzureSpeechAudioToTextConverter(azure_speech_region="region", azure_speech_key="key"),
             ["audio_path"],
             ["text"],
-            marks=pytest.mark.skipif(not if_speechsdk_installed(), reason="Azure Speech SDK is not installed.")
+            marks=pytest.mark.skipif(not is_speechsdk_installed(), reason="Azure Speech SDK is not installed.")
         ),
         pytest.param(
             AzureSpeechTextToAudioConverter(azure_speech_region="region", azure_speech_key="key"),
             ["text"],
             ["audio_path"],
-            marks=pytest.mark.skipif(not if_speechsdk_installed(), reason="Azure Speech SDK is not installed.")
+            marks=pytest.mark.skipif(not is_speechsdk_installed(), reason="Azure Speech SDK is not installed.")
         ),
         (Base64Converter(), ["text"], ["text"]),
         (BinaryConverter(), ["text"], ["text"]),

--- a/tests/unit/converter/test_prompt_converter.py
+++ b/tests/unit/converter/test_prompt_converter.py
@@ -463,6 +463,11 @@ def setup_memory():
     CentralMemory.set_memory_instance(None)
 
 
+def if_speechsdk_installed():
+    import importlib.util
+    return importlib.util.find_spec("azure-cognitiveservices-speech") is not None
+
+
 @pytest.mark.parametrize(
     "converter, expected_input_types, expected_output_types",
     [
@@ -473,15 +478,17 @@ def setup_memory():
         (AsciiSmugglerConverter(), ["text"], ["text"]),
         (AtbashConverter(), ["text"], ["text"]),
         (AudioFrequencyConverter(), ["audio_path"], ["audio_path"]),
-        (
+        pytest.param(
             AzureSpeechAudioToTextConverter(azure_speech_region="region", azure_speech_key="key"),
             ["audio_path"],
             ["text"],
+            marks=pytest.mark.skipif(not if_speechsdk_installed(), reason="Azure Speech SDK is not installed.")
         ),
-        (
+        pytest.param(
             AzureSpeechTextToAudioConverter(azure_speech_region="region", azure_speech_key="key"),
             ["text"],
             ["audio_path"],
+            marks=pytest.mark.skipif(not if_speechsdk_installed(), reason="Azure Speech SDK is not installed.")
         ),
         (Base64Converter(), ["text"], ["text"]),
         (BinaryConverter(), ["text"], ["text"]),

--- a/tests/unit/converter/test_prompt_converter.py
+++ b/tests/unit/converter/test_prompt_converter.py
@@ -466,6 +466,7 @@ def setup_memory():
 def is_speechsdk_installed():
     try:
         import azure.cognitiveservices.speech  # noqa: F401
+
         return True
     except ModuleNotFoundError:
         return False
@@ -485,13 +486,13 @@ def is_speechsdk_installed():
             AzureSpeechAudioToTextConverter(azure_speech_region="region", azure_speech_key="key"),
             ["audio_path"],
             ["text"],
-            marks=pytest.mark.skipif(not is_speechsdk_installed(), reason="Azure Speech SDK is not installed.")
+            marks=pytest.mark.skipif(not is_speechsdk_installed(), reason="Azure Speech SDK is not installed."),
         ),
         pytest.param(
             AzureSpeechTextToAudioConverter(azure_speech_region="region", azure_speech_key="key"),
             ["text"],
             ["audio_path"],
-            marks=pytest.mark.skipif(not is_speechsdk_installed(), reason="Azure Speech SDK is not installed.")
+            marks=pytest.mark.skipif(not is_speechsdk_installed(), reason="Azure Speech SDK is not installed."),
         ),
         (Base64Converter(), ["text"], ["text"]),
         (BinaryConverter(), ["text"], ["text"]),


### PR DESCRIPTION
<!--- Please add one of the following as a prefix to the pull request title: -->
<!--- DOC for documentation changes -->
<!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
<!--- FIX for bug fixes -->
<!--- TEST for adding tests -->
<!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
<!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->

<!--- Note on BREAKING changes: If your PR includes a change that will require users to make a corresponding
change (e.g. naming changes), please list [BREAKING] in front of the above prefix in the PR title.
For example, [BREAKING] FEAT or [BREAKING] MAINT -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

<!--- If you are considering making a contribution please open an issue first. -->
<!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
<!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->

<!--- If your change is BREAKING please include reasoning for why below. -->
Removes Azure Speech SDK module as required dependency and move into the optionals as per request.

## Tests and Documentation

<!--- Contributions require tests and documentation (if applicable). -->
<!--- Include a description of tests and documentation updated (if applicable) -->

<!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
<!--- Include how you/if ran JupyText here -->
<!--- This is described at: https://github.com/Azure/PyRIT/tree/main/doc  -->
Add `skipif` conditions if module is unavailable. Verify that tests run/pass as expected when module is installed.