### PR TITLE
FIX: Change realtime target api_version

### DIFF
--- a/pyrit/prompt_target/openai/openai_realtime_target.py
+++ b/pyrit/prompt_target/openai/openai_realtime_target.py
@@ -51,7 +51,7 @@ class RealtimeTarget(OpenAITarget):
     def __init__(
         self,
         *,
-        api_version: str = "2024-12-17",
+        api_version: str = "2025-04-01-preview",
         system_prompt: Optional[str] = None,
         voice: Optional[RealTimeVoice] = None,
         existing_convo: Optional[dict] = None,


### PR DESCRIPTION
This PR changes the default realtime target api_version to 2025-04-01-preview. Using 2024-10-21 led to connection issues that failed two integration tests. Integration tests should pass now. 