### PR TITLE
FEAT Allow preserving order of message in memory with intermediary message in target

### DIFF
--- a/pyrit/prompt_normalizer/prompt_normalizer.py
+++ b/pyrit/prompt_normalizer/prompt_normalizer.py
@@ -92,13 +92,11 @@ class PromptNormalizer:
 
         response = None
 
+        self._memory.add_message_to_memory(request=request)
         try:
             response = await target.send_prompt_async(prompt_request=request)
-            self._memory.add_message_to_memory(request=request)
         except EmptyResponseException:
             # Empty responses are retried, but we don't want them to stop execution
-            self._memory.add_message_to_memory(request=request)
-
             response = construct_response_from_request(
                 request=request.message_pieces[0],
                 response_text_pieces=[""],
@@ -107,9 +105,6 @@ class PromptNormalizer:
             )
 
         except Exception as ex:
-            # Ensure request to memory before processing exception
-            self._memory.add_message_to_memory(request=request)
-
             error_response = construct_response_from_request(
                 request=request.message_pieces[0],
                 response_text_pieces=[f"{ex}\n{repr(ex)}\n{traceback.format_exc()}"],


### PR DESCRIPTION
<!--- Please add one of the following as a prefix to the pull request title: -->
<!--- DOC for documentation changes -->
<!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
<!--- FIX for bug fixes -->
<!--- TEST for adding tests -->
<!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
<!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->

<!--- Note on BREAKING changes: If your PR includes a change that will require users to make a corresponding
change (e.g. naming changes), please list [BREAKING] in front of the above prefix in the PR title.
For example, [BREAKING] FEAT or [BREAKING] MAINT -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

<!--- If you are considering making a contribution please open an issue first. -->
<!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
<!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->

<!--- If your change is BREAKING please include reasoning for why below. -->

This PR fixes an issue in the conversation flow where the prompt was not stored in the central memory before being sent via send_prompt_async in `PromptNormalizer`. Previously, the flow would first call `send_prompt_async`, and only afterward would the prompt be added to the central memory.

Additionally, `send_prompt_async` currently only returns a single `Message` containing `MessagePiece` objects of a single type. This limitation prevented proper handling of intermediary steps in targets such as `OpenAIResponseTarget`, since those messages were not being stored anywhere. Attempts to store them in the central memory directly by modifying the target resulted in out-of-order messages due to the aforementioned sequencing issue.

This PR addresses the problem by:

Ensuring that the prompt is first inserted into the central memory before calling `send_prompt_async`.

Simplifying error-handling logic by removing redundant calls that are now unnecessary thanks to the corrected flow.

As a result, intermediary messages can now be correctly ordered and consistently stored in the central memory.

## Tests and Documentation
N/A

<!--- Contributions require tests and documentation (if applicable). -->
<!--- Include a description of tests and documentation updated (if applicable) -->

<!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
<!--- Include how you/if ran JupyText here -->
<!--- This is described at: https://github.com/Azure/PyRIT/tree/main/doc  -->
