### PR TITLE
[DRAFT] FEAT: add TextBugger attack as prompt converter

### DIFF
--- a/pyrit/prompt_converter/__init__.py
+++ b/pyrit/prompt_converter/__init__.py
@@ -55,6 +55,7 @@ from pyrit.prompt_converter.suffix_append_converter import SuffixAppendConverter
 from pyrit.prompt_converter.superscript_converter import SuperscriptConverter
 from pyrit.prompt_converter.tense_converter import TenseConverter
 from pyrit.prompt_converter.text_to_hex_converter import TextToHexConverter
+from pyrit.prompt_converter.text_bugger_converter import TextBuggerConverter
 from pyrit.prompt_converter.tone_converter import ToneConverter
 from pyrit.prompt_converter.translation_converter import TranslationConverter
 from pyrit.prompt_converter.unicode_confusable_converter import UnicodeConfusableConverter
@@ -121,6 +122,7 @@ __all__ = [
     "StringJoinConverter",
     "SuffixAppendConverter",
     "SuperscriptConverter",
+    "TextBuggerConverter",
     "TextToHexConverter",
     "TenseConverter",
     "ToneConverter",

--- a/pyrit/prompt_converter/text_bugger_converter.py
+++ b/pyrit/prompt_converter/text_bugger_converter.py
@@ -37,7 +37,7 @@ class TextBuggerConverter(PromptConverter):
         - 4. SUB-C: Replaces characters with visually similar characters (homoglyphs).
         - 5. SUB-W: Replaces words with semantically similar words using GloVe embeddings.
 
-    Inspired by TextBugger from Project Moonshot:
+    Inspired by TextBugger attack implementation from Project Moonshot:
     https://github.com/aiverify-foundation/moonshot-data/blob/main/attack-modules/textbugger_attack.py
 
     Original paper: https://arxiv.org/abs/1812.05271

--- a/pyrit/prompt_converter/text_bugger_converter.py
+++ b/pyrit/prompt_converter/text_bugger_converter.py
@@ -56,10 +56,12 @@ class TextBuggerConverter(PromptConverter):
 
     def __init__(
         self,
+        *,
         word_swap_ratio: float = 0.2,
         top_k: int = 5,
-        semantic_threshold: float = 0.8,
         max_transformations: int = 5,
+        use_universal_sentence_encoder: bool = False,
+        semantic_threshold: float = 0.8,
     ) -> None:
         """
         Initializes the converter with TextBugger parameters.
@@ -69,11 +71,12 @@ class TextBuggerConverter(PromptConverter):
                 Default is 0.2 (20% of words). Range: 0.0 to 1.0.
             top_k (int): Number of top semantic word candidates from GloVe embedding.
                 Default is 5. Higher values provide more word substitution options.
+            max_transformations (int): Maximum number of transformed versions to generate.
+                Default is 5. Higher values create more adversarial variations.
+            use_universal_sentence_encoder (bool): Whether to use Universal Sentence Encoder.
             semantic_threshold (float): Threshold for Universal Sentence Encoder similarity.
                 Default is 0.8. Higher values ensure transformed text stays more semantically similar.
                 Range: 0.0 to 1.0 (1.0 = identical meaning, 0.0 = completely different).
-            max_transformations (int): Maximum number of transformed versions to generate.
-                Default is 5. Higher values create more adversarial variations.
 
         Raises:
             ImportError: If TextAttack framework is not installed.
@@ -95,10 +98,15 @@ class TextBuggerConverter(PromptConverter):
 
         self._word_swap_ratio = word_swap_ratio
         self._top_k = top_k
-        self._semantic_threshold = semantic_threshold
         self._max_transformations = max_transformations
+        self._use_universal_sentence_encoder = use_universal_sentence_encoder
+        self._semantic_threshold = semantic_threshold
 
-        self._use_universal_sentence_encoder = False if find_spec("tensorflow_hub") is None else True
+        if self._use_universal_sentence_encoder:
+            if find_spec("tensorflow_hub") is None:
+                raise ImportError(
+                    "Universal Sentence Encoder requires tensorflow_hub. Install it with: pip install tensorflow-hub"
+                )
 
         # Augmenter instance that applies TextBugger transformations
         self._augmenter = self._create_augmenter()

--- a/pyrit/prompt_converter/text_bugger_converter.py
+++ b/pyrit/prompt_converter/text_bugger_converter.py
@@ -1,0 +1,166 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import logging
+import random
+
+from pyrit.models import PromptDataType
+from pyrit.prompt_converter import ConverterResult, PromptConverter
+
+# TODO: consider adding textattack as PyRIT dependency?
+try:
+    from textattack.augmentation import Augmenter
+    from textattack.transformations import (
+        CompositeTransformation,
+        WordSwapEmbedding,
+        WordSwapHomoglyphSwap,
+        WordSwapNeighboringCharacterSwap,
+        WordSwapRandomCharacterDeletion,
+        WordSwapRandomCharacterInsertion,
+    )
+
+    TEXTATTACK_AVAILABLE = True
+except ImportError:
+    TEXTATTACK_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+
+class TextBuggerConverter(PromptConverter):
+    """
+    Converts text using TextBugger adversarial attack techniques.
+
+    The TextBugger attack applies five types of transformations:
+        - 1. INSERT: Inserts a space into words to deceive classifiers.
+        - 2. DELETE: Deletes random characters (except first/last).
+        - 3. SWAP: Swaps adjacent characters (except first/last).
+        - 4. SUB-C: Replaces characters with visually similar characters (homoglyphs).
+        - 5. SUB-W: Replaces words with semantically similar words using GloVe embeddings.
+
+    Inspired by TextBugger from Project Moonshot:
+    https://github.com/aiverify-foundation/moonshot-data/blob/main/attack-modules/textbugger_attack.py
+
+    Original paper: https://arxiv.org/abs/1812.05271
+    """
+
+    def __init__(
+        self,
+        word_swap_ratio: float = 0.2,
+        top_k: int = 5,
+        semantic_threshold: float = 0.8,
+        max_transformations: int = 5,
+    ) -> None:
+        """
+        Initializes the converter with TextBugger parameters.
+
+        Args:
+            word_swap_ratio (float): Percentage of words in a prompt that should be changed.
+                Default is 0.2 (20% of words). Range: 0.0 to 1.0
+            top_k (int): Number of top semantic word candidates from GloVe embedding.
+                Default is 5. Higher values provide more word substitution options.
+            semantic_threshold (float): Threshold for Universal Sentence Encoder similarity.
+                Default is 0.8. Higher values ensure transformed text stays more semantically similar.
+                Range: 0.0 to 1.0 (1.0 = identical meaning, 0.0 = completely different)
+            max_transformations (int): Maximum number of transformed versions to generate.
+                Default is 5. Higher values create more adversarial variations.
+
+        Raises:
+            ImportError: If TextAttack framework is not installed.
+        """
+        if not TEXTATTACK_AVAILABLE:
+            raise ImportError(
+                "TextAttack framework is required for TextBuggerConverter. Install it with: pip install textattack"
+            )
+
+        # TODO: validate parameters
+        self._word_swap_ratio = word_swap_ratio
+        self._top_k = top_k
+        self._semantic_threshold = semantic_threshold
+        self._max_transformations = max_transformations
+
+        # Augmenter instance that applies TextBugger transformations
+        self._augmenter = self._create_augmenter()
+
+    def _create_augmenter(self) -> "Augmenter":
+        """
+        Creates and configures the TextAttack augmenter with TextBugger transformations.
+
+        Returns:
+            Augmenter: Configured TextAttack augmenter instance.
+        """
+        # The five TEXTBUGGER transformations as defined in the paper
+        transformation = CompositeTransformation(
+            [
+                # (1) Insert: Insert a space into the word
+                WordSwapRandomCharacterInsertion(
+                    random_one=True,
+                    letters_to_insert=" ",
+                    skip_first_char=True,
+                    skip_last_char=True,
+                ),
+                # (2) Delete: Delete a random character of the word
+                WordSwapRandomCharacterDeletion(
+                    random_one=True,
+                    skip_first_char=True,
+                    skip_last_char=True,
+                ),
+                # (3) Swap: Swap random two adjacent letters in the word
+                WordSwapNeighboringCharacterSwap(
+                    random_one=True,
+                    skip_first_char=True,
+                    skip_last_char=True,
+                ),
+                # (4) Substitute-C: Replace characters with visually similar characters
+                WordSwapHomoglyphSwap(),
+                # (5) Substitute-W: Replace a word with its topk nearest neighbors
+                WordSwapEmbedding(max_candidates=self._top_k),
+            ]
+        )
+
+        # TODO: add constraints
+
+        # Create the augmenter that orchestrates all transformations
+        return Augmenter(
+            transformation=transformation,
+            pct_words_to_swap=self._word_swap_ratio,
+            transformations_per_example=self._max_transformations,
+        )
+
+    async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
+        """
+        Converts the given prompt using TextBugger transformations.
+
+        Args:
+            prompt (str): The prompt to be converted.
+            input_type (PromptDataType): The type of input data.
+
+        Returns:
+            ConverterResult: The result containing the transformed text.
+
+        Raises:
+            ValueError: If the input type is not supported.
+        """
+        if not self.input_supported(input_type):
+            raise ValueError(f"Input type {input_type} not supported. Only 'text' is supported.")
+
+        try:
+            # Apply TextBugger transformations using TextAttack augmenter
+            # This will generate multiple variants of the input prompt
+            transformed_texts = self._augmenter.augment(prompt)
+
+            logger.debug(f"Generated {len(transformed_texts)} transformed texts for prompt: {prompt}")
+            logger.debug(f"Transformed texts: {transformed_texts}")
+
+            # TODO: should I return all transformed texts or just one?
+            selected_text = random.choice(transformed_texts)
+            return ConverterResult(output_text=selected_text, output_type="text")
+
+        except Exception:
+            # Return original prompt if transformation fails
+            return ConverterResult(output_text=prompt, output_type="text")
+
+    def input_supported(self, input_type: PromptDataType) -> bool:
+        return input_type == "text"
+
+    def output_supported(self, output_type: PromptDataType) -> bool:
+        return output_type == "text"

--- a/pyrit/prompt_converter/text_bugger_converter.py
+++ b/pyrit/prompt_converter/text_bugger_converter.py
@@ -55,24 +55,33 @@ class TextBuggerConverter(PromptConverter):
 
         Args:
             word_swap_ratio (float): Percentage of words in a prompt that should be changed.
-                Default is 0.2 (20% of words). Range: 0.0 to 1.0
+                Default is 0.2 (20% of words). Range: 0.0 to 1.0.
             top_k (int): Number of top semantic word candidates from GloVe embedding.
                 Default is 5. Higher values provide more word substitution options.
             semantic_threshold (float): Threshold for Universal Sentence Encoder similarity.
                 Default is 0.8. Higher values ensure transformed text stays more semantically similar.
-                Range: 0.0 to 1.0 (1.0 = identical meaning, 0.0 = completely different)
+                Range: 0.0 to 1.0 (1.0 = identical meaning, 0.0 = completely different).
             max_transformations (int): Maximum number of transformed versions to generate.
                 Default is 5. Higher values create more adversarial variations.
 
         Raises:
             ImportError: If TextAttack framework is not installed.
+            ValueError: If any parameter is out of valid range.
         """
         if not TEXTATTACK_AVAILABLE:
             raise ImportError(
                 "TextAttack framework is required for TextBuggerConverter. Install it with: pip install textattack"
             )
 
-        # TODO: validate parameters
+        if not (0.0 <= word_swap_ratio <= 1.0):
+            raise ValueError(f"word_swap_ratio must be between 0.0 and 1.0, got {word_swap_ratio}")
+        if not (0.0 <= semantic_threshold <= 1.0):
+            raise ValueError(f"semantic_threshold must be between 0.0 and 1.0, got {semantic_threshold}")
+        if top_k < 1:
+            raise ValueError(f"top_k must be at least 1, got {top_k}")
+        if max_transformations < 1:
+            raise ValueError(f"max_transformations must be at least 1, got {max_transformations}")
+
         self._word_swap_ratio = word_swap_ratio
         self._top_k = top_k
         self._semantic_threshold = semantic_threshold

--- a/pyrit/prompt_converter/text_bugger_converter.py
+++ b/pyrit/prompt_converter/text_bugger_converter.py
@@ -98,38 +98,38 @@ class TextBuggerConverter(PromptConverter):
             Augmenter: Configured TextAttack augmenter instance.
         """
         # The five TEXTBUGGER transformations as defined in the paper
-        transformation = CompositeTransformation(
+        transformation = CompositeTransformation( # type: ignore
             [
                 # (1) Insert: Insert a space into the word
-                WordSwapRandomCharacterInsertion(
+                WordSwapRandomCharacterInsertion( # type: ignore
                     random_one=True,
                     letters_to_insert=" ",
                     skip_first_char=True,
                     skip_last_char=True,
                 ),
                 # (2) Delete: Delete a random character of the word
-                WordSwapRandomCharacterDeletion(
+                WordSwapRandomCharacterDeletion( # type: ignore
                     random_one=True,
                     skip_first_char=True,
                     skip_last_char=True,
                 ),
                 # (3) Swap: Swap random two adjacent letters in the word
-                WordSwapNeighboringCharacterSwap(
+                WordSwapNeighboringCharacterSwap( # type: ignore
                     random_one=True,
                     skip_first_char=True,
                     skip_last_char=True,
                 ),
                 # (4) Substitute-C: Replace characters with visually similar characters
-                WordSwapHomoglyphSwap(),
+                WordSwapHomoglyphSwap(), # type: ignore
                 # (5) Substitute-W: Replace a word with its topk nearest neighbors
-                WordSwapEmbedding(max_candidates=self._top_k),
+                WordSwapEmbedding(max_candidates=self._top_k), # type: ignore
             ]
         )
 
         # TODO: add constraints
 
         # Create the augmenter that orchestrates all transformations
-        return Augmenter(
+        return Augmenter( # type: ignore
             transformation=transformation,
             pct_words_to_swap=self._word_swap_ratio,
             transformations_per_example=self._max_transformations,
@@ -161,7 +161,7 @@ class TextBuggerConverter(PromptConverter):
             logger.debug(f"Transformed texts: {transformed_texts}")
 
             # TODO: should I return all transformed texts or just one?
-            selected_text = random.choice(transformed_texts)
+            selected_text = str(random.choice(transformed_texts))
             return ConverterResult(output_text=selected_text, output_type="text")
 
         except Exception:

--- a/pyrit/prompt_converter/text_bugger_converter.py
+++ b/pyrit/prompt_converter/text_bugger_converter.py
@@ -4,6 +4,8 @@
 import logging
 import random
 
+from importlib.util import find_spec
+
 from pyrit.models import PromptDataType
 from pyrit.prompt_converter import ConverterResult, PromptConverter
 
@@ -96,6 +98,8 @@ class TextBuggerConverter(PromptConverter):
         self._semantic_threshold = semantic_threshold
         self._max_transformations = max_transformations
 
+        self._use_universal_sentence_encoder = False if find_spec("tensorflow_hub") is None else True
+
         # Augmenter instance that applies TextBugger transformations
         self._augmenter = self._create_augmenter()
 
@@ -139,10 +143,10 @@ class TextBuggerConverter(PromptConverter):
         constraints = [
             RepeatModification(),  # type: ignore
             StopwordModification(),  # type: ignore
-
-            # Universal Sentence Encoder model is used, tensorflow_hub is required
-            UniversalSentenceEncoder(threshold=self._semantic_threshold),  # type: ignore
         ]
+        if self._use_universal_sentence_encoder is True:
+            # Universal Sentence Encoder model is used, tensorflow_hub is required
+            constraints.append(UniversalSentenceEncoder(threshold=self._semantic_threshold))  # type: ignore
 
         # Create the augmenter that orchestrates all transformations
         return Augmenter(  # type: ignore


### PR DESCRIPTION
<!--- Please add one of the following as a prefix to the pull request title: -->
<!--- DOC for documentation changes -->
<!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
<!--- FIX for bug fixes -->
<!--- TEST for adding tests -->
<!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
<!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->

<!--- Note on BREAKING changes: If your PR includes a change that will require users to make a corresponding
change (e.g. naming changes), please list [BREAKING] in front of the above prefix in the PR title.
For example, [BREAKING] FEAT or [BREAKING] MAINT -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

<!--- If you are considering making a contribution please open an issue first. -->
<!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
<!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->

<!--- If your change is BREAKING please include reasoning for why below. -->

#951

This PR adds the [TextBugger attack from Project Moonshot](https://github.com/aiverify-foundation/moonshot-data/blob/main/attack-modules/textbugger_attack.py), adapted as a converter under `pyrit.prompt_converter`.

The TextBugger attack applies five types of transformations:
1. INSERT: Inserts a space into words to deceive classifiers.
2. DELETE: Deletes random characters (except first/last).
3. SWAP: Swaps adjacent characters (except first/last).
4. SUB-C: Replaces characters with visually similar characters (homoglyphs).
5. SUB-W: Replaces words with semantically similar words using GloVe embeddings.

Inspired by TextBugger attack implementation from Project Moonshot:
https://github.com/aiverify-foundation/moonshot-data/blob/main/attack-modules/textbugger_attack.py

Original paper: https://arxiv.org/abs/1812.05271

## Tests and Documentation

<!--- Contributions require tests and documentation (if applicable). -->
<!--- Include a description of tests and documentation updated (if applicable) -->

<!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
<!--- Include how you/if ran JupyText here -->
<!--- This is described at: https://github.com/Azure/PyRIT/tree/main/doc  -->

In the making ...
