### PR TITLE
FIX: passing in target for update_conversation_state_async

### DIFF
--- a/pyrit/attacks/single_turn/flip_attack.py
+++ b/pyrit/attacks/single_turn/flip_attack.py
@@ -94,9 +94,11 @@ class FlipAttack(PromptSendingAttack):
         context.memory_labels = combine_dict(self._memory_labels, context.memory_labels)
 
         # System prompt should not be converted, and the new implementation correctly
-        # skips converters for system messages, so we can pass empty converter lists
+        # skips converters for system messages
         await self._conversation_manager.update_conversation_state_async(
-            conversation_id=context.conversation_id, prepended_conversation=context.prepended_conversation
+            target=self._objective_target,
+            conversation_id=context.conversation_id,
+            prepended_conversation=context.prepended_conversation,
         )
 
     async def _perform_attack_async(self, *, context: SingleTurnAttackContext) -> AttackResult:

--- a/tests/unit/attacks/test_flip_attack.py
+++ b/tests/unit/attacks/test_flip_attack.py
@@ -160,6 +160,7 @@ class TestFlipAttackSetup:
 
         # Verify conversation manager was called with empty converter list
         flip_attack._conversation_manager.update_conversation_state_async.assert_called_once_with(
+            target=flip_attack._objective_target,
             conversation_id=basic_context.conversation_id,
             prepended_conversation=[flip_attack._system_prompt],
         )


### PR DESCRIPTION
## Description
This PR fixes a bug where the objective target was not properly passed into `update_conversation_state_async` call in `setup_async`. Now, the target system prompt is set properly. 

This PR is a follow up on the below PRs:
- https://github.com/Azure/PyRIT/pull/1035
- https://github.com/Azure/PyRIT/pull/1010

## Tests and Documentation
Re-ran notebook.
