### PR TITLE
DOC Fix typos discovered by codespell

### DIFF
--- a/doc/blog/2025_02_11.md
+++ b/doc/blog/2025_02_11.md
@@ -32,6 +32,6 @@ See the updated documentation [here](../code/datasets/2_fetch_dataset.ipynb).
 
 ## What else can we do with this?
 
-Now that we've loaded our dataset into PyRIT as a `SeedPromptDataset` the really exciting red teaming can begin. A great example of this is in our [Sending a Million Prompts](../cookbooks/1_sending_prompts.ipynb) notebook! We can use the prompts to evaluate the target by sending all the previously loaded promtps, modifying which attacks to use, and storing the scores for further analysis.
+Now that we've loaded our dataset into PyRIT as a `SeedPromptDataset` the really exciting red teaming can begin. A great example of this is in our [Sending a Million Prompts](../cookbooks/1_sending_prompts.ipynb) notebook! We can use the prompts to evaluate the target by sending all the previously loaded prompts, modifying which attacks to use, and storing the scores for further analysis.
 
 In this blog post, we've walked through how we use structured datasets through our `SeedPrompt` and `SeedPromptDataset` classes. PyRIT's architecture allows for customization at every stage - whether through converters or configuring different scorers - and seed prompts set us up to effectively probe for risks in AI systems. Send over any contributions to add more datasets, refine seed prompts, or any open issues on Github! Now that you understand a core component of PyRIT, go ahead and try it out!

--- a/doc/code/converters/1_llm_converters.ipynb
+++ b/doc/code/converters/1_llm_converters.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# 1. Converters with LLMs\n",
     "\n",
-    "Some converters use external infrastructure like attacker LLMs. `VariationConverter` is a converter that does this. However, converters like this are significantly slower to run than some simple converters, so if there is a static way to do a task, that is generally preffered."
+    "Some converters use external infrastructure like attacker LLMs. `VariationConverter` is a converter that does this. However, converters like this are significantly slower to run than some simple converters, so if there is a static way to do a task, that is generally preferred."
    ]
   },
   {

--- a/doc/code/converters/1_llm_converters.py
+++ b/doc/code/converters/1_llm_converters.py
@@ -11,7 +11,7 @@
 # %% [markdown]
 # # 1. Converters with LLMs
 #
-# Some converters use external infrastructure like attacker LLMs. `VariationConverter` is a converter that does this. However, converters like this are significantly slower to run than some simple converters, so if there is a static way to do a task, that is generally preffered.
+# Some converters use external infrastructure like attacker LLMs. `VariationConverter` is a converter that does this. However, converters like this are significantly slower to run than some simple converters, so if there is a static way to do a task, that is generally preferred.
 
 # %%
 import pathlib

--- a/doc/code/converters/2_using_converters.ipynb
+++ b/doc/code/converters/2_using_converters.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# 2. Using Prompt Converters\n",
     "\n",
-    "Although converters can be used on their own, they should be thought of as a piece in the pipeine. Typically any attack will have arguments so that prompts can be converted before being sent to the target. They can be stacked, use LLMs, and are a powerful tool.\n",
+    "Although converters can be used on their own, they should be thought of as a piece in the pipeline. Typically any attack will have arguments so that prompts can be converted before being sent to the target. They can be stacked, use LLMs, and are a powerful tool.\n",
     "\n",
     "Before you begin, ensure you are setup with the correct version of PyRIT installed and have secrets configured as described [here](../../setup/populating_secrets.md).\n",
     "\n",

--- a/doc/code/converters/2_using_converters.py
+++ b/doc/code/converters/2_using_converters.py
@@ -11,7 +11,7 @@
 # %% [markdown]
 # # 2. Using Prompt Converters
 #
-# Although converters can be used on their own, they should be thought of as a piece in the pipeine. Typically any attack will have arguments so that prompts can be converted before being sent to the target. They can be stacked, use LLMs, and are a powerful tool.
+# Although converters can be used on their own, they should be thought of as a piece in the pipeline. Typically any attack will have arguments so that prompts can be converted before being sent to the target. They can be stacked, use LLMs, and are a powerful tool.
 #
 # Before you begin, ensure you are setup with the correct version of PyRIT installed and have secrets configured as described [here](../../setup/populating_secrets.md).
 #

--- a/doc/code/converters/6_human_converter.ipynb
+++ b/doc/code/converters/6_human_converter.ipynb
@@ -17,7 +17,7 @@
     "In this example, we'll try to convince a chatbot to give instructions to commit check fraud using `RedTeamingAttack`. We will pass three different converters:\n",
     "`TranslationConverter`, `LeetspeakConverter`, and `RandomCapitalLettersConverter` into our `HumanInTheLoopConverter` to potentially use later.\n",
     "\n",
-    "Note: Since the target's reponses are sent to the scorer LLM for evaluation, you will see them pop up with the ability to modify them. You likely do not need to modify\n",
+    "Note: Since the target's responses are sent to the scorer LLM for evaluation, you will see them pop up with the ability to modify them. You likely do not need to modify\n",
     "them; however, you can if you wish to alter the feedback for generating the next prompt.\n",
     "\n",
     "\n",

--- a/doc/code/converters/6_human_converter.py
+++ b/doc/code/converters/6_human_converter.py
@@ -21,7 +21,7 @@
 # In this example, we'll try to convince a chatbot to give instructions to commit check fraud using `RedTeamingAttack`. We will pass three different converters:
 # `TranslationConverter`, `LeetspeakConverter`, and `RandomCapitalLettersConverter` into our `HumanInTheLoopConverter` to potentially use later.
 #
-# Note: Since the target's reponses are sent to the scorer LLM for evaluation, you will see them pop up with the ability to modify them. You likely do not need to modify
+# Note: Since the target's responses are sent to the scorer LLM for evaluation, you will see them pop up with the ability to modify them. You likely do not need to modify
 # them; however, you can if you wish to alter the feedback for generating the next prompt.
 #
 #

--- a/doc/code/datasets/0_dataset.md
+++ b/doc/code/datasets/0_dataset.md
@@ -1,6 +1,6 @@
 # Datasets
 
-The datasets component within PyRIT is the first piece of an attack. By fetching datsets from different sources, we often load them into PyRIT as a `SeedPromptDataset` to build out the prompts which we will attack with. The building block of this dataset consists of a `SeedPrompt` which can use a template with parameters or just a prompt. The datasets can be loaded through different formats such as from an open source repository or through a YAML file. By storing these datasets within PyRIT, we can further distinguish them by incorporating data attributes such as `harm_categories` or other labels. In order to further define these datasets, we use `SeedPrompts`.
+The datasets component within PyRIT is the first piece of an attack. By fetching datasets from different sources, we often load them into PyRIT as a `SeedPromptDataset` to build out the prompts which we will attack with. The building block of this dataset consists of a `SeedPrompt` which can use a template with parameters or just a prompt. The datasets can be loaded through different formats such as from an open source repository or through a YAML file. By storing these datasets within PyRIT, we can further distinguish them by incorporating data attributes such as `harm_categories` or other labels. In order to further define these datasets, we use `SeedPrompts`.
 
 **Seed Prompts**:
 

--- a/doc/code/executor/0_executor.md
+++ b/doc/code/executor/0_executor.md
@@ -25,7 +25,7 @@ To execute, one generally follows this pattern:
 1. Create an **strategy context** containing state information
 2. Initialize a **strategy** (with optional **configurations** for converters etc.)
 3. _Execute_ the attack strategy with the created context
-4. Recieve and process the **strategy result**
+4. Receive and process the **strategy result**
 
 Each attack implements a lifecycle with distinct phases (all abstract methods), and the `Strategy` class provides a non-abstract `execute_async()` method that enforces this lifecycle:
 * `_validate_context`: Validate context

--- a/doc/code/executor/attack/0_attack.md
+++ b/doc/code/executor/attack/0_attack.md
@@ -16,7 +16,7 @@ To execute an Attack, one generally follows this pattern:
 1. Create an **attack context** containing state information (i.e. attack objective, memory labels, prepended conversations, seed prompts)
 2. Initialize an **attack strategy** (with optional **attack configurations** for converters, scorers, and adversarial chat targets)
 3. _Execute_ the attack strategy with the created context
-4. Recieve and process the **attack result**
+4. Receive and process the **attack result**
 
 ## Types of Attacks
 

--- a/doc/code/memory/1_sqlite_memory.ipynb
+++ b/doc/code/memory/1_sqlite_memory.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "The memory SQLite database can be thought of as a normalized source of truth. The memory module is the primary way PyRIT keeps track of requests and responses to targets and scores. Most of this is done automatically. All Prompt Targets write to memory for later retrieval. All scorers also write to memory when scoring.\n",
     "\n",
-    "The schema is found in `memory_models.py` and can be programatically viewed as follows"
+    "The schema is found in `memory_models.py` and can be programmatically viewed as follows"
    ]
   },
   {

--- a/doc/code/memory/1_sqlite_memory.py
+++ b/doc/code/memory/1_sqlite_memory.py
@@ -14,7 +14,7 @@
 #
 # The memory SQLite database can be thought of as a normalized source of truth. The memory module is the primary way PyRIT keeps track of requests and responses to targets and scores. Most of this is done automatically. All Prompt Targets write to memory for later retrieval. All scorers also write to memory when scoring.
 #
-# The schema is found in `memory_models.py` and can be programatically viewed as follows
+# The schema is found in `memory_models.py` and can be programmatically viewed as follows
 
 # %%
 from pyrit.memory import SQLiteMemory

--- a/doc/code/memory/6_azure_sql_memory.ipynb
+++ b/doc/code/memory/6_azure_sql_memory.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "The memory AzureSQL database can be thought of as a normalized source of truth. The memory module is the primary way pyrit keeps track of requests and responses to targets and scores. Most of this is done automatically. All attacks write to memory for later retrieval. All scorers also write to memory when scoring.\n",
     "\n",
-    "The schema is found in `memory_models.py` and can be programatically viewed as follows\n",
+    "The schema is found in `memory_models.py` and can be programmatically viewed as follows\n",
     "\n",
     "## Azure Login\n",
     "\n",

--- a/doc/code/memory/6_azure_sql_memory.py
+++ b/doc/code/memory/6_azure_sql_memory.py
@@ -18,7 +18,7 @@
 #
 # The memory AzureSQL database can be thought of as a normalized source of truth. The memory module is the primary way pyrit keeps track of requests and responses to targets and scores. Most of this is done automatically. All attacks write to memory for later retrieval. All scorers also write to memory when scoring.
 #
-# The schema is found in `memory_models.py` and can be programatically viewed as follows
+# The schema is found in `memory_models.py` and can be programmatically viewed as follows
 #
 # ## Azure Login
 #

--- a/doc/code/memory/8_seed_prompt_database.ipynb
+++ b/doc/code/memory/8_seed_prompt_database.ipynb
@@ -149,9 +149,9 @@
     "<br> <center> <img src=\"../../../assets/seed_prompt.png\" alt=\"seed_prompt.png\" height=\"600\" /> </center> </br>\n",
     "When we add non-text seed prompts to memory, encoding data will automatically populate in the seed prompt's\n",
     "`metadata` field, including `format` (i.e. png, mp4, wav, etc.) as well as additional metadata for audio\n",
-    "and video files, inclduing `bitrate` (kBits/s as int), `samplerate` (samples/second as int), `bitdepth` (as int),\n",
+    "and video files, including `bitrate` (kBits/s as int), `samplerate` (samples/second as int), `bitdepth` (as int),\n",
     "`filesize` (bytes as int), and `duration` (seconds as int) if the file type is supported by TinyTag.\n",
-    "Example suppported file types include: MP3, MP4, M4A, and WAV. These may be helpful to filter for as some targets\n",
+    "Example supported file types include: MP3, MP4, M4A, and WAV. These may be helpful to filter for as some targets\n",
     "have specific input prompt requirements."
    ]
   },

--- a/doc/code/memory/8_seed_prompt_database.py
+++ b/doc/code/memory/8_seed_prompt_database.py
@@ -69,9 +69,9 @@ for prompt in prompts:
 # <br> <center> <img src="../../../assets/seed_prompt.png" alt="seed_prompt.png" height="600" /> </center> </br>
 # When we add non-text seed prompts to memory, encoding data will automatically populate in the seed prompt's
 # `metadata` field, including `format` (i.e. png, mp4, wav, etc.) as well as additional metadata for audio
-# and video files, inclduing `bitrate` (kBits/s as int), `samplerate` (samples/second as int), `bitdepth` (as int),
+# and video files, including `bitrate` (kBits/s as int), `samplerate` (samples/second as int), `bitdepth` (as int),
 # `filesize` (bytes as int), and `duration` (seconds as int) if the file type is supported by TinyTag.
-# Example suppported file types include: MP3, MP4, M4A, and WAV. These may be helpful to filter for as some targets
+# Example supported file types include: MP3, MP4, M4A, and WAV. These may be helpful to filter for as some targets
 # have specific input prompt requirements.
 # %%
 import pathlib

--- a/doc/cookbooks/2_precomputing_turns.ipynb
+++ b/doc/cookbooks/2_precomputing_turns.ipynb
@@ -2422,7 +2422,7 @@
     "\n",
     "# Configure any converters you want to use for the first few turns of the conversation.\n",
     "# In this case, we are using a tense converter to make the prompts in past tense, and then\n",
-    "# we are using a translation converter to translate the promtps to Spanish.\n",
+    "# we are using a translation converter to translate the prompts to Spanish.\n",
     "\n",
     "# All of this is very slow (but we only are doing it once)\n",
     "\n",

--- a/doc/cookbooks/2_precomputing_turns.py
+++ b/doc/cookbooks/2_precomputing_turns.py
@@ -67,7 +67,7 @@ memory_labels = {"op_name": "new_op", "user_name": "roakey", "test_name": "cookb
 
 # Configure any converters you want to use for the first few turns of the conversation.
 # In this case, we are using a tense converter to make the prompts in past tense, and then
-# we are using a translation converter to translate the promtps to Spanish.
+# we are using a translation converter to translate the prompts to Spanish.
 
 # All of this is very slow (but we only are doing it once)
 

--- a/doc/deployment/deploy_hf_model_aml.ipynb
+++ b/doc/deployment/deploy_hf_model_aml.ipynb
@@ -214,7 +214,7 @@
     "    Generates a unique string based on the Azure ML endpoint name.\n",
     "\n",
     "    This function takes the first 26 characters of the given endpoint name and appends\n",
-    "    a 5-character random alphanumeric string with hypen to ensure uniqueness.\n",
+    "    a 5-character random alphanumeric string with hyphen to ensure uniqueness.\n",
     "    \"\"\"\n",
     "    # Take the first 26 characters of the endpoint name\n",
     "    base_name = endpoint_name[:26]\n",

--- a/doc/deployment/deploy_hf_model_aml.py
+++ b/doc/deployment/deploy_hf_model_aml.py
@@ -177,7 +177,7 @@ def get_updated_endpoint_name(endpoint_name):
     Generates a unique string based on the Azure ML endpoint name.
 
     This function takes the first 26 characters of the given endpoint name and appends
-    a 5-character random alphanumeric string with hypen to ensure uniqueness.
+    a 5-character random alphanumeric string with hyphen to ensure uniqueness.
     """
     # Take the first 26 characters of the endpoint name
     base_name = endpoint_name[:26]

--- a/pyrit/common/default_values.py
+++ b/pyrit/common/default_values.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 def get_required_value(*, env_var_name: str, passed_value: str) -> str:
     """
     Gets a required value from an environment variable or a passed value,
-    prefering the passed value
+    preferring the passed value
 
     If no value is found, raises a KeyError
 
@@ -38,7 +38,7 @@ def get_required_value(*, env_var_name: str, passed_value: str) -> str:
 def get_non_required_value(*, env_var_name: str, passed_value: Optional[str] = None) -> str:
     """
     Gets a non-required value from an environment variable or a passed value,
-    prefering the passed value.
+    preferring the passed value.
 
     Args:
         env_var_name (str): The name of the environment variable to check.

--- a/pyrit/models/prompt_request_response.py
+++ b/pyrit/models/prompt_request_response.py
@@ -157,7 +157,7 @@ def group_conversation_request_pieces_by_sequence(
     >>>     favorite:"),
     >>>     PromptRequestPiece(conversation_id=1, sequence=2, text="Good question!"),
     >>>     PromptRequestPiece(conversation_id=1, sequence=1, text="Raccoon, Narwhal, or Sloth?"),
-    >>>     PromptRequestPiece(conversation_id=1, sequence=2, text="I'd have to say racoons are my favorite!"),
+    >>>     PromptRequestPiece(conversation_id=1, sequence=2, text="I'd have to say raccoons are my favorite!"),
     >>> ]
     >>> grouped_responses = group_conversation_request_pieces(request_pieces)
     ... [
@@ -168,7 +168,7 @@ def group_conversation_request_pieces_by_sequence(
     ...     ]),
     ...     PromptRequestResponse(request_pieces=[
     ...         PromptRequestPiece(conversation_id=1, sequence=2, text="Good question!"),
-    ...         PromptRequestPiece(conversation_id=1, sequence=2, text="I'd have to say racoons are my favorite!")
+    ...         PromptRequestPiece(conversation_id=1, sequence=2, text="I'd have to say raccoons are my favorite!")
     ...     ])
     ... ]
     """

--- a/pyrit/models/seed_prompt.py
+++ b/pyrit/models/seed_prompt.py
@@ -187,7 +187,7 @@ class SeedPrompt(YamlLoadable):
         This method sets the encoding data for the prompt within metadata dictionary. For images, this is just the
         file format. For audio and video, this also includes bitrate (kBits/s as int), samplerate (samples/second
         as int), bitdepth (as int), filesize (bytes as int), and duration (seconds as int) if the file type is
-        supported by TinyTag. Example suppported file types include: MP3, MP4, M4A, and WAV.
+        supported by TinyTag. Example supported file types include: MP3, MP4, M4A, and WAV.
         """
         if self.data_type not in ["audio_path", "video_path", "image_path"]:
             return

--- a/pyrit/prompt_converter/caesar_converter.py
+++ b/pyrit/prompt_converter/caesar_converter.py
@@ -14,7 +14,7 @@ class CaesarConverter(PromptConverter):
     Encodes text using the Caesar cipher with a specified offset.
 
     Using ``offset=1``, 'Hello 123' would encode to 'Ifmmp 234', as each character would shift by 1.
-    Shifts for digits 0-9 only work if the offset is less than 10, if the offset is equal to or greather than 10,
+    Shifts for digits 0-9 only work if the offset is less than 10, if the offset is equal to or greater than 10,
     any numeric values will not be shifted.
     """
 

--- a/pyrit/prompt_converter/insert_punctuation_converter.py
+++ b/pyrit/prompt_converter/insert_punctuation_converter.py
@@ -64,7 +64,7 @@ class InsertPunctuationConverter(PromptConverter):
             punctuation_list (Optional[List[str]]): List of punctuations to use for insertion.
 
         Returns:
-            ConverterResult: The result containing a interation of modified prompts.
+            ConverterResult: The result containing an iteration of modified prompts.
 
         Raises:
             ValueError: If the input type is not supported.

--- a/pyrit/prompt_converter/unicode_confusable_converter.py
+++ b/pyrit/prompt_converter/unicode_confusable_converter.py
@@ -62,7 +62,7 @@ class UnicodeConfusableConverter(PromptConverter):
             input_type (PromptDataType): The type of input data.
 
         Returns:
-            ConverterResult: The result containing the prompt with confusable subsitutions applied.
+            ConverterResult: The result containing the prompt with confusable substitutions applied.
 
         Raises:
             ValueError: If the input type is not supported.

--- a/pyrit/prompt_target/openai/openai_chat_target.py
+++ b/pyrit/prompt_target/openai/openai_chat_target.py
@@ -153,7 +153,7 @@ class OpenAIChatTarget(OpenAIChatTargetBase):
     def _build_chat_messages_for_text(self, conversation: MutableSequence[PromptRequestResponse]) -> list[dict]:
         """
         Builds chat messages based on prompt request response entries. This is needed because many
-        openai "compatible" models don't support ChatMessageListDictContent format (this is more univerally accepted)
+        openai "compatible" models don't support ChatMessageListDictContent format (this is more universally accepted)
 
         Args:
             conversation (list[PromptRequestResponse]): A list of PromptRequestResponse objects.

--- a/pyrit/prompt_target/openai/openai_sora_target.py
+++ b/pyrit/prompt_target/openai/openai_sora_target.py
@@ -224,7 +224,7 @@ class OpenAISoraTarget(OpenAITarget):
         """
         Asynchronously check status of a submitted video generation job using the job_id.
 
-        Retries a maxium of {self.CHECK_JOB_RETRY_MAX_NUM_ATTEMPTS} times,
+        Retries a maximum of {self.CHECK_JOB_RETRY_MAX_NUM_ATTEMPTS} times,
         until the job is complete (succeeded, failed, or cancelled). Also
         retries upon RateLimitException.
 

--- a/pyrit/score/true_false/self_ask_category_scorer.py
+++ b/pyrit/score/true_false/self_ask_category_scorer.py
@@ -26,7 +26,7 @@ class ContentClassifierPaths(enum.Enum):
 class SelfAskCategoryScorer(TrueFalseScorer):
     """
     A class that represents a self-ask score for text classification and scoring.
-    Given a classifer file, it scores according to these categories and returns the category
+    Given a classifier file, it scores according to these categories and returns the category
     the PromptRequestPiece fits best.
 
     There is also a false category that is used if the promptrequestpiece does not fit any of the categories.

--- a/pyrit/ui/rpc.py
+++ b/pyrit/ui/rpc.py
@@ -81,7 +81,7 @@ class AppRPCServer:
 
         def exposed_receive_ping(self):
             # A ping should be received every 2s from the client. If a client misses a ping then the server should
-            # stoped
+            # stopped
             self._last_ping = time.time()
             logger.debug("Ping received")
 

--- a/tests/unit/test_chat_message_normalizer.py
+++ b/tests/unit/test_chat_message_normalizer.py
@@ -11,7 +11,7 @@ def test_chat_message_nop():
     messages = [
         ChatMessage(role="system", content="System message"),
         ChatMessage(role="user", content="User message 1"),
-        ChatMessage(role="assistant", content="Assitant message"),
+        ChatMessage(role="assistant", content="Assistant message"),
     ]
     chat_message_nop = ChatMessageNop()
     result = chat_message_nop.normalize(messages)
@@ -23,14 +23,14 @@ def test_generic_squash_system_message():
     messages = [
         ChatMessage(role="system", content="System message"),
         ChatMessage(role="user", content="User message 1"),
-        ChatMessage(role="assistant", content="Assitant message"),
+        ChatMessage(role="assistant", content="Assistant message"),
     ]
     result = GenericSystemSquash().normalize(messages)
     assert len(result) == 2
     assert result[0].role == "user"
     assert result[0].content == "### Instructions ###\n\nSystem message\n\n######\n\nUser message 1"
     assert result[1].role == "assistant"
-    assert result[1].content == "Assitant message"
+    assert result[1].content == "Assistant message"
 
 
 def test_generic_squash_system_message_empty_list():
@@ -50,14 +50,14 @@ def test_generic_squash_system_message_multiple_messages():
     messages = [
         ChatMessage(role="system", content="System message"),
         ChatMessage(role="user", content="User message 1"),
-        ChatMessage(role="assistant", content="Assitant message"),
+        ChatMessage(role="assistant", content="Assistant message"),
     ]
     result = GenericSystemSquash().normalize(messages)
     assert len(result) == 2
     assert result[0].role == "user"
     assert result[0].content == "### Instructions ###\n\nSystem message\n\n######\n\nUser message 1"
     assert result[1].role == "assistant"
-    assert result[1].content == "Assitant message"
+    assert result[1].content == "Assistant message"
 
 
 def test_generic_squash_system_message_no_system_message():


### PR DESCRIPTION
## Description

Fix typos discovered by codespell - https://pypi.org/project/codespell

```
codespell --ignore-words-list="ans,beng,bolor,ect,hte,ist,punctuations,sie" \
    --skip="NOTICE.txt,*.csv,*.ipynb,*.yaml"

codespell --ignore-words-list="ans,beng,bolor,ect,hte,ist,punctuations,sie" \
    --skip="NOTICE.txt,*.csv,*.ipynb,*.yaml" --write-changes
```
Extra review please, on:
pyrit/prompt_converter/insert_punctuation_converter.py:67: interation ==> iteration, interaction, integration

## Tests and Documentation