### PR TITLE
FIX for code scanning alert no. 9: Clear-text logging of sensitive information

### DIFF
--- a/doc/deployment/score_aml_endpoint.py
+++ b/doc/deployment/score_aml_endpoint.py
@@ -45,7 +45,10 @@ api_key = os.getenv("AZURE_ML_SCORE_API_KEY")
 # %%
 print(f"Deployment name {deployment_name}")
 print(f"Azure ML endpoint uri: {url}")
-print(f"API key: {api_key}")
+if api_key:
+    print("API key is set.")
+else:
+    print("API key is not set.")
 
 # %% [markdown]
 # **Azure ML endpoint JSON body**


### PR DESCRIPTION
Potential fix for [https://github.com/Azure/PyRIT/security/code-scanning/9](https://github.com/Azure/PyRIT/security/code-scanning/9)

To fix the problem, we should remove or redact the logging of sensitive information. Specifically, the line that prints the API key (`print(f"API key: {api_key}")`) should be removed or modified so that it does not output the actual key. If it is necessary to confirm that an API key is present, we can log only the presence of the key or a masked version (e.g., showing only the last 4 characters). The best fix is to replace the print statement with a message indicating whether the API key is set, or, if needed, print a masked version for debugging without exposing the full value.

Only the code in `doc/deployment/score_aml_endpoint.py` needs to be changed, specifically line 48.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
