### PR TITLE
FIX pip upgrade issue on windows

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -50,7 +50,7 @@ jobs:
             pre-commit-${{ runner.os }}-
 
       - name: Upgrade pip and setuptools
-        run: pip install --upgrade pip setuptools packaging
+        run: python -m pip install --upgrade pip setuptools packaging
 
       - name: Install dev extras
         run: pip install --cache-dir "$PIP_CACHE_DIR" .[dev,all]
@@ -106,7 +106,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Install setuptools and pip
-        run: pip install --upgrade setuptools pip packaging
+        run: python -m pip install --upgrade pip setuptools packaging
 
       # Install PyRIT with optional extras
       - name: Install PyRIT with pip


### PR DESCRIPTION
## Description
On Windows runners the pip.exe wrapper is running and it looks like starting with recent pip releases, pip refuses to overwrite its own exec while that executable is in use. It doesn't happen on Ubuntu, I did a test run.
When pip tries to do `pip install --upgrade  pip ..` it errors out because it detects it's overwriting the exec.
 
The easiest solution is to change the workflow to load the module instead. `python -m pip install --upgrade ...` as it is in the error message.


## Tests and Documentation
this PR build