### PR TITLE
FIX: Added Azure Speech dependencies to the Dev Container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -39,6 +39,14 @@ RUN apt-get update && apt-get install -y \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
+# audio back-ends needed by Azure Speech SDK
+RUN apt-get update \ 
+ && DEBIAN_FRONTEND=noninteractive \
+ apt-get install -y --no-install-recommends \
+      libasound2 \
+      libpulse0 \
+ && rm -rf /var/lib/apt/lists/*
+
 # Create conda env and install pyodbc into it
 RUN conda create -n pyrit-dev python=3.11 -y && \
     conda install -n pyrit-dev -c conda-forge pyodbc -y && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update && apt-get install -y \
  && rm -rf /var/lib/apt/lists/*
 
 # audio back-ends needed by Azure Speech SDK
-RUN apt-get update \ 
+RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive \
  apt-get install -y --no-install-recommends \
       libasound2 \

--- a/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
+++ b/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
@@ -86,6 +86,8 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
                 subscription=self._azure_speech_key,
                 region=self._azure_speech_region,
             )
+            pull_stream = speechsdk.audio.PullAudioOutputStream()
+            audio_cfg = speechsdk.audio.AudioOutputConfig(stream=pull_stream)
             speech_config.speech_synthesis_language = self._synthesis_language
             speech_config.speech_synthesis_voice_name = self._synthesis_voice_name
 
@@ -94,7 +96,7 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
                     speechsdk.SpeechSynthesisOutputFormat.Audio16Khz32KBitRateMonoMp3
                 )
 
-            speech_synthesizer = speechsdk.SpeechSynthesizer(speech_config=speech_config)
+            speech_synthesizer = speechsdk.SpeechSynthesizer(speech_config=speech_config, audio_config=audio_cfg)
 
             result = speech_synthesizer.speak_text_async(prompt).get()
             if result.reason == speechsdk.ResultReason.SynthesizingAudioCompleted:


### PR DESCRIPTION
## Description
- Added dependencies for Azure Speech to Dev Container image
- Changed the converter code to use buffered memory to do the conversion instead of the speaker stream (Speaker is not available inside the dev container, therefore, the notebook fails to do the conversion)


## Tests and Documentation
Ran the audio converter notebook and listen to the generated audio, works perfectly
