### PR TITLE
DOC: Update copyright year to 2025 in documentation config

### DIFF
--- a/doc/_config.yml
+++ b/doc/_config.yml
@@ -3,7 +3,7 @@
 
 title: PyRIT Documentation
 author: Microsoft AI Red Team
-copyright: Copyright 2024, Microsoft AI Red Team
+copyright: 2025, Microsoft AI Red Team
 logo: roakey.png
 
 # Force re-execution of notebooks on each build.


### PR DESCRIPTION
This pull request includes a minor update to the doc/_config.yml file.

- **What changed**: Updated the copyright field from `Copyright 2024, Microsoft AI Red Team` to `2025, Microsoft AI Red Team`.
- **Why**: The field was rendering duplicate copyright statements on the webpage, so the field was removed entirely.

This change ensures the updated year copyright information is displayed correctly and avoids redundant rendering of word "Copyright" in the generated documentation.
<img width="369" alt="image" src="https://github.com/user-attachments/assets/a462676a-af94-4002-a125-39bbbc64deab" />

**Tests and Documentation**

- No code changes or documentation content updates beyond configuration.
- No additional tests are required for this change.
- Jupytext execution was not applicable.
