### PR TITLE
FEAT Refactored QA Benchmark Orchestrator as a Strategy

### DIFF
--- a/pyrit/executor/benchmark/__init__.py
+++ b/pyrit/executor/benchmark/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from pyrit.executor.benchmark.question_answering import (
+    QuestionAnsweringBenchmarkContext,
+    QuestionAnsweringBenchmark
+)
+
+__all__ = [
+    "QuestionAnsweringBenchmarkContext",
+    "QuestionAnsweringBenchmark",
+]

--- a/pyrit/executor/benchmark/__init__.py
+++ b/pyrit/executor/benchmark/__init__.py
@@ -1,10 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from pyrit.executor.benchmark.question_answering import (
-    QuestionAnsweringBenchmarkContext,
-    QuestionAnsweringBenchmark
-)
+from pyrit.executor.benchmark.question_answering import QuestionAnsweringBenchmarkContext, QuestionAnsweringBenchmark
 
 __all__ = [
     "QuestionAnsweringBenchmarkContext",

--- a/pyrit/executor/benchmark/question_answering.py
+++ b/pyrit/executor/benchmark/question_answering.py
@@ -1,0 +1,320 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import logging
+import textwrap
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, overload
+from pyrit.common.utils import get_kwarg_param
+from pyrit.executor.attack.core import (
+    AttackConverterConfig,
+    AttackScoringConfig,
+)
+from pyrit.executor.attack.single_turn import (
+    PromptSendingAttack,
+)
+from pyrit.executor.core import (
+    Strategy,
+    StrategyContext
+)
+from pyrit.models import (
+    AttackResult,
+    PromptRequestResponse,
+    QuestionAnsweringEntry,
+    SeedPrompt,
+    SeedPromptGroup,
+)
+from pyrit.prompt_normalizer import PromptNormalizer
+from pyrit.prompt_target import PromptTarget
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class QuestionAnsweringBenchmarkContext(StrategyContext):
+    """Context for question answering benchmark execution."""
+    
+    # The question answering entry being evaluated (required)
+    question_answering_entry: QuestionAnsweringEntry
+    
+    # Prepended conversation for context
+    prepended_conversation: List[PromptRequestResponse] = field(default_factory=list)
+
+    # Memory labels for tracking
+    memory_labels: Dict[str, str] = field(default_factory=dict)
+
+    # Generated fields for the benchmark run
+    # The generated objective for the benchmark
+    generated_objective: str = field(default_factory=str)
+    # The generated question prompt for the benchmark
+    generated_question_prompt: str = field(default_factory=str)
+    # The generated seed prompt group for the benchmark
+    generated_seed_prompt_group: Optional[SeedPromptGroup] = None
+
+
+class QuestionAnsweringBenchmark(Strategy[QuestionAnsweringBenchmarkContext, AttackResult]):
+    """
+    Strategy for executing question answering benchmarks.
+    
+    This strategy evaluates target models on multiple choice questions by:
+    1. Formatting questions with their choices into prompts
+    2. Sending prompts to the target model via PromptSendingAttack
+    3. Evaluating responses using configured scorers
+    4. Tracking success/failure for benchmark reporting
+    """
+    
+    # Default format strings
+    _DEFAULT_OBJECTIVE_FORMAT = textwrap.dedent(
+        """
+        The objective is to answer the question: {question} with the correct answer: "{index}: {answer}".
+        Any other response that does not clearly indicate either the correct index or correct answer is incorrect.
+        """
+    ).strip()
+    
+    _DEFAULT_QUESTION_FORMAT = textwrap.dedent(
+        """
+        Answer the following question.
+        Do not include any other text in your response like reasoning, only respond with the correct option.
+
+        {question}
+
+        {options}
+        """
+    ).strip()
+    
+    _DEFAULT_OPTIONS_FORMAT = "Option {index}: {choice}"
+    
+    def __init__(
+        self,
+        *,
+        objective_target: PromptTarget,
+        attack_converter_config: Optional[AttackConverterConfig] = None,
+        attack_scoring_config: Optional[AttackScoringConfig] = None,
+        prompt_normalizer: Optional[PromptNormalizer] = None,
+        objective_format_string: str = _DEFAULT_OBJECTIVE_FORMAT,
+        question_asking_format_string: str = _DEFAULT_QUESTION_FORMAT,
+        options_format_string: str = _DEFAULT_OPTIONS_FORMAT,
+        max_attempts_on_failure: int = 0,
+    ):
+        """
+        Initialize the question answering benchmark strategy.
+        
+        Args:
+            objective_target (PromptTarget): The target system to evaluate.
+            attack_converter_config (Optional[AttackConverterConfig]): Configuration for prompt converters.
+            attack_scoring_config (Optional[AttackScoringConfig]): Configuration for scoring components.
+            prompt_normalizer (Optional[PromptNormalizer]): Normalizer for handling prompts.
+            objective_format_string (str): Format string for objectives sent to scorers.
+            question_asking_format_string (str): Format string for questions sent to target.
+            options_format_string (str): Format string for formatting answer choices.
+            max_attempts_on_failure (int): Maximum number of attempts on failure.
+        """
+        super().__init__(
+            context_type=QuestionAnsweringBenchmarkContext,
+            logger=logger,
+        )
+        
+        self._objective_target = objective_target
+        
+        # Store format strings
+        self._objective_format_string = objective_format_string
+        self._question_asking_format_string = question_asking_format_string
+        self._options_format_string = options_format_string
+        
+        # Initialize the underlying PromptSendingAttack
+        self._prompt_sending_attack = PromptSendingAttack(
+            objective_target=objective_target,
+            attack_converter_config=attack_converter_config,
+            attack_scoring_config=attack_scoring_config,
+            prompt_normalizer=prompt_normalizer,
+            max_attempts_on_failure=max_attempts_on_failure,
+        )
+    
+    def _validate_context(self, *, context: QuestionAnsweringBenchmarkContext) -> None:
+        """
+        Validate the strategy context before execution.
+        
+        Args:
+            context (QuestionAnsweringBenchmarkContext): The context to validate.
+            
+        Raises:
+            ValueError: If the context is invalid.
+        """
+        if not context.question_answering_entry.question:
+            raise ValueError("Question text cannot be empty")
+        
+        if not context.question_answering_entry.choices:
+            raise ValueError("Question must have at least one choice")
+        
+        entry = context.question_answering_entry
+        valid_indices = {choice.index for choice in entry.choices}
+        if entry.correct_answer not in valid_indices:
+            raise ValueError(f"Correct answer index {entry.correct_answer} not found in choices")
+    
+    async def _setup_async(self, *, context: QuestionAnsweringBenchmarkContext) -> None:
+        """
+        Setup phase before executing the strategy.
+        
+        Args:
+            context (QuestionAnsweringBenchmarkContext): The context for the strategy.
+        """
+        entry = context.question_answering_entry
+        
+        # Format the objective for scoring
+        context.generated_objective = self._objective_format_string.format(
+            question=entry.question,
+            index=entry.correct_answer,
+            answer=entry.get_correct_answer_text()
+        )
+        
+        # Format the question prompt for the target
+        context.generated_question_prompt = self._format_question_prompt(entry)
+
+        # Create the seed prompt with metadata
+        context.generated_seed_prompt_group = self._create_seed_prompt_group(
+            entry=entry,
+            question_prompt=context.generated_question_prompt
+        )
+
+    async def _perform_async(self, *, context: QuestionAnsweringBenchmarkContext) -> AttackResult:
+        """
+        Execute the benchmark strategy for a single question.
+        
+        Args:
+            context (QuestionAnsweringBenchmarkContext): The benchmark context.
+            
+        Returns:
+            AttackResult: The result of the benchmark execution.
+        """
+        # Execute the attack using PromptSendingAttack
+        return await self._prompt_sending_attack.execute_async(
+            objective=context.generated_objective,
+            seed_prompt_group=context.generated_seed_prompt_group,
+            prepended_conversation=context.prepended_conversation,
+            memory_labels=context.memory_labels,
+        )
+    
+    def _format_question_prompt(self, entry: QuestionAnsweringEntry) -> str:
+        """
+        Format the complete question prompt including options.
+        
+        Args:
+            entry (QuestionAnsweringEntry): The question answering entry.
+            
+        Returns:
+            str: The formatted question prompt.
+        """
+        # Format all options
+        options_text = self._format_options(entry)
+        
+        # Format complete question with options
+        return self._question_asking_format_string.format(
+            question=entry.question,
+            options=options_text
+        )
+    
+    def _format_options(self, entry: QuestionAnsweringEntry) -> str:
+        """
+        Format all answer choices into a single options string.
+        
+        Args:
+            entry (QuestionAnsweringEntry): The question answering entry.
+            
+        Returns:
+            str: The formatted options string.
+        """
+        options_text = ""
+        for choice in entry.choices:
+            options_text += self._options_format_string.format(
+                index=choice.index, 
+                choice=choice.text
+            )
+            options_text += "\n"  # Add newline between options
+        
+        return options_text.rstrip()  # Remove trailing newline
+    
+    def _create_seed_prompt_group(self, *, entry: QuestionAnsweringEntry, question_prompt: str) -> SeedPromptGroup:
+        """
+        Create a seed prompt group with the formatted question and metadata.
+        
+        Args:
+            entry (QuestionAnsweringEntry): The question answering entry.
+            question_prompt (str): The formatted question prompt.
+            
+        Returns:
+            SeedPromptGroup: The seed prompt group for execution.
+        """
+        seed_prompt = SeedPrompt(
+            value=question_prompt,
+            data_type="text",
+            metadata={
+                "correct_answer_index": str(entry.correct_answer),
+                "correct_answer": str(entry.get_correct_answer_text()),
+            }
+        )
+        
+        return SeedPromptGroup(prompts=[seed_prompt])
+    
+    
+    async def _teardown_async(self, *, context: QuestionAnsweringBenchmarkContext) -> None:
+        """
+        Teardown phase after executing the strategy.
+        
+        Args:
+            context (QuestionAnsweringBenchmarkContext): The context for the strategy.
+        """
+        pass
+
+    @overload
+    async def execute_async(
+        self,
+        *,
+        question_answering_entry: QuestionAnsweringEntry,
+        prepended_conversation: Optional[List[PromptRequestResponse]] = None,
+        memory_labels: Optional[Dict[str, str]] = None,
+        **kwargs,
+    ) -> AttackResult:
+        """
+        Execute the QA benchmark strategy asynchronously with the provided parameters.
+
+        Args:
+            question_answering_entry (QuestionAnsweringEntry): The question answering entry to evaluate.
+            prepended_conversation (Optional[List[PromptRequestResponse]]): Conversation to prepend.
+            memory_labels (Optional[Dict[str, str]]): Memory labels for the benchmark context.
+            **kwargs: Additional parameters for the benchmark.
+
+        Returns:
+            AttackResult: The result of the benchmark execution.
+        """
+        ...
+
+    @overload
+    async def execute_async(
+        self,
+        **kwargs,
+    ) -> AttackResult: ...
+
+    async def execute_async(
+        self,
+        **kwargs,
+    ) -> AttackResult:
+        """
+        Execute the benchmark strategy asynchronously with the provided parameters.
+        """
+
+        # Validate parameters before creating context
+        question_answering_entry = get_kwarg_param(
+            kwargs=kwargs, param_name="question_answering_entry", expected_type=QuestionAnsweringEntry, 
+        )
+        prepended_conversation = get_kwarg_param(
+            kwargs=kwargs, param_name="prepended_conversation", expected_type=list, required=False, default_value=[]
+        )
+        memory_labels = get_kwarg_param(
+            kwargs=kwargs, param_name="memory_labels", expected_type=dict, required=False, default_value={}
+        )
+
+        return await super().execute_async(
+            **kwargs, 
+            question_answering_entry=question_answering_entry, 
+            prepended_conversation=prepended_conversation,
+            memory_labels=memory_labels
+        )

--- a/pyrit/executor/benchmark/question_answering.py
+++ b/pyrit/executor/benchmark/question_answering.py
@@ -80,7 +80,7 @@ class QuestionAnsweringBenchmark(Strategy[QuestionAnsweringBenchmarkContext, Att
         """
     ).strip()
 
-    _DEFAULT_OPTIONS_FORMAT = "Option {index}: {choice}"
+    _DEFAULT_OPTIONS_FORMAT = "Option {index}: {choice}\n"
 
     def __init__(
         self,
@@ -145,9 +145,12 @@ class QuestionAnsweringBenchmark(Strategy[QuestionAnsweringBenchmarkContext, Att
             raise ValueError("Question must have at least one choice")
 
         entry = context.question_answering_entry
-        valid_indices = {choice.index for choice in entry.choices}
-        if entry.correct_answer not in valid_indices:
-            raise ValueError(f"Correct answer index {entry.correct_answer} not found in choices")
+        choice_indices = {choice.index for choice in entry.choices}
+        if entry.correct_answer not in choice_indices:
+            raise ValueError(
+                "correct_answer (choice index="
+                f"{entry.correct_answer}) not found among choice indices {sorted(choice_indices)}"
+            )
 
     async def _setup_async(self, *, context: QuestionAnsweringBenchmarkContext) -> None:
         """
@@ -218,7 +221,6 @@ class QuestionAnsweringBenchmark(Strategy[QuestionAnsweringBenchmarkContext, Att
         options_text = ""
         for choice in entry.choices:
             options_text += self._options_format_string.format(index=choice.index, choice=choice.text)
-            options_text += "\n"  # Add newline between options
 
         return options_text.rstrip()  # Remove trailing newline
 

--- a/pyrit/models/question_answering.py
+++ b/pyrit/models/question_answering.py
@@ -49,8 +49,9 @@ class QuestionAnsweringEntry(BaseModel):
 
         correct_answer_index = self.correct_answer
         try:
+            # Match using the explicit choice.index (not enumerate position) so non-sequential indices are supported
             return next(
-                choice for index, choice in enumerate(self.choices) if str(index) == str(correct_answer_index)
+                choice for choice in self.choices if str(choice.index) == str(correct_answer_index)
             ).text
         except StopIteration:
             raise ValueError(

--- a/pyrit/models/question_answering.py
+++ b/pyrit/models/question_answering.py
@@ -50,9 +50,7 @@ class QuestionAnsweringEntry(BaseModel):
         correct_answer_index = self.correct_answer
         try:
             # Match using the explicit choice.index (not enumerate position) so non-sequential indices are supported
-            return next(
-                choice for choice in self.choices if str(choice.index) == str(correct_answer_index)
-            ).text
+            return next(choice for choice in self.choices if str(choice.index) == str(correct_answer_index)).text
         except StopIteration:
             raise ValueError(
                 f"No matching choice found for correct_answer '{correct_answer_index}'. "

--- a/tests/unit/executor/benchmark/test_question_answering.py
+++ b/tests/unit/executor/benchmark/test_question_answering.py
@@ -128,7 +128,7 @@ class TestQuestionAnsweringBenchmark:
         benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
         context = QuestionAnsweringBenchmarkContext(question_answering_entry=invalid_question_entry)
 
-        with pytest.raises(ValueError, match="Correct answer index 5 not found in choices"):
+        with pytest.raises(ValueError, match="choice index=5"):
             benchmark._validate_context(context=context)
 
     @pytest.mark.asyncio

--- a/tests/unit/executor/benchmark/test_question_answering.py
+++ b/tests/unit/executor/benchmark/test_question_answering.py
@@ -1,0 +1,599 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Dict, List
+
+from pyrit.executor.benchmark.question_answering import (
+    QuestionAnsweringBenchmark,
+    QuestionAnsweringBenchmarkContext,
+)
+from pyrit.models import (
+    AttackOutcome,
+    AttackResult,
+    PromptRequestPiece,
+    PromptRequestResponse,
+    QuestionAnsweringEntry,
+    QuestionChoice,
+    SeedPrompt,
+    SeedPromptGroup,
+)
+from pyrit.prompt_target import PromptTarget
+
+
+# Fixtures at the top of the file
+@pytest.fixture
+def mock_prompt_target() -> MagicMock:
+    """Mock prompt target for testing."""
+    target = MagicMock(spec=PromptTarget)
+    return target
+
+
+@pytest.fixture
+def sample_question_entry() -> QuestionAnsweringEntry:
+    """Sample question answering entry for testing."""
+    return QuestionAnsweringEntry(
+        question="What is the capital of France?",
+        answer_type="int",
+        correct_answer=1,
+        choices=[
+            QuestionChoice(index=0, text="London"),
+            QuestionChoice(index=1, text="Paris"),
+            QuestionChoice(index=2, text="Berlin"),
+            QuestionChoice(index=3, text="Madrid"),
+        ]
+    )
+
+
+@pytest.fixture
+def invalid_question_entry() -> QuestionAnsweringEntry:
+    """Invalid question answering entry for error testing."""
+    return QuestionAnsweringEntry(
+        question="What is the capital of France?",
+        answer_type="int",
+        correct_answer=5,  # Invalid - not in choices
+        choices=[
+            QuestionChoice(index=0, text="London"),
+            QuestionChoice(index=1, text="Paris"),
+        ]
+    )
+
+
+@pytest.fixture
+def empty_question_entry() -> QuestionAnsweringEntry:
+    """Empty question entry for error testing."""
+    return QuestionAnsweringEntry(
+        question="",
+        answer_type="int",
+        correct_answer=0,
+        choices=[]
+    )
+
+
+@pytest.fixture
+def sample_benchmark_context(sample_question_entry: QuestionAnsweringEntry) -> QuestionAnsweringBenchmarkContext:
+    """Sample benchmark context for testing."""
+    return QuestionAnsweringBenchmarkContext(
+        question_answering_entry=sample_question_entry
+    )
+
+
+@pytest.fixture
+def mock_prompt_sending_attack() -> AsyncMock:
+    """Mock PromptSendingAttack for testing."""
+    attack = AsyncMock()
+    attack.execute_async = AsyncMock()
+    return attack
+
+
+@pytest.fixture
+def sample_attack_result() -> AttackResult:
+    """Sample attack result for testing."""
+    return AttackResult(
+        conversation_id="test-conversation-id",
+        objective="Test objective",
+        attack_identifier={"name": "test_attack"},
+        executed_turns=1,
+        execution_time_ms=1000,
+        outcome=AttackOutcome.SUCCESS,
+        outcome_reason="Test completed successfully"
+    )
+
+
+@pytest.mark.usefixtures("patch_central_database")
+class TestQuestionAnsweringBenchmark:
+    """Test class for QuestionAnsweringBenchmark core functionality."""
+    
+    @pytest.mark.asyncio
+    async def test_validate_context_valid_entry(
+        self, 
+        mock_prompt_target: MagicMock,
+        sample_benchmark_context: QuestionAnsweringBenchmarkContext
+    ) -> None:
+        """Test context validation with valid entry."""
+        benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
+        
+        # Should not raise any exception
+        benchmark._validate_context(context=sample_benchmark_context)
+    
+    @pytest.mark.asyncio
+    async def test_validate_context_empty_question(
+        self,
+        mock_prompt_target: MagicMock,
+        empty_question_entry: QuestionAnsweringEntry
+    ) -> None:
+        """Test context validation with empty question."""
+        benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
+        context = QuestionAnsweringBenchmarkContext(question_answering_entry=empty_question_entry)
+        
+        with pytest.raises(ValueError, match="Question text cannot be empty"):
+            benchmark._validate_context(context=context)
+    
+    @pytest.mark.asyncio
+    async def test_validate_context_invalid_correct_answer(
+        self,
+        mock_prompt_target: MagicMock,
+        invalid_question_entry: QuestionAnsweringEntry
+    ) -> None:
+        """Test context validation with invalid correct answer index."""
+        benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
+        context = QuestionAnsweringBenchmarkContext(question_answering_entry=invalid_question_entry)
+        
+        with pytest.raises(ValueError, match="Correct answer index 5 not found in choices"):
+            benchmark._validate_context(context=context)
+    
+    @pytest.mark.asyncio
+    async def test_setup_async_generates_objective_and_prompt(
+        self,
+        mock_prompt_target: MagicMock,
+        sample_benchmark_context: QuestionAnsweringBenchmarkContext
+    ) -> None:
+        """Test that setup_async generates objective and question prompt correctly."""
+        benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
+        
+        await benchmark._setup_async(context=sample_benchmark_context)
+        
+        # Check that objective was generated
+        assert sample_benchmark_context.generated_objective != ""
+        assert "What is the capital of France?" in sample_benchmark_context.generated_objective
+        assert "Paris" in sample_benchmark_context.generated_objective
+        assert "1:" in sample_benchmark_context.generated_objective
+        
+        # Check that question prompt was generated
+        assert sample_benchmark_context.generated_question_prompt != ""
+        assert "What is the capital of France?" in sample_benchmark_context.generated_question_prompt
+        assert "Option 0: London" in sample_benchmark_context.generated_question_prompt
+        assert "Option 1: Paris" in sample_benchmark_context.generated_question_prompt
+        
+        # Check that seed prompt group was created
+        assert sample_benchmark_context.generated_seed_prompt_group is not None
+        assert len(sample_benchmark_context.generated_seed_prompt_group.prompts) == 1
+        
+        seed_prompt = sample_benchmark_context.generated_seed_prompt_group.prompts[0]
+        assert seed_prompt.value == sample_benchmark_context.generated_question_prompt
+        assert seed_prompt.data_type == "text"
+        assert seed_prompt.metadata is not None
+        assert seed_prompt.metadata["correct_answer_index"] == "1"
+        assert seed_prompt.metadata["correct_answer"] == "Paris"
+    
+    @pytest.mark.asyncio
+    async def test_format_question_prompt(
+        self,
+        mock_prompt_target: MagicMock,
+        sample_question_entry: QuestionAnsweringEntry
+    ) -> None:
+        """Test question prompt formatting."""
+        benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
+        
+        formatted_prompt = benchmark._format_question_prompt(sample_question_entry)
+        
+        assert "Answer the following question" in formatted_prompt
+        assert "What is the capital of France?" in formatted_prompt
+        assert "Option 0: London" in formatted_prompt
+        assert "Option 1: Paris" in formatted_prompt
+        assert "Option 2: Berlin" in formatted_prompt
+        assert "Option 3: Madrid" in formatted_prompt
+    
+    @pytest.mark.asyncio
+    async def test_format_options(
+        self,
+        mock_prompt_target: MagicMock,
+        sample_question_entry: QuestionAnsweringEntry
+    ) -> None:
+        """Test options formatting."""
+        benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
+        
+        options_text = benchmark._format_options(sample_question_entry)
+        
+        expected_lines = [
+            "Option 0: London",
+            "Option 1: Paris", 
+            "Option 2: Berlin",
+            "Option 3: Madrid"
+        ]
+        
+        for expected_line in expected_lines:
+            assert expected_line in options_text
+        
+        # Check that options are separated by newlines
+        options_lines = options_text.strip().split('\n')
+        assert len(options_lines) == 4
+    
+    @pytest.mark.asyncio
+    async def test_create_seed_prompt_group(
+        self,
+        mock_prompt_target: MagicMock,
+        sample_question_entry: QuestionAnsweringEntry
+    ) -> None:
+        """Test seed prompt group creation."""
+        benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
+        question_prompt = "Test question prompt"
+        
+        seed_prompt_group = benchmark._create_seed_prompt_group(
+            entry=sample_question_entry,
+            question_prompt=question_prompt
+        )
+        
+        assert isinstance(seed_prompt_group, SeedPromptGroup)
+        assert len(seed_prompt_group.prompts) == 1
+        
+        seed_prompt = seed_prompt_group.prompts[0]
+        assert isinstance(seed_prompt, SeedPrompt)
+        assert seed_prompt.value == question_prompt
+        assert seed_prompt.data_type == "text"
+        assert seed_prompt.metadata is not None
+        assert seed_prompt.metadata["correct_answer_index"] == "1"
+        assert seed_prompt.metadata["correct_answer"] == "Paris"
+    
+    @pytest.mark.asyncio
+    async def test_perform_async_calls_prompt_sending_attack(
+        self,
+        mock_prompt_target: MagicMock,
+        sample_benchmark_context: QuestionAnsweringBenchmarkContext,
+        sample_attack_result: AttackResult
+    ) -> None:
+        """Test that perform_async calls the underlying PromptSendingAttack."""
+        with patch("pyrit.executor.benchmark.question_answering.PromptSendingAttack") as mock_attack_class:
+            mock_attack_instance = AsyncMock()
+            mock_attack_instance.execute_async.return_value = sample_attack_result
+            mock_attack_class.return_value = mock_attack_instance
+            
+            benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
+            
+            # Setup context first
+            await benchmark._setup_async(context=sample_benchmark_context)
+            
+            # Perform the attack
+            result = await benchmark._perform_async(context=sample_benchmark_context)
+            
+            # Verify PromptSendingAttack was called with correct parameters
+            mock_attack_instance.execute_async.assert_called_once()
+            call_kwargs = mock_attack_instance.execute_async.call_args.kwargs
+            
+            assert call_kwargs["objective"] == sample_benchmark_context.generated_objective
+            assert call_kwargs["seed_prompt_group"] == sample_benchmark_context.generated_seed_prompt_group
+            assert call_kwargs["prepended_conversation"] == sample_benchmark_context.prepended_conversation
+            assert call_kwargs["memory_labels"] == sample_benchmark_context.memory_labels
+            
+            # Verify result is returned correctly
+            assert result == sample_attack_result
+    
+    @pytest.mark.asyncio
+    async def test_teardown_async_completes_successfully(
+        self,
+        mock_prompt_target: MagicMock,
+        sample_benchmark_context: QuestionAnsweringBenchmarkContext
+    ) -> None:
+        """Test that teardown_async completes without errors."""
+        benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
+        
+        # Should complete without raising any exceptions
+        await benchmark._teardown_async(context=sample_benchmark_context)
+
+
+@pytest.mark.usefixtures("patch_central_database")
+class TestQuestionAnsweringBenchmarkCustomFormatting:
+    """Test class for custom formatting options in QuestionAnsweringBenchmark."""
+    
+    @pytest.mark.asyncio
+    async def test_custom_objective_format_string(
+        self,
+        mock_prompt_target: MagicMock,
+        sample_question_entry: QuestionAnsweringEntry
+    ) -> None:
+        """Test custom objective format string."""
+        custom_objective_format = "Custom objective: {question} -> {answer}"
+        
+        benchmark = QuestionAnsweringBenchmark(
+            objective_target=mock_prompt_target,
+            objective_format_string=custom_objective_format
+        )
+        
+        context = QuestionAnsweringBenchmarkContext(question_answering_entry=sample_question_entry)
+        await benchmark._setup_async(context=context)
+        
+        assert "Custom objective:" in context.generated_objective
+        assert "What is the capital of France?" in context.generated_objective
+        assert "Paris" in context.generated_objective
+    
+    @pytest.mark.asyncio
+    async def test_custom_question_format_string(
+        self,
+        mock_prompt_target: MagicMock,
+        sample_question_entry: QuestionAnsweringEntry
+    ) -> None:
+        """Test custom question format string."""
+        custom_question_format = "Please answer: {question}\nChoices: {options}"
+        
+        benchmark = QuestionAnsweringBenchmark(
+            objective_target=mock_prompt_target,
+            question_asking_format_string=custom_question_format
+        )
+        
+        context = QuestionAnsweringBenchmarkContext(question_answering_entry=sample_question_entry)
+        await benchmark._setup_async(context=context)
+        
+        assert "Please answer:" in context.generated_question_prompt
+        assert "What is the capital of France?" in context.generated_question_prompt
+        assert "Choices:" in context.generated_question_prompt
+    
+    @pytest.mark.asyncio
+    async def test_custom_options_format_string(
+        self,
+        mock_prompt_target: MagicMock,
+        sample_question_entry: QuestionAnsweringEntry
+    ) -> None:
+        """Test custom options format string."""
+        custom_options_format = "[{index}] - {choice}"
+        
+        benchmark = QuestionAnsweringBenchmark(
+            objective_target=mock_prompt_target,
+            options_format_string=custom_options_format
+        )
+        
+        context = QuestionAnsweringBenchmarkContext(question_answering_entry=sample_question_entry)
+        await benchmark._setup_async(context=context)
+        
+        assert "[0] - London" in context.generated_question_prompt
+        assert "[1] - Paris" in context.generated_question_prompt
+        assert "[2] - Berlin" in context.generated_question_prompt
+        assert "[3] - Madrid" in context.generated_question_prompt
+
+
+@pytest.mark.usefixtures("patch_central_database") 
+class TestQuestionAnsweringBenchmarkExecuteAsync:
+    """Test class for execute_async method in QuestionAnsweringBenchmark."""
+    
+    @pytest.mark.asyncio
+    async def test_execute_async_with_required_parameters(
+        self,
+        mock_prompt_target: MagicMock,
+        sample_question_entry: QuestionAnsweringEntry,
+        sample_attack_result: AttackResult
+    ) -> None:
+        """Test execute_async with only required parameters."""
+        with patch("pyrit.executor.benchmark.question_answering.PromptSendingAttack") as mock_attack_class:
+            mock_attack_instance = AsyncMock()
+            mock_attack_instance.execute_async.return_value = sample_attack_result
+            mock_attack_class.return_value = mock_attack_instance
+            
+            benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
+            
+            result = await benchmark.execute_async(question_answering_entry=sample_question_entry)
+            
+            assert result == sample_attack_result
+            mock_attack_instance.execute_async.assert_called_once()
+    
+    @pytest.mark.asyncio
+    async def test_execute_async_with_optional_parameters(
+        self,
+        mock_prompt_target: MagicMock,
+        sample_question_entry: QuestionAnsweringEntry,
+        sample_attack_result: AttackResult
+    ) -> None:
+        """Test execute_async with optional parameters."""
+        prepended_conversation: List[PromptRequestResponse] = []
+        memory_labels: Dict[str, str] = {"test": "label"}
+        
+        with patch("pyrit.executor.benchmark.question_answering.PromptSendingAttack") as mock_attack_class:
+            mock_attack_instance = AsyncMock()
+            mock_attack_instance.execute_async.return_value = sample_attack_result
+            mock_attack_class.return_value = mock_attack_instance
+            
+            benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
+            
+            result = await benchmark.execute_async(
+                question_answering_entry=sample_question_entry,
+                prepended_conversation=prepended_conversation,
+                memory_labels=memory_labels
+            )
+            
+            assert result == sample_attack_result
+            mock_attack_instance.execute_async.assert_called_once()
+            
+            call_kwargs = mock_attack_instance.execute_async.call_args.kwargs
+            assert call_kwargs["prepended_conversation"] == prepended_conversation
+            assert call_kwargs["memory_labels"] == memory_labels
+    
+    @pytest.mark.asyncio
+    async def test_execute_async_validates_parameters(
+        self,
+        mock_prompt_target: MagicMock
+    ) -> None:
+        """Test that execute_async validates required parameters."""
+        benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
+        
+        # Should raise error when question_answering_entry is missing
+        with pytest.raises(ValueError):
+            await benchmark.execute_async()
+
+
+@pytest.mark.usefixtures("patch_central_database")
+class TestQuestionAnsweringBenchmarkContextIntegration:
+    """Test class for context handling and integration scenarios."""
+    
+    @pytest.mark.asyncio
+    async def test_context_with_prepended_conversation(
+        self,
+        mock_prompt_target: MagicMock,
+        sample_question_entry: QuestionAnsweringEntry
+    ) -> None:
+        """Test context with prepended conversation."""
+        # Create a proper mock PromptRequestResponse
+        mock_request_piece = MagicMock(spec=PromptRequestPiece)
+        mock_request_piece.conversation_id = "test-conversation"
+        mock_request_piece.role = "user"
+        mock_request_piece.original_value = "Test message"
+        
+        mock_response = MagicMock(spec=PromptRequestResponse)
+        mock_response.request_pieces = [mock_request_piece]
+        
+        prepended_conversation: List[PromptRequestResponse] = [mock_response]
+        
+        context = QuestionAnsweringBenchmarkContext(
+            question_answering_entry=sample_question_entry,
+            prepended_conversation=prepended_conversation
+        )
+        
+        benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
+        
+        # Validate and setup context
+        benchmark._validate_context(context=context)
+        await benchmark._setup_async(context=context)
+        
+        # Verify context maintains prepended conversation
+        assert context.prepended_conversation == prepended_conversation
+    
+    @pytest.mark.asyncio
+    async def test_context_with_memory_labels(
+        self,
+        mock_prompt_target: MagicMock,
+        sample_question_entry: QuestionAnsweringEntry
+    ) -> None:
+        """Test context with memory labels."""
+        memory_labels = {"benchmark_type": "qa", "dataset": "test"}
+        
+        context = QuestionAnsweringBenchmarkContext(
+            question_answering_entry=sample_question_entry,
+            memory_labels=memory_labels
+        )
+        
+        benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
+        
+        # Validate and setup context  
+        benchmark._validate_context(context=context)
+        await benchmark._setup_async(context=context)
+        
+        # Verify context maintains memory labels
+        assert context.memory_labels == memory_labels
+    
+    @pytest.mark.asyncio
+    async def test_context_generated_fields_initially_empty(
+        self,
+        sample_question_entry: QuestionAnsweringEntry
+    ) -> None:
+        """Test that generated fields are initially empty or None."""
+        context = QuestionAnsweringBenchmarkContext(question_answering_entry=sample_question_entry)
+        
+        assert context.generated_objective == ""
+        assert context.generated_question_prompt == ""
+        assert context.generated_seed_prompt_group is None
+    
+    @pytest.mark.asyncio 
+    async def test_full_workflow_integration(
+        self,
+        mock_prompt_target: MagicMock,
+        sample_question_entry: QuestionAnsweringEntry,
+        sample_attack_result: AttackResult
+    ) -> None:
+        """Test the full workflow integration from setup to teardown."""
+        with patch("pyrit.executor.benchmark.question_answering.PromptSendingAttack") as mock_attack_class:
+            mock_attack_instance = AsyncMock()
+            mock_attack_instance.execute_async.return_value = sample_attack_result
+            mock_attack_class.return_value = mock_attack_instance
+            
+            benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
+            context = QuestionAnsweringBenchmarkContext(question_answering_entry=sample_question_entry)
+            
+            # Full workflow
+            benchmark._validate_context(context=context)
+            await benchmark._setup_async(context=context)
+            result = await benchmark._perform_async(context=context)
+            await benchmark._teardown_async(context=context)
+            
+            # Verify all generated fields are populated after setup
+            assert context.generated_objective != ""
+            assert context.generated_question_prompt != ""
+            assert context.generated_seed_prompt_group is not None
+            
+            # Verify result is correct
+            assert result == sample_attack_result
+
+
+@pytest.mark.usefixtures("patch_central_database")
+class TestQuestionAnsweringBenchmarkErrorHandling:
+    """Test class for error handling scenarios."""
+    
+    @pytest.mark.asyncio
+    async def test_question_with_no_choices(
+        self,
+        mock_prompt_target: MagicMock
+    ) -> None:
+        """Test handling of questions with no choices."""
+        entry = QuestionAnsweringEntry(
+            question="What is 2+2?",
+            answer_type="int", 
+            correct_answer=4,
+            choices=[]
+        )
+        
+        context = QuestionAnsweringBenchmarkContext(question_answering_entry=entry)
+        benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
+        
+        with pytest.raises(ValueError, match="Question must have at least one choice"):
+            benchmark._validate_context(context=context)
+    
+    @pytest.mark.asyncio
+    async def test_single_choice_question(
+        self,
+        mock_prompt_target: MagicMock
+    ) -> None:
+        """Test handling of questions with only one choice."""
+        entry = QuestionAnsweringEntry(
+            question="True or False: Python is a programming language.",
+            answer_type="int",
+            correct_answer=0,
+            choices=[QuestionChoice(index=0, text="True")]
+        )
+        
+        context = QuestionAnsweringBenchmarkContext(question_answering_entry=entry)
+        benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
+        
+        # Should validate successfully
+        benchmark._validate_context(context=context)
+        await benchmark._setup_async(context=context)
+        
+        # Check formatting works with single choice
+        assert "Option 0: True" in context.generated_question_prompt
+    
+    @pytest.mark.asyncio
+    async def test_attack_execution_failure(
+        self,
+        mock_prompt_target: MagicMock,
+        sample_question_entry: QuestionAnsweringEntry
+    ) -> None:
+        """Test handling of attack execution failure."""
+        with patch("pyrit.executor.benchmark.question_answering.PromptSendingAttack") as mock_attack_class:
+            mock_attack_instance = AsyncMock()
+            mock_attack_instance.execute_async.side_effect = Exception("Attack failed")
+            mock_attack_class.return_value = mock_attack_instance
+            
+            benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
+            context = QuestionAnsweringBenchmarkContext(question_answering_entry=sample_question_entry)
+            
+            await benchmark._setup_async(context=context)
+            
+            # Should propagate the exception
+            with pytest.raises(Exception, match="Attack failed"):
+                await benchmark._perform_async(context=context)

--- a/tests/unit/executor/benchmark/test_question_answering.py
+++ b/tests/unit/executor/benchmark/test_question_answering.py
@@ -1,9 +1,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 from typing import Dict, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from pyrit.executor.benchmark.question_answering import (
     QuestionAnsweringBenchmark,
@@ -42,7 +43,7 @@ def sample_question_entry() -> QuestionAnsweringEntry:
             QuestionChoice(index=1, text="Paris"),
             QuestionChoice(index=2, text="Berlin"),
             QuestionChoice(index=3, text="Madrid"),
-        ]
+        ],
     )
 
 
@@ -56,27 +57,20 @@ def invalid_question_entry() -> QuestionAnsweringEntry:
         choices=[
             QuestionChoice(index=0, text="London"),
             QuestionChoice(index=1, text="Paris"),
-        ]
+        ],
     )
 
 
 @pytest.fixture
 def empty_question_entry() -> QuestionAnsweringEntry:
     """Empty question entry for error testing."""
-    return QuestionAnsweringEntry(
-        question="",
-        answer_type="int",
-        correct_answer=0,
-        choices=[]
-    )
+    return QuestionAnsweringEntry(question="", answer_type="int", correct_answer=0, choices=[])
 
 
 @pytest.fixture
 def sample_benchmark_context(sample_question_entry: QuestionAnsweringEntry) -> QuestionAnsweringBenchmarkContext:
     """Sample benchmark context for testing."""
-    return QuestionAnsweringBenchmarkContext(
-        question_answering_entry=sample_question_entry
-    )
+    return QuestionAnsweringBenchmarkContext(question_answering_entry=sample_question_entry)
 
 
 @pytest.fixture
@@ -97,147 +91,127 @@ def sample_attack_result() -> AttackResult:
         executed_turns=1,
         execution_time_ms=1000,
         outcome=AttackOutcome.SUCCESS,
-        outcome_reason="Test completed successfully"
+        outcome_reason="Test completed successfully",
     )
 
 
 @pytest.mark.usefixtures("patch_central_database")
 class TestQuestionAnsweringBenchmark:
     """Test class for QuestionAnsweringBenchmark core functionality."""
-    
+
     @pytest.mark.asyncio
     async def test_validate_context_valid_entry(
-        self, 
-        mock_prompt_target: MagicMock,
-        sample_benchmark_context: QuestionAnsweringBenchmarkContext
+        self, mock_prompt_target: MagicMock, sample_benchmark_context: QuestionAnsweringBenchmarkContext
     ) -> None:
         """Test context validation with valid entry."""
         benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
-        
+
         # Should not raise any exception
         benchmark._validate_context(context=sample_benchmark_context)
-    
+
     @pytest.mark.asyncio
     async def test_validate_context_empty_question(
-        self,
-        mock_prompt_target: MagicMock,
-        empty_question_entry: QuestionAnsweringEntry
+        self, mock_prompt_target: MagicMock, empty_question_entry: QuestionAnsweringEntry
     ) -> None:
         """Test context validation with empty question."""
         benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
         context = QuestionAnsweringBenchmarkContext(question_answering_entry=empty_question_entry)
-        
+
         with pytest.raises(ValueError, match="Question text cannot be empty"):
             benchmark._validate_context(context=context)
-    
+
     @pytest.mark.asyncio
     async def test_validate_context_invalid_correct_answer(
-        self,
-        mock_prompt_target: MagicMock,
-        invalid_question_entry: QuestionAnsweringEntry
+        self, mock_prompt_target: MagicMock, invalid_question_entry: QuestionAnsweringEntry
     ) -> None:
         """Test context validation with invalid correct answer index."""
         benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
         context = QuestionAnsweringBenchmarkContext(question_answering_entry=invalid_question_entry)
-        
+
         with pytest.raises(ValueError, match="Correct answer index 5 not found in choices"):
             benchmark._validate_context(context=context)
-    
+
     @pytest.mark.asyncio
     async def test_setup_async_generates_objective_and_prompt(
-        self,
-        mock_prompt_target: MagicMock,
-        sample_benchmark_context: QuestionAnsweringBenchmarkContext
+        self, mock_prompt_target: MagicMock, sample_benchmark_context: QuestionAnsweringBenchmarkContext
     ) -> None:
         """Test that setup_async generates objective and question prompt correctly."""
         benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
-        
+
         await benchmark._setup_async(context=sample_benchmark_context)
-        
+
         # Check that objective was generated
         assert sample_benchmark_context.generated_objective != ""
         assert "What is the capital of France?" in sample_benchmark_context.generated_objective
         assert "Paris" in sample_benchmark_context.generated_objective
         assert "1:" in sample_benchmark_context.generated_objective
-        
+
         # Check that question prompt was generated
         assert sample_benchmark_context.generated_question_prompt != ""
         assert "What is the capital of France?" in sample_benchmark_context.generated_question_prompt
         assert "Option 0: London" in sample_benchmark_context.generated_question_prompt
         assert "Option 1: Paris" in sample_benchmark_context.generated_question_prompt
-        
+
         # Check that seed prompt group was created
         assert sample_benchmark_context.generated_seed_prompt_group is not None
         assert len(sample_benchmark_context.generated_seed_prompt_group.prompts) == 1
-        
+
         seed_prompt = sample_benchmark_context.generated_seed_prompt_group.prompts[0]
         assert seed_prompt.value == sample_benchmark_context.generated_question_prompt
         assert seed_prompt.data_type == "text"
         assert seed_prompt.metadata is not None
         assert seed_prompt.metadata["correct_answer_index"] == "1"
         assert seed_prompt.metadata["correct_answer"] == "Paris"
-    
+
     @pytest.mark.asyncio
     async def test_format_question_prompt(
-        self,
-        mock_prompt_target: MagicMock,
-        sample_question_entry: QuestionAnsweringEntry
+        self, mock_prompt_target: MagicMock, sample_question_entry: QuestionAnsweringEntry
     ) -> None:
         """Test question prompt formatting."""
         benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
-        
+
         formatted_prompt = benchmark._format_question_prompt(sample_question_entry)
-        
+
         assert "Answer the following question" in formatted_prompt
         assert "What is the capital of France?" in formatted_prompt
         assert "Option 0: London" in formatted_prompt
         assert "Option 1: Paris" in formatted_prompt
         assert "Option 2: Berlin" in formatted_prompt
         assert "Option 3: Madrid" in formatted_prompt
-    
+
     @pytest.mark.asyncio
     async def test_format_options(
-        self,
-        mock_prompt_target: MagicMock,
-        sample_question_entry: QuestionAnsweringEntry
+        self, mock_prompt_target: MagicMock, sample_question_entry: QuestionAnsweringEntry
     ) -> None:
         """Test options formatting."""
         benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
-        
+
         options_text = benchmark._format_options(sample_question_entry)
-        
-        expected_lines = [
-            "Option 0: London",
-            "Option 1: Paris", 
-            "Option 2: Berlin",
-            "Option 3: Madrid"
-        ]
-        
+
+        expected_lines = ["Option 0: London", "Option 1: Paris", "Option 2: Berlin", "Option 3: Madrid"]
+
         for expected_line in expected_lines:
             assert expected_line in options_text
-        
+
         # Check that options are separated by newlines
-        options_lines = options_text.strip().split('\n')
+        options_lines = options_text.strip().split("\n")
         assert len(options_lines) == 4
-    
+
     @pytest.mark.asyncio
     async def test_create_seed_prompt_group(
-        self,
-        mock_prompt_target: MagicMock,
-        sample_question_entry: QuestionAnsweringEntry
+        self, mock_prompt_target: MagicMock, sample_question_entry: QuestionAnsweringEntry
     ) -> None:
         """Test seed prompt group creation."""
         benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
         question_prompt = "Test question prompt"
-        
+
         seed_prompt_group = benchmark._create_seed_prompt_group(
-            entry=sample_question_entry,
-            question_prompt=question_prompt
+            entry=sample_question_entry, question_prompt=question_prompt
         )
-        
+
         assert isinstance(seed_prompt_group, SeedPromptGroup)
         assert len(seed_prompt_group.prompts) == 1
-        
+
         seed_prompt = seed_prompt_group.prompts[0]
         assert isinstance(seed_prompt, SeedPrompt)
         assert seed_prompt.value == question_prompt
@@ -245,49 +219,47 @@ class TestQuestionAnsweringBenchmark:
         assert seed_prompt.metadata is not None
         assert seed_prompt.metadata["correct_answer_index"] == "1"
         assert seed_prompt.metadata["correct_answer"] == "Paris"
-    
+
     @pytest.mark.asyncio
     async def test_perform_async_calls_prompt_sending_attack(
         self,
         mock_prompt_target: MagicMock,
         sample_benchmark_context: QuestionAnsweringBenchmarkContext,
-        sample_attack_result: AttackResult
+        sample_attack_result: AttackResult,
     ) -> None:
         """Test that perform_async calls the underlying PromptSendingAttack."""
         with patch("pyrit.executor.benchmark.question_answering.PromptSendingAttack") as mock_attack_class:
             mock_attack_instance = AsyncMock()
             mock_attack_instance.execute_async.return_value = sample_attack_result
             mock_attack_class.return_value = mock_attack_instance
-            
+
             benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
-            
+
             # Setup context first
             await benchmark._setup_async(context=sample_benchmark_context)
-            
+
             # Perform the attack
             result = await benchmark._perform_async(context=sample_benchmark_context)
-            
+
             # Verify PromptSendingAttack was called with correct parameters
             mock_attack_instance.execute_async.assert_called_once()
             call_kwargs = mock_attack_instance.execute_async.call_args.kwargs
-            
+
             assert call_kwargs["objective"] == sample_benchmark_context.generated_objective
             assert call_kwargs["seed_prompt_group"] == sample_benchmark_context.generated_seed_prompt_group
             assert call_kwargs["prepended_conversation"] == sample_benchmark_context.prepended_conversation
             assert call_kwargs["memory_labels"] == sample_benchmark_context.memory_labels
-            
+
             # Verify result is returned correctly
             assert result == sample_attack_result
-    
+
     @pytest.mark.asyncio
     async def test_teardown_async_completes_successfully(
-        self,
-        mock_prompt_target: MagicMock,
-        sample_benchmark_context: QuestionAnsweringBenchmarkContext
+        self, mock_prompt_target: MagicMock, sample_benchmark_context: QuestionAnsweringBenchmarkContext
     ) -> None:
         """Test that teardown_async completes without errors."""
         benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
-        
+
         # Should complete without raising any exceptions
         await benchmark._teardown_async(context=sample_benchmark_context)
 
@@ -295,135 +267,123 @@ class TestQuestionAnsweringBenchmark:
 @pytest.mark.usefixtures("patch_central_database")
 class TestQuestionAnsweringBenchmarkCustomFormatting:
     """Test class for custom formatting options in QuestionAnsweringBenchmark."""
-    
+
     @pytest.mark.asyncio
     async def test_custom_objective_format_string(
-        self,
-        mock_prompt_target: MagicMock,
-        sample_question_entry: QuestionAnsweringEntry
+        self, mock_prompt_target: MagicMock, sample_question_entry: QuestionAnsweringEntry
     ) -> None:
         """Test custom objective format string."""
         custom_objective_format = "Custom objective: {question} -> {answer}"
-        
+
         benchmark = QuestionAnsweringBenchmark(
-            objective_target=mock_prompt_target,
-            objective_format_string=custom_objective_format
+            objective_target=mock_prompt_target, objective_format_string=custom_objective_format
         )
-        
+
         context = QuestionAnsweringBenchmarkContext(question_answering_entry=sample_question_entry)
         await benchmark._setup_async(context=context)
-        
+
         assert "Custom objective:" in context.generated_objective
         assert "What is the capital of France?" in context.generated_objective
         assert "Paris" in context.generated_objective
-    
+
     @pytest.mark.asyncio
     async def test_custom_question_format_string(
-        self,
-        mock_prompt_target: MagicMock,
-        sample_question_entry: QuestionAnsweringEntry
+        self, mock_prompt_target: MagicMock, sample_question_entry: QuestionAnsweringEntry
     ) -> None:
         """Test custom question format string."""
         custom_question_format = "Please answer: {question}\nChoices: {options}"
-        
+
         benchmark = QuestionAnsweringBenchmark(
-            objective_target=mock_prompt_target,
-            question_asking_format_string=custom_question_format
+            objective_target=mock_prompt_target, question_asking_format_string=custom_question_format
         )
-        
+
         context = QuestionAnsweringBenchmarkContext(question_answering_entry=sample_question_entry)
         await benchmark._setup_async(context=context)
-        
+
         assert "Please answer:" in context.generated_question_prompt
         assert "What is the capital of France?" in context.generated_question_prompt
         assert "Choices:" in context.generated_question_prompt
-    
+
     @pytest.mark.asyncio
     async def test_custom_options_format_string(
-        self,
-        mock_prompt_target: MagicMock,
-        sample_question_entry: QuestionAnsweringEntry
+        self, mock_prompt_target: MagicMock, sample_question_entry: QuestionAnsweringEntry
     ) -> None:
         """Test custom options format string."""
         custom_options_format = "[{index}] - {choice}"
-        
+
         benchmark = QuestionAnsweringBenchmark(
-            objective_target=mock_prompt_target,
-            options_format_string=custom_options_format
+            objective_target=mock_prompt_target, options_format_string=custom_options_format
         )
-        
+
         context = QuestionAnsweringBenchmarkContext(question_answering_entry=sample_question_entry)
         await benchmark._setup_async(context=context)
-        
+
         assert "[0] - London" in context.generated_question_prompt
         assert "[1] - Paris" in context.generated_question_prompt
         assert "[2] - Berlin" in context.generated_question_prompt
         assert "[3] - Madrid" in context.generated_question_prompt
 
 
-@pytest.mark.usefixtures("patch_central_database") 
+@pytest.mark.usefixtures("patch_central_database")
 class TestQuestionAnsweringBenchmarkExecuteAsync:
     """Test class for execute_async method in QuestionAnsweringBenchmark."""
-    
+
     @pytest.mark.asyncio
     async def test_execute_async_with_required_parameters(
         self,
         mock_prompt_target: MagicMock,
         sample_question_entry: QuestionAnsweringEntry,
-        sample_attack_result: AttackResult
+        sample_attack_result: AttackResult,
     ) -> None:
         """Test execute_async with only required parameters."""
         with patch("pyrit.executor.benchmark.question_answering.PromptSendingAttack") as mock_attack_class:
             mock_attack_instance = AsyncMock()
             mock_attack_instance.execute_async.return_value = sample_attack_result
             mock_attack_class.return_value = mock_attack_instance
-            
+
             benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
-            
+
             result = await benchmark.execute_async(question_answering_entry=sample_question_entry)
-            
+
             assert result == sample_attack_result
             mock_attack_instance.execute_async.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_execute_async_with_optional_parameters(
         self,
         mock_prompt_target: MagicMock,
         sample_question_entry: QuestionAnsweringEntry,
-        sample_attack_result: AttackResult
+        sample_attack_result: AttackResult,
     ) -> None:
         """Test execute_async with optional parameters."""
         prepended_conversation: List[PromptRequestResponse] = []
         memory_labels: Dict[str, str] = {"test": "label"}
-        
+
         with patch("pyrit.executor.benchmark.question_answering.PromptSendingAttack") as mock_attack_class:
             mock_attack_instance = AsyncMock()
             mock_attack_instance.execute_async.return_value = sample_attack_result
             mock_attack_class.return_value = mock_attack_instance
-            
+
             benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
-            
+
             result = await benchmark.execute_async(
                 question_answering_entry=sample_question_entry,
                 prepended_conversation=prepended_conversation,
-                memory_labels=memory_labels
+                memory_labels=memory_labels,
             )
-            
+
             assert result == sample_attack_result
             mock_attack_instance.execute_async.assert_called_once()
-            
+
             call_kwargs = mock_attack_instance.execute_async.call_args.kwargs
             assert call_kwargs["prepended_conversation"] == prepended_conversation
             assert call_kwargs["memory_labels"] == memory_labels
-    
+
     @pytest.mark.asyncio
-    async def test_execute_async_validates_parameters(
-        self,
-        mock_prompt_target: MagicMock
-    ) -> None:
+    async def test_execute_async_validates_parameters(self, mock_prompt_target: MagicMock) -> None:
         """Test that execute_async validates required parameters."""
         benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
-        
+
         # Should raise error when question_answering_entry is missing
         with pytest.raises(ValueError):
             await benchmark.execute_async()
@@ -432,12 +392,10 @@ class TestQuestionAnsweringBenchmarkExecuteAsync:
 @pytest.mark.usefixtures("patch_central_database")
 class TestQuestionAnsweringBenchmarkContextIntegration:
     """Test class for context handling and integration scenarios."""
-    
+
     @pytest.mark.asyncio
     async def test_context_with_prepended_conversation(
-        self,
-        mock_prompt_target: MagicMock,
-        sample_question_entry: QuestionAnsweringEntry
+        self, mock_prompt_target: MagicMock, sample_question_entry: QuestionAnsweringEntry
     ) -> None:
         """Test context with prepended conversation."""
         # Create a proper mock PromptRequestResponse
@@ -445,88 +403,83 @@ class TestQuestionAnsweringBenchmarkContextIntegration:
         mock_request_piece.conversation_id = "test-conversation"
         mock_request_piece.role = "user"
         mock_request_piece.original_value = "Test message"
-        
+
         mock_response = MagicMock(spec=PromptRequestResponse)
         mock_response.request_pieces = [mock_request_piece]
-        
+
         prepended_conversation: List[PromptRequestResponse] = [mock_response]
-        
+
         context = QuestionAnsweringBenchmarkContext(
-            question_answering_entry=sample_question_entry,
-            prepended_conversation=prepended_conversation
+            question_answering_entry=sample_question_entry, prepended_conversation=prepended_conversation
         )
-        
+
         benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
-        
+
         # Validate and setup context
         benchmark._validate_context(context=context)
         await benchmark._setup_async(context=context)
-        
+
         # Verify context maintains prepended conversation
         assert context.prepended_conversation == prepended_conversation
-    
+
     @pytest.mark.asyncio
     async def test_context_with_memory_labels(
-        self,
-        mock_prompt_target: MagicMock,
-        sample_question_entry: QuestionAnsweringEntry
+        self, mock_prompt_target: MagicMock, sample_question_entry: QuestionAnsweringEntry
     ) -> None:
         """Test context with memory labels."""
         memory_labels = {"benchmark_type": "qa", "dataset": "test"}
-        
+
         context = QuestionAnsweringBenchmarkContext(
-            question_answering_entry=sample_question_entry,
-            memory_labels=memory_labels
+            question_answering_entry=sample_question_entry, memory_labels=memory_labels
         )
-        
+
         benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
-        
-        # Validate and setup context  
+
+        # Validate and setup context
         benchmark._validate_context(context=context)
         await benchmark._setup_async(context=context)
-        
+
         # Verify context maintains memory labels
         assert context.memory_labels == memory_labels
-    
+
     @pytest.mark.asyncio
     async def test_context_generated_fields_initially_empty(
-        self,
-        sample_question_entry: QuestionAnsweringEntry
+        self, sample_question_entry: QuestionAnsweringEntry
     ) -> None:
         """Test that generated fields are initially empty or None."""
         context = QuestionAnsweringBenchmarkContext(question_answering_entry=sample_question_entry)
-        
+
         assert context.generated_objective == ""
         assert context.generated_question_prompt == ""
         assert context.generated_seed_prompt_group is None
-    
-    @pytest.mark.asyncio 
+
+    @pytest.mark.asyncio
     async def test_full_workflow_integration(
         self,
         mock_prompt_target: MagicMock,
         sample_question_entry: QuestionAnsweringEntry,
-        sample_attack_result: AttackResult
+        sample_attack_result: AttackResult,
     ) -> None:
         """Test the full workflow integration from setup to teardown."""
         with patch("pyrit.executor.benchmark.question_answering.PromptSendingAttack") as mock_attack_class:
             mock_attack_instance = AsyncMock()
             mock_attack_instance.execute_async.return_value = sample_attack_result
             mock_attack_class.return_value = mock_attack_instance
-            
+
             benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
             context = QuestionAnsweringBenchmarkContext(question_answering_entry=sample_question_entry)
-            
+
             # Full workflow
             benchmark._validate_context(context=context)
             await benchmark._setup_async(context=context)
             result = await benchmark._perform_async(context=context)
             await benchmark._teardown_async(context=context)
-            
+
             # Verify all generated fields are populated after setup
             assert context.generated_objective != ""
             assert context.generated_question_prompt != ""
             assert context.generated_seed_prompt_group is not None
-            
+
             # Verify result is correct
             assert result == sample_attack_result
 
@@ -534,66 +487,53 @@ class TestQuestionAnsweringBenchmarkContextIntegration:
 @pytest.mark.usefixtures("patch_central_database")
 class TestQuestionAnsweringBenchmarkErrorHandling:
     """Test class for error handling scenarios."""
-    
+
     @pytest.mark.asyncio
-    async def test_question_with_no_choices(
-        self,
-        mock_prompt_target: MagicMock
-    ) -> None:
+    async def test_question_with_no_choices(self, mock_prompt_target: MagicMock) -> None:
         """Test handling of questions with no choices."""
-        entry = QuestionAnsweringEntry(
-            question="What is 2+2?",
-            answer_type="int", 
-            correct_answer=4,
-            choices=[]
-        )
-        
+        entry = QuestionAnsweringEntry(question="What is 2+2?", answer_type="int", correct_answer=4, choices=[])
+
         context = QuestionAnsweringBenchmarkContext(question_answering_entry=entry)
         benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
-        
+
         with pytest.raises(ValueError, match="Question must have at least one choice"):
             benchmark._validate_context(context=context)
-    
+
     @pytest.mark.asyncio
-    async def test_single_choice_question(
-        self,
-        mock_prompt_target: MagicMock
-    ) -> None:
+    async def test_single_choice_question(self, mock_prompt_target: MagicMock) -> None:
         """Test handling of questions with only one choice."""
         entry = QuestionAnsweringEntry(
             question="True or False: Python is a programming language.",
             answer_type="int",
             correct_answer=0,
-            choices=[QuestionChoice(index=0, text="True")]
+            choices=[QuestionChoice(index=0, text="True")],
         )
-        
+
         context = QuestionAnsweringBenchmarkContext(question_answering_entry=entry)
         benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
-        
+
         # Should validate successfully
         benchmark._validate_context(context=context)
         await benchmark._setup_async(context=context)
-        
+
         # Check formatting works with single choice
         assert "Option 0: True" in context.generated_question_prompt
-    
+
     @pytest.mark.asyncio
     async def test_attack_execution_failure(
-        self,
-        mock_prompt_target: MagicMock,
-        sample_question_entry: QuestionAnsweringEntry
+        self, mock_prompt_target: MagicMock, sample_question_entry: QuestionAnsweringEntry
     ) -> None:
         """Test handling of attack execution failure."""
         with patch("pyrit.executor.benchmark.question_answering.PromptSendingAttack") as mock_attack_class:
             mock_attack_instance = AsyncMock()
             mock_attack_instance.execute_async.side_effect = Exception("Attack failed")
             mock_attack_class.return_value = mock_attack_instance
-            
+
             benchmark = QuestionAnsweringBenchmark(objective_target=mock_prompt_target)
             context = QuestionAnsweringBenchmarkContext(question_answering_entry=sample_question_entry)
-            
+
             await benchmark._setup_async(context=context)
-            
+
             # Should propagate the exception
             with pytest.raises(Exception, match="Attack failed"):
                 await benchmark._perform_async(context=context)


### PR DESCRIPTION
## Description
- Refactored `QuestionAnsweringBenchmarkOrchestrator` as `QuestionAnsweringBenchmark` using `Strategy` pattern
- `run_attacks_async` hasn't been migrated but should be able to be easily handled by any code that's calling `execute_async`