### PR TITLE
FIX Conversation Manager should properly apply converters

### DIFF
--- a/pyrit/attacks/multi_turn/crescendo.py
+++ b/pyrit/attacks/multi_turn/crescendo.py
@@ -252,7 +252,8 @@ class CrescendoAttack(AttackStrategy[CrescendoAttackContext, CrescendoAttackResu
             max_turns=self._max_turns,
             conversation_id=context.session.conversation_id,
             prepended_conversation=context.prepended_conversation,
-            converter_configurations=self._request_converters,
+            request_converters=self._request_converters,
+            response_converters=self._response_converters,
         )
 
         # Update turns based on prepended conversation

--- a/pyrit/attacks/multi_turn/red_teaming.py
+++ b/pyrit/attacks/multi_turn/red_teaming.py
@@ -210,7 +210,8 @@ class RedTeamingAttack(AttackStrategy[MultiTurnAttackContext, AttackResult]):
             max_turns=self._max_turns,
             conversation_id=context.session.conversation_id,
             prepended_conversation=context.prepended_conversation,
-            converter_configurations=self._request_converters,
+            request_converters=self._request_converters,
+            response_converters=self._response_converters,
         )
 
         # update the turns based on prepend conversation

--- a/pyrit/attacks/single_turn/flip_attack.py
+++ b/pyrit/attacks/single_turn/flip_attack.py
@@ -93,11 +93,10 @@ class FlipAttack(PromptSendingAttack):
         # Combine memory labels from context and attack strategy
         context.memory_labels = combine_dict(self._memory_labels, context.memory_labels)
 
-        # System prompt should not be converted, so we pass an empty list for converter_configurations
+        # System prompt should not be converted, and the new implementation correctly
+        # skips converters for system messages, so we can pass empty converter lists
         await self._conversation_manager.update_conversation_state_async(
-            conversation_id=context.conversation_id,
-            prepended_conversation=context.prepended_conversation,
-            converter_configurations=[],
+            conversation_id=context.conversation_id, prepended_conversation=context.prepended_conversation
         )
 
     async def _perform_attack_async(self, *, context: SingleTurnAttackContext) -> AttackResult:

--- a/pyrit/attacks/single_turn/prompt_sending.py
+++ b/pyrit/attacks/single_turn/prompt_sending.py
@@ -134,9 +134,11 @@ class PromptSendingAttack(AttackStrategy[SingleTurnAttackContext, AttackResult])
 
         # Process prepended conversation if provided
         await self._conversation_manager.update_conversation_state_async(
+            target=self._objective_target,
             conversation_id=context.conversation_id,
             prepended_conversation=context.prepended_conversation,
-            converter_configurations=self._request_converters,
+            request_converters=self._request_converters,
+            response_converters=self._response_converters,
         )
 
     async def _perform_attack_async(self, *, context: SingleTurnAttackContext) -> AttackResult:
@@ -198,8 +200,7 @@ class PromptSendingAttack(AttackStrategy[SingleTurnAttackContext, AttackResult])
                         conversation_type=ConversationType.PRUNED,
                     )
                 )
-
-                context.conversation_id = str(uuid.uuid4())
+                await self._setup_async(context=context)  # Reset conversation for next attempt
 
         # Determine the outcome
         outcome, outcome_reason = self._determine_attack_outcome(response=response, score=score, context=context)

--- a/tests/unit/attacks/test_conversation_manager.py
+++ b/tests/unit/attacks/test_conversation_manager.py
@@ -335,29 +335,77 @@ class TestConversationStateUpdate:
         assert state.last_user_message == sample_user_piece.converted_value
 
     @pytest.mark.asyncio
-    async def test_update_conversation_state_with_converters(
+    async def test_update_conversation_state_with_role_specific_converters(
         self,
         attack_identifier: dict[str, str],
         mock_prompt_normalizer: MagicMock,
         sample_conversation: list[PromptRequestResponse],
     ):
+        """Test that role-specific converters apply correctly"""
         manager = ConversationManager(attack_identifier=attack_identifier, prompt_normalizer=mock_prompt_normalizer)
         conversation_id = str(uuid.uuid4())
-        converter_config = [PromptConverterConfiguration(converters=[])]
+
+        request_converter_config = [PromptConverterConfiguration(converters=[])]
+        response_converter_config = [PromptConverterConfiguration(converters=[])]
 
         await manager.update_conversation_state_async(
             conversation_id=conversation_id,
             prepended_conversation=sample_conversation,
-            converter_configurations=converter_config,
+            request_converters=request_converter_config,
+            response_converters=response_converter_config,
         )
 
-        # Verify converters were applied to each message
+        # Verify converters were applied to both user and assistant messages
         assert mock_prompt_normalizer.convert_values.call_count == 2
-        for call in mock_prompt_normalizer.convert_values.call_args_list:
-            assert call.kwargs["converter_configurations"] == converter_config
+
+        # First call should be for user message with request converters
+        user_call = mock_prompt_normalizer.convert_values.call_args_list[0]
+        assert user_call.kwargs["converter_configurations"] == request_converter_config
+
+        # Second call should be for assistant message with response converters
+        assistant_call = mock_prompt_normalizer.convert_values.call_args_list[1]
+        assert assistant_call.kwargs["converter_configurations"] == response_converter_config
+        assert mock_prompt_normalizer.convert_values.call_count == 2
+
+        # Check that the right converters were applied to the right roles
+        calls = mock_prompt_normalizer.convert_values.call_args_list
+        # First call should be for user message with request converters
+        assert calls[0].kwargs["converter_configurations"] == request_converter_config
+        # Second call should be for assistant message with response converters
+        assert calls[1].kwargs["converter_configurations"] == response_converter_config
 
     @pytest.mark.asyncio
-    async def test_update_conversation_state_processes_system_prompts(
+    async def test_update_conversation_state_system_messages_no_converters(
+        self,
+        attack_identifier: dict[str, str],
+        mock_prompt_normalizer: MagicMock,
+        mock_chat_target: MagicMock,
+        sample_system_piece: PromptRequestPiece,
+    ):
+        """Test that system messages do not get converters applied regardless of config"""
+        manager = ConversationManager(attack_identifier=attack_identifier, prompt_normalizer=mock_prompt_normalizer)
+        conversation_id = str(uuid.uuid4())
+
+        # Create conversation with just a system message
+        conversation = [PromptRequestResponse(request_pieces=[sample_system_piece])]
+
+        request_converter_config = [PromptConverterConfiguration(converters=[])]
+        response_converter_config = [PromptConverterConfiguration(converters=[])]
+
+        await manager.update_conversation_state_async(
+            conversation_id=conversation_id,
+            prepended_conversation=conversation,
+            target=mock_chat_target,
+            request_converters=request_converter_config,
+            response_converters=response_converter_config,
+            max_turns=5,  # Multi-turn mode to trigger system prompt handling
+        )
+
+        # No converters should be applied to system messages
+        assert mock_prompt_normalizer.convert_values.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_update_conversation_state_processes_system_prompts_multi_turn(
         self, attack_identifier: dict[str, str], mock_chat_target: MagicMock, sample_system_piece: PromptRequestPiece
     ):
         manager = ConversationManager(attack_identifier=attack_identifier)
@@ -379,6 +427,188 @@ class TestConversationStateUpdate:
         # System messages should not be added to memory in multi-turn mode
         stored_conversation = manager.get_conversation(conversation_id)
         assert len(stored_conversation) == 0
+
+    @pytest.mark.asyncio
+    async def test_update_conversation_state_processes_system_prompts_single_turn(
+        self, attack_identifier: dict[str, str], mock_chat_target: MagicMock, sample_system_piece: PromptRequestPiece
+    ):
+        """Test that system messages in single-turn mode are NOT added to memory"""
+        manager = ConversationManager(attack_identifier=attack_identifier)
+        conversation_id = str(uuid.uuid4())
+
+        # Create conversation with system message
+        conversation = [PromptRequestResponse(request_pieces=[sample_system_piece])]
+
+        await manager.update_conversation_state_async(
+            conversation_id=conversation_id,
+            prepended_conversation=conversation,
+            target=mock_chat_target,
+            # No max_turns = single-turn mode
+        )
+
+        # System prompt should be set on target
+        mock_chat_target.set_system_prompt.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_conversation_state_single_turn_behavior_matches_legacy(
+        self,
+        attack_identifier: dict[str, str],
+        mock_chat_target: MagicMock,
+        sample_user_piece: PromptRequestPiece,
+        sample_assistant_piece: PromptRequestPiece,
+        sample_system_piece: PromptRequestPiece,
+    ):
+        """Test that single-turn behavior correctly excludes system messages from memory"""
+        manager = ConversationManager(attack_identifier=attack_identifier)
+        conversation_id = str(uuid.uuid4())
+
+        # Create conversation with all types of messages
+        conversation = [
+            PromptRequestResponse(request_pieces=[sample_system_piece]),
+            PromptRequestResponse(request_pieces=[sample_user_piece]),
+            PromptRequestResponse(request_pieces=[sample_assistant_piece]),
+        ]
+
+        # Store original IDs to verify they get updated
+        # Since we are mocking the target, the system piece won't be stored, so we only check user and assistant
+        original_user_id = sample_user_piece.id
+        original_assistant_id = sample_assistant_piece.id
+
+        await manager.update_conversation_state_async(
+            conversation_id=conversation_id,
+            prepended_conversation=conversation,
+            target=mock_chat_target,
+            # No max_turns = single-turn mode
+        )
+
+        stored_conversation = manager.get_conversation(conversation_id)
+        assert len(stored_conversation) == 2
+
+        # Verify that user and assistant pieces have the correct conversation_id and orchestrator_identifier
+        for stored_response in stored_conversation:
+            for piece in stored_response.request_pieces:
+                assert piece.conversation_id == conversation_id
+                assert piece.orchestrator_identifier == attack_identifier
+                # Verify that IDs were regenerated
+                assert piece.id != original_user_id
+                assert piece.id != original_assistant_id
+                # System piece should not be in memory, since we mocked the target
+
+        # Verify roles are preserved and in order (excluding system)
+        assert stored_conversation[0].get_piece().role == "user"
+        assert stored_conversation[1].get_piece().role == "assistant"
+
+        # System prompt should still be set on target even in single-turn mode
+        mock_chat_target.set_system_prompt.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_conversation_state_system_prompt_without_target_raises_error(
+        self, attack_identifier: dict[str, str], sample_system_piece: PromptRequestPiece
+    ):
+        """Test that providing system prompts without a target raises an error"""
+        manager = ConversationManager(attack_identifier=attack_identifier)
+        conversation_id = str(uuid.uuid4())
+
+        # Create conversation with system message
+        conversation = [PromptRequestResponse(request_pieces=[sample_system_piece])]
+
+        with pytest.raises(ValueError, match="Target must be provided to handle system prompts"):
+            await manager.update_conversation_state_async(
+                conversation_id=conversation_id,
+                prepended_conversation=conversation,
+                # No target provided
+            )
+
+    @pytest.mark.asyncio
+    async def test_update_conversation_state_system_prompt_with_non_chat_target_raises_error(
+        self, attack_identifier: dict[str, str], mock_prompt_target: MagicMock, sample_system_piece: PromptRequestPiece
+    ):
+        """Test that providing system prompts with non-chat target raises an error"""
+        manager = ConversationManager(attack_identifier=attack_identifier)
+        conversation_id = str(uuid.uuid4())
+
+        # Create conversation with system message
+        conversation = [PromptRequestResponse(request_pieces=[sample_system_piece])]
+
+        with pytest.raises(ValueError, match="Target must be a PromptChatTarget to set system prompts"):
+            await manager.update_conversation_state_async(
+                conversation_id=conversation_id,
+                prepended_conversation=conversation,
+                target=mock_prompt_target,  # Non-chat target
+            )
+
+    @pytest.mark.asyncio
+    async def test_update_conversation_state_mixed_conversation_multi_turn(
+        self,
+        attack_identifier: dict[str, str],
+        mock_chat_target: MagicMock,
+        sample_user_piece: PromptRequestPiece,
+        sample_assistant_piece: PromptRequestPiece,
+        sample_system_piece: PromptRequestPiece,
+    ):
+        """Test that in multi-turn mode, system prompts are excluded but other messages are added"""
+        manager = ConversationManager(attack_identifier=attack_identifier)
+        conversation_id = str(uuid.uuid4())
+
+        # Create conversation with mixed message types
+        conversation = [
+            PromptRequestResponse(request_pieces=[sample_system_piece]),
+            PromptRequestResponse(request_pieces=[sample_user_piece]),
+            PromptRequestResponse(request_pieces=[sample_assistant_piece]),
+        ]
+
+        await manager.update_conversation_state_async(
+            conversation_id=conversation_id,
+            prepended_conversation=conversation,
+            target=mock_chat_target,
+            max_turns=5,  # Multi-turn mode
+        )
+
+        # System prompt should be set on target
+        mock_chat_target.set_system_prompt.assert_called_once()
+
+        # Only user and assistant messages should be in memory
+        # Since the target is mocked, the system piece won't be stored
+        stored_conversation = manager.get_conversation(conversation_id)
+        assert len(stored_conversation) == 2
+        assert stored_conversation[0].get_piece().role == "user"
+        assert stored_conversation[1].get_piece().role == "assistant"
+
+    @pytest.mark.asyncio
+    async def test_update_conversation_state_preserves_original_values_like_legacy(
+        self,
+        attack_identifier: dict[str, str],
+        sample_user_piece: PromptRequestPiece,
+    ):
+        """Test that original values and other piece properties are preserved like the legacy function"""
+        manager = ConversationManager(attack_identifier=attack_identifier)
+        conversation_id = str(uuid.uuid4())
+
+        # Set up piece with various properties that should be preserved
+        sample_user_piece.original_value = "Original user message"
+        sample_user_piece.converted_value = "Converted user message"
+        sample_user_piece.labels = {"test": "label", "category": "user"}
+        sample_user_piece.prompt_metadata = {"timestamp": "2023-01-01", "version": 1}
+
+        conversation = [PromptRequestResponse(request_pieces=[sample_user_piece])]
+
+        await manager.update_conversation_state_async(
+            conversation_id=conversation_id,
+            prepended_conversation=conversation,
+            # Single-turn mode
+        )
+
+        # Verify piece was stored with all properties preserved
+        stored_conversation = manager.get_conversation(conversation_id)
+        assert len(stored_conversation) == 1
+
+        stored_piece = stored_conversation[0].get_piece()
+        assert stored_piece.original_value == "Original user message"
+        assert stored_piece.converted_value == "Converted user message"
+        assert stored_piece.labels == {"test": "label", "category": "user"}
+        assert stored_piece.prompt_metadata == {"timestamp": "2023-01-01", "version": 1}
+        assert stored_piece.conversation_id == conversation_id
+        assert stored_piece.orchestrator_identifier == attack_identifier
 
     @pytest.mark.asyncio
     async def test_update_conversation_state_counts_turns_correctly(
@@ -523,12 +753,20 @@ class TestPrivateMethods:
     """Tests for private helper methods"""
 
     def test_should_exclude_piece_from_memory_single_turn_mode(self, sample_system_piece: PromptRequestPiece):
-        # In single-turn mode (max_turns=None), nothing should be excluded
-        assert not ConversationManager._should_exclude_piece_from_memory(piece=sample_system_piece, max_turns=None)
+        # System pieces should be excluded in both single-turn and multi-turn modes
+        # because set_system_prompt() is called on the target, which internally adds them to memory
+        assert ConversationManager._should_exclude_piece_from_memory(piece=sample_system_piece, max_turns=None)
 
     def test_should_exclude_piece_from_memory_multi_turn_system_piece(self, sample_system_piece: PromptRequestPiece):
-        # In multi-turn mode, system pieces should be excluded
+        # System pieces should be excluded in both single-turn and multi-turn modes
         assert ConversationManager._should_exclude_piece_from_memory(piece=sample_system_piece, max_turns=5)
+
+    def test_should_exclude_piece_from_memory_single_turn_non_system_piece(
+        self, sample_user_piece: PromptRequestPiece, sample_assistant_piece: PromptRequestPiece
+    ):
+        # In single-turn mode, non-system pieces should not be excluded
+        assert not ConversationManager._should_exclude_piece_from_memory(piece=sample_user_piece, max_turns=None)
+        assert not ConversationManager._should_exclude_piece_from_memory(piece=sample_assistant_piece, max_turns=None)
 
     def test_should_exclude_piece_from_memory_multi_turn_non_system_piece(
         self, sample_user_piece: PromptRequestPiece, sample_assistant_piece: PromptRequestPiece

--- a/tests/unit/attacks/test_flip_attack.py
+++ b/tests/unit/attacks/test_flip_attack.py
@@ -162,7 +162,6 @@ class TestFlipAttackSetup:
         flip_attack._conversation_manager.update_conversation_state_async.assert_called_once_with(
             conversation_id=basic_context.conversation_id,
             prepended_conversation=[flip_attack._system_prompt],
-            converter_configurations=[],  # Empty list - no converters for system prompt
         )
 
 

--- a/tests/unit/attacks/test_prompt_sending.py
+++ b/tests/unit/attacks/test_prompt_sending.py
@@ -246,9 +246,11 @@ class TestSetupPhase:
         await attack._setup_async(context=basic_context)
 
         attack._conversation_manager.update_conversation_state_async.assert_called_once_with(
+            target=mock_target,
             conversation_id=basic_context.conversation_id,
             prepended_conversation=basic_context.prepended_conversation,
-            converter_configurations=converter_config,
+            request_converters=converter_config,
+            response_converters=[],
         )
 
 


### PR DESCRIPTION
## Description
- Simplified the logic in the conversation manager
- Conversation manager now properly applies converters (request converters for `user`, response converters for `assistant`, and no converters for system prompts)
- Fixed a bug with PromptSendingAttack - when resetting the conversation, prepended conversations should be applied to the new conversation again

## Tests and Documentation
unittests and notebooks