### PR TITLE
DOC Create RSS feed for blog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ mypy:
 
 docs-build:
 	jb build -W -v ./doc
+	python ./build_scripts/generate_rss.py
 
 unit-test:
 	$(CMD) pytest --cov=$(PYMODULE) $(UNIT_TESTS)

--- a/build_scripts/generate_rss.py
+++ b/build_scripts/generate_rss.py
@@ -34,6 +34,7 @@ class BlogEntryParser(HTMLParser):
 
 
 # Generate the RSS feed structure
+print("Generating RSS feed structure...")
 fg = FeedGenerator()
 fg.link(href="https://azure.github.io/PyRIT/blog/rss.xml", rel="self")
 fg.title("PyRIT Blog")
@@ -41,12 +42,15 @@ fg.description("PyRIT Blog")
 fg.logo("https://azure.github.io/PyRIT/_static/roakey.png")
 fg.language("en")
 
-# Iterate over the blog files
+# Iterate over the blog files and sort them
+print("Pulling blog files...")
 directory = Path("doc/_build/html/blog/")
 files = [file for file in directory.iterdir() if file.is_file() and file.name.startswith("20")]
+files.sort(key=lambda x: x.name)
 
 # Add a feed entry for each file
 for file in files:
+    print(f"Parsing {file.name}...")
     fe = fg.add_entry()
     fe.link(href=f"https://azure.github.io/PyRIT/blog/{file.name}")
     fe.guid(f"https://azure.github.io/PyRIT/blog/{file.name}")
@@ -62,4 +66,7 @@ for file in files:
     fe.pubDate(f"{file.name[:10].replace('_', '-')}T10:00:00Z")
 
 # Export the RSS feed
+print("Exporting RSS feed...")
 fg.rss_file("doc/_build/html/blog/rss.xml", pretty=True)
+
+print("Done.")

--- a/build_scripts/generate_rss.py
+++ b/build_scripts/generate_rss.py
@@ -75,9 +75,10 @@ first_entry = fg.entry()[-1]
 if first_entry.title() != "Multi-Turn orchestrators — PyRIT Documentation":
     print("Error: Title parsing failed. Exiting.")
     sys.exit(1)
-if (
-    first_entry.description()
-    != "In PyRIT, orchestrators are typically seen as the top-level component. This is where your attack logic is implemented, while notebooks should primarily be used to configure orchestrators."
+if first_entry.description() != (
+    "In PyRIT, orchestrators are typically seen as the top-level component. "
+    "This is where your attack logic is implemented, while notebooks should "
+    "primarily be used to configure orchestrators."
 ):
     print("Error: Description parsing failed. Exiting.")
     sys.exit(1)

--- a/build_scripts/generate_rss.py
+++ b/build_scripts/generate_rss.py
@@ -1,0 +1,65 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from html.parser import HTMLParser
+from pathlib import Path
+
+from feedgen.feed import FeedGenerator
+
+
+# HTML parser to extract title and description
+class BlogEntryParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.title = ""
+        self.description = ""
+        self.current_tag = ""
+        self.description_step = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "p":
+            self.description_step += 1
+        self.current_tag = tag
+
+    def handle_endtag(self, tag):
+        if tag == "p":
+            self.description_step += 1
+        self.current_tag = ""
+
+    def handle_data(self, data):
+        if self.current_tag == "title":
+            self.title = data
+        elif self.description_step == 3:
+            self.description = self.description + data
+
+
+# Generate the RSS feed structure
+fg = FeedGenerator()
+fg.link(href="https://azure.github.io/PyRIT/blog/rss.xml", rel="self")
+fg.title("PyRIT Blog")
+fg.description("PyRIT Blog")
+fg.logo("https://azure.github.io/PyRIT/_static/roakey.png")
+fg.language("en")
+
+# Iterate over the blog files
+directory = Path("doc/_build/html/blog/")
+files = [file for file in directory.iterdir() if file.is_file() and file.name.startswith("20")]
+
+# Add a feed entry for each file
+for file in files:
+    fe = fg.add_entry()
+    fe.link(href=f"https://azure.github.io/PyRIT/blog/{file.name}")
+    fe.guid(f"https://azure.github.io/PyRIT/blog/{file.name}")
+
+    # Extract title and description from HTML content
+    with open(file, "r", encoding="utf-8") as f:
+        parser = BlogEntryParser()
+        parser.feed(f.read())
+        fe.title(parser.title)
+        fe.description(parser.description)
+
+    # Extract publication date from file name
+    fe.pubDate(f"{file.name[:10].replace('_', '-')}T10:00:00Z")
+
+# Export the RSS feed
+fg.rss_file("doc/_build/html/blog/rss.xml", pretty=True)

--- a/build_scripts/generate_rss.py
+++ b/build_scripts/generate_rss.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import sys
 from html.parser import HTMLParser
 from pathlib import Path
 
@@ -46,6 +47,9 @@ fg.language("en")
 print("Pulling blog files...")
 directory = Path("doc/_build/html/blog/")
 files = [file for file in directory.iterdir() if file.is_file() and file.name.startswith("20")]
+if len(files) == 0:
+    print("Error: No blog files found. Exiting.")
+    sys.exit(1)
 files.sort(key=lambda x: x.name)
 
 # Add a feed entry for each file
@@ -65,8 +69,25 @@ for file in files:
     # Extract publication date from file name
     fe.pubDate(f"{file.name[:10].replace('_', '-')}T10:00:00Z")
 
+# Validating the RSS feed
+print("Validating RSS feed...")
+first_entry = fg.entry()[-1]
+if first_entry.title() != "Multi-Turn orchestrators — PyRIT Documentation":
+    print("Error: Title parsing failed. Exiting.")
+    sys.exit(1)
+if (
+    first_entry.description()
+    != "In PyRIT, orchestrators are typically seen as the top-level component. This is where your attack logic is implemented, while notebooks should primarily be used to configure orchestrators."
+):
+    print("Error: Description parsing failed. Exiting.")
+    sys.exit(1)
+
 # Export the RSS feed
 print("Exporting RSS feed...")
 fg.rss_file("doc/_build/html/blog/rss.xml", pretty=True)
+file = Path("doc/_build/html/blog/rss.xml")
+if not file.exists() or file.stat().st_size == 0:
+    print("Error: RSS feed export failed. Exiting.")
+    sys.exit(1)
 
-print("Done.")
+print("RSS feed generated and exported successfully.")

--- a/doc/_static/custom.js
+++ b/doc/_static/custom.js
@@ -14,6 +14,17 @@ window.addEventListener("DOMContentLoaded", () => {
 
 		headerButtons.prepend(discordBtn);
 	}
+
+	// Add RSS feed link to the blog README page only
+	if (window.location.pathname.endsWith('/blog/README.html')) {
+		const rssLink = document.createElement('link');
+		rssLink.rel = 'alternate';
+		rssLink.type = 'application/rss+xml';
+		rssLink.title = 'PyRIT Blog RSS Feed';
+		rssLink.href = 'https://azure.github.io/PyRIT/blog/rss.xml';
+
+		document.head.appendChild(rssLink);
+	}
 });
 (function(cfg) {
 	function e() {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dependencies = [
 # always make sure the individual ones are in sync with the all group
 dev = [
     "black>=25.1.0",
+    "feedgen>=1.0.0",
     "flake8>=7.2.0",
     "flake8-copyright>=0.2.4",
     "ipykernel>=6.29.5",


### PR DESCRIPTION
## Description

This PR addresses issue #672 opened by @rlundeen2. The proposed solution is:

- Create build-time Python script that generates the RSS feed based on the blog folder HTML content.
- Make a small addition to `custom.js` to add a reference to the RSS feed URL in the blog landing page HTML.
- Add the script to `Makefile` to run it right after jupyter-book as part of the build process.

## Tests and Documentation

- Basic console logging
- Basic runtime checks

We could also include the script in pre-commit right after the test hook that builds the Jupyter book, if deemed necessary.