### PR TITLE
FIX: OpenAIChatTarget inheritance

### DIFF
--- a/pyrit/prompt_target/openai/openai_chat_target_base.py
+++ b/pyrit/prompt_target/openai/openai_chat_target_base.py
@@ -18,12 +18,16 @@ from pyrit.models import (
     PromptRequestPiece,
     PromptRequestResponse,
 )
-from pyrit.prompt_target import OpenAITarget, limit_requests_per_minute
+from pyrit.prompt_target import (
+    OpenAITarget,
+    PromptChatTarget,
+    limit_requests_per_minute,
+)
 
 logger = logging.getLogger(__name__)
 
 
-class OpenAIChatTargetBase(OpenAITarget):
+class OpenAIChatTargetBase(OpenAITarget, PromptChatTarget):
     """
     This is the base class for multimodal (image and text) input and text output generation.
 

--- a/tests/unit/target/test_openai_chat_target.py
+++ b/tests/unit/target/test_openai_chat_target.py
@@ -513,6 +513,23 @@ def test_is_json_response_supported(target: OpenAIChatTarget):
     assert target.is_json_response_supported() is True
 
 
+def test_inheritance_from_prompt_chat_target(target: OpenAIChatTarget):
+    """Test that OpenAIChatTarget properly inherits from PromptChatTarget."""
+    from pyrit.prompt_target.common.prompt_chat_target import PromptChatTarget
+
+    assert isinstance(target, PromptChatTarget), "OpenAIChatTarget must inherit from PromptChatTarget"
+
+
+def test_inheritance_from_prompt_chat_target_base():
+    """Test that OpenAIChatTargetBase properly inherits from PromptChatTarget."""
+    from pyrit.prompt_target.common.prompt_chat_target import PromptChatTarget
+    from pyrit.prompt_target.openai.openai_chat_target_base import OpenAIChatTargetBase
+
+    # Create a minimal instance to test inheritance
+    target = OpenAIChatTargetBase(model_name="test-model", endpoint="https://test.com", api_key="test-key")
+    assert isinstance(target, PromptChatTarget), "OpenAIChatTargetBase must inherit from PromptChatTarget"
+
+
 def test_is_response_format_json_supported(target: OpenAIChatTarget):
 
     request_piece = PromptRequestPiece(

--- a/tests/unit/target/test_openai_chat_target.py
+++ b/tests/unit/target/test_openai_chat_target.py
@@ -23,7 +23,7 @@ from pyrit.exceptions.exception_classes import (
 )
 from pyrit.memory.memory_interface import MemoryInterface
 from pyrit.models import PromptRequestPiece, PromptRequestResponse
-from pyrit.prompt_target import OpenAIChatTarget
+from pyrit.prompt_target import OpenAIChatTarget, PromptChatTarget
 
 
 def fake_construct_response_from_request(request, response_text_pieces):
@@ -515,19 +515,17 @@ def test_is_json_response_supported(target: OpenAIChatTarget):
 
 def test_inheritance_from_prompt_chat_target(target: OpenAIChatTarget):
     """Test that OpenAIChatTarget properly inherits from PromptChatTarget."""
-    from pyrit.prompt_target.common.prompt_chat_target import PromptChatTarget
-
     assert isinstance(target, PromptChatTarget), "OpenAIChatTarget must inherit from PromptChatTarget"
 
 
 def test_inheritance_from_prompt_chat_target_base():
     """Test that OpenAIChatTargetBase properly inherits from PromptChatTarget."""
-    from pyrit.prompt_target.common.prompt_chat_target import PromptChatTarget
-    from pyrit.prompt_target.openai.openai_chat_target_base import OpenAIChatTargetBase
 
     # Create a minimal instance to test inheritance
-    target = OpenAIChatTargetBase(model_name="test-model", endpoint="https://test.com", api_key="test-key")
-    assert isinstance(target, PromptChatTarget), "OpenAIChatTargetBase must inherit from PromptChatTarget"
+    target = OpenAIChatTarget(model_name="test-model", endpoint="https://test.com", api_key="test-key")
+    assert isinstance(
+        target, PromptChatTarget
+    ), "OpenAIChatTarget must inherit from PromptChatTarget through OpenAIChatTargetBase"
 
 
 def test_is_response_format_json_supported(target: OpenAIChatTarget):

--- a/tests/unit/target/test_openai_response_target.py
+++ b/tests/unit/target/test_openai_response_target.py
@@ -542,6 +542,13 @@ def test_is_json_response_supported(target: OpenAIResponseTarget):
     assert target.is_json_response_supported() is True
 
 
+def test_inheritance_from_prompt_chat_target(target: OpenAIResponseTarget):
+    """Test that OpenAIResponseTarget properly inherits from PromptChatTarget."""
+    from pyrit.prompt_target.common.prompt_chat_target import PromptChatTarget
+
+    assert isinstance(target, PromptChatTarget), "OpenAIResponseTarget must inherit from PromptChatTarget"
+
+
 def test_is_response_format_json_supported(target: OpenAIResponseTarget):
 
     request_piece = PromptRequestPiece(


### PR DESCRIPTION
Adding `PromptChatTarget` inheritance for OpenAI chat targets. A `PromptChatTarget` indicates whether a target can modify conversation history or not. Attacks that modify conversation history improperly would throw exceptions, even though the attacks are supported with these targets. 
