### PR TITLE
FIX Use custom prompt regardless of turn count in RedTeamingAttack

### DIFF
--- a/pyrit/attacks/multi_turn/red_teaming.py
+++ b/pyrit/attacks/multi_turn/red_teaming.py
@@ -298,7 +298,7 @@ class RedTeamingAttack(AttackStrategy[MultiTurnAttackContext, AttackResult]):
         Generate the next prompt to be sent to the target during the red teaming attack.
 
         This method is called each turn to obtain fresh adversarial text based on previous feedback,
-        error states, or the custom prompt if it is the first turn. It integrates feedback from the
+        error states, or the custom prompt if it is available. It integrates feedback from the
         scorer when available, and handles blocked or error responses by returning fallback prompts.
 
         Args:
@@ -307,10 +307,13 @@ class RedTeamingAttack(AttackStrategy[MultiTurnAttackContext, AttackResult]):
         Returns:
             str: The generated prompt to be sent to the adversarial chat.
         """
-        # If first turn and custom prompt provided, use it
-        if context.executed_turns == 0 and context.custom_prompt:
-            logger.debug("Using custom prompt for first turn")
-            return context.custom_prompt
+        # If custom prompt provided, use it and clear it
+        if context.custom_prompt:
+            logger.debug("Using custom prompt")
+            prompt = context.custom_prompt
+            # Clear to prevent reuse
+            context.custom_prompt = None
+            return prompt
 
         # Generate prompt using adversarial chat
         logger.debug(f"Generating prompt for turn {context.executed_turns + 1}")

--- a/tests/unit/attacks/test_red_teaming.py
+++ b/tests/unit/attacks/test_red_teaming.py
@@ -644,7 +644,7 @@ class TestPromptGeneration:
         mock_prompt_normalizer: MagicMock,
         basic_context: MultiTurnAttackContext,
     ):
-        """Test that custom prompt is used on first turn when provided."""
+        """Test that custom prompt is used when provided and cleared after use."""
         adversarial_config = AttackAdversarialConfig(target=mock_adversarial_chat)
         scoring_config = AttackScoringConfig(objective_scorer=mock_objective_scorer)
 
@@ -662,6 +662,38 @@ class TestPromptGeneration:
         result = await attack._generate_next_prompt_async(context=basic_context)
 
         assert result == first_prompt
+        assert basic_context.custom_prompt is None  # Should be cleared after use
+        # Should not call adversarial chat
+        mock_prompt_normalizer.send_prompt_async.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_generate_next_prompt_uses_custom_prompt_regardless_of_turn(
+        self,
+        mock_objective_target: MagicMock,
+        mock_objective_scorer: MagicMock,
+        mock_adversarial_chat: MagicMock,
+        mock_prompt_normalizer: MagicMock,
+        basic_context: MultiTurnAttackContext,
+    ):
+        """Test that custom prompt is used even when executed_turns > 0."""
+        adversarial_config = AttackAdversarialConfig(target=mock_adversarial_chat)
+        scoring_config = AttackScoringConfig(objective_scorer=mock_objective_scorer)
+
+        attack = RedTeamingAttack(
+            objective_target=mock_objective_target,
+            attack_adversarial_config=adversarial_config,
+            attack_scoring_config=scoring_config,
+            prompt_normalizer=mock_prompt_normalizer,
+        )
+
+        custom_prompt = "Custom prompt at turn 1"
+        basic_context.executed_turns = 1  # Not first turn
+        basic_context.custom_prompt = custom_prompt
+
+        result = await attack._generate_next_prompt_async(context=basic_context)
+
+        assert result == custom_prompt
+        assert basic_context.custom_prompt is None  # Should be cleared after use
         # Should not call adversarial chat
         mock_prompt_normalizer.send_prompt_async.assert_not_called()
 
@@ -675,7 +707,7 @@ class TestPromptGeneration:
         basic_context: MultiTurnAttackContext,
         sample_response: PromptRequestResponse,
     ):
-        """Test that adversarial chat is used to generate prompts after first turn."""
+        """Test that adversarial chat is used to generate prompts when no custom prompt."""
         adversarial_config = AttackAdversarialConfig(target=mock_adversarial_chat)
         scoring_config = AttackScoringConfig(objective_scorer=mock_objective_scorer)
 
@@ -687,6 +719,7 @@ class TestPromptGeneration:
         )
 
         basic_context.executed_turns = 1
+        basic_context.custom_prompt = None  # No custom prompt
         mock_prompt_normalizer.send_prompt_async.return_value = sample_response
 
         # Mock build_adversarial_prompt


### PR DESCRIPTION
# Summary

This PR fixes a bug in the `RedTeamingAttack` class where custom prompts were not being used when prepended conversations contained user messages. The issue occurred because the turn count was incremented before checking for custom prompts, causing the logic to skip custom prompts when `executed_turns > 0`.


## Problem

When a user sets a prepended conversation with a user message:

1. The `ConversationManager` correctly updates the turn count to 1 in `_setup_async`
2. It sets the `custom_prompt` in the context to the last user message
3. However, in `_perform_attack_async`, the custom prompt was not used because the original logic only checked for `executed_turns == 0`

This meant that prepended user messages were never sent to the target, breaking the intended conversation flow.

## Solution

The fix simplifies the logic in `_generate_next_prompt_async` to:

1. Check if a custom prompt exists (regardless of turn count)
2. Use the custom prompt if available
3. Clear the custom prompt after use to prevent it from being used multiple times

This ensures that custom prompts are always used when available, whether they come from the initial setup or from prepended conversations. This also follows the original behavior of RTO

## Changes

- Modified `_generate_next_prompt_async` to use custom prompts whenever they exist, not just on the first turn
- Added logic to clear the custom prompt after use to prevent reuse
- Updated tests to verify the new behavior

## Testing

- Added test case to verify custom prompts are used regardless of turn count
- Updated existing tests to check that custom prompts are cleared after use
- All existing tests continue to pass