### PR TITLE
FIX: Auxiliary scores in PromptSendingAttack

### DIFF
--- a/pyrit/attacks/single_turn/prompt_sending.py
+++ b/pyrit/attacks/single_turn/prompt_sending.py
@@ -180,12 +180,12 @@ class PromptSendingAttack(AttackStrategy[SingleTurnAttackContext, AttackResult])
                 self._logger.warning(f"No response received on attempt {attempt+1} (likely filtered)")
                 continue  # Retry if no response (filtered or error)
 
-            # If no objective scorer, we have a response but can't determine success
+            # Score the response including auxiliary and objective scoring
+            score = await self._evaluate_response_async(response=response, objective=context.objective)
+
+            # If there is no objective, we have a response but can't determine success
             if not self._objective_scorer:
                 break
-
-            # Score the response
-            score = await self._evaluate_response_async(response=response, objective=context.objective)
 
             # On success, return immediately
             if bool(score and score.get_value()):

--- a/tests/unit/attacks/test_prompt_sending.py
+++ b/tests/unit/attacks/test_prompt_sending.py
@@ -551,7 +551,7 @@ class TestAttackExecution:
 
         # Verify only one attempt was made (no retries without scorer)
         attack._send_prompt_to_objective_target_async.assert_called_once()
-        
+
         # Verify that _evaluate_response_async was called even without objective scorer
         # This ensures auxiliary scores are still collected
         attack._evaluate_response_async.assert_called_once_with(

--- a/tests/unit/attacks/test_prompt_sending.py
+++ b/tests/unit/attacks/test_prompt_sending.py
@@ -537,7 +537,7 @@ class TestAttackExecution:
             return_value=SeedPromptGroup(prompts=[SeedPrompt(value="Test prompt", data_type="text")])
         )
         attack._send_prompt_to_objective_target_async = AsyncMock(return_value=sample_response)
-        attack._evaluate_response_async = AsyncMock()
+        attack._evaluate_response_async = AsyncMock(return_value=None)
 
         # Execute the attack
         result = await attack._perform_attack_async(context=basic_context)
@@ -551,7 +551,12 @@ class TestAttackExecution:
 
         # Verify only one attempt was made (no retries without scorer)
         attack._send_prompt_to_objective_target_async.assert_called_once()
-        attack._evaluate_response_async.assert_not_called()
+        
+        # Verify that _evaluate_response_async was called even without objective scorer
+        # This ensures auxiliary scores are still collected
+        attack._evaluate_response_async.assert_called_once_with(
+            response=sample_response, objective=basic_context.objective
+        )
 
     @pytest.mark.asyncio
     async def test_perform_attack_without_scorer_retries_on_filtered_response(

--- a/tests/unit/score/test_gandalf_scorer.py
+++ b/tests/unit/score/test_gandalf_scorer.py
@@ -122,10 +122,10 @@ async def test_gandalf_scorer_adds_to_memory(mocked_post, level: GandalfLevel, d
 
     chat_target = MagicMock()
     chat_target.send_prompt_async = AsyncMock(return_value=response)
-    
+
     # Mock the requests.post call to return a successful response
     mocked_post.return_value = MagicMock(status_code=200, json=lambda: {"success": True, "message": "Message"})
-    
+
     with patch.object(duckdb_instance, "get_prompt_request_pieces", return_value=[generated_request.request_pieces[0]]):
         scorer = GandalfScorer(level=level, chat_target=chat_target)
 


### PR DESCRIPTION
Previously, if no objective scorer was supplied, but auxiliary scorers were, the attack loop would skip the aux scorers.

This fixes it so that auxiliary scores happen in that condition, even if no objective scorer is supplied, working as expected.