### PR TITLE
FIX: escape prompt in HTTPTarget

### DIFF
--- a/pyrit/prompt_target/http_target/http_target.py
+++ b/pyrit/prompt_target/http_target/http_target.py
@@ -65,7 +65,11 @@ class HTTPTarget(PromptTarget):
         # Add Prompt into URL (if the URL takes it)
         re_pattern = re.compile(self.prompt_regex_string)
         if re.search(self.prompt_regex_string, self.http_request):
-            http_request_w_prompt = re_pattern.sub(request.converted_value, self.http_request)
+            escaped_prompt = json.dumps(request.converted_value)[1:-1]
+            try:
+                http_request_w_prompt = re_pattern.sub(escaped_prompt, self.http_request)
+            except re.error:
+                http_request_w_prompt = self.http_request.replace(self.prompt_regex_string, escaped_prompt)
         else:
             http_request_w_prompt = self.http_request
 


### PR DESCRIPTION
## Description
Fixes a bug in `HTTPTarget` where prompts containing special characters such as escaped quotes (`\"`), newlines (`\n`), or triple quotes (`"""`) would cause the target API to return a 400 Bad Request error.

This was due to unsafe injection of raw prompt text into the HTTP request body, breaking JSON formatting or request structure.

## Changes
- Escapes the prompt using `json.dumps(prompt)[1:-1]` before injecting it into the HTTP request.  
  This ensures special characters are correctly encoded and do not break the JSON structure.
- Adjusts the replacement logic of the `{PROMPT}` placeholder:
  Instead of using `re.sub`, which may interpret sequences like `\uXXXX` and raise `re.error`, the replacement is now done via `.replace()` to treat the prompt as a raw string.

## Related Issue
#908