### PR TITLE
FIX fixing pre-commit windows job to use cache

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,6 +2,9 @@
 
 name: build_and_test
 
+env:
+  PRE_COMMIT_PYTHON_VERSION: '3.11'
+
 on:
   push:
     branches:
@@ -30,14 +33,14 @@ jobs:
 
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.11
+          python-version: ${{ env.PRE_COMMIT_PYTHON_VERSION }}
       - name: Cache pip packages
         uses: actions/cache@v3
         with:
           path: ${{ env.PIP_CACHE_DIR }}
-          key: ${{ runner.os }}-pip-3.11-${{ hashFiles('pyproject.toml') }}
+          key: ${{ runner.os }}-pip-${{ env.PRE_COMMIT_PYTHON_VERSION }}-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
-            ${{ runner.os }}-pip-3.11-
+            ${{ runner.os }}-pip-${{ env.PRE_COMMIT_PYTHON_VERSION }}-
             ${{ runner.os }}-pip-
 
       - name: Cache pre-commit environments
@@ -77,15 +80,15 @@ jobs:
 
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.11
+          python-version: ${{ env.PRE_COMMIT_PYTHON_VERSION }}
 
       - name: Cache pip packages
         uses: actions/cache@v3
         with:
           path: ${{ env.PIP_CACHE_DIR }}
-          key: ${{ runner.os }}-pip-3.11-${{ hashFiles('pyproject.toml') }}
+          key: ${{ runner.os }}-pip-${{ env.PRE_COMMIT_PYTHON_VERSION }}-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
-            ${{ runner.os }}-pip-3.11-
+            ${{ runner.os }}-pip-${{ env.PRE_COMMIT_PYTHON_VERSION }}-
             ${{ runner.os }}-pip-
 
       - name: Cache pre-commit environments

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -19,14 +19,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Pre-commit job runs only once on Ubuntu
-  pre-commit:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-        python-version: ["3.11"]
-    runs-on: ${{ matrix.os }}
+  pre-commit-linux:
+    runs-on: ubuntu-latest
 
     env:
       PIP_CACHE_DIR: ${{ github.workspace }}/.cache/pip
@@ -36,15 +30,14 @@ jobs:
 
       - uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-version }}
-
+          python-version: 3.11
       - name: Cache pip packages
         uses: actions/cache@v3
         with:
           path: ${{ env.PIP_CACHE_DIR }}
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          key: ${{ runner.os }}-pip-3.11-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+            ${{ runner.os }}-pip-3.11-
             ${{ runner.os }}-pip-
 
       - name: Cache pre-commit environments
@@ -60,6 +53,55 @@ jobs:
 
       - name: Install dev extras
         run: pip install --cache-dir "$PIP_CACHE_DIR" .[dev,all]
+
+      - name: Run pre-commit incrementally (on PR)
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin main
+          pre-commit run --from-ref origin/main --to-ref HEAD
+
+      - name: Run pre-commit fully (on main)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          pre-commit run --all-files
+
+  pre-commit-windows:
+    runs-on: windows-latest
+    env:
+      PIP_CACHE_DIR: ${{ github.workspace }}\.cache\pip
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.11
+
+      - name: Cache pip packages
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.PIP_CACHE_DIR }}
+          key: ${{ runner.os }}-pip-3.11-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-3.11-
+            ${{ runner.os }}-pip-
+
+      - name: Cache pre-commit environments
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-${{ runner.os }}-
+
+      - name: Upgrade pip and setuptools
+        run: python -m pip install --upgrade pip setuptools packaging
+
+      - name: Install dev extras
+        run: |
+          pip install --cache-dir "$env:PIP_CACHE_DIR" '.[dev,all]'
 
       - name: Run pre-commit incrementally (on PR)
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Pre-commit job for windows currently is not using cache because it is using the default powershell and the env variable doesn't translate well. I am separating the precommit jobs to define that better. 
