### PR TITLE
FIX: Replace expired blob storage links

### DIFF
--- a/doc/blog/2025_01_14.md
+++ b/doc/blog/2025_01_14.md
@@ -13,6 +13,6 @@ The talk covered:
 
 You can watch the talk here: https://www.youtube.com/watch?v=jq9DcEL3cHE
 
-And here are the slides: https://airedteamwhitepapers.blob.core.windows.net/lessonswhitepaper/2025_masterclass_pyrit_public.pptx
+And here are the slides: https://aka.ms/pyritmasterclass
 
 Happy bug hunting!

--- a/doc/blog/2025_06_06.md
+++ b/doc/blog/2025_06_06.md
@@ -59,7 +59,7 @@ The consequences of manipulation do not stop at résumé scoring:
 
 ## Beyond Recruitment: The Broader Threat Landscape
 
-While our demonstration focused on AI-driven recruitment, the underlying vulnerability extends to any AI system that processes external data for decision-making. Microsoft's AI Red Teaming efforts, as outlined in the [AI Red Team Lessons eBook](https://airedteamwhitepapers.blob.core.windows.net/lessonswhitepaper/MS_AIRT_Lessons_eBook.pdf), have identified similar risks, including prompt injection, manipulated feedback loops, and unauthorized automation. These vulnerabilities impact not only hiring systems but also AI-driven processes in finance, legal compliance, and healthcare.
+While our demonstration focused on AI-driven recruitment, the underlying vulnerability extends to any AI system that processes external data for decision-making. Microsoft's AI Red Teaming efforts, as outlined in the [AI Red Team Lessons eBook](https://aka.ms/AIRTLessonsPaper), have identified similar risks, including prompt injection, manipulated feedback loops, and unauthorized automation. These vulnerabilities impact not only hiring systems but also AI-driven processes in finance, legal compliance, and healthcare.
 
 ### Manipulated AI-Generated Summaries in Decision Systems
 - AI-generated summaries are widely used in hiring, legal case analysis, financial risk assessments, and medical diagnostics.


### PR DESCRIPTION
## Description
A couple links from our blog pointed to resources in a deleted blob storage account (AIRT Lessons Paper and 2025 PyRIT Masterclass slides). This PR replaces them with fixed aka.ms links to (SFI-compliant) Azure Static Web Apps.


## Tests and Documentation
N/A