### PR TITLE
FIX: Retry bug with single turn retry

### DIFF
--- a/pyrit/orchestrator/single_turn/prompt_sending_orchestrator.py
+++ b/pyrit/orchestrator/single_turn/prompt_sending_orchestrator.py
@@ -231,7 +231,7 @@ class PromptSendingOrchestrator(Orchestrator):
 
             status, objective_score = await self._score_objective_async(result, objective)
 
-            if status == "success":
+            if status == "success" or status == "unknown":
                 break
 
         return OrchestratorResult(

--- a/tests/unit/orchestrator/test_prompt_sending_orchestrator.py
+++ b/tests/unit/orchestrator/test_prompt_sending_orchestrator.py
@@ -422,6 +422,33 @@ async def test_run_attack_with_retries(mock_target: MockPromptTarget):
 
 
 @pytest.mark.asyncio
+async def test_run_attack_with_default_retries(mock_target: MockPromptTarget):
+
+    orchestrator = PromptSendingOrchestrator(objective_target=mock_target)
+
+    # Mock the normalizer to return a simple response
+    conversation_id = str(uuid.uuid4())
+    orchestrator_id = orchestrator.get_identifier()
+    response = PromptRequestResponse(
+        request_pieces=[
+            PromptRequestPiece(
+                role="assistant",
+                original_value="test response",
+                conversation_id=conversation_id,
+                orchestrator_identifier=orchestrator_id,
+            )
+        ]
+    )
+
+    with patch.object(
+        orchestrator._prompt_normalizer, "send_prompt_async", new_callable=AsyncMock, return_value=response
+    ) as mock_send_prompt:
+        result = await orchestrator.run_attack_async(objective="test prompt")
+        assert result.status == "unknown"
+        assert mock_send_prompt.call_count == 1
+
+
+@pytest.mark.asyncio
 async def test_run_attack_with_skip_criteria(mock_target: MockPromptTarget):
     orchestrator = PromptSendingOrchestrator(objective_target=mock_target)
 


### PR DESCRIPTION
This fixes the following bug: if PromptSendingOrchestrator was initialized with no objective scorer and max retry of 10, the loop would keep on going for all 10 attempts. 