### PR TITLE
MAINT: testing aad auth in integration test pipeline

### DIFF
--- a/integration-tests.yml
+++ b/integration-tests.yml
@@ -57,8 +57,18 @@ jobs:
       cp -r $PyRIT_DIR/tests/integration $NEW_DIR/tests
       cd $NEW_DIR
     displayName: "Create and switch to new integration test directory"
-  - bash: make integration-test
-    name: run_integration_tests
+
+  - task: AzureCLI@2
+    displayName: "Run integration tests with service principal login"
+    inputs:
+      azureSubscription: 'integration-test-service-connection'
+      addSpnToEnvironment: true
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
+        # Run integration tests
+        make integration-test
+
   - bash: rm -f .env
     name: clean_up_env_file
   - task: PublishTestResults@2

--- a/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
+++ b/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from azure.identity import DefaultAzureCredential
 import logging
 from typing import TYPE_CHECKING, Literal, Optional
 
@@ -106,13 +105,10 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
 
         audio_serializer_file = None
         try:
-            credential = DefaultAzureCredential()
-            aad_token = credential.get_token("https://cognitiveservices.azure.com/.default").token
-            # auth_token = "aad#" + resourceID + "#" + aad_token
             speech_config = speechsdk.SpeechConfig(
+                subscription=self._azure_speech_key,
                 region=self._azure_speech_region,
             )
-            speech_config.authorization_token = aad_token
             pull_stream = speechsdk.audio.PullAudioOutputStream()
             audio_cfg = speechsdk.audio.AudioOutputConfig(stream=pull_stream)
             speech_config.speech_synthesis_language = self._synthesis_language

--- a/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
+++ b/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+from azure.identity import DefaultAzureCredential
 import logging
 from typing import TYPE_CHECKING, Literal, Optional
 
@@ -105,10 +106,13 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
 
         audio_serializer_file = None
         try:
+            credential = DefaultAzureCredential()
+            aad_token = credential.get_token("https://cognitiveservices.azure.com/.default").token
+            # auth_token = "aad#" + resourceID + "#" + aad_token
             speech_config = speechsdk.SpeechConfig(
-                subscription=self._azure_speech_key,
                 region=self._azure_speech_region,
             )
+            speech_config.authorization_token = aad_token
             pull_stream = speechsdk.audio.PullAudioOutputStream()
             audio_cfg = speechsdk.audio.AudioOutputConfig(stream=pull_stream)
             speech_config.speech_synthesis_language = self._synthesis_language

--- a/tests/integration/targets/test_aad_auth.py
+++ b/tests/integration/targets/test_aad_auth.py
@@ -10,7 +10,6 @@ from pyrit.prompt_target import OpenAIChatTarget, RealtimeTarget
 
 
 @pytest.mark.asyncio
-@pytest.mark.run_only_if_all_tests
 @pytest.mark.parametrize(
     ("endpoint", "model_name"),
     [


### PR DESCRIPTION
## Description
This is a test to see if AAD authentication works inside our DevOps integration test pipeline to enable sending prompts to an AzureOpenAI endpoint without using any keys. The integration test yaml file is changed to wrap the test execution step inside an AzureCLI@2 step to ensure an authenticated Azure CLI session (without keys/secrets) via our service connection. The `@pytest.mark.run_only_if_all_tests` decorator is removed from the relevant test so that authentication can be tested. 


## Tests and Documentation
N/A
