### PR TITLE
FIX Add missing function and tool serializer

### DIFF
--- a/pyrit/models/data_type_serializer.py
+++ b/pyrit/models/data_type_serializer.py
@@ -54,8 +54,8 @@ def data_serializer_factory(
             f"The 'category' argument is mandatory and must be one of the following: {get_args(AllowedCategories)}."
         )
     if value is not None:
-        if data_type in ["text", "reasoning"]:
-            return TextDataTypeSerializer(prompt_text=value)
+        if data_type in ["text", "reasoning", "function_call", "tool_call", "function_call_output"]:
+            return TextDataTypeSerializer(prompt_text=value, data_type=data_type)
         elif data_type == "image_path":
             return ImagePathDataTypeSerializer(category=category, prompt_text=value, extension=extension)
         elif data_type == "audio_path":
@@ -297,9 +297,8 @@ class DataTypeSerializer(abc.ABC):
 
 
 class TextDataTypeSerializer(DataTypeSerializer):
-
-    def __init__(self, *, prompt_text: str):
-        self.data_type = "text"
+    def __init__(self, *, prompt_text: str, data_type: PromptDataType = "text"):
+        self.data_type = data_type
         self.value = prompt_text
 
     def data_on_disk(self) -> bool:


### PR DESCRIPTION
<!--- Please add one of the following as a prefix to the pull request title: -->
<!--- DOC for documentation changes -->
<!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
<!--- FIX for bug fixes -->
<!--- TEST for adding tests -->
<!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
<!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->

<!--- Note on BREAKING changes: If your PR includes a change that will require users to make a corresponding
change (e.g. naming changes), please list [BREAKING] in front of the above prefix in the PR title.
For example, [BREAKING] FEAT or [BREAKING] MAINT -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

<!--- If you are considering making a contribution please open an issue first. -->
<!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
<!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->

<!--- If your change is BREAKING please include reasoning for why below. -->

(Branching from #1149, see PR for more context)
At the moment, you can't pass `function_call`, `function_call_output` or `tool_call` to the `Message` that is returned by `send_prompt_async` because in the `PromptNormalizer` a call to `_calc_hash` is done. This method calls a Serializer factory `data_serializer_factory` to be able to compute said hash. However, those three `PromptDataType` are missing a Serializer. So far, they are used in the `OpenAIResponseTarget` and are dumped as string using `json.dumps`. In particular, `original_value` in `MessagePiece` only appears to accept strings (to match the type hint). So in the end, they serialize like any `text` data type. This motivates this PR to just extend the serializer to support those types.

## Tests and Documentation

<!--- Contributions require tests and documentation (if applicable). -->
<!--- Include a description of tests and documentation updated (if applicable) -->

<!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
<!--- Include how you/if ran JupyText here -->
<!--- This is described at: https://github.com/Azure/PyRIT/tree/main/doc  -->
