### PR TITLE
FIX: bug where scorer_type is not set in AzureContentFilterScorer 

### DIFF
--- a/pyrit/score/azure_content_filter_scorer.py
+++ b/pyrit/score/azure_content_filter_scorer.py
@@ -63,6 +63,8 @@ class AzureContentFilterScorer(Scorer):
                 azure.ai.contentsafety.models.TextCategory.
         """
 
+        self.scorer_type = "float_scale"
+
         if harm_categories:
             self._score_categories = [category.value for category in harm_categories]
         else:


### PR DESCRIPTION
Previously, this caused an issue when using AzureContentFilterScorer with FloatScaleThreshholdScorer
