### PR TITLE
FIX: Stop tracking .vscode/settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "codeQL.githubDatabase.download": "never",
-    "python.testing.pytestArgs": [
-        "tests"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
-}


### PR DESCRIPTION
This is already in .gitignore but being tracked because it was previously committed 