### PR TITLE
FEAT Add FirstLetterConverter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: ['flake8-copyright']
-        exclude: (doc/|.github/|pyrit/prompt_converter/morse_converter.py|tests/unit/converter/test_prompt_converter.py|pyrit/prompt_converter/emoji_converter.py|tests/unit/models/test_seed_prompt.py|tests/unit/converter/test_unicode_confusable_converter.py)
+        exclude: (doc/|.github/|pyrit/prompt_converter/morse_converter.py|tests/unit/converter/test_prompt_converter.py|pyrit/prompt_converter/emoji_converter.py|tests/unit/models/test_seed_prompt.py|tests/unit/converter/test_unicode_confusable_converter.py|tests/unit/converter/test_first_letter_converter.py)
 
   - repo: local
     hooks:

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -335,6 +335,7 @@ API Reference
     DenylistConverter
     DiacriticConverter
     EmojiConverter
+    FirstLetterConverter
     FlipConverter
     FuzzerCrossOverConverter
     FuzzerExpandConverter

--- a/pyrit/prompt_converter/__init__.py
+++ b/pyrit/prompt_converter/__init__.py
@@ -26,6 +26,7 @@ from pyrit.prompt_converter.codechameleon_converter import CodeChameleonConverte
 from pyrit.prompt_converter.colloquial_wordswap_converter import ColloquialWordswapConverter
 from pyrit.prompt_converter.diacritic_converter import DiacriticConverter
 from pyrit.prompt_converter.emoji_converter import EmojiConverter
+from pyrit.prompt_converter.first_letter_converter import FirstLetterConverter
 from pyrit.prompt_converter.flip_converter import FlipConverter
 from pyrit.prompt_converter.fuzzer_converter import (
     FuzzerConverter,
@@ -93,6 +94,7 @@ __all__ = [
     "DiacriticConverter",
     "ConverterResult",
     "EmojiConverter",
+    "FirstLetterConverter",
     "FlipConverter",
     "FuzzerConverter",
     "FuzzerCrossOverConverter",

--- a/pyrit/prompt_converter/first_letter_converter.py
+++ b/pyrit/prompt_converter/first_letter_converter.py
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from pyrit.prompt_converter.word_level_converter import WordLevelConverter
+
+
+class FirstLetterConverter(WordLevelConverter):
+    """
+    Replaces each word of the prompt with its first letter (or digit).
+    Whitespace and words that do not contain any letter or digit are ignored.
+    """
+
+    async def convert_word_async(self, word: str) -> str:
+        stripped_word = "".join(filter(str.isalnum, word))
+        return stripped_word[:1]
+
+    def join_words(self, words: list[str]) -> str:
+        return "".join(words)  # Join first letters without separator

--- a/tests/integration/cli/test_cli_integration.py
+++ b/tests/integration/cli/test_cli_integration.py
@@ -90,6 +90,10 @@ converters = [
     ),
     (
         "text",
+        {"type": "FirstLetterConverter"},
+    ),
+    (
+        "text",
         {"type": "FlipConverter"},
     ),
     (

--- a/tests/unit/cli/prompt_send_success_converters_default.yaml
+++ b/tests/unit/cli/prompt_send_success_converters_default.yaml
@@ -33,6 +33,7 @@ converters:
   - type: "DenylistConverter"
   - type: "DiacriticConverter"
   - type: "EmojiConverter"
+  - type: "FirstLetterConverter"
   - type: "FlipConverter"
   - type: "FuzzerCrossOverConverter"
   - type: "FuzzerExpandConverter"

--- a/tests/unit/converter/test_first_letter_converter.py
+++ b/tests/unit/converter/test_first_letter_converter.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import pytest
+
+from pyrit.prompt_converter import FirstLetterConverter
+
+
+# Test that the default converter settings produce the expected result
+@pytest.mark.asyncio
+async def test_first_letter_converter_default():
+    converter = FirstLetterConverter()
+    prompt = "Lorem ipsum dolor sit amet"
+    output = await converter.convert_async(prompt=prompt, input_type="text")
+    assert output.output_text == "Lidsa"
+    assert output.output_type == "text"
+
+
+# Test that the converter produces the expected result with French punctuation
+@pytest.mark.asyncio
+async def test_first_letter_converter_french():
+    converter = FirstLetterConverter()
+    prompt = """
+    En 1815, M. Charles-François-Bienvenu Myriel était évêque de Digne.
+    C'était un vieillard d'environ soixante-quinze ans ; il occupait le siége de Digne depuis 1806.
+    """
+    output = await converter.convert_async(prompt=prompt, input_type="text")
+    assert output.output_text == "E1MCMéédDCuvdsaiolsdDd1"
+    assert output.output_type == "text"
+
+
+# Test that the converter produces the expected result with non-Latin alphabets
+@pytest.mark.asyncio
+async def test_first_letter_converter_japanese():
+    converter = FirstLetterConverter()
+    prompt = """
+    ふるいけ や
+    かわず とびこむ
+    みず の おと
+    """
+    output = await converter.convert_async(prompt=prompt, input_type="text")
+    assert output.output_text == "ふやかとみのお"
+    assert output.output_type == "text"


### PR DESCRIPTION
## Description

This PR adds a converter that replaces each word of the prompt with its first letter (or digit).

Design choices:

- Anything that's not a letter or digit is stripped from the tokens (split by space in `WordLevelConverter`).
- Hyphenated compounds (e.g. "mother-in-law") and contractions (e.g. "don't") are considered single words.
- First letters are joined without separator so that users can apply `StringJoinConverter` with the separator of their choice.

## Tests and Documentation

Added unit tests, including multi-line prompts, French punctuation and Japanese characters.

I excluded the test script from flake8 because it contains UTF-8 characters that are not supporter by flake8-copyright.

I did not add this converter to the doc notebook that has other converter examples because it's a simple one.