### PR TITLE
MAINT: Relaxing websockets and numpy dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "httpx[http2]>=0.27.2",
     "jinja2>=3.1.6",
     "krippendorff>=0.8.1",
-    "numpy>=2.2.6",
+    "numpy>=1.26.0",
     "openai>=1.58.1",
     "openpyxl>=3.1.5",
     "pillow>=11.2.1",
@@ -60,7 +60,7 @@ dependencies = [
     "tqdm>=4.67.1",
     "transformers>=4.52.4",
     "treelib>=1.7.1",
-    "websockets>=15.0.1",
+    "websockets>=14.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
One of our partners uses versions of these packages that are below our version. But we don't need anything from the latest.

I installed numpy 1.26, websockets 14.0 and ran the applicable unit tests and integration tests and everything worked with the lower versions.
