### PR TITLE
FIX RTO was not honoring prepended conversations

### DIFF
--- a/pyrit/attacks/base/attack_strategy.py
+++ b/pyrit/attacks/base/attack_strategy.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 import ast
+import copy
 import logging
 import time
 import uuid
@@ -308,9 +309,12 @@ class AttackStrategy(ABC, Identifier, Generic[ContextT, AttackResultT]):
             AttackResultT: The result of the attack execution, including outcome and reason.
         """
 
+        # Deep copy the prepended conversation to avoid modifying the original
+        prepended_conversation_copy = copy.deepcopy(prepended_conversation) if prepended_conversation else []
+
         context = self._context_type.create_from_params(
             objective=objective,
-            prepended_conversation=prepended_conversation or [],
+            prepended_conversation=prepended_conversation_copy,
             memory_labels=memory_labels or {},
             **attack_params,
         )

--- a/pyrit/orchestrator/multi_turn/red_teaming_orchestrator.py
+++ b/pyrit/orchestrator/multi_turn/red_teaming_orchestrator.py
@@ -15,7 +15,6 @@ from pyrit.attacks import (
     AttackAdversarialConfig,
     AttackConverterConfig,
     AttackScoringConfig,
-    MultiTurnAttackContext,
     RedTeamingAttack,
 )
 from pyrit.common import deprecation_message
@@ -147,13 +146,11 @@ class RedTeamingOrchestrator(MultiTurnOrchestrator):
         self, *, objective: str, memory_labels: Optional[dict[str, str]] = None
     ) -> OrchestratorResult:
 
-        # Transitions to the new attack model
-        context = MultiTurnAttackContext(
+        result = await self._attack.execute_async(
             objective=objective,
-            memory_labels=memory_labels or {},
+            prepended_conversation=self._prepended_conversation,
+            memory_labels=memory_labels,
         )
-
-        result = await self._attack.execute_with_context_async(context=context)
         objective_achieved = result.outcome == AttackOutcome.SUCCESS
 
         # Translating the result back to the orchestrator result format

--- a/pyrit/orchestrator/multi_turn/red_teaming_orchestrator.py
+++ b/pyrit/orchestrator/multi_turn/red_teaming_orchestrator.py
@@ -149,7 +149,7 @@ class RedTeamingOrchestrator(MultiTurnOrchestrator):
         result = await self._attack.execute_async(
             objective=objective,
             prepended_conversation=self._prepended_conversation,
-            memory_labels=memory_labels,
+            memory_labels=memory_labels or {},
         )
         objective_achieved = result.outcome == AttackOutcome.SUCCESS
 

--- a/tests/unit/attacks/test_prompt_sending.py
+++ b/tests/unit/attacks/test_prompt_sending.py
@@ -939,7 +939,6 @@ class TestAttackLifecycle:
         assert isinstance(context, SingleTurnAttackContext)
         assert context.objective == "Test objective"
         assert context.memory_labels == {"test": "label"}
-        assert context.prepended_conversation == [sample_response]
         assert context.seed_prompt_group == seed_group
         assert context.system_prompt == "System prompt"
 


### PR DESCRIPTION
## Description
Since `prepended_conversation` in the multiturn orchestrator is set through the use of `set_prepended_conversation` which is part of the base class, it was missed during migration to attacks. I fixed the `run_attack_async` to set the `prepended_conversation` before executing the attack. 


## Tests and Documentation
Added unittests 
