### PR TITLE
FIX: run inline script for integration tests

### DIFF
--- a/integration-tests.yml
+++ b/integration-tests.yml
@@ -58,7 +58,7 @@ jobs:
       cd $NEW_DIR
     displayName: "Create and switch to new integration test directory"
   - task: AzureCLI@2
-    displayName: "Authenticate with service principal and cache Cognitive Services access token"
+    displayName: "Authenticate with service principal, cache Cognitive Services access token, and run tests"
     inputs:
       azureSubscription: 'integration-test-service-connection'
       scriptType: 'bash'
@@ -67,8 +67,9 @@ jobs:
         # Prefetch token for Cognitive Services before ID token expires (60-90 minute validity)
         az account get-access-token --scope https://cognitiveservices.azure.com/.default --output none
         echo "Cognitive Services access token cached successfully."
-  - bash: make integration-test
-    name: run_integration_tests
+
+        # Run integration tests
+        make integration-test
   - bash: rm -f .env
     name: clean_up_env_file
   - task: PublishTestResults@2


### PR DESCRIPTION
## Description
Integration test command now running inside the AzureCLI@2 task session so that authentication occurs within same shell, instead of as separate task. 


## Tests and Documentation
n/a