### PR TITLE
FIX for code scanning alert no. 7 and 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,6 +24,8 @@ concurrency:
 jobs:
   pre-commit-linux:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     env:
       PIP_CACHE_DIR: ${{ github.workspace }}/.cache/pip

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -70,6 +70,8 @@ jobs:
 
   pre-commit-windows:
     runs-on: windows-latest
+    permissions:
+      contents: read
     env:
       PIP_CACHE_DIR: ${{ github.workspace }}\.cache\pip
     defaults:


### PR DESCRIPTION
Potential fix for [https://github.com/Azure/PyRIT/security/code-scanning/7](https://github.com/Azure/PyRIT/security/code-scanning/7) and [https://github.com/Azure/PyRIT/security/code-scanning/8](https://github.com/Azure/PyRIT/security/code-scanning/8)

To fix the issue, we need to add a `permissions` block to the `pre-commit-windows` job. This block should specify the minimal permissions required for the job to function correctly. Based on the job's tasks, it likely only needs `contents: read` access to fetch repository files and run pre-commit checks.

The `permissions` block should be added directly under the `runs-on` key in the `pre-commit-windows` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
