### PR TITLE
FIX: Pin jupyterbook version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dev = [
     "flake8-copyright>=0.2.4",
     "ipykernel>=6.29.5",
     "jupyter>=1.1.1",
-    "jupyter-book>=1.0.4",
+    "jupyter-book==1.0.4",
     "jupytext>=1.17.1",
     "mypy>=1.16.0",
     "mock-alchemy>=0.2.6",


### PR DESCRIPTION
## Description
Pinning jupyterbook version to 1.0.4, the latest 1.0 version since 2.0 had some changes that are breaking our build-book pre-commit. 