### PR TITLE
FIX: HuggingFace and SQLAlchemy pre-commit issues

### DIFF
--- a/pyrit/memory/memory_interface.py
+++ b/pyrit/memory/memory_interface.py
@@ -11,7 +11,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, MutableSequence, Optional, Sequence, TypeVar, Union
 
-from sqlalchemy import Engine, MetaData, and_
+from sqlalchemy import MetaData, and_
+from sqlalchemy.engine.base import Engine
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.sql.elements import ColumnElement
 

--- a/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
+++ b/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
@@ -4,9 +4,14 @@
 import asyncio
 import logging
 import os
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, ClassVar, Optional
 
-from transformers import AutoModelForCausalLM, AutoTokenizer, PretrainedConfig
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    PretrainedConfig,
+    PreTrainedModel,
+)
 
 from pyrit.common import default_values
 from pyrit.common.download_hf_model import download_specific_files
@@ -29,8 +34,8 @@ class HuggingFaceChatTarget(PromptChatTarget):
     """
 
     # Class-level cache for model and tokenizer
-    _cached_model = None
-    _cached_tokenizer = None
+    _cached_model: ClassVar[Optional[PreTrainedModel]] = None
+    _cached_tokenizer: ClassVar[Optional[AutoTokenizer]] = None
     _cached_model_id = None
 
     # Class-level flag to enable or disable cache

--- a/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
+++ b/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
@@ -10,7 +10,6 @@ from transformers import (
     AutoModelForCausalLM,
     AutoTokenizer,
     PretrainedConfig,
-    PreTrainedModel,
 )
 
 from pyrit.common import default_values
@@ -40,9 +39,6 @@ class HuggingFaceChatTarget(PromptChatTarget):
 
     # Class-level flag to enable or disable cache
     _cache_enabled = True
-
-    # Explicit typing for model to avoid mypy errors
-    model: PreTrainedModel
 
     # Define the environment variable name for the Hugging Face token
     HUGGINGFACE_TOKEN_ENVIRONMENT_VARIABLE = "HUGGINGFACE_TOKEN"
@@ -245,14 +241,14 @@ class HuggingFaceChatTarget(PromptChatTarget):
 
         try:
             # Ensure model is on the correct device (should already be the case from `load_model_and_tokenizer`)
-            self.model.to(self.device)  # type: ignore[attr-defined]
+            self.model.to(self.device)  # type: ignore[arg-type]
 
             # Record the length of the input tokens to later extract only the generated tokens
             input_length = input_ids.shape[-1]
 
             # Generate the response
             logger.info("Generating response from model...")
-            generated_ids = self.model.generate(  # type: ignore[attr-defined]
+            generated_ids = self.model.generate(
                 input_ids=input_ids,
                 attention_mask=attention_mask,
                 max_new_tokens=self.max_new_tokens,

--- a/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
+++ b/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
@@ -10,7 +10,7 @@ from transformers import (
     AutoModelForCausalLM,
     AutoTokenizer,
     PretrainedConfig,
-    PreTrainedModel
+    PreTrainedModel,
 )
 
 from pyrit.common import default_values
@@ -252,7 +252,7 @@ class HuggingFaceChatTarget(PromptChatTarget):
 
             # Generate the response
             logger.info("Generating response from model...")
-            generated_ids = self.model.generate(    # type: ignore[attr-defined]
+            generated_ids = self.model.generate(  # type: ignore[attr-defined]
                 input_ids=input_ids,
                 attention_mask=attention_mask,
                 max_new_tokens=self.max_new_tokens,

--- a/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
+++ b/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
@@ -4,13 +4,13 @@
 import asyncio
 import logging
 import os
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import TYPE_CHECKING, Optional
 
 from transformers import (
     AutoModelForCausalLM,
     AutoTokenizer,
     PretrainedConfig,
-    PreTrainedModel,
+    PreTrainedModel
 )
 
 from pyrit.common import default_values
@@ -34,12 +34,15 @@ class HuggingFaceChatTarget(PromptChatTarget):
     """
 
     # Class-level cache for model and tokenizer
-    _cached_model: ClassVar[Optional[PreTrainedModel]] = None
-    _cached_tokenizer: ClassVar[Optional[AutoTokenizer]] = None
+    _cached_model = None
+    _cached_tokenizer = None
     _cached_model_id = None
 
     # Class-level flag to enable or disable cache
     _cache_enabled = True
+
+    # Explicit typing for model to avoid mypy errors
+    model: PreTrainedModel
 
     # Define the environment variable name for the Hugging Face token
     HUGGINGFACE_TOKEN_ENVIRONMENT_VARIABLE = "HUGGINGFACE_TOKEN"
@@ -242,14 +245,14 @@ class HuggingFaceChatTarget(PromptChatTarget):
 
         try:
             # Ensure model is on the correct device (should already be the case from `load_model_and_tokenizer`)
-            self.model.to(self.device)
+            self.model.to(self.device)  # type: ignore[attr-defined]
 
             # Record the length of the input tokens to later extract only the generated tokens
             input_length = input_ids.shape[-1]
 
             # Generate the response
             logger.info("Generating response from model...")
-            generated_ids = self.model.generate(
+            generated_ids = self.model.generate(    # type: ignore[attr-defined]
                 input_ids=input_ids,
                 attention_mask=attention_mask,
                 max_new_tokens=self.max_new_tokens,


### PR DESCRIPTION
## Description
This PR fixes a couple issues flagged by pre-commit hooks, including fixing `import Engine` in `memory_interface.py` and adding `# type: ignore[arg-type]` as mypy does not recognize device strings as valid args (e.g. "cuda" or "cpu").

~~and adding explicit typing for the `model` instance variable in `hugging_face_chat_target.py`. Note that with the explicit typing to `PreTrainedModel`, mypy doesn't know that `self.model` has the attributes `to` and `generate`. This seems to be unavoidable since `from_pretrained` is a factory method without a predefined type (other than being a subclass of `PreTrainedModel`). See this [thread](https://github.com/huggingface/transformers/issues/22937). It's not possible to statically check the type that is returned (since it depends on model_id or path) so mypy will struggle to know that the `to` and `generate` attributes are valid; thus, `type: ignore[attr-defined]` is added for those lines.~~
## Tests and Documentation
N/A
