### PR TITLE
MAINT: Switch to DefaultAzureCredential and inject env vars into integration test pipeline

### DIFF
--- a/integration-tests.yml
+++ b/integration-tests.yml
@@ -59,16 +59,24 @@ jobs:
     displayName: "Create and switch to new integration test directory"
 
   - task: AzureCLI@2
-    displayName: "Run integration tests with service principal login"
+    displayName: "Authenticate with service principal and set environment variables"
     inputs:
       azureSubscription: 'integration-test-service-connection'
       addSpnToEnvironment: true
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
-        # Run integration tests
-        make integration-test
+        # map the service principal variables to the ones expected by DefaultAzureCredential
+        echo "##vso[task.setvariable variable=AZURE_CLIENT_ID;issecret=true]$servicePrincipalId"
+        echo "##vso[task.setvariable variable=AZURE_CLIENT_SECRET;issecret=true]$servicePrincipalKey"
+        echo "##vso[task.setvariable variable=AZURE_TENANT_ID;issecret=true]$tenantId"
 
+  - bash: make integration-test
+    name: run_integration_tests
+    env:
+      AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
+      AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
+      AZURE_TENANT_ID: $(AZURE_TENANT_ID)
   - bash: rm -f .env
     name: clean_up_env_file
   - task: PublishTestResults@2


### PR DESCRIPTION
This PR switches AzureAuth from using `AzureCliCredential` to `DefaultAzureCredential` for better robustness in authentication. `DefaultAzureCredential` will try a series of credential types in order until one succeeds and includes the AzureCliCredential as an option. For users using `az login`, the functionality will be identical. See [here](https://learn.microsoft.com/en-us/dotnet/azure/sdk/authentication/credential-chains?tabs=dac#defaultazurecredential-overview) for more information. 

Previously, our AzureDevOps integration test pipeline did not work properly as the Azure CLI ID token generated by our `AzureAuth` constructor would only last 10 minutes, which would not be enough time for all the integration tests to run. There is no published way to extend this duration, so a possible workaround is securely injecting environment variables into the pipeline (marking them as `issecret=true`, so the pipeline treats those variables as secrets in subsequent steps and are masked in logging). As a result, `DefaultAzureCredential()` will now use environment variables to authenticate instead of `az login`, so the issue with expiring authenticated context should be addressed and authentication-required integration tests can proceed.

## Tests and Documentation
N/A
