### PR TITLE
MAINT Removed achieved_objective field from context

### DIFF
--- a/pyrit/attacks/base/attack_context.py
+++ b/pyrit/attacks/base/attack_context.py
@@ -23,9 +23,6 @@ class AttackContext:
     # Natural-language description of what the attack tries to achieve
     objective: str
 
-    # Indicates whether the objective has already been fulfilled
-    achieved_objective: bool = False
-
     # Conversation that is automatically prepended to the target model
     prepended_conversation: List[PromptRequestResponse] = field(default_factory=list)
 

--- a/pyrit/attacks/single_turn/prompt_sending.py
+++ b/pyrit/attacks/single_turn/prompt_sending.py
@@ -115,9 +115,6 @@ class PromptSendingAttack(AttackStrategy[SingleTurnAttackContext, AttackResult])
         # Ensure the context has a conversation ID
         context.conversation_id = str(uuid.uuid4())
 
-        # Initialize achieved_objective to False
-        context.achieved_objective = False
-
         # Combine memory labels from context and attack strategy
         context.memory_labels = combine_dict(self._memory_labels, context.memory_labels)
 

--- a/tests/unit/attacks/test_prompt_sending.py
+++ b/tests/unit/attacks/test_prompt_sending.py
@@ -194,19 +194,6 @@ class TestSetupPhase:
     """Tests for the setup phase of the attack"""
 
     @pytest.mark.asyncio
-    async def test_setup_initializes_achieved_objective_to_false(self, mock_target, basic_context):
-        attack = PromptSendingAttack(objective_target=mock_target)
-        attack._conversation_manager = MagicMock()
-        attack._conversation_manager.update_conversation_state_async = AsyncMock()
-
-        # Set to True to verify it gets reset
-        basic_context.achieved_objective = True
-
-        await attack._setup_async(context=basic_context)
-
-        assert basic_context.achieved_objective is False
-
-    @pytest.mark.asyncio
     async def test_setup_merges_memory_labels_correctly(self, mock_target, basic_context):
         attack = PromptSendingAttack(objective_target=mock_target)
 

--- a/tests/unit/attacks/test_red_teaming.py
+++ b/tests/unit/attacks/test_red_teaming.py
@@ -334,24 +334,15 @@ class TestContextValidation:
 class TestSetupPhase:
     """Tests for the setup phase of the attack."""
 
-    @pytest.mark.parametrize(
-        "initial_value,expected_value",
-        [
-            (True, False),  # Test it gets reset
-            (False, False),  # Test it stays false
-        ],
-    )
     @pytest.mark.asyncio
-    async def test_setup_initializes_achieved_objective(
+    async def test_setup_initializes_conversation_session(
         self,
         mock_objective_target: MagicMock,
         mock_objective_scorer: MagicMock,
         mock_adversarial_chat: MagicMock,
         basic_context: MultiTurnAttackContext,
-        initial_value: bool,
-        expected_value: bool,
     ):
-        """Test that setup correctly initializes the achieved_objective flag."""
+        """Test that setup correctly initializes a conversation session."""
         adversarial_config = AttackAdversarialConfig(target=mock_adversarial_chat)
         scoring_config = AttackScoringConfig(objective_scorer=mock_objective_scorer)
 
@@ -361,14 +352,13 @@ class TestSetupPhase:
             attack_scoring_config=scoring_config,
         )
 
-        basic_context.achieved_objective = initial_value
-
         # Mock conversation manager
         mock_state = ConversationState(turn_count=0)
         with patch.object(attack._conversation_manager, "update_conversation_state_async", return_value=mock_state):
             await attack._setup_async(context=basic_context)
 
-        assert basic_context.achieved_objective == expected_value
+        assert basic_context.session is not None
+        assert isinstance(basic_context.session, ConversationSession)
 
     @pytest.mark.asyncio
     async def test_setup_updates_turn_count_from_prepended_conversation(


### PR DESCRIPTION
## Description
I have been thinking about it, and I do feel like `achieved_objective` doesn't really belong in `AttackContext`. This will be reflected in the outcome of the attack anyway. Removing it to keep the context concise and to the point


## Tests and Documentation
- Unit tests