### PR TITLE
MAINT: Refactoring exception globals

### DIFF
--- a/pyrit/exceptions/exception_classes.py
+++ b/pyrit/exceptions/exception_classes.py
@@ -102,9 +102,7 @@ class MissingPromptPlaceholderException(PyritException):
         super().__init__(message=message)
 
 
-def pyrit_custom_result_retry(
-    retry_function: Callable, retry_max_num_attempts: Optional[int] = None
-) -> Callable:
+def pyrit_custom_result_retry(retry_function: Callable, retry_max_num_attempts: Optional[int] = None) -> Callable:
     """
     A decorator to apply retry logic with exponential backoff to a function.
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,10 +15,6 @@ from pyrit.memory.sqlite_memory import SQLiteMemory
 from pyrit.setup import IN_MEMORY, initialize_pyrit
 
 # This limits retries to 10 attempts with a 1 second wait between retries
-# note this needs to be set before libraries that use them are imported
-
-# Note this module needs to be imported at the top of a file so the values are modified
-
 os.environ["RETRY_MAX_NUM_ATTEMPTS"] = "9"
 os.environ["RETRY_WAIT_MIN_SECONDS"] = "0"
 os.environ["RETRY_WAIT_MAX_SECONDS"] = "1"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,19 +9,14 @@ from unittest.mock import patch
 import pytest
 from sqlalchemy import inspect
 
+from pyrit.memory.central_memory import CentralMemory
+from pyrit.memory.sqlite_memory import SQLiteMemory
+
 # This limits retries and speeds up execution
-# note this needs to be set before libraries that use them are imported
-
-# Note this module needs to be imported at the top of a file so the values are modified
-
 os.environ["CUSTOM_RESULT_RETRY_MAX_NUM_ATTEMPTS"] = "5"
 os.environ["RETRY_MAX_NUM_ATTEMPTS"] = "2"
 os.environ["RETRY_WAIT_MIN_SECONDS"] = "0"
 os.environ["RETRY_WAIT_MAX_SECONDS"] = "1"
-
-
-from pyrit.memory.central_memory import CentralMemory  # noqa: E402
-from pyrit.memory.sqlite_memory import SQLiteMemory  # noqa: E402
 
 
 @pytest.fixture


### PR DESCRIPTION
Refactoring how we configure low level retries to not use globals. This is less error prone and better code.
