### PR TITLE
MAINT: Adding REQUIRED_VALUE as a placeholder for apply_defaults

### DIFF
--- a/pyrit/common/__init__.py
+++ b/pyrit/common/__init__.py
@@ -10,6 +10,7 @@ from pyrit.common.apply_defaults import (
     reset_default_values,
     get_global_default_values,
     DefaultValueScope,
+    REQUIRED_VALUE,
 )
 from pyrit.common.data_url_converter import convert_local_image_to_data_url
 from pyrit.common.default_values import get_non_required_value, get_required_value
@@ -53,6 +54,7 @@ __all__ = [
     "is_in_ipython_session",
     "make_request_and_raise_if_error_async",
     "print_chat_messages_with_color",
+    "REQUIRED_VALUE",
     "reset_default_values",
     "set_default_value",
     "Singleton",

--- a/pyrit/common/apply_defaults.py
+++ b/pyrit/common/apply_defaults.py
@@ -20,6 +20,34 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
+class _RequiredValueSentinel:
+    """
+    Sentinel type to mark parameters as required but eligible for apply_defaults.
+
+    This allows parameters to have no default value in the function signature
+    (making them appear required), while still allowing apply_defaults to provide
+    a value if one is registered globally.
+
+    Usage:
+        @apply_defaults
+        def __init__(self, *, objective_target: PromptTarget = REQUIRED_VALUE):
+            # If apply_defaults finds a default for objective_target, it will be used.
+            # Otherwise, an error will be raised for missing required parameter.
+            pass
+    """
+
+    def __repr__(self) -> str:
+        return "REQUIRED_VALUE"
+
+    def __bool__(self) -> bool:
+        # Ensure this evaluates to False in boolean context
+        return False
+
+
+# Global sentinel instance
+REQUIRED_VALUE = _RequiredValueSentinel()
+
+
 @dataclass(frozen=True)
 class DefaultValueScope:
     """
@@ -218,13 +246,13 @@ def apply_defaults_to_method(method):
         bound_args = sig.bind(self, *args, **kwargs)
         bound_args.apply_defaults()
 
-        # Apply default values for parameters that are None
+        # Apply default values for parameters that are None or REQUIRED_VALUE
         for param_name, param_value in bound_args.arguments.items():
             if param_name == "self":
                 continue
 
-            # Only apply defaults if the parameter is None
-            if param_value is None:
+            # Apply defaults if parameter is None or REQUIRED_VALUE sentinel
+            if param_value is None or isinstance(param_value, _RequiredValueSentinel):
                 found, default_value = _global_default_values.get_default_value(
                     class_type=cls,
                     parameter_name=param_name,
@@ -232,6 +260,21 @@ def apply_defaults_to_method(method):
                 if found:
                     bound_args.arguments[param_name] = default_value
                     logger.debug(f"Applied default value for {cls.__name__}.{param_name} = {default_value}")
+                elif isinstance(param_value, _RequiredValueSentinel):
+                    # REQUIRED_VALUE was used but no default found - raise clear error
+                    raise ValueError(
+                        f"{param_name} is required for {cls.__name__}. "
+                        f"Either pass the parameter explicitly or register a default using set_default_value()."
+                    )
+                # If None was explicitly passed and parameter has REQUIRED_VALUE as default, also raise
+                elif param_value is None:
+                    # Check if the parameter's default in the signature is REQUIRED_VALUE
+                    param_obj = sig.parameters.get(param_name)
+                    if param_obj and isinstance(param_obj.default, _RequiredValueSentinel):
+                        raise ValueError(
+                            f"{param_name} is required for {cls.__name__}. "
+                            f"Either pass a valid value or register a default using set_default_value()."
+                        )
 
         # Call the original method with updated arguments
         return method(*bound_args.args, **bound_args.kwargs)

--- a/pyrit/executor/attack/multi_turn/crescendo.py
+++ b/pyrit/executor/attack/multi_turn/crescendo.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Union
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import DATASETS_PATH
 from pyrit.common.utils import combine_dict
 from pyrit.exceptions import (
@@ -117,7 +117,7 @@ class CrescendoAttack(MultiTurnAttackStrategy[CrescendoAttackContext, CrescendoA
     def __init__(
         self,
         *,
-        objective_target: PromptChatTarget,
+        objective_target: PromptChatTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         attack_adversarial_config: AttackAdversarialConfig,
         attack_converter_config: Optional[AttackConverterConfig] = None,
         attack_scoring_config: Optional[AttackScoringConfig] = None,

--- a/pyrit/executor/attack/multi_turn/multi_prompt_sending.py
+++ b/pyrit/executor/attack/multi_turn/multi_prompt_sending.py
@@ -5,7 +5,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import List, Optional
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.utils import combine_dict, get_kwarg_param
 from pyrit.executor.attack.component import ConversationManager
 from pyrit.executor.attack.core import (
@@ -66,7 +66,7 @@ class MultiPromptSendingAttack(MultiTurnAttackStrategy[MultiPromptSendingAttackC
     def __init__(
         self,
         *,
-        objective_target: PromptTarget,
+        objective_target: PromptTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         attack_converter_config: Optional[AttackConverterConfig] = None,
         attack_scoring_config: Optional[AttackScoringConfig] = None,
         prompt_normalizer: Optional[PromptNormalizer] = None,

--- a/pyrit/executor/attack/multi_turn/red_teaming.py
+++ b/pyrit/executor/attack/multi_turn/red_teaming.py
@@ -8,7 +8,7 @@ import logging
 from pathlib import Path
 from typing import Optional, Union
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import RED_TEAM_EXECUTOR_PATH
 from pyrit.common.utils import combine_dict, warn_if_set
 from pyrit.executor.attack.component import (
@@ -84,7 +84,7 @@ class RedTeamingAttack(MultiTurnAttackStrategy[MultiTurnAttackContext, AttackRes
     def __init__(
         self,
         *,
-        objective_target: PromptTarget,
+        objective_target: PromptTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         attack_adversarial_config: AttackAdversarialConfig,
         attack_converter_config: Optional[AttackConverterConfig] = None,
         attack_scoring_config: Optional[AttackScoringConfig] = None,

--- a/pyrit/executor/attack/multi_turn/tree_of_attacks.py
+++ b/pyrit/executor/attack/multi_turn/tree_of_attacks.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional, cast, overload
 
 from treelib.tree import Tree
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import DATASETS_PATH
 from pyrit.common.utils import combine_dict, warn_if_set
 from pyrit.exceptions import (
@@ -934,7 +934,7 @@ class TreeOfAttacksWithPruningAttack(AttackStrategy[TAPAttackContext, TAPAttackR
     def __init__(
         self,
         *,
-        objective_target: PromptChatTarget,
+        objective_target: PromptChatTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         attack_adversarial_config: AttackAdversarialConfig,
         attack_converter_config: Optional[AttackConverterConfig] = None,
         attack_scoring_config: Optional[AttackScoringConfig] = None,

--- a/pyrit/executor/attack/single_turn/context_compliance.py
+++ b/pyrit/executor/attack/single_turn/context_compliance.py
@@ -5,7 +5,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import DATASETS_PATH
 from pyrit.executor.attack.core import (
     AttackAdversarialConfig,
@@ -54,7 +54,7 @@ class ContextComplianceAttack(PromptSendingAttack):
     def __init__(
         self,
         *,
-        objective_target: PromptChatTarget,
+        objective_target: PromptChatTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         attack_adversarial_config: AttackAdversarialConfig,
         attack_converter_config: Optional[AttackConverterConfig] = None,
         attack_scoring_config: Optional[AttackScoringConfig] = None,

--- a/pyrit/executor/attack/single_turn/flip_attack.py
+++ b/pyrit/executor/attack/single_turn/flip_attack.py
@@ -6,7 +6,7 @@ import pathlib
 import uuid
 from typing import Optional
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import DATASETS_PATH
 from pyrit.common.utils import combine_dict
 from pyrit.executor.attack.core import AttackConverterConfig, AttackScoringConfig
@@ -38,7 +38,7 @@ class FlipAttack(PromptSendingAttack):
     @apply_defaults
     def __init__(
         self,
-        objective_target: PromptChatTarget,
+        objective_target: PromptChatTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         attack_converter_config: Optional[AttackConverterConfig] = None,
         attack_scoring_config: Optional[AttackScoringConfig] = None,
         prompt_normalizer: Optional[PromptNormalizer] = None,

--- a/pyrit/executor/attack/single_turn/many_shot_jailbreak.py
+++ b/pyrit/executor/attack/single_turn/many_shot_jailbreak.py
@@ -5,7 +5,7 @@ import logging
 import pathlib
 from typing import Optional
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import DATASETS_PATH
 from pyrit.datasets import fetch_many_shot_jailbreaking_dataset
 from pyrit.executor.attack.core import AttackConverterConfig, AttackScoringConfig
@@ -31,7 +31,7 @@ class ManyShotJailbreakAttack(PromptSendingAttack):
     @apply_defaults
     def __init__(
         self,
-        objective_target: PromptTarget,
+        objective_target: PromptTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         attack_converter_config: Optional[AttackConverterConfig] = None,
         attack_scoring_config: Optional[AttackScoringConfig] = None,
         prompt_normalizer: Optional[PromptNormalizer] = None,

--- a/pyrit/executor/attack/single_turn/prompt_sending.py
+++ b/pyrit/executor/attack/single_turn/prompt_sending.py
@@ -5,7 +5,7 @@ import logging
 import uuid
 from typing import Optional
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.utils import combine_dict, warn_if_set
 from pyrit.executor.attack.component import ConversationManager
 from pyrit.executor.attack.core import AttackConverterConfig, AttackScoringConfig
@@ -53,7 +53,7 @@ class PromptSendingAttack(SingleTurnAttackStrategy):
     def __init__(
         self,
         *,
-        objective_target: PromptTarget,
+        objective_target: PromptTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         attack_converter_config: Optional[AttackConverterConfig] = None,
         attack_scoring_config: Optional[AttackScoringConfig] = None,
         prompt_normalizer: Optional[PromptNormalizer] = None,

--- a/pyrit/executor/attack/single_turn/role_play.py
+++ b/pyrit/executor/attack/single_turn/role_play.py
@@ -6,7 +6,7 @@ import logging
 import pathlib
 from typing import Optional
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import DATASETS_PATH
 from pyrit.executor.attack.core import AttackConverterConfig, AttackScoringConfig
 from pyrit.executor.attack.single_turn.prompt_sending import PromptSendingAttack
@@ -56,7 +56,7 @@ class RolePlayAttack(PromptSendingAttack):
     def __init__(
         self,
         *,
-        objective_target: PromptTarget,
+        objective_target: PromptTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         adversarial_chat: PromptChatTarget,
         role_play_definition_path: pathlib.Path,
         attack_converter_config: Optional[AttackConverterConfig] = None,

--- a/pyrit/executor/attack/single_turn/skeleton_key.py
+++ b/pyrit/executor/attack/single_turn/skeleton_key.py
@@ -5,7 +5,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import DATASETS_PATH
 from pyrit.executor.attack.core import AttackConverterConfig, AttackScoringConfig
 from pyrit.executor.attack.single_turn.prompt_sending import PromptSendingAttack
@@ -50,7 +50,7 @@ class SkeletonKeyAttack(PromptSendingAttack):
     def __init__(
         self,
         *,
-        objective_target: PromptTarget,
+        objective_target: PromptTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         attack_converter_config: Optional[AttackConverterConfig] = None,
         attack_scoring_config: Optional[AttackScoringConfig] = None,
         prompt_normalizer: Optional[PromptNormalizer] = None,

--- a/pyrit/prompt_converter/denylist_converter.py
+++ b/pyrit/prompt_converter/denylist_converter.py
@@ -5,7 +5,7 @@ import logging
 import pathlib
 from typing import Optional
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import DATASETS_PATH
 from pyrit.models import PromptDataType, SeedPrompt
 from pyrit.prompt_converter import ConverterResult, LLMGenericTextConverter
@@ -25,7 +25,7 @@ class DenylistConverter(LLMGenericTextConverter):
     def __init__(
         self,
         *,
-        converter_target: Optional[PromptChatTarget] = None,
+        converter_target: PromptChatTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         system_prompt_template: Optional[SeedPrompt] = None,
         denylist: list[str] = [],
     ):

--- a/pyrit/prompt_converter/fuzzer_converter/fuzzer_converter_base.py
+++ b/pyrit/prompt_converter/fuzzer_converter/fuzzer_converter_base.py
@@ -4,9 +4,8 @@
 import json
 import logging
 import uuid
-from typing import Optional
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.exceptions import (
     InvalidJsonException,
     pyrit_json_retry,
@@ -34,7 +33,12 @@ class FuzzerConverter(PromptConverter):
     """
 
     @apply_defaults
-    def __init__(self, *, converter_target: Optional[PromptChatTarget] = None, prompt_template: SeedPrompt):
+    def __init__(
+        self,
+        *,
+        converter_target: PromptChatTarget = REQUIRED_VALUE,  # type: ignore[assignment]
+        prompt_template: SeedPrompt,
+    ):
         """
         Initializes the converter with the specified chat target and prompt template.
 
@@ -47,13 +51,6 @@ class FuzzerConverter(PromptConverter):
         Raises:
             ValueError: If converter_target is not provided and no default has been configured.
         """
-        if converter_target is None:
-            raise ValueError(
-                "converter_target is required for LLM-based converters. "
-                "Either pass it explicitly or configure a default via PyRIT initialization "
-                "(e.g., initialize_pyrit with SimpleInitializer or AIRTInitializer)."
-            )
-
         self.converter_target = converter_target
         self.system_prompt = prompt_template.value
         self.template_label = "TEMPLATE"

--- a/pyrit/prompt_converter/llm_generic_text_converter.py
+++ b/pyrit/prompt_converter/llm_generic_text_converter.py
@@ -5,7 +5,7 @@ import logging
 import uuid
 from typing import Optional
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.models import (
     Message,
     MessagePiece,
@@ -27,7 +27,7 @@ class LLMGenericTextConverter(PromptConverter):
     def __init__(
         self,
         *,
-        converter_target: Optional[PromptChatTarget] = None,
+        converter_target: PromptChatTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         system_prompt_template: Optional[SeedPrompt] = None,
         user_prompt_template_with_objective: Optional[SeedPrompt] = None,
         **kwargs,
@@ -46,13 +46,6 @@ class LLMGenericTextConverter(PromptConverter):
         Raises:
             ValueError: If converter_target is not provided and no default has been configured.
         """
-        if converter_target is None:
-            raise ValueError(
-                "converter_target is required for LLM-based converters. "
-                "Either pass it explicitly or configure a default via PyRIT initialization "
-                "(e.g., initialize_pyrit with SimpleInitializer or AIRTInitializer)."
-            )
-
         self._converter_target = converter_target
         self._system_prompt_template = system_prompt_template
         self._prompt_kwargs = kwargs

--- a/pyrit/prompt_converter/malicious_question_generator_converter.py
+++ b/pyrit/prompt_converter/malicious_question_generator_converter.py
@@ -5,7 +5,7 @@ import logging
 import pathlib
 from typing import Optional
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import DATASETS_PATH
 from pyrit.models import PromptDataType, SeedPrompt
 from pyrit.prompt_converter import ConverterResult, LLMGenericTextConverter
@@ -23,7 +23,10 @@ class MaliciousQuestionGeneratorConverter(LLMGenericTextConverter):
 
     @apply_defaults
     def __init__(
-        self, *, converter_target: Optional[PromptChatTarget] = None, prompt_template: Optional[SeedPrompt] = None
+        self,
+        *,
+        converter_target: PromptChatTarget = REQUIRED_VALUE,  # type: ignore[assignment]
+        prompt_template: Optional[SeedPrompt] = None,
     ):
         """
         Initializes the converter with a specific target and template.

--- a/pyrit/prompt_converter/math_prompt_converter.py
+++ b/pyrit/prompt_converter/math_prompt_converter.py
@@ -5,7 +5,7 @@ import logging
 import pathlib
 from typing import Optional
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import DATASETS_PATH
 from pyrit.models import PromptDataType, SeedPrompt
 from pyrit.prompt_converter import ConverterResult, LLMGenericTextConverter
@@ -23,7 +23,10 @@ class MathPromptConverter(LLMGenericTextConverter):
 
     @apply_defaults
     def __init__(
-        self, *, converter_target: Optional[PromptChatTarget] = None, prompt_template: Optional[SeedPrompt] = None
+        self,
+        *,
+        converter_target: PromptChatTarget = REQUIRED_VALUE,  # type: ignore[assignment]
+        prompt_template: Optional[SeedPrompt] = None,
     ):
         """
         Initializes the converter with a specific target and template.

--- a/pyrit/prompt_converter/noise_converter.py
+++ b/pyrit/prompt_converter/noise_converter.py
@@ -6,7 +6,7 @@ import pathlib
 import textwrap
 from typing import Optional
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import DATASETS_PATH
 from pyrit.models import SeedPrompt
 from pyrit.prompt_converter import LLMGenericTextConverter
@@ -26,7 +26,7 @@ class NoiseConverter(LLMGenericTextConverter):
     def __init__(
         self,
         *,
-        converter_target: Optional[PromptChatTarget] = None,
+        converter_target: PromptChatTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         noise: Optional[str] = None,
         number_errors: int = 5,
         prompt_template: Optional[SeedPrompt] = None,

--- a/pyrit/prompt_converter/persuasion_converter.py
+++ b/pyrit/prompt_converter/persuasion_converter.py
@@ -5,9 +5,8 @@ import json
 import logging
 import pathlib
 import uuid
-from typing import Optional
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import DATASETS_PATH
 from pyrit.exceptions import (
     InvalidJsonException,
@@ -46,7 +45,12 @@ class PersuasionConverter(PromptConverter):
     """
 
     @apply_defaults
-    def __init__(self, *, converter_target: Optional[PromptChatTarget] = None, persuasion_technique: str):
+    def __init__(
+        self,
+        *,
+        converter_target: PromptChatTarget = REQUIRED_VALUE,  # type: ignore[assignment]
+        persuasion_technique: str,
+    ):
         """
         Initializes the converter with the specified target and prompt template.
 
@@ -61,13 +65,6 @@ class PersuasionConverter(PromptConverter):
             ValueError: If converter_target is not provided and no default has been configured.
             ValueError: If the persuasion technique is not supported or does not exist.
         """
-        if converter_target is None:
-            raise ValueError(
-                "converter_target is required for LLM-based converters. "
-                "Either pass it explicitly or configure a default via PyRIT initialization "
-                "(e.g., initialize_pyrit with SimpleInitializer or AIRTInitializer)."
-            )
-
         self.converter_target = converter_target
 
         try:

--- a/pyrit/prompt_converter/random_translation_converter.py
+++ b/pyrit/prompt_converter/random_translation_converter.py
@@ -7,7 +7,7 @@ import re
 from pathlib import Path
 from typing import List, Optional, Union
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import DATASETS_PATH
 from pyrit.models import PromptDataType, SeedDataset, SeedPrompt
 from pyrit.prompt_converter import ConverterResult, LLMGenericTextConverter
@@ -31,7 +31,7 @@ class RandomTranslationConverter(LLMGenericTextConverter, WordLevelConverter):
     def __init__(
         self,
         *,
-        converter_target: Optional[PromptChatTarget] = None,
+        converter_target: PromptChatTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         system_prompt_template: Optional[SeedPrompt] = None,
         languages: Optional[List[str]] = None,
         indices: Optional[List[int]] = None,

--- a/pyrit/prompt_converter/tense_converter.py
+++ b/pyrit/prompt_converter/tense_converter.py
@@ -5,7 +5,7 @@ import logging
 import pathlib
 from typing import Optional
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import DATASETS_PATH
 from pyrit.models import SeedPrompt
 from pyrit.prompt_converter import LLMGenericTextConverter
@@ -25,7 +25,7 @@ class TenseConverter(LLMGenericTextConverter):
     def __init__(
         self,
         *,
-        converter_target: Optional[PromptChatTarget] = None,
+        converter_target: PromptChatTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         tense: str,
         prompt_template: Optional[SeedPrompt] = None,
     ):

--- a/pyrit/prompt_converter/tone_converter.py
+++ b/pyrit/prompt_converter/tone_converter.py
@@ -5,7 +5,7 @@ import logging
 import pathlib
 from typing import Optional
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import DATASETS_PATH
 from pyrit.models import SeedPrompt
 from pyrit.prompt_converter import LLMGenericTextConverter
@@ -25,7 +25,7 @@ class ToneConverter(LLMGenericTextConverter):
     def __init__(
         self,
         *,
-        converter_target: Optional[PromptChatTarget] = None,
+        converter_target: PromptChatTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         tone: str,
         prompt_template: Optional[SeedPrompt] = None,
     ):

--- a/pyrit/prompt_converter/toxic_sentence_generator_converter.py
+++ b/pyrit/prompt_converter/toxic_sentence_generator_converter.py
@@ -9,7 +9,7 @@ import logging
 import pathlib
 from typing import Optional
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import DATASETS_PATH
 from pyrit.models import PromptDataType, SeedPrompt
 from pyrit.prompt_converter import ConverterResult, LLMGenericTextConverter
@@ -31,7 +31,10 @@ class ToxicSentenceGeneratorConverter(LLMGenericTextConverter):
 
     @apply_defaults
     def __init__(
-        self, *, converter_target: Optional[PromptChatTarget] = None, prompt_template: Optional[SeedPrompt] = None
+        self,
+        *,
+        converter_target: PromptChatTarget = REQUIRED_VALUE,  # type: ignore[assignment]
+        prompt_template: Optional[SeedPrompt] = None,
     ):
         """
         Initializes the converter with a specific target and template.

--- a/pyrit/prompt_converter/translation_converter.py
+++ b/pyrit/prompt_converter/translation_converter.py
@@ -14,7 +14,7 @@ from tenacity import (
     wait_exponential,
 )
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import DATASETS_PATH
 from pyrit.models import (
     Message,
@@ -37,7 +37,7 @@ class TranslationConverter(PromptConverter):
     def __init__(
         self,
         *,
-        converter_target: Optional[PromptChatTarget] = None,
+        converter_target: PromptChatTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         language: str,
         prompt_template: Optional[SeedPrompt] = None,
         max_retries: int = 3,
@@ -58,13 +58,6 @@ class TranslationConverter(PromptConverter):
             ValueError: If converter_target is not provided and no default has been configured.
             ValueError: If the language is not provided.
         """
-        if converter_target is None:
-            raise ValueError(
-                "converter_target is required for LLM-based converters. "
-                "Either pass it explicitly or configure a default via PyRIT initialization "
-                "(e.g., initialize_pyrit with SimpleInitializer or AIRTInitializer)."
-            )
-
         self.converter_target = converter_target
 
         # Retry strategy for the conversion

--- a/pyrit/prompt_converter/variation_converter.py
+++ b/pyrit/prompt_converter/variation_converter.py
@@ -8,7 +8,7 @@ import uuid
 from textwrap import dedent
 from typing import Optional
 
-from pyrit.common.apply_defaults import apply_defaults
+from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import DATASETS_PATH
 from pyrit.exceptions import (
     InvalidJsonException,
@@ -34,7 +34,10 @@ class VariationConverter(PromptConverter):
 
     @apply_defaults
     def __init__(
-        self, *, converter_target: Optional[PromptChatTarget] = None, prompt_template: Optional[SeedPrompt] = None
+        self,
+        *,
+        converter_target: PromptChatTarget = REQUIRED_VALUE,  # type: ignore[assignment]
+        prompt_template: Optional[SeedPrompt] = None,
     ):
         """
         Initializes the converter with the specified target and prompt template.
@@ -48,13 +51,6 @@ class VariationConverter(PromptConverter):
         Raises:
             ValueError: If converter_target is not provided and no default has been configured.
         """
-        if converter_target is None:
-            raise ValueError(
-                "converter_target is required for LLM-based converters. "
-                "Either pass it explicitly or configure a default via PyRIT initialization "
-                "(e.g., initialize_pyrit with SimpleInitializer or AIRTInitializer)."
-            )
-
         self.converter_target = converter_target
 
         # set to default strategy if not provided

--- a/pyrit/scenarios/scenarios/encoding_scenario.py
+++ b/pyrit/scenarios/scenarios/encoding_scenario.py
@@ -5,7 +5,7 @@
 import pathlib
 from typing import Dict, List, Optional, Sequence
 
-from pyrit.common import apply_defaults
+from pyrit.common import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import DATASETS_PATH
 from pyrit.executor.attack.core.attack_config import (
     AttackConverterConfig,
@@ -120,7 +120,7 @@ class EncodingScenario(Scenario):
     def __init__(
         self,
         *,
-        objective_target: PromptTarget,
+        objective_target: PromptTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         scenario_strategies: list[EncodingStrategy | ScenarioCompositeStrategy] | None = None,
         seed_prompts: Optional[list[str]] = None,
         objective_scorer: Optional[TrueFalseScorer] = None,

--- a/pyrit/scenarios/scenarios/foundry_scenario.py
+++ b/pyrit/scenarios/scenarios/foundry_scenario.py
@@ -13,7 +13,7 @@ import os
 from inspect import signature
 from typing import Dict, List, Optional, Sequence, Type, TypeVar
 
-from pyrit.common import apply_defaults
+from pyrit.common import REQUIRED_VALUE, apply_defaults
 from pyrit.datasets.harmbench_dataset import fetch_harmbench_dataset
 from pyrit.datasets.text_jailbreak import TextJailBreak
 from pyrit.executor.attack.core.attack_config import (
@@ -233,7 +233,7 @@ class FoundryScenario(Scenario):
     def __init__(
         self,
         *,
-        objective_target: Optional[PromptTarget] = None,
+        objective_target: PromptTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         scenario_strategies: Sequence[FoundryStrategy | ScenarioCompositeStrategy] | None = None,
         adversarial_chat: Optional[PromptChatTarget] = None,
         objectives: Optional[list[str]] = None,


### PR DESCRIPTION
Introduces REQUIRED_VALUE sentinel to mark required parameters that can still receive defaults via @apply_defaults. This improves API clarity by making parameters appear required in signatures while maintaining flexibility through PyRIT's initialization system.

This allows a clearer API (before we used None which is confusing), better errors, better type safety (type checkers treat these as non-optional), and flexibility.

Testing
Unit tests updated and added