### PR TITLE
Fix: Always display objective scores; auxiliary scores shown only if requested (Issue #1096)

### DIFF
--- a/pyrit/executor/attack/printer/console_printer.py
+++ b/pyrit/executor/attack/printer/console_printer.py
@@ -152,13 +152,19 @@ class ConsoleAttackResultPrinter(AttackResultPrinter):
                 # Display images if present
                 await display_image_response(piece)
 
-                # Print scores with better formatting (only if auxiliary scores are requested)
+                # Always print objective scores
+                scores = self._memory.get_prompt_scores(prompt_ids=[str(piece.id)])
+                if scores:
+                    print()
+                    self._print_colored(f"{self._indent}📊 Scores:", Style.DIM, Fore.MAGENTA)
+                    for score in scores:
+                        if score.score_category == "objective":
+                            self._print_score(score)
+                
+                # Print auxiliary scores only if requested
                 if include_auxiliary_scores:
-                    scores = self._memory.get_prompt_scores(prompt_ids=[str(piece.id)])
-                    if scores:
-                        print()
-                        self._print_colored(f"{self._indent}📊 Scores:", Style.DIM, Fore.MAGENTA)
-                        for score in scores:
+                    for score in scores:
+                        if score.score_category == "auxiliary":
                             self._print_score(score)
 
         print()

--- a/pyrit/executor/attack/printer/console_printer.py
+++ b/pyrit/executor/attack/printer/console_printer.py
@@ -157,9 +157,8 @@ class ConsoleAttackResultPrinter(AttackResultPrinter):
                 if scores:
                     print()
                     self._print_colored(f"{self._indent}📊 Scores:", Style.DIM, Fore.MAGENTA)
-                    for score in scores:
-                        if score.score_category == "objective":
-                            self._print_score(score)
+                    objective_score = [score for score in scores if score.score_category == "objective"][0]
+                    self.print_score(objective_score)
                 
                 # Print auxiliary scores only if requested
                 if include_auxiliary_scores:


### PR DESCRIPTION
### Update
This PR fixes Issue #1096:
- Objective scores are now always displayed.
- Auxiliary scores are only shown if explicitly requested.

### Related Issue
Fixes #1096