### PR TITLE
FIX: Fetch MedSafetyBench fix

### DIFF
--- a/pyrit/datasets/medsafetybench_dataset.py
+++ b/pyrit/datasets/medsafetybench_dataset.py
@@ -74,9 +74,9 @@ def fetch_medsafetybench_dataset(
         )
 
         for ex in examples:
-            prompt = ex.get("harmful_medical_request")
+            prompt = ex.get("harmful_medical_request") or ex.get("prompt")
             if not prompt:
-                raise KeyError(f"No 'harmful_medical_request' found in example from {source}")
+                raise KeyError(f"No 'harmful_medical_request' or 'prompt' found in example from {source}")
 
             url_parts = source.split("/")
             model_type = url_parts[-2] if len(url_parts) >= 2 else "unknown"


### PR DESCRIPTION
## Description
Some of the datasets in .txt files were not getting parsed properly since the column was "prompt" and not "harmful_medical_request". This PR makes a small fix to check for "prompt" if "harmful_medical_request" value does not exist. 

## Tests and Documentation
Integration test passes.