### PR TITLE
MAINT refactored Scoring Orchestrator

### DIFF
--- a/pyrit/score/__init__.py
+++ b/pyrit/score/__init__.py
@@ -4,6 +4,7 @@
 from pyrit.score.scorer import Scorer
 
 from pyrit.score.azure_content_filter_scorer import AzureContentFilterScorer
+from pyrit.score.batch_scorer import BatchScorer
 from pyrit.score.composite_scorer import CompositeScorer
 from pyrit.score.float_scale_threshold_scorer import FloatScaleThresholdScorer
 from pyrit.score.self_ask_general_scorer import SelfAskGeneralScorer
@@ -43,6 +44,7 @@ from pyrit.score.question_answer_scorer import QuestionAnswerScorer
 __all__ = [
     "AND_",
     "AzureContentFilterScorer",
+    "BatchScorer",
     "ContentClassifierPaths",
     "CompositeScorer",
     "FloatScaleThresholdScorer",

--- a/pyrit/score/batch_scorer.py
+++ b/pyrit/score/batch_scorer.py
@@ -1,0 +1,168 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Optional, Sequence
+
+from pyrit.memory import CentralMemory, MemoryInterface
+from pyrit.models import PromptRequestPiece, Score
+from pyrit.score.scorer import Scorer
+
+logger = logging.getLogger(__name__)
+
+
+class BatchScorer:
+    """
+    A utility class for scoring prompts in batches in a parallelizable and convenient way.
+    
+    This class provides functionality to score existing prompts stored in memory
+    without any target interaction, making it a pure scoring utility.
+    """
+
+    def __init__(
+        self,
+        *,
+        batch_size: int = 10,
+    ) -> None:
+        """
+        Initialize the BatchScorer.
+        
+        Args:
+            batch_size (int): The (max) batch size for sending prompts. Defaults to 10.
+                Note: If using a scorer that takes a prompt target, and providing max requests per
+                minute on the target, this should be set to 1 to ensure proper rate limit management.
+        """
+        self._memory = CentralMemory.get_memory_instance()
+        self._batch_size = batch_size
+
+    async def score_prompts_by_id_async(
+        self,
+        *,
+        scorer: Scorer,
+        prompt_ids: list[str],
+        responses_only: bool = False,
+        task: str = "",
+    ) -> list[Score]:
+        """
+        Score prompts using the Scorer for prompts with the prompt_ids.
+        
+        Use this function if you want to score prompt requests as well as prompt responses,
+        or if you want more fine-grained control over the scorer tasks. If you only want to
+        score prompt responses, use the `score_responses_by_filters_async` function.
+
+        Args:
+            scorer (Scorer): The Scorer object to use for scoring.
+            prompt_ids (list[str]): A list of prompt IDs correlating to the prompts to score.
+            responses_only (bool): If True, only the responses (messages with role "assistant") are
+                scored. Defaults to False.
+            task (str): A task is used to give the scorer more context on what exactly to score.
+                A task might be the request prompt text or the original attack model's objective.
+                **Note: the same task is to applied to all prompt_ids.** Defaults to an empty string.
+
+        Returns:
+            list[Score]: A list of Score objects for the prompts with the prompt_ids.
+        """
+        request_pieces: Sequence[PromptRequestPiece] = []
+        request_pieces = self._memory.get_prompt_request_pieces(prompt_ids=prompt_ids)
+
+        if responses_only:
+            request_pieces = self._extract_responses_only(request_pieces)
+
+        request_pieces = self._remove_duplicates(request_pieces)
+
+        return await scorer.score_prompts_with_tasks_batch_async(
+            request_responses=request_pieces, batch_size=self._batch_size, tasks=[task] * len(request_pieces)
+        )
+
+    async def score_responses_by_filters_async(
+        self,
+        *,
+        scorer: Scorer,
+        orchestrator_id: Optional[str | uuid.UUID] = None,
+        conversation_id: Optional[str | uuid.UUID] = None,
+        prompt_ids: Optional[list[str] | list[uuid.UUID]] = None,
+        labels: Optional[dict[str, str]] = None,
+        sent_after: Optional[datetime] = None,
+        sent_before: Optional[datetime] = None,
+        original_values: Optional[list[str]] = None,
+        converted_values: Optional[list[str]] = None,
+        data_type: Optional[str] = None,
+        not_data_type: Optional[str] = None,
+        converted_value_sha256: Optional[list[str]] = None,
+    ) -> list[Score]:
+        """
+        Score the responses that match the specified filters.
+
+        Args:
+            scorer (Scorer): The Scorer object to use for scoring.
+            orchestrator_id (Optional[str | uuid.UUID]): The ID of the orchestrator. Defaults to None.
+            conversation_id (Optional[str | uuid.UUID]): The ID of the conversation. Defaults to None.
+            prompt_ids (Optional[list[str] | list[uuid.UUID]]): A list of prompt IDs. Defaults to None.
+            labels (Optional[dict[str, str]]): A dictionary of labels. Defaults to None.
+            sent_after (Optional[datetime]): Filter for prompts sent after this datetime. Defaults to None.
+            sent_before (Optional[datetime]): Filter for prompts sent before this datetime. Defaults to None.
+            original_values (Optional[list[str]]): A list of original values. Defaults to None.
+            converted_values (Optional[list[str]]): A list of converted values. Defaults to None.
+            data_type (Optional[str]): The data type to filter by. Defaults to None.
+            not_data_type (Optional[str]): The data type to exclude. Defaults to None.
+            converted_value_sha256 (Optional[list[str]]): A list of SHA256 hashes of converted values.
+                Defaults to None.
+                
+        Returns:
+            list[Score]: A list of Score objects for responses that match the specified filters.
+            
+        Raises:
+            ValueError: If no entries match the provided filters.
+        """
+        request_pieces: Sequence[PromptRequestPiece] = []
+        request_pieces = self._memory.get_prompt_request_pieces(
+            orchestrator_id=orchestrator_id,
+            conversation_id=conversation_id,
+            prompt_ids=prompt_ids,
+            labels=labels,
+            sent_after=sent_after,
+            sent_before=sent_before,
+            original_values=original_values,
+            converted_values=converted_values,
+            data_type=data_type,
+            not_data_type=not_data_type,
+            converted_value_sha256=converted_value_sha256,
+        )
+
+        request_pieces = self._remove_duplicates(request_pieces)
+
+        if not request_pieces:
+            raise ValueError("No entries match the provided filters. Please check your filters.")
+
+        return await scorer.score_responses_inferring_tasks_batch_async(
+            request_responses=request_pieces, batch_size=self._batch_size
+        )
+
+    def _extract_responses_only(self, request_responses: Sequence[PromptRequestPiece]) -> list[PromptRequestPiece]:
+        """
+        Extract the responses from the list of PromptRequestPiece objects.
+        
+        Args:
+            request_responses (Sequence[PromptRequestPiece]): The request responses to filter.
+            
+        Returns:
+            list[PromptRequestPiece]: A list containing only assistant responses.
+        """
+        return [response for response in request_responses if response.role == "assistant"]
+
+    def _remove_duplicates(self, request_responses: Sequence[PromptRequestPiece]) -> list[PromptRequestPiece]:
+        """
+        Remove duplicates from the list of PromptRequestPiece objects.
+        
+        This ensures that identical prompts are not scored twice by filtering
+        to only include original prompts (where original_prompt_id == id).
+        
+        Args:
+            request_responses (Sequence[PromptRequestPiece]): The request responses to deduplicate.
+            
+        Returns:
+            list[PromptRequestPiece]: A list with duplicates removed.
+        """
+        return [response for response in request_responses if response.original_prompt_id == response.id]

--- a/pyrit/score/batch_scorer.py
+++ b/pyrit/score/batch_scorer.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime
 from typing import Optional, Sequence
 
-from pyrit.memory import CentralMemory, MemoryInterface
+from pyrit.memory import CentralMemory
 from pyrit.models import PromptRequestPiece, Score
 from pyrit.score.scorer import Scorer
 
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 class BatchScorer:
     """
     A utility class for scoring prompts in batches in a parallelizable and convenient way.
-    
+
     This class provides functionality to score existing prompts stored in memory
     without any target interaction, making it a pure scoring utility.
     """
@@ -28,7 +28,7 @@ class BatchScorer:
     ) -> None:
         """
         Initialize the BatchScorer.
-        
+
         Args:
             batch_size (int): The (max) batch size for sending prompts. Defaults to 10.
                 Note: If using a scorer that takes a prompt target, and providing max requests per
@@ -47,7 +47,7 @@ class BatchScorer:
     ) -> list[Score]:
         """
         Score prompts using the Scorer for prompts with the prompt_ids.
-        
+
         Use this function if you want to score prompt requests as well as prompt responses,
         or if you want more fine-grained control over the scorer tasks. If you only want to
         score prompt responses, use the `score_responses_by_filters_async` function.
@@ -109,10 +109,10 @@ class BatchScorer:
             not_data_type (Optional[str]): The data type to exclude. Defaults to None.
             converted_value_sha256 (Optional[list[str]]): A list of SHA256 hashes of converted values.
                 Defaults to None.
-                
+
         Returns:
             list[Score]: A list of Score objects for responses that match the specified filters.
-            
+
         Raises:
             ValueError: If no entries match the provided filters.
         """
@@ -143,10 +143,10 @@ class BatchScorer:
     def _extract_responses_only(self, request_responses: Sequence[PromptRequestPiece]) -> list[PromptRequestPiece]:
         """
         Extract the responses from the list of PromptRequestPiece objects.
-        
+
         Args:
             request_responses (Sequence[PromptRequestPiece]): The request responses to filter.
-            
+
         Returns:
             list[PromptRequestPiece]: A list containing only assistant responses.
         """
@@ -155,13 +155,13 @@ class BatchScorer:
     def _remove_duplicates(self, request_responses: Sequence[PromptRequestPiece]) -> list[PromptRequestPiece]:
         """
         Remove duplicates from the list of PromptRequestPiece objects.
-        
+
         This ensures that identical prompts are not scored twice by filtering
         to only include original prompts (where original_prompt_id == id).
-        
+
         Args:
             request_responses (Sequence[PromptRequestPiece]): The request responses to deduplicate.
-            
+
         Returns:
             list[PromptRequestPiece]: A list with duplicates removed.
         """

--- a/tests/unit/score/test_batch_scorer.py
+++ b/tests/unit/score/test_batch_scorer.py
@@ -39,7 +39,7 @@ class TestBatchScorerInitialization:
         mock_memory = MagicMock()
         with patch.object(CentralMemory, "get_memory_instance", return_value=mock_memory) as mock_get_memory:
             batch_scorer = BatchScorer()
-            
+
             mock_get_memory.assert_called_once()
             assert batch_scorer._memory == mock_memory
 
@@ -63,7 +63,7 @@ class TestBatchScorerScorePromptsById:
             batch_scorer = BatchScorer()
 
             await batch_scorer.score_prompts_by_id_async(scorer=scorer, prompt_ids=["id1"])
-            
+
             memory.get_prompt_request_pieces.assert_called_once_with(prompt_ids=["id1"])
             scorer.score_prompts_with_tasks_batch_async.assert_called_once()
 
@@ -81,9 +81,7 @@ class TestBatchScorerScorePromptsById:
 
             batch_scorer = BatchScorer()
 
-            await batch_scorer.score_prompts_by_id_async(
-                scorer=scorer, prompt_ids=["id1"], responses_only=True
-            )
+            await batch_scorer.score_prompts_by_id_async(scorer=scorer, prompt_ids=["id1"], responses_only=True)
 
             # Verify that only assistant responses are passed to scorer
             _, kwargs = scorer.score_prompts_with_tasks_batch_async.call_args
@@ -105,9 +103,7 @@ class TestBatchScorerScorePromptsById:
             batch_scorer = BatchScorer()
             test_task = "custom task"
 
-            await batch_scorer.score_prompts_by_id_async(
-                scorer=scorer, prompt_ids=["id1"], task=test_task
-            )
+            await batch_scorer.score_prompts_by_id_async(scorer=scorer, prompt_ids=["id1"], task=test_task)
 
             _, kwargs = scorer.score_prompts_with_tasks_batch_async.call_args
             tasks = kwargs["tasks"]

--- a/tests/unit/score/test_batch_scorer.py
+++ b/tests/unit/score/test_batch_scorer.py
@@ -171,29 +171,35 @@ class TestBatchScorerScoreResponsesByFilters:
 
             batch_scorer = BatchScorer()
 
-            test_filters = {
-                "orchestrator_id": str(uuid.uuid4()),
-                "conversation_id": str(uuid.uuid4()),
-                "prompt_ids": ["id1", "id2"],
-                "labels": {"test": "value"},
-                "data_type": "text",
-                "not_data_type": "image",
-            }
+            test_orchestrator_id = str(uuid.uuid4())
+            test_conversation_id = str(uuid.uuid4())
+            test_prompt_ids = ["id1", "id2"]
+            test_labels = {"test": "value"}
+            test_data_type = "text"
+            test_not_data_type = "image"
 
-            await batch_scorer.score_responses_by_filters_async(scorer=scorer, **test_filters)
+            await batch_scorer.score_responses_by_filters_async(
+                scorer=scorer,
+                orchestrator_id=test_orchestrator_id,
+                conversation_id=test_conversation_id,
+                prompt_ids=test_prompt_ids,
+                labels=test_labels,
+                data_type=test_data_type,
+                not_data_type=test_not_data_type,
+            )
 
             # Should call memory with all parameters including None for unspecified ones
             memory.get_prompt_request_pieces.assert_called_once_with(
-                orchestrator_id=test_filters["orchestrator_id"],
-                conversation_id=test_filters["conversation_id"],
-                prompt_ids=test_filters["prompt_ids"],
-                labels=test_filters["labels"],
+                orchestrator_id=test_orchestrator_id,
+                conversation_id=test_conversation_id,
+                prompt_ids=test_prompt_ids,
+                labels=test_labels,
                 sent_after=None,
                 sent_before=None,
                 original_values=None,
                 converted_values=None,
-                data_type=test_filters["data_type"],
-                not_data_type=test_filters["not_data_type"],
+                data_type=test_data_type,
+                not_data_type=test_not_data_type,
                 converted_value_sha256=None,
             )
 

--- a/tests/unit/score/test_batch_scorer.py
+++ b/tests/unit/score/test_batch_scorer.py
@@ -1,0 +1,353 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import uuid
+from typing import MutableSequence
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from unit.mocks import get_sample_conversations
+
+from pyrit.memory import CentralMemory
+from pyrit.models import PromptRequestPiece
+from pyrit.score import BatchScorer, SubStringScorer
+
+
+@pytest.fixture
+def sample_conversations() -> MutableSequence[PromptRequestPiece]:
+    return get_sample_conversations()
+
+
+@pytest.mark.usefixtures("patch_central_database")
+class TestBatchScorerInitialization:
+    """Test BatchScorer initialization scenarios."""
+
+    def test_init_with_default_batch_size(self) -> None:
+        """Test initialization with default batch size."""
+        with patch.object(CentralMemory, "get_memory_instance", return_value=MagicMock()):
+            batch_scorer = BatchScorer()
+            assert batch_scorer._batch_size == 10
+
+    def test_init_with_custom_batch_size(self) -> None:
+        """Test initialization with custom batch size."""
+        with patch.object(CentralMemory, "get_memory_instance", return_value=MagicMock()):
+            batch_scorer = BatchScorer(batch_size=5)
+            assert batch_scorer._batch_size == 5
+
+    def test_init_memory_initialization(self) -> None:
+        """Test that memory is properly initialized from CentralMemory."""
+        mock_memory = MagicMock()
+        with patch.object(CentralMemory, "get_memory_instance", return_value=mock_memory) as mock_get_memory:
+            batch_scorer = BatchScorer()
+            
+            mock_get_memory.assert_called_once()
+            assert batch_scorer._memory == mock_memory
+
+
+@pytest.mark.usefixtures("patch_central_database")
+class TestBatchScorerScorePromptsById:
+    """Test score_prompts_by_id_async method functionality."""
+
+    @pytest.mark.asyncio
+    async def test_score_prompts_by_id_basic_functionality(
+        self, sample_conversations: MutableSequence[PromptRequestPiece]
+    ) -> None:
+        """Test basic scoring functionality with prompt IDs."""
+        memory = MagicMock()
+        memory.get_prompt_request_pieces.return_value = sample_conversations
+
+        with patch.object(CentralMemory, "get_memory_instance", return_value=memory):
+            scorer = SubStringScorer(substring="test", category="test")
+            scorer.score_prompts_with_tasks_batch_async = AsyncMock(return_value=[])  # type: ignore
+
+            batch_scorer = BatchScorer()
+
+            await batch_scorer.score_prompts_by_id_async(scorer=scorer, prompt_ids=["id1"])
+            
+            memory.get_prompt_request_pieces.assert_called_once_with(prompt_ids=["id1"])
+            scorer.score_prompts_with_tasks_batch_async.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_score_prompts_by_id_with_responses_only(
+        self, sample_conversations: MutableSequence[PromptRequestPiece]
+    ) -> None:
+        """Test scoring with responses_only flag."""
+        memory = MagicMock()
+        memory.get_prompt_request_pieces.return_value = sample_conversations
+
+        with patch.object(CentralMemory, "get_memory_instance", return_value=memory):
+            scorer = MagicMock()
+            scorer.score_prompts_with_tasks_batch_async = AsyncMock(return_value=[])
+
+            batch_scorer = BatchScorer()
+
+            await batch_scorer.score_prompts_by_id_async(
+                scorer=scorer, prompt_ids=["id1"], responses_only=True
+            )
+
+            # Verify that only assistant responses are passed to scorer
+            _, kwargs = scorer.score_prompts_with_tasks_batch_async.call_args
+            request_responses = kwargs["request_responses"]
+            assert all(piece.role == "assistant" for piece in request_responses)
+
+    @pytest.mark.asyncio
+    async def test_score_prompts_by_id_with_task(
+        self, sample_conversations: MutableSequence[PromptRequestPiece]
+    ) -> None:
+        """Test scoring with custom task."""
+        memory = MagicMock()
+        memory.get_prompt_request_pieces.return_value = sample_conversations
+
+        with patch.object(CentralMemory, "get_memory_instance", return_value=memory):
+            scorer = MagicMock()
+            scorer.score_prompts_with_tasks_batch_async = AsyncMock(return_value=[])
+
+            batch_scorer = BatchScorer()
+            test_task = "custom task"
+
+            await batch_scorer.score_prompts_by_id_async(
+                scorer=scorer, prompt_ids=["id1"], task=test_task
+            )
+
+            _, kwargs = scorer.score_prompts_with_tasks_batch_async.call_args
+            tasks = kwargs["tasks"]
+            assert all(task == test_task for task in tasks)
+
+    @pytest.mark.asyncio
+    async def test_score_prompts_by_id_uses_correct_batch_size(
+        self, sample_conversations: MutableSequence[PromptRequestPiece]
+    ) -> None:
+        """Test that correct batch size is passed to scorer."""
+        memory = MagicMock()
+        memory.get_prompt_request_pieces.return_value = sample_conversations
+
+        with patch.object(CentralMemory, "get_memory_instance", return_value=memory):
+            scorer = MagicMock()
+            scorer.score_prompts_with_tasks_batch_async = AsyncMock(return_value=[])
+
+            custom_batch_size = 15
+            batch_scorer = BatchScorer(batch_size=custom_batch_size)
+
+            await batch_scorer.score_prompts_by_id_async(scorer=scorer, prompt_ids=["id1"])
+
+            _, kwargs = scorer.score_prompts_with_tasks_batch_async.call_args
+            assert kwargs["batch_size"] == custom_batch_size
+
+
+@pytest.mark.usefixtures("patch_central_database")
+class TestBatchScorerScoreResponsesByFilters:
+    """Test score_responses_by_filters_async method functionality."""
+
+    @pytest.mark.asyncio
+    async def test_score_responses_by_filters_basic_functionality(
+        self, sample_conversations: MutableSequence[PromptRequestPiece]
+    ) -> None:
+        """Test basic scoring functionality with filters."""
+        memory = MagicMock()
+        memory.get_prompt_request_pieces.return_value = sample_conversations
+
+        with patch.object(CentralMemory, "get_memory_instance", return_value=memory):
+            scorer = MagicMock()
+            test_score = MagicMock()
+            scorer.score_responses_inferring_tasks_batch_async = AsyncMock(return_value=[test_score])
+
+            batch_scorer = BatchScorer()
+
+            scores = await batch_scorer.score_responses_by_filters_async(
+                scorer=scorer, orchestrator_id=str(uuid.uuid4())
+            )
+
+            memory.get_prompt_request_pieces.assert_called_once()
+            scorer.score_responses_inferring_tasks_batch_async.assert_called_once()
+            assert scores[0] == test_score
+
+    @pytest.mark.asyncio
+    async def test_score_responses_by_filters_with_all_parameters(
+        self, sample_conversations: MutableSequence[PromptRequestPiece]
+    ) -> None:
+        """Test scoring with all filter parameters."""
+        memory = MagicMock()
+        memory.get_prompt_request_pieces.return_value = sample_conversations
+
+        with patch.object(CentralMemory, "get_memory_instance", return_value=memory):
+            scorer = MagicMock()
+            scorer.score_responses_inferring_tasks_batch_async = AsyncMock(return_value=[])
+
+            batch_scorer = BatchScorer()
+
+            test_filters = {
+                "orchestrator_id": str(uuid.uuid4()),
+                "conversation_id": str(uuid.uuid4()),
+                "prompt_ids": ["id1", "id2"],
+                "labels": {"test": "value"},
+                "data_type": "text",
+                "not_data_type": "image",
+            }
+
+            await batch_scorer.score_responses_by_filters_async(scorer=scorer, **test_filters)
+
+            # Should call memory with all parameters including None for unspecified ones
+            memory.get_prompt_request_pieces.assert_called_once_with(
+                orchestrator_id=test_filters["orchestrator_id"],
+                conversation_id=test_filters["conversation_id"],
+                prompt_ids=test_filters["prompt_ids"],
+                labels=test_filters["labels"],
+                sent_after=None,
+                sent_before=None,
+                original_values=None,
+                converted_values=None,
+                data_type=test_filters["data_type"],
+                not_data_type=test_filters["not_data_type"],
+                converted_value_sha256=None,
+            )
+
+    @pytest.mark.asyncio
+    async def test_score_responses_by_filters_raises_error_no_matching_filters(self) -> None:
+        """Test that ValueError is raised when no entries match filters."""
+        memory = MagicMock()
+        memory.get_prompt_request_pieces.return_value = []
+
+        with patch.object(CentralMemory, "get_memory_instance", return_value=memory):
+            batch_scorer = BatchScorer()
+
+            with pytest.raises(ValueError, match="No entries match the provided filters. Please check your filters."):
+                await batch_scorer.score_responses_by_filters_async(
+                    scorer=MagicMock(),
+                    labels={"op_name": "nonexistent_op", "user_name": "nonexistent_user"},
+                )
+
+
+@pytest.mark.usefixtures("patch_central_database")
+class TestBatchScorerUtilityMethods:
+    """Test utility methods of BatchScorer."""
+
+    def test_remove_duplicates(self) -> None:
+        """Test removal of duplicate prompt request pieces."""
+        prompt_id1 = uuid.uuid4()
+        prompt_id2 = uuid.uuid4()
+
+        with patch.object(CentralMemory, "get_memory_instance", return_value=MagicMock()):
+            batch_scorer = BatchScorer()
+
+            pieces = [
+                PromptRequestPiece(
+                    id=prompt_id1,
+                    role="user",
+                    original_value="original prompt text",
+                    converted_value="Hello, how are you?",
+                    sequence=0,
+                ),
+                PromptRequestPiece(
+                    id=prompt_id2,
+                    role="assistant",
+                    original_value="original prompt text",
+                    converted_value="I'm fine, thank you!",
+                    sequence=1,
+                ),
+                PromptRequestPiece(
+                    role="user",
+                    original_value="original prompt text",
+                    converted_value="Hello, how are you?",
+                    sequence=0,
+                    original_prompt_id=prompt_id1,
+                ),
+                PromptRequestPiece(
+                    role="assistant",
+                    original_value="original prompt text",
+                    converted_value="I'm fine, thank you!",
+                    sequence=1,
+                    original_prompt_id=prompt_id2,
+                ),
+            ]
+
+            orig_pieces = batch_scorer._remove_duplicates(pieces)
+
+            assert len(orig_pieces) == 2
+            for piece in orig_pieces:
+                assert piece.id in [prompt_id1, prompt_id2]
+                assert piece.id == piece.original_prompt_id
+
+    def test_extract_responses_only(self) -> None:
+        """Test extraction of assistant responses only."""
+        with patch.object(CentralMemory, "get_memory_instance", return_value=MagicMock()):
+            batch_scorer = BatchScorer()
+
+            pieces = [
+                PromptRequestPiece(
+                    role="user",
+                    original_value="user message",
+                    converted_value="user message",
+                    sequence=0,
+                ),
+                PromptRequestPiece(
+                    role="assistant",
+                    original_value="assistant response",
+                    converted_value="assistant response",
+                    sequence=1,
+                ),
+                PromptRequestPiece(
+                    role="system",
+                    original_value="system message",
+                    converted_value="system message",
+                    sequence=2,
+                ),
+            ]
+
+            responses = batch_scorer._extract_responses_only(pieces)
+
+            assert len(responses) == 1
+            assert responses[0].role == "assistant"
+            assert responses[0].original_value == "assistant response"
+
+
+@pytest.mark.usefixtures("patch_central_database")
+class TestBatchScorerErrorHandling:
+    """Test error handling scenarios for BatchScorer."""
+
+    @pytest.mark.asyncio
+    async def test_score_prompts_by_id_empty_prompt_ids(self) -> None:
+        """Test scoring with empty prompt_ids list."""
+        memory = MagicMock()
+        memory.get_prompt_request_pieces.return_value = []
+
+        with patch.object(CentralMemory, "get_memory_instance", return_value=memory):
+            scorer = MagicMock()
+            scorer.score_prompts_with_tasks_batch_async = AsyncMock(return_value=[])
+
+            batch_scorer = BatchScorer()
+
+            result = await batch_scorer.score_prompts_by_id_async(scorer=scorer, prompt_ids=[])
+
+            assert result == []
+            memory.get_prompt_request_pieces.assert_called_once_with(prompt_ids=[])
+
+    @pytest.mark.asyncio
+    async def test_score_responses_by_filters_no_filters_provided(
+        self, sample_conversations: MutableSequence[PromptRequestPiece]
+    ) -> None:
+        """Test scoring when no filters are provided."""
+        memory = MagicMock()
+        memory.get_prompt_request_pieces.return_value = sample_conversations
+
+        with patch.object(CentralMemory, "get_memory_instance", return_value=memory):
+            scorer = MagicMock()
+            scorer.score_responses_inferring_tasks_batch_async = AsyncMock(return_value=[])
+
+            batch_scorer = BatchScorer()
+
+            await batch_scorer.score_responses_by_filters_async(scorer=scorer)
+
+            # Should call memory with all None parameters
+            memory.get_prompt_request_pieces.assert_called_once_with(
+                orchestrator_id=None,
+                conversation_id=None,
+                prompt_ids=None,
+                labels=None,
+                sent_after=None,
+                sent_before=None,
+                original_values=None,
+                converted_values=None,
+                data_type=None,
+                not_data_type=None,
+                converted_value_sha256=None,
+            )


### PR DESCRIPTION
## Description
### The Problem 
We have two orchestrators that do not fit the `AttackStrategy` pattern, and forcing them into it creates architectural inconsistencies: 
- `ScoringOrchestrator`: Performs batch scoring operations on existing data rather than probing a target 
- `XPIAOrchestrator`: Requires human intervention and external callbacks, breaking the autonomous execution model that attacks follow 

### Proposed Solution 
For `ScoringOrchestrator`, the solution is straightforward, move it to `pyrit/score/batch_scorer.py` as a utility class called `BatchScorer`. This makes sense because scoring existing prompts is fundamentally a utility operation, not an attack. It processes data already in the system without any target interaction. 

## Tests and Documentation
Improved existing tests for `ScoringOrchestrator` as `BatchScorer`
