### PR TITLE
FIX: Fixing Scorer Memory Add and Validate

### DIFF
--- a/pyrit/memory/memory_models.py
+++ b/pyrit/memory/memory_models.py
@@ -196,7 +196,7 @@ class ScoreEntry(Base):  # type: ignore
     score_value = mapped_column(String, nullable=False)
     score_value_description = mapped_column(String, nullable=True)
     score_type: Mapped[Literal["true_false", "float_scale"]] = mapped_column(String, nullable=False)
-    score_category = mapped_column(String, nullable=False)
+    score_category = mapped_column(String, nullable=True)
     score_rationale = mapped_column(String, nullable=True)
     score_metadata = mapped_column(String, nullable=True)
     scorer_class_identifier: Mapped[dict[str, str]] = mapped_column(JSON)

--- a/pyrit/models/score.py
+++ b/pyrit/models/score.py
@@ -130,10 +130,9 @@ class Score:
         }
 
     def __str__(self):
+        category_str = f": {self.score_category or ''}"
         if self.scorer_class_identifier:
-            category_str = f": {self.score_category}" if self.score_category else ""
             return f"{self.scorer_class_identifier['__type__']}{category_str}: {self.score_value}"
-        category_str = f": {self.score_category}" if self.score_category else ""
         return f"{category_str}: {self.score_value}"
 
     __repr__ = __str__

--- a/pyrit/models/score.py
+++ b/pyrit/models/score.py
@@ -23,7 +23,7 @@ class Score:
     score_type: ScoreType
 
     # The type of the harms category (e.g. "hate" or "violence")
-    score_category: str
+    score_category: Optional[str]
 
     # Extra data the scorer provides around the rationale of the score
     score_rationale: str
@@ -54,7 +54,7 @@ class Score:
         score_value: str,
         score_value_description: str,
         score_type: ScoreType,
-        score_category: str,
+        score_category: Optional[str] = None,
         score_rationale: str,
         score_metadata: str,
         prompt_request_response_id: str | uuid.UUID,
@@ -131,8 +131,10 @@ class Score:
 
     def __str__(self):
         if self.scorer_class_identifier:
-            return f"{self.scorer_class_identifier['__type__']}: {self.score_category}: {self.score_value}"
-        return f": {self.score_category}: {self.score_value}"
+            category_str = f": {self.score_category}" if self.score_category else ""
+            return f"{self.scorer_class_identifier['__type__']}{category_str}: {self.score_value}"
+        category_str = f": {self.score_category}" if self.score_category else ""
+        return f"{category_str}: {self.score_value}"
 
     __repr__ = __str__
 
@@ -149,7 +151,7 @@ class UnvalidatedScore:
 
     score_value_description: str
     score_type: ScoreType
-    score_category: str
+    score_category: Optional[str]
     score_rationale: str
     score_metadata: str
     scorer_class_identifier: Dict[str, str]

--- a/pyrit/score/__init__.py
+++ b/pyrit/score/__init__.py
@@ -6,7 +6,7 @@ from pyrit.score.scorer import Scorer
 from pyrit.score.azure_content_filter_scorer import AzureContentFilterScorer
 from pyrit.score.composite_scorer import CompositeScorer
 from pyrit.score.float_scale_threshold_scorer import FloatScaleThresholdScorer
-from pyrit.score.general_scorer import SelfAskGeneralScorer
+from pyrit.score.self_ask_general_scorer import SelfAskGeneralScorer
 from pyrit.score.gandalf_scorer import GandalfScorer
 from pyrit.score.human_in_the_loop_scorer import HumanInTheLoopScorer
 from pyrit.score.human_in_the_loop_gradio import HumanInTheLoopScorerGradio

--- a/pyrit/score/azure_content_filter_scorer.py
+++ b/pyrit/score/azure_content_filter_scorer.py
@@ -91,7 +91,7 @@ class AzureContentFilterScorer(Scorer):
         else:
             raise ValueError("Please provide the Azure Content Safety endpoint")
 
-    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         """Evaluating the input text or image using the Azure Content Filter API
 
         Args:
@@ -113,8 +113,6 @@ class AzureContentFilterScorer(Scorer):
         Raises:
             ValueError if converted_value_data_type is not "text" or "image_path" or image isn't in supported format
         """
-        self.validate(request_response, task=task)
-
         filter_result: dict[str, list] = {}
         if request_response.converted_value_data_type == "text":
             text_request_options = AnalyzeTextOptions(
@@ -155,7 +153,6 @@ class AzureContentFilterScorer(Scorer):
                 prompt_request_response_id=request_response.id,
                 task=task,
             )
-            self._memory.add_scores_to_memory(scores=[score])
             scores.append(score)
 
         return scores

--- a/pyrit/score/composite_scorer.py
+++ b/pyrit/score/composite_scorer.py
@@ -38,7 +38,7 @@ class CompositeScorer(Scorer):
 
         self._scorers = scorers
 
-    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> List[Score]:
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> List[Score]:
         """Scores the request response by combining results from all constituent scorers.
 
         Args:
@@ -48,7 +48,6 @@ class CompositeScorer(Scorer):
         Returns:
             List containing a single Score object representing the combined result
         """
-        self.validate(request_response, task=task)
         scores = await self._score_all_async(request_response, task=task)
 
         identifier_dict = self.get_identifier()

--- a/pyrit/score/float_scale_threshold_scorer.py
+++ b/pyrit/score/float_scale_threshold_scorer.py
@@ -23,7 +23,7 @@ class FloatScaleThresholdScorer(Scorer):
 
         self.scorer_type = "true_false"
 
-    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         """Scores the piece using the underlying float-scale scorer and thresholds the resulting score.
 
         Args:
@@ -51,7 +51,6 @@ class FloatScaleThresholdScorer(Scorer):
             score.id = uuid.uuid4()
             score.scorer_class_identifier = self.get_identifier()
             score.scorer_class_identifier["sub_identifier"] = self._scorer.get_identifier()
-        self._memory.add_scores_to_memory(scores=scores)
         return scores
 
     def validate(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> None:

--- a/pyrit/score/gandalf_scorer.py
+++ b/pyrit/score/gandalf_scorer.py
@@ -80,7 +80,7 @@ class GandalfScorer(Scorer):
             return ""
         return response_text
 
-    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         """Scores the text based on the password found in the text.
 
         Args:
@@ -150,7 +150,6 @@ class GandalfScorer(Scorer):
                     task=task,
                 )
 
-        self._memory.add_scores_to_memory(scores=[score])
         return [score]
 
     def validate(self, request_response: PromptRequestPiece, *, task: Optional[str] = None):

--- a/pyrit/score/human_in_the_loop_gradio.py
+++ b/pyrit/score/human_in_the_loop_gradio.py
@@ -23,11 +23,10 @@ class HumanInTheLoopScorerGradio(Scorer):
         self._rpc_server = AppRPCServer(open_browser=open_browser)
         self._rpc_server.start()
 
-    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         self.validate(request_response=request_response)
         try:
             score = await asyncio.to_thread(self.retrieve_score, request_response, task=task)
-            self._memory.add_scores_to_memory(scores=score)
             return score
         except asyncio.CancelledError:
             self._rpc_server.stop()

--- a/pyrit/score/human_in_the_loop_scorer.py
+++ b/pyrit/score/human_in_the_loop_scorer.py
@@ -93,7 +93,7 @@ class HumanInTheLoopScorer(Scorer):
 
         return [score]
 
-    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         """
         Score the prompt with a human in the loop.
 

--- a/pyrit/score/insecure_code_scorer.py
+++ b/pyrit/score/insecure_code_scorer.py
@@ -41,7 +41,7 @@ class InsecureCodeScorer(Scorer):
         # Render the system prompt with the harm category
         self._system_prompt = scoring_instructions_template.render_template_value(harm_categories=self._harm_category)
 
-    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         """
         Scores the given request response using LLM to detect vulnerabilities.
 
@@ -52,9 +52,6 @@ class InsecureCodeScorer(Scorer):
         Returns:
             list[Score]: A list of Score objects.
         """
-        # Validate the input piece
-        self.validate(request_response, task=task)
-
         # Use _score_value_with_llm to interact with the LLM and retrieve an UnvalidatedScore
         unvalidated_score = await self._score_value_with_llm(
             prompt_target=self._prompt_target,
@@ -78,9 +75,6 @@ class InsecureCodeScorer(Scorer):
         score = unvalidated_score.to_score(
             score_value=str(self.scale_value_float(raw_score_value, 0, 1)),
         )
-
-        # Add the score to memory
-        self._memory.add_scores_to_memory(scores=[score])
 
         return [score]
 

--- a/pyrit/score/look_back_scorer.py
+++ b/pyrit/score/look_back_scorer.py
@@ -40,7 +40,7 @@ class LookBackScorer(Scorer):
             step_description=behavior_change_scale
         )
 
-    async def score_async(self, request_piece: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
+    async def _score_async(self, request_piece: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         """
         Scores the entire conversation based on detected behavior change.
 
@@ -87,7 +87,6 @@ class LookBackScorer(Scorer):
         )
 
         score = unvalidated_score.to_score(score_value=unvalidated_score.raw_score_value)
-        self._memory.add_scores_to_memory(scores=[score])
 
         # Output score results
         print("LookBackScorer:", score.score_value, score.score_value_description, "Rationale: ", score.score_rationale)

--- a/pyrit/score/markdown_injection.py
+++ b/pyrit/score/markdown_injection.py
@@ -14,7 +14,7 @@ class MarkdownInjectionScorer(Scorer):
         self._category = "security"
         self.scorer_type = "true_false"
 
-    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         """
         Check for markdown injection in the text. It returns True if markdown injection is detected, else False.
 
@@ -28,13 +28,6 @@ class MarkdownInjectionScorer(Scorer):
             list[Score]: A list of Score objects with the score value as True if markdown injection is detected,
             else False.
         """
-        # This regular expression is designed to match two different patterns for inserting images in Markdown, as
-        # follows:
-        # !\[.*?\]\((.*?)\) - This is for the inline image format in Markdown, which is ![alt_text](url).
-        # !\[.*?\]\[(.*?)\] - This is for the reference-style image format in Markdown, which is
-        #   ![alt_text][image_reference].
-
-        self.validate(request_response, task=task)
         text = request_response.converted_value
 
         pattern = r"!\[.*?\]\((.*?)\)|!\[.*?\]\[(.*?)\]"
@@ -54,7 +47,6 @@ class MarkdownInjectionScorer(Scorer):
             )
         ]
 
-        self._memory.add_scores_to_memory(scores=scores)
         return scores
 
     def validate(self, request_response: PromptRequestPiece, *, task: Optional[str] = None):

--- a/pyrit/score/prompt_shield_scorer.py
+++ b/pyrit/score/prompt_shield_scorer.py
@@ -30,7 +30,7 @@ class PromptShieldScorer(Scorer):
         self._prompt_target = prompt_shield_target
         self.scorer_type = "true_false"
 
-    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         self.validate(request_response=request_response)
 
         self._conversation_id = str(uuid.uuid4())
@@ -69,7 +69,6 @@ class PromptShieldScorer(Scorer):
             task=task,
         )
 
-        self._memory.add_scores_to_memory(scores=[score])
         return [score]
 
     def _parse_response_to_boolean_list(self, response: str) -> list[bool]:

--- a/pyrit/score/question_answer_scorer.py
+++ b/pyrit/score/question_answer_scorer.py
@@ -35,7 +35,7 @@ class QuestionAnswerScorer(Scorer):
         self._score_category = category
         self.scorer_type = "true_false"
 
-    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         """
         Score the request_reponse using the QuestionAnsweringEntry
         and return a single score object
@@ -46,8 +46,6 @@ class QuestionAnswerScorer(Scorer):
         Returns:
             Score: A single Score object representing the result
         """
-
-        self.validate(request_response, task=task)
 
         result = False
         matching_text = None
@@ -80,7 +78,6 @@ class QuestionAnswerScorer(Scorer):
             )
         ]
 
-        self._memory.add_scores_to_memory(scores=scores)
         return scores
 
     def validate(self, request_response: PromptRequestPiece, *, task: Optional[str] = None):

--- a/pyrit/score/scorer.py
+++ b/pyrit/score/scorer.py
@@ -44,7 +44,6 @@ class Scorer(abc.ABC):
     def _memory(self) -> MemoryInterface:
         return CentralMemory.get_memory_instance()
 
-    @abstractmethod
     async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         """
         Score the request_response, add the results to the database
@@ -57,6 +56,13 @@ class Scorer(abc.ABC):
         Returns:
             list[Score]: A list of Score objects representing the results.
         """
+        self.validate(request_response, task=task)
+        scores = await self._score_async(request_response, task=task)
+        self._memory.add_scores_to_memory(scores=scores)
+        return scores
+
+    @abstractmethod
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         raise NotImplementedError("score_async method not implemented")
 
     @abstractmethod

--- a/pyrit/score/self_ask_category_scorer.py
+++ b/pyrit/score/self_ask_category_scorer.py
@@ -82,9 +82,9 @@ class SelfAskCategoryScorer(Scorer):
 
         return category_descriptions
 
-    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         """
-        Scores the given request_response using the chat target and adds score to memory.
+        Scores the given request_response using the chat target.
 
         Args:
             request_response (PromptRequestPiece): The prompt request piece to score.
@@ -97,8 +97,6 @@ class SelfAskCategoryScorer(Scorer):
                          The score_value is True in all cases unless no category fits. In which case,
                          the score value is false and the _false_category is used.
         """
-        self.validate(request_response, task=task)
-
         unvalidated_score: UnvalidatedScore = await self._score_value_with_llm(
             prompt_target=self._prompt_target,
             system_prompt=self._system_prompt,
@@ -111,7 +109,6 @@ class SelfAskCategoryScorer(Scorer):
 
         score = unvalidated_score.to_score(score_value=unvalidated_score.raw_score_value)
 
-        self._memory.add_scores_to_memory(scores=[score])
         return [score]
 
     def validate(self, request_response: PromptRequestPiece, *, task: Optional[str] = None):

--- a/pyrit/score/self_ask_general_scorer.py
+++ b/pyrit/score/self_ask_general_scorer.py
@@ -79,8 +79,7 @@ class SelfAskGeneralScorer(Scorer):
         self._metadata_output_key = metadata_output_key
         self._category_output_key = category_output_key
 
-    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
-        self.validate(request_response, task=task)
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         prompt = request_response.converted_value
 
         system_prompt = self._system_prompt.format(task=task, prompt=prompt, request_response=request_response)
@@ -116,7 +115,6 @@ class SelfAskGeneralScorer(Scorer):
                 )
             )
 
-        self._memory.add_scores_to_memory(scores=[score])
         return [score]
 
     def validate(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> None:

--- a/pyrit/score/self_ask_likert_scorer.py
+++ b/pyrit/score/self_ask_likert_scorer.py
@@ -92,9 +92,9 @@ class SelfAskLikertScorer(Scorer):
 
         return likert_scale_description
 
-    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         """
-        Scores the given request_response using "self-ask" for the chat target and adds score to memory.
+        Scores the given request_response using "self-ask" for the chat target.
 
         Args:
             request_response (PromptRequestPiece): The prompt request piece containing the text to be scored.
@@ -106,8 +106,6 @@ class SelfAskLikertScorer(Scorer):
                          The category is configured from the likert_scale.
                          The score_value is a value from [0,1] that is scaled from the likert scale.
         """
-        self.validate(request_response, task=task)
-
         unvalidated_score: UnvalidatedScore = await self._score_value_with_llm(
             prompt_target=self._prompt_target,
             system_prompt=self._system_prompt,
@@ -124,7 +122,6 @@ class SelfAskLikertScorer(Scorer):
 
         score.score_metadata = str({"likert_value": str(unvalidated_score.raw_score_value)})
 
-        self._memory.add_scores_to_memory(scores=[score])
         return [score]
 
     def validate(self, request_response: PromptRequestPiece, *, task: Optional[str] = None):

--- a/pyrit/score/self_ask_question_answer_scorer.py
+++ b/pyrit/score/self_ask_question_answer_scorer.py
@@ -48,7 +48,7 @@ class SelfAskQuestionAnswerScorer(SelfAskTrueFalseScorer):
             true_false_question_path=true_false_question_path,
         )
 
-    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         """
         Score the request_reponse using the QuestionAnsweringEntry
         and return a single score object
@@ -59,8 +59,6 @@ class SelfAskQuestionAnswerScorer(SelfAskTrueFalseScorer):
         Returns:
             Score: A single Score object representing the result
         """
-
-        self.validate(request_response, task=task)
 
         prompt = (
             f"{task}\n\nThe target response is as follows. "
@@ -80,7 +78,6 @@ class SelfAskQuestionAnswerScorer(SelfAskTrueFalseScorer):
 
         score = unvalidated_score.to_score(score_value=unvalidated_score.raw_score_value)
 
-        self._memory.add_scores_to_memory(scores=[score])
         return [score]
 
     def validate(self, request_response: PromptRequestPiece, *, task: Optional[str] = None):

--- a/pyrit/score/self_ask_refusal_scorer.py
+++ b/pyrit/score/self_ask_refusal_scorer.py
@@ -48,7 +48,7 @@ class SelfAskRefusalScorer(Scorer):
 
         self._score_category = "refusal"
 
-    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         """Scores the prompt and determines whether the response is a refusal.
 
         Args:
@@ -58,8 +58,6 @@ class SelfAskRefusalScorer(Scorer):
         Returns:
             list[Score]: The request_response scored.
         """
-        self.validate(request_response, task=task)
-
         if request_response.response_error == "blocked":
             return [
                 Score(
@@ -113,7 +111,6 @@ class SelfAskRefusalScorer(Scorer):
 
         score = unvalidated_score.to_score(score_value=unvalidated_score.raw_score_value)
 
-        self._memory.add_scores_to_memory(scores=[score])
         return [score]
 
     def validate(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> None:

--- a/pyrit/score/self_ask_scale_scorer.py
+++ b/pyrit/score/self_ask_scale_scorer.py
@@ -56,9 +56,9 @@ class SelfAskScaleScorer(Scorer):
 
         self._system_prompt = scoring_instructions_template.render_template_value(**scale_args)
 
-    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         """
-        Scores the given request_response using "self-ask" for the chat target and adds score to memory.
+        Scores the given request_response using "self-ask" for the chat target.
 
         Args:
             request_response (PromptRequestPiece): The prompt request piece containing the text to be scored.
@@ -68,8 +68,6 @@ class SelfAskScaleScorer(Scorer):
             list[Score]: The request_response scored.
                          The score_value is a value from [0,1] that is scaled based on the scorer's scale.
         """
-        self.validate(request_response, task=task)
-
         scoring_prompt = f"task: {task}\nresponse: {request_response.converted_value}"
 
         unvalidated_score: UnvalidatedScore = await self._score_value_with_llm(
@@ -90,7 +88,6 @@ class SelfAskScaleScorer(Scorer):
             )
         )
 
-        self._memory.add_scores_to_memory(scores=[score])
         return [score]
 
     def validate(self, request_response: PromptRequestPiece, *, task: Optional[str] = None):

--- a/pyrit/score/self_ask_true_false_scorer.py
+++ b/pyrit/score/self_ask_true_false_scorer.py
@@ -97,9 +97,9 @@ class SelfAskTrueFalseScorer(Scorer):
             true_description=true_category, false_description=false_category, metadata=metadata
         )
 
-    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         """
-        Scores the given request_response using "self-ask" for the chat target and adds score to memory.
+        Scores the given request_response using "self-ask" for the chat target.
 
         Args:
             request_response (PromptRequestPiece): The prompt request piece containing the text to be scored.
@@ -113,8 +113,6 @@ class SelfAskTrueFalseScorer(Scorer):
                          metadata can be configured to provide additional information.
         """
 
-        self.validate(request_response, task=task)
-
         unvalidated_score: UnvalidatedScore = await self._score_value_with_llm(
             prompt_target=self._prompt_target,
             system_prompt=self._system_prompt,
@@ -127,8 +125,6 @@ class SelfAskTrueFalseScorer(Scorer):
         )
 
         score = unvalidated_score.to_score(score_value=unvalidated_score.raw_score_value)
-
-        self._memory.add_scores_to_memory(scores=[score])
         return [score]
 
     def validate(self, request_response: PromptRequestPiece, *, task: Optional[str] = None):

--- a/pyrit/score/substring_scorer.py
+++ b/pyrit/score/substring_scorer.py
@@ -26,7 +26,7 @@ class SubStringScorer(Scorer):
         self._score_category = category
         self.scorer_type = "true_false"
 
-    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         """Score the given request_response based on presence of the substring.
 
         Args:
@@ -37,9 +37,6 @@ class SubStringScorer(Scorer):
             A list containing a single Score object with a boolean value indicating
             whether the substring is present in the text.
         """
-
-        self.validate(request_response, task=task)
-
         expected_output_substring_present = self._substring in request_response.converted_value
 
         score = [
@@ -56,7 +53,6 @@ class SubStringScorer(Scorer):
             )
         ]
 
-        self._memory.add_scores_to_memory(scores=score)
         return score
 
     def validate(self, request_response: PromptRequestPiece, *, task: Optional[str] = None):

--- a/pyrit/score/true_false_inverter_scorer.py
+++ b/pyrit/score/true_false_inverter_scorer.py
@@ -19,7 +19,7 @@ class TrueFalseInverterScorer(Scorer):
 
         self.scorer_type = "true_false"
 
-    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         """Scores the piece using the underlying true-false scorer and returns the opposite score.
 
         Args:
@@ -40,7 +40,6 @@ class TrueFalseInverterScorer(Scorer):
             score.scorer_class_identifier = self.get_identifier()
             score.scorer_class_identifier["sub_identifier"] = self._scorer.get_identifier()
 
-        self._memory.add_scores_to_memory(scores=scores)
         return scores
 
     def validate(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> None:

--- a/pyrit/ui/rpc.py
+++ b/pyrit/ui/rpc.py
@@ -223,7 +223,7 @@ class AppRPCServer:
         score = Score(
             score_value=score_ref.score_value,
             score_type=score_ref.score_type,
-            score_category=str(score_ref.score_category),
+            score_category=score_ref.score_category,
             score_value_description=score_ref.score_value_description,
             score_rationale=score_ref.score_rationale,
             score_metadata=score_ref.score_metadata,

--- a/tests/unit/attacks/test_crescendo.py
+++ b/tests/unit/attacks/test_crescendo.py
@@ -69,7 +69,7 @@ def create_score(
     *,
     score_type: ScoreType,
     score_value: str,
-    score_category: str,
+    score_category: Optional[str] = None,
     scorer_class: str,
     score_rationale: str = "Test rationale",
     score_value_description: str = "Test description",

--- a/tests/unit/score/test_generic_scorer.py
+++ b/tests/unit/score/test_generic_scorer.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from pyrit.models import PromptRequestPiece, PromptRequestResponse
-from pyrit.score.general_scorer import SelfAskGeneralScorer
+from pyrit.score import SelfAskGeneralScorer
 
 
 @pytest.fixture

--- a/tests/unit/score/test_scorer.py
+++ b/tests/unit/score/test_scorer.py
@@ -17,7 +17,7 @@ from pyrit.score import Scorer
 
 
 class MockScorer(Scorer):
-    async def score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
+    async def _score_async(self, request_response: PromptRequestPiece, *, task: Optional[str] = None) -> list[Score]:
         return []
 
     def validate(self, request_response: PromptRequestPiece, *, task: Optional[str] = None):

--- a/tests/unit/score/test_self_ask_refusal.py
+++ b/tests/unit/score/test_self_ask_refusal.py
@@ -162,11 +162,13 @@ async def test_self_ask_objective_scorer_bad_json_exception_retries(patch_centra
 
 
 @pytest.mark.asyncio
-async def test_score_async_filtered_response():
+async def test_score_async_filtered_response(patch_central_database):
+    memory = CentralMemory.get_memory_instance()
     chat_target = MagicMock()
     scorer = SelfAskRefusalScorer(chat_target=chat_target)
 
     request_piece = PromptRequestPiece(role="assistant", original_value="blocked response", response_error="blocked")
+    memory.add_request_pieces_to_memory(request_pieces=[request_piece])
     scores = await scorer.score_async(request_piece)
 
     assert len(scores) == 1


### PR DESCRIPTION
Several scorers were not adding scores to memory or validating during score_async. Amongst other things, this was causing a failure in our "sending a million prompts" cookbook because the composite scorer was not adding the score to memory.

This change centralizes that operation so that validate and memory addition are called in the base class, and the _score_async is now the abstract method.