### PR TITLE
MAINT: Unit test and pre-commit speedup

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -64,12 +64,16 @@ jobs:
 
       - name: Run pre-commit incrementally (on PR)
         if: github.event_name == 'pull_request'
+        env:
+          RUN_LONG_PRECOMMIT: true
         run: |
           git fetch origin main
           pre-commit run --from-ref origin/main --to-ref HEAD
 
       - name: Run pre-commit fully (on main)
         if: github.ref == 'refs/heads/main'
+        env:
+          RUN_LONG_PRECOMMIT: true
         run: |
           pre-commit run --all-files
 
@@ -117,12 +121,16 @@ jobs:
 
       - name: Run pre-commit incrementally (on PR)
         if: github.event_name == 'pull_request'
+        env:
+          RUN_LONG_PRECOMMIT: true
         run: |
           git fetch origin main
           pre-commit run --from-ref origin/main --to-ref HEAD
 
       - name: Run pre-commit fully (on main)
         if: github.ref == 'refs/heads/main'
+        env:
+          RUN_LONG_PRECOMMIT: true
         run: |
           pre-commit run --all-files
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,9 +86,16 @@ repos:
 
   - repo: local
     hooks:
+      - id: validate-jupyter-book
+        name: Validate Jupyter Book Structure
+        entry: python ./build_scripts/validate_jupyter_book.py
+        language: python
+        files: ^(doc/.*\.(py|ipynb|md|rst)|doc/_toc\.yml)$
+        pass_filenames: false
+        additional_dependencies: ['pyyaml']
       - id: website
         name: Jupyter Book Build Check
-        entry: jb build -W -q ./doc
+        entry: python ./build_scripts/conditional_jb_build.py
         language: system
         types: [python]
         pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,15 @@ docs-build:
 	jb build -W -v ./doc
 	python ./build_scripts/generate_rss.py
 
+# Because of import time, "auto" seemed to actually go slower than just using 4 processes
 unit-test:
-	$(CMD) pytest --cov=$(PYMODULE) $(UNIT_TESTS)
+	$(CMD) pytest -n 4 --dist=loadfile --cov=$(PYMODULE) $(UNIT_TESTS)
 
 unit-test-cov-html:
-	$(CMD) pytest --cov=$(PYMODULE) $(UNIT_TESTS) --cov-report html
+	$(CMD) pytest -n 4 --dist=loadfile --cov=$(PYMODULE) $(UNIT_TESTS) --cov-report html
 
 unit-test-cov-xml:
-	$(CMD) pytest --cov=$(PYMODULE) $(UNIT_TESTS) --cov-report xml --junitxml=junit/test-results.xml --doctest-modules
+	$(CMD) pytest -n 4 --dist=loadfile --cov=$(PYMODULE) $(UNIT_TESTS) --cov-report xml --junitxml=junit/test-results.xml --doctest-modules
 
 integration-test:
 	$(CMD) pytest $(INTEGRATION_TESTS) --cov=$(PYMODULE) $(INTEGRATION_TESTS) --cov-report xml --junitxml=junit/test-results.xml --doctest-modules

--- a/build_scripts/check_links.py
+++ b/build_scripts/check_links.py
@@ -118,35 +118,88 @@ def check_url(url, retries=2, delay=2):
     return url, False
 
 
-def check_links_in_file(file_path):
-    urls = extract_urls(file_path)
-    resolved_urls = [resolve_relative_url(file_path, url) for url in urls]
-    broken_urls = []
-    with ThreadPoolExecutor(max_workers=10) as executor:
-        futures = {executor.submit(check_url, url): url for url in resolved_urls}
+def extract_all_urls_from_files(files):
+    """
+    Extract all URLs from all files, returning a dict of {file_path: [urls]}.
+    """
+    file_urls = {}
+    skipped_files = ["doc/blog/"]
+    
+    for file_path in files:
+        if any(file_path.startswith(skipped) for skipped in skipped_files):
+            continue
+        urls = extract_urls(file_path)
+        resolved_urls = [resolve_relative_url(file_path, url) for url in urls]
+        if resolved_urls:
+            file_urls[file_path] = resolved_urls
+    
+    return file_urls
+
+
+def check_all_links_parallel(file_urls, max_workers=20):
+    """
+    Check all URLs across all files in parallel with a shared thread pool.
+    
+    Args:
+        file_urls: Dict of {file_path: [urls]}
+        max_workers: Max concurrent HTTP requests across ALL files
+    
+    Returns:
+        Dict of {file_path: [broken_urls]}
+    """
+    all_broken_urls = {}
+    
+    # Create a mapping of url -> file_path for tracking which file each URL came from
+    url_to_files = {}
+    for file_path, urls in file_urls.items():
+        for url in urls:
+            if url not in url_to_files:
+                url_to_files[url] = []
+            url_to_files[url].append(file_path)
+    
+    # Check all unique URLs in parallel
+    url_results = {}
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {executor.submit(check_url, url): url for url in url_to_files.keys()}
         for future in as_completed(futures):
-            url, is_valid = future.result()
-            if not is_valid:
-                broken_urls.append(url)
-    return broken_urls
+            url = futures[future]
+            _, is_valid = future.result()
+            url_results[url] = is_valid
+    
+    # Map broken URLs back to their files
+    for url, is_valid in url_results.items():
+        if not is_valid:
+            for file_path in url_to_files[url]:
+                if file_path not in all_broken_urls:
+                    all_broken_urls[file_path] = []
+                all_broken_urls[file_path].append(url)
+    
+    return all_broken_urls
 
 
 if __name__ == "__main__":
     files = sys.argv[1:]
-    all_broken_urls = {}
-    skipped_files = ["doc/blog/"]
-    for file_path in files:
-        if any(file_path.startswith(skipped) for skipped in skipped_files):
-            continue
-        print(f"Checking links in {file_path}")
-        broken_urls = check_links_in_file(file_path)
-        if broken_urls:
-            all_broken_urls[file_path] = broken_urls
+    
+    print(f"Extracting URLs from {len(files)} file(s)...")
+    file_urls = extract_all_urls_from_files(files)
+    
+    if not file_urls:
+        print("No URLs found to check.")
+        sys.exit(0)
+    
+    total_urls = sum(len(urls) for urls in file_urls.values())
+    unique_urls = len(set(url for urls in file_urls.values() for url in urls))
+    print(f"Checking {unique_urls} unique URL(s) across {len(file_urls)} file(s) (total: {total_urls})...")
+    
+    all_broken_urls = check_all_links_parallel(file_urls, max_workers=30)
+    
     if all_broken_urls:
+        print("\n" + "=" * 80)
         for file_path, urls in all_broken_urls.items():
             print(f"Broken links in {file_path}:")
             for url in urls:
                 print(f"  - {url}")
+        print("=" * 80)
         sys.exit(1)
     else:
         print("No broken links found.")

--- a/build_scripts/conditional_jb_build.py
+++ b/build_scripts/conditional_jb_build.py
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""
+Conditional Jupyter Book build wrapper for pre-commit.
+
+This script checks the RUN_LONG_PRECOMMIT environment variable:
+- If set to "true", runs the full `jb build -W -q ./doc` command
+- Otherwise, exits successfully (fast validation script runs instead)
+
+This allows CI/pipeline to run full builds while local development uses fast validation.
+"""
+
+import os
+import subprocess
+import sys
+
+
+def main():
+    run_long = os.environ.get("RUN_LONG_PRECOMMIT", "").lower() == "true"
+
+    if run_long:
+        print("RUN_LONG_PRECOMMIT=true: Running full Jupyter Book build...")
+        # Run jb build with the same flags as before
+        result = subprocess.run(
+            ["jb", "build", "-W", "-q", "./doc"],
+            cwd=os.path.dirname(os.path.dirname(__file__))  # Repository root
+        )
+        return result.returncode
+    else:
+        print("RUN_LONG_PRECOMMIT not set: Skipping full Jupyter Book build (fast validation runs instead)")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build_scripts/conditional_jb_build.py
+++ b/build_scripts/conditional_jb_build.py
@@ -23,8 +23,7 @@ def main():
         print("RUN_LONG_PRECOMMIT=true: Running full Jupyter Book build...")
         # Run jb build with the same flags as before
         result = subprocess.run(
-            ["jb", "build", "-W", "-q", "./doc"],
-            cwd=os.path.dirname(os.path.dirname(__file__))  # Repository root
+            ["jb", "build", "-W", "-q", "./doc"], cwd=os.path.dirname(os.path.dirname(__file__))  # Repository root
         )
         return result.returncode
     else:

--- a/build_scripts/validate_jupyter_book.py
+++ b/build_scripts/validate_jupyter_book.py
@@ -1,0 +1,303 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""
+Fast validation script for Jupyter Book documentation.
+
+This script performs comprehensive validation of:
+1. doc/api.rst - Validates that all module references exist and autosummary members are defined
+2. doc/_toc.yml - Validates that all file references exist and detects orphaned doc files
+
+Designed to replace the slow `jb build` command for local pre-commit validation while
+maintaining thoroughness. The full `jb build` still runs in CI/pipeline.
+
+Exit codes:
+    0: All validations passed
+    1: Validation errors found
+"""
+
+import importlib
+import os
+import re
+import sys
+from pathlib import Path
+from typing import List, Set, Tuple
+
+import yaml
+
+
+def parse_api_rst(api_rst_path: Path) -> List[Tuple[str, List[str]]]:
+    """
+    Parse api.rst file to extract module names and their autosummary members.
+
+    Returns:
+        List of tuples: (module_name, [member_names])
+    """
+    with open(api_rst_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    modules = []
+    # Pattern to match :py:mod:`module.name`
+    module_pattern = re.compile(r":py:mod:`(pyrit\.[^`]+)`")
+    # Pattern to match autosummary sections
+    autosummary_pattern = re.compile(r"\.\. autosummary::\s+:nosignatures:\s+:toctree: _autosummary/\s+((?:\s+\w+\s*\n)+)", re.MULTILINE)
+
+    # Find all modules
+    module_matches = module_pattern.findall(content)
+
+    # Split content by module sections
+    sections = re.split(r":py:mod:`(pyrit\.[^`]+)`", content)
+
+    for i in range(1, len(sections), 2):
+        if i + 1 < len(sections):
+            module_name = sections[i]
+            section_content = sections[i + 1]
+
+            # Extract autosummary members from this section
+            members = []
+            autosummary_match = autosummary_pattern.search(section_content)
+            if autosummary_match:
+                members_text = autosummary_match.group(1)
+                members = [m.strip() for m in members_text.strip().split("\n") if m.strip()]
+
+            modules.append((module_name, members))
+
+    return modules
+
+
+def validate_api_rst_modules(modules: List[Tuple[str, List[str]]], repo_root: Path) -> List[str]:
+    """
+    Validate that modules exist and autosummary members are defined.
+
+    Returns:
+        List of error messages (empty if all validations passed)
+    """
+    errors = []
+
+    for module_name, members in modules:
+        # Check if module file exists
+        # Convert module name to path: pyrit.analytics -> pyrit/analytics/__init__.py
+        module_path = module_name.replace(".", os.sep)
+        possible_paths = [
+            repo_root / f"{module_path}.py",
+            repo_root / module_path / "__init__.py",
+        ]
+
+        module_exists = any(p.exists() for p in possible_paths)
+        if not module_exists:
+            errors.append(f"Module file not found for '{module_name}': checked {[str(p) for p in possible_paths]}")
+            continue
+
+        # Try to import the module and validate members (skip if dependencies missing)
+        if members:
+            try:
+                mod = importlib.import_module(module_name)
+
+                for member in members:
+                    if not hasattr(mod, member):
+                        errors.append(f"Member '{member}' not found in module '{module_name}'")
+
+            except ImportError as e:
+                # Check if it's a missing dependency (not a module structure issue)
+                error_msg = str(e)
+                if "No module named 'pyrit" in error_msg:
+                    # This is a structural issue - pyrit module itself not found
+                    errors.append(f"Failed to import module '{module_name}': {e}")
+                # Otherwise, it's likely a missing dependency - skip validation
+                # (dependencies may not be installed in pre-commit environment)
+            except Exception as e:
+                # Only report unexpected errors
+                errors.append(f"Error validating module '{module_name}': {e}")
+
+    return errors
+
+
+def parse_toc_yml(toc_path: Path) -> Set[str]:
+    """
+    Parse _toc.yml file to extract all file references.
+
+    Returns:
+        Set of file paths (relative to doc/ directory, without extensions)
+    """
+    with open(toc_path, "r", encoding="utf-8") as f:
+        toc_data = yaml.safe_load(f)
+
+    files = set()
+
+    def extract_files(node):
+        if isinstance(node, dict):
+            if "file" in node:
+                files.add(node["file"])
+            if "root" in node:
+                files.add(node["root"])
+            for value in node.values():
+                extract_files(value)
+        elif isinstance(node, list):
+            for item in node:
+                extract_files(item)
+
+    extract_files(toc_data)
+    return files
+
+
+def validate_toc_yml_files(toc_files: Set[str], doc_root: Path) -> List[str]:
+    """
+    Validate that all files referenced in _toc.yml exist.
+
+    Returns:
+        List of error messages (empty if all validations passed)
+    """
+    errors = []
+
+    for file_ref in toc_files:
+        # Check if file reference already includes an extension
+        if file_ref.endswith((".rst", ".md", ".ipynb", ".py")):
+            if not (doc_root / file_ref).exists():
+                errors.append(f"File referenced in _toc.yml not found: '{file_ref}'")
+            continue
+
+        # Files in _toc.yml are usually listed without extensions
+        # Check for .md, .ipynb, or .py files
+        possible_extensions = [".md", ".ipynb", ".py"]
+        file_exists = any((doc_root / f"{file_ref}{ext}").exists() for ext in possible_extensions)
+
+        if not file_exists:
+            errors.append(f"File referenced in _toc.yml not found: '{file_ref}' (checked extensions: {possible_extensions})")
+
+    return errors
+
+
+def find_orphaned_doc_files(toc_files: Set[str], doc_root: Path) -> List[str]:
+    """
+    Find documentation files that exist but are not referenced in _toc.yml.
+
+    Returns:
+        List of orphaned file paths
+    """
+    # Directories to skip
+    skip_dirs = {
+        "_build", "_autosummary", "_static", "_templates", "generate_docs",
+        ".ipynb_checkpoints", "__pycache__", "playwright_demo"
+    }
+
+    # Files to skip (these are special/configuration files)
+    skip_files = {
+        "_config.yml", "conf.py", "references.bib", "roakey.png",
+        ".gitignore", "requirements.txt"
+    }
+
+    # Normalize toc_files to handle both with and without extensions
+    normalized_toc_files = set()
+    for file_ref in toc_files:
+        # Add the reference as-is
+        normalized_toc_files.add(file_ref.replace(os.sep, "/"))
+        # Also add without extension if it has one
+        if file_ref.endswith((".rst", ".md", ".ipynb", ".py")):
+            normalized_toc_files.add(Path(file_ref).with_suffix("").as_posix())
+
+    orphaned = []
+
+    for file_path in doc_root.rglob("*"):
+        # Skip directories
+        if file_path.is_dir():
+            continue
+
+        # Skip if in excluded directories
+        if any(skip_dir in file_path.parts for skip_dir in skip_dirs):
+            continue
+
+        # Skip if in excluded files
+        if file_path.name in skip_files:
+            continue
+
+        # Only check documentation files
+        if file_path.suffix not in [".md", ".ipynb", ".py", ".rst"]:
+            continue
+
+        # Get relative path without extension
+        rel_path = file_path.relative_to(doc_root)
+        rel_path_no_ext = str(rel_path.with_suffix("")).replace(os.sep, "/")
+        rel_path_with_ext = str(rel_path).replace(os.sep, "/")
+
+        # Check if this file is referenced in _toc.yml (with or without extension)
+        if rel_path_no_ext in normalized_toc_files or rel_path_with_ext in normalized_toc_files:
+            continue
+
+        # Check if companion .py file for .ipynb (notebooks often have both)
+        if file_path.suffix == ".py":
+            notebook_version = file_path.with_suffix(".ipynb")
+            if notebook_version.exists():
+                # .py file is companion to .ipynb, not orphaned
+                continue
+
+        orphaned.append(str(rel_path))
+
+    return orphaned
+
+
+def main():
+    # Determine repository root (parent of build_scripts)
+    script_dir = Path(__file__).parent
+    repo_root = script_dir.parent
+    doc_root = repo_root / "doc"
+    pyrit_root = repo_root / "pyrit"
+    api_rst = doc_root / "api.rst"
+    toc_yml = doc_root / "_toc.yml"
+
+    # Add repo root to sys.path so we can import pyrit modules
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    # Ensure required files exist
+    if not api_rst.exists():
+        print(f"ERROR: api.rst not found at {api_rst}", file=sys.stderr)
+        return 1
+
+    if not toc_yml.exists():
+        print(f"ERROR: _toc.yml not found at {toc_yml}", file=sys.stderr)
+        return 1
+
+    all_errors = []
+
+    # Validate api.rst
+    print("Validating api.rst module references...")
+    modules = parse_api_rst(api_rst)
+    api_errors = validate_api_rst_modules(modules, repo_root)
+    if api_errors:
+        all_errors.extend([f"[api.rst] {err}" for err in api_errors])
+    else:
+        print(f"[OK] Validated {len(modules)} modules in api.rst")
+
+    # Validate _toc.yml
+    print("Validating _toc.yml file references...")
+    toc_files = parse_toc_yml(toc_yml)
+    toc_errors = validate_toc_yml_files(toc_files, doc_root)
+    if toc_errors:
+        all_errors.extend([f"[_toc.yml] {err}" for err in toc_errors])
+    else:
+        print(f"[OK] Validated {len(toc_files)} file references in _toc.yml")
+
+    # Check for orphaned files
+    print("Checking for orphaned documentation files...")
+    orphaned = find_orphaned_doc_files(toc_files, doc_root)
+    if orphaned:
+        all_errors.extend([f"[orphaned] File exists but not in _toc.yml: {f}" for f in orphaned])
+    else:
+        print("[OK] No orphaned documentation files found")
+
+    # Report results
+    if all_errors:
+        print("\n" + "=" * 80, file=sys.stderr)
+        print("VALIDATION ERRORS FOUND:", file=sys.stderr)
+        print("=" * 80, file=sys.stderr)
+        for error in all_errors:
+            print(f"  • {error}", file=sys.stderr)
+        print("=" * 80, file=sys.stderr)
+        return 1
+    else:
+        print("\n[OK] All Jupyter Book validations passed!")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build_scripts/validate_jupyter_book.py
+++ b/build_scripts/validate_jupyter_book.py
@@ -16,7 +16,6 @@ Exit codes:
     1: Validation errors found
 """
 
-import importlib
 import os
 import re
 import sys
@@ -37,14 +36,12 @@ def parse_api_rst(api_rst_path: Path) -> List[Tuple[str, List[str]]]:
         content = f.read()
 
     modules = []
-    # Pattern to match :py:mod:`module.name`
-    module_pattern = re.compile(r":py:mod:`(pyrit\.[^`]+)`")
     # Pattern to match autosummary sections
     autosummary_pattern = re.compile(
         r"\.\. autosummary::\s+:nosignatures:\s+:toctree: _autosummary/\s+((?:\s+\w+\s*\n)+)", re.MULTILINE
     )
 
-    # Split content by module sections
+    # Split content by module sections using :py:mod:`module.name`
     sections = re.split(r":py:mod:`(pyrit\.[^`]+)`", content)
 
     for i in range(1, len(sections), 2):
@@ -95,13 +92,13 @@ def validate_api_rst_modules(modules: List[Tuple[str, List[str]]], repo_root: Pa
                 if path.exists():
                     module_file = path
                     break
-            
+
             if module_file:
                 # Read the source file and check for member definitions
                 try:
-                    with open(module_file, 'r', encoding='utf-8') as f:
+                    with open(module_file, "r", encoding="utf-8") as f:
                         source_content = f.read()
-                    
+
                     for member in members:
                         # Check for various definition patterns:
                         # - def member(...
@@ -116,12 +113,14 @@ def validate_api_rst_modules(modules: List[Tuple[str, List[str]]], repo_root: Pa
                             rf'"{re.escape(member)}"',  # in __all__ or strings
                             rf"'{re.escape(member)}'",
                         ]
-                        
+
                         found = any(re.search(pattern, source_content, re.MULTILINE) for pattern in patterns)
-                        
+
                         if not found:
-                            errors.append(f"Member '{member}' not found in module '{module_name}' (searched {module_file})")
-                            
+                            errors.append(
+                                f"Member '{member}' not found in module '{module_name}' (searched {module_file})"
+                            )
+
                 except Exception as e:
                     errors.append(f"Error reading source file for '{module_name}': {e}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ dev = [
     "pytest-asyncio>=1.0.0",
     "pytest-cov>=6.1.1",
     "pytest-timeout>=2.4.0",
+    "pytest-xdist>=3.6.1",
     "respx>=0.22.0",
     "ruff>=0.14.4",
     "sphinxcontrib-mermaid>=1.0.0",

--- a/tests/integration/converter/test_retry_timing_integration.py
+++ b/tests/integration/converter/test_retry_timing_integration.py
@@ -1,0 +1,45 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""
+Integration test for retry timing mechanism.
+Verifies that exponential backoff retry delays work correctly with real timing.
+"""
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from unit.mocks import MockPromptTarget
+
+from pyrit.prompt_converter import TranslationConverter
+
+
+@pytest.mark.asyncio
+async def test_translation_converter_exponential_backoff_timing(sqlite_instance):
+    """
+    Integration test: Verify TranslationConverter uses exponential backoff with real delays.
+    This tests the actual timing behavior that unit tests mock out.
+    """
+    prompt_target = MockPromptTarget()
+    max_retries = 3
+    translation_converter = TranslationConverter(
+        converter_target=prompt_target,
+        language="spanish",
+        max_retries=max_retries,
+        max_wait_time_in_seconds=10,  # Cap wait time
+    )
+
+    mock_send_prompt = AsyncMock(side_effect=Exception("Test failure"))
+
+    start_time = time.time()
+    with patch.object(prompt_target, "send_prompt_async", mock_send_prompt):
+        with pytest.raises(Exception):
+            await translation_converter.convert_async(prompt="hello")
+    elapsed_time = time.time() - start_time
+
+    # With exponential backoff (multiplier=1, min=1): 1s + 2s = 3s minimum
+    # Allow some tolerance for execution overhead
+    assert elapsed_time >= 2.5, f"Expected at least 2.5s for exponential backoff, got {elapsed_time:.2f}s"
+    assert elapsed_time < 6.0, f"Expected less than 6s total, got {elapsed_time:.2f}s"
+    assert mock_send_prompt.call_count == max_retries

--- a/tests/integration/targets/test_rate_limiting_integration.py
+++ b/tests/integration/targets/test_rate_limiting_integration.py
@@ -16,7 +16,9 @@ from pyrit.memory import CentralMemory
 from pyrit.models import SeedGroup, SeedPrompt
 from pyrit.prompt_converter import Base64Converter, StringJoinConverter
 from pyrit.prompt_normalizer import NormalizerRequest, PromptNormalizer
-from pyrit.prompt_normalizer.prompt_converter_configuration import PromptConverterConfiguration
+from pyrit.prompt_normalizer.prompt_converter_configuration import (
+    PromptConverterConfiguration,
+)
 
 
 @pytest.fixture
@@ -45,7 +47,7 @@ def mock_memory_instance():
 async def test_rate_limiting_with_real_delay(mock_memory_instance, seed_group):
     """
     Integration test: Verify rate limiting enforces actual delays.
-    
+
     With rpm=10, each request should sleep 60/10 = 6 seconds.
     This tests the actual timing behavior that unit tests mock out.
     """

--- a/tests/integration/targets/test_rate_limiting_integration.py
+++ b/tests/integration/targets/test_rate_limiting_integration.py
@@ -1,0 +1,78 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""
+Integration test for rate limiting mechanism.
+Verifies that actual rate limiting delays work correctly with real timing.
+"""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from unit.mocks import MockPromptTarget
+
+from pyrit.memory import CentralMemory
+from pyrit.models import SeedGroup, SeedPrompt
+from pyrit.prompt_converter import Base64Converter, StringJoinConverter
+from pyrit.prompt_normalizer import NormalizerRequest, PromptNormalizer
+from pyrit.prompt_normalizer.prompt_converter_configuration import PromptConverterConfiguration
+
+
+@pytest.fixture
+def seed_group() -> SeedGroup:
+    return SeedGroup(
+        seeds=[
+            SeedPrompt(
+                value="Hello",
+                data_type="text",
+                role="system",
+                sequence=1,
+            )
+        ]
+    )
+
+
+@pytest.fixture
+def mock_memory_instance():
+    """Fixture to mock CentralMemory.get_memory_instance"""
+    memory = MagicMock()
+    with patch.object(CentralMemory, "get_memory_instance", return_value=memory):
+        yield memory
+
+
+@pytest.mark.asyncio
+async def test_rate_limiting_with_real_delay(mock_memory_instance, seed_group):
+    """
+    Integration test: Verify rate limiting enforces actual delays.
+    
+    With rpm=10, each request should sleep 60/10 = 6 seconds.
+    This tests the actual timing behavior that unit tests mock out.
+    """
+    rpm = 10
+    prompt_target = MockPromptTarget(rpm=rpm)
+
+    request_converters = PromptConverterConfiguration(
+        converters=[Base64Converter(), StringJoinConverter(join_value="_")]
+    )
+
+    normalizer_request = NormalizerRequest(
+        seed_group=seed_group,
+        request_converter_configurations=[request_converters],
+    )
+
+    normalizer = PromptNormalizer()
+
+    start_time = time.time()
+    results = await normalizer.send_prompt_batch_to_target_async(
+        requests=[normalizer_request],
+        target=prompt_target,
+        batch_size=1,  # batch_size must be 1 with rpm
+    )
+    elapsed_time = time.time() - start_time
+
+    # Should have 6 second delay (60/rpm = 60/10 = 6)
+    assert elapsed_time >= 5.8, f"Expected at least 5.8s for rate limiting, got {elapsed_time:.2f}s"
+    assert elapsed_time < 8.0, f"Expected less than 8s total, got {elapsed_time:.2f}s"
+    assert "S_G_V_s_b_G_8_=" in prompt_target.prompt_sent
+    assert len(results) == 1

--- a/tests/unit/converter/test_azure_speech_text_converter.py
+++ b/tests/unit/converter/test_azure_speech_text_converter.py
@@ -32,9 +32,13 @@ class TestAzureSpeechAudioToTextConverter:
         assert converter._azure_speech_key == "dummy_key"
         assert converter.done is False
 
+    @patch(
+        "pyrit.common.default_values.get_required_value",
+        side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
+    )
     @patch("azure.cognitiveservices.speech.SpeechRecognizer")
     @patch("pyrit.prompt_converter.azure_speech_audio_to_text_converter.logger")
-    def test_stop_cb(self, mock_logger, MockSpeechRecognizer):
+    def test_stop_cb(self, mock_logger, MockSpeechRecognizer, mock_get_required_value):
         import azure.cognitiveservices.speech as speechsdk
 
         # Create a mock event
@@ -59,9 +63,13 @@ class TestAzureSpeechAudioToTextConverter:
         )
         mock_logger.info.assert_called_with("End of audio stream detected.")
 
+    @patch(
+        "pyrit.common.default_values.get_required_value",
+        side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
+    )
     @patch("azure.cognitiveservices.speech.SpeechRecognizer")
     @patch("pyrit.prompt_converter.azure_speech_audio_to_text_converter.logger")
-    def test_transcript_cb(self, mock_logger, MockSpeechRecognizer):
+    def test_transcript_cb(self, mock_logger, MockSpeechRecognizer, mock_get_required_value):
         import azure.cognitiveservices.speech as speechsdk
 
         # Create a mock event
@@ -82,21 +90,33 @@ class TestAzureSpeechAudioToTextConverter:
         mock_logger.info.assert_called_once_with("RECOGNIZED: {}".format(mock_event.result.text))
         assert mock_event.result.text in transcript
 
-    def test_azure_speech_audio_text_converter_input_supported(self):
+    @patch(
+        "pyrit.common.default_values.get_required_value",
+        side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
+    )
+    def test_azure_speech_audio_text_converter_input_supported(self, mock_get_required_value):
         converter = AzureSpeechAudioToTextConverter()
         assert converter.input_supported("image_path") is False
         assert converter.input_supported("audio_path") is True
 
     @pytest.mark.asyncio
-    async def test_azure_speech_audio_text_converter_nonexistent_path(self):
+    @patch(
+        "pyrit.common.default_values.get_required_value",
+        side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
+    )
+    async def test_azure_speech_audio_text_converter_nonexistent_path(self, mock_get_required_value):
         converter = AzureSpeechAudioToTextConverter()
         prompt = "nonexistent_path2.wav"
         with pytest.raises(FileNotFoundError):
             assert await converter.convert_async(prompt=prompt, input_type="audio_path")
 
     @pytest.mark.asyncio
+    @patch(
+        "pyrit.common.default_values.get_required_value",
+        side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
+    )
     @patch("os.path.exists", return_value=True)
-    async def test_azure_speech_audio_text_converter_non_wav_file(self, mock_path_exists):
+    async def test_azure_speech_audio_text_converter_non_wav_file(self, mock_path_exists, mock_get_required_value):
         converter = AzureSpeechAudioToTextConverter()
         prompt = "dummy_audio.mp3"
         with pytest.raises(ValueError):

--- a/tests/unit/executor/attack/single_turn/test_prompt_sending.py
+++ b/tests/unit/executor/attack/single_turn/test_prompt_sending.py
@@ -176,7 +176,11 @@ class TestContextValidation:
     @pytest.mark.parametrize(
         "objective,conversation_id,expected_error",
         [
-            ("", "a6742ba7-3ce7-4db7-a0f5-769a0fb18c3c", "Attack objective must be provided and non-empty in the context"),
+            (
+                "",
+                "a6742ba7-3ce7-4db7-a0f5-769a0fb18c3c",
+                "Attack objective must be provided and non-empty in the context",
+            ),
         ],
     )
     def test_validate_context_raises_errors(self, mock_target, objective, conversation_id, expected_error):

--- a/tests/unit/executor/attack/single_turn/test_prompt_sending.py
+++ b/tests/unit/executor/attack/single_turn/test_prompt_sending.py
@@ -176,7 +176,7 @@ class TestContextValidation:
     @pytest.mark.parametrize(
         "objective,conversation_id,expected_error",
         [
-            ("", str(uuid.uuid4()), "Attack objective must be provided and non-empty in the context"),
+            ("", "a6742ba7-3ce7-4db7-a0f5-769a0fb18c3c", "Attack objective must be provided and non-empty in the context"),
         ],
     )
     def test_validate_context_raises_errors(self, mock_target, objective, conversation_id, expected_error):

--- a/tests/unit/scenarios/test_content_harms_scenario.py
+++ b/tests/unit/scenarios/test_content_harms_scenario.py
@@ -51,7 +51,7 @@ def sample_objectives():
     return ["objective1", "objective2", "objective3"]
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def mock_seed_groups():
     """Create mock seed groups for testing."""
 
@@ -73,6 +73,20 @@ def mock_seed_groups():
         ]
 
     return create_seed_groups_for_strategy
+
+
+@pytest.fixture(scope="class")
+def mock_all_harm_objectives(mock_seed_groups):
+    """Class-scoped fixture for all harm category objectives to reduce test code duplication."""
+    return {
+        "hate": mock_seed_groups("hate"),
+        "fairness": mock_seed_groups("fairness"),
+        "violence": mock_seed_groups("violence"),
+        "sexual": mock_seed_groups("sexual"),
+        "harassment": mock_seed_groups("harassment"),
+        "misinformation": mock_seed_groups("misinformation"),
+        "leakage": mock_seed_groups("leakage"),
+    }
 
 
 class TestContentHarmsStrategy:
@@ -194,20 +208,11 @@ class TestContentHarmsScenarioBasic:
         mock_objective_target,
         mock_adversarial_target,
         mock_objective_scorer,
-        mock_seed_groups,
+        mock_all_harm_objectives,
     ):
         """Test initialization with only required parameters."""
         mock_get_scorer.return_value = mock_objective_scorer
-        # Return seed groups for all harm strategies that might be used
-        mock_get_objectives.return_value = {
-            "hate": mock_seed_groups("hate"),
-            "fairness": mock_seed_groups("fairness"),
-            "violence": mock_seed_groups("violence"),
-            "sexual": mock_seed_groups("sexual"),
-            "harassment": mock_seed_groups("harassment"),
-            "misinformation": mock_seed_groups("misinformation"),
-            "leakage": mock_seed_groups("leakage"),
-        }
+        mock_get_objectives.return_value = mock_all_harm_objectives
 
         scenario = ContentHarmsScenario(adversarial_chat=mock_adversarial_target)
 
@@ -271,19 +276,11 @@ class TestContentHarmsScenarioBasic:
         mock_objective_target,
         mock_adversarial_target,
         mock_objective_scorer,
-        mock_seed_groups,
+        mock_all_harm_objectives,
     ):
         """Test initialization with custom max concurrency."""
         mock_get_scorer.return_value = mock_objective_scorer
-        mock_get_objectives.return_value = {
-            "hate": mock_seed_groups("hate"),
-            "fairness": mock_seed_groups("fairness"),
-            "violence": mock_seed_groups("violence"),
-            "sexual": mock_seed_groups("sexual"),
-            "harassment": mock_seed_groups("harassment"),
-            "misinformation": mock_seed_groups("misinformation"),
-            "leakage": mock_seed_groups("leakage"),
-        }
+        mock_get_objectives.return_value = mock_all_harm_objectives
 
         scenario = ContentHarmsScenario(adversarial_chat=mock_adversarial_target)
 
@@ -301,19 +298,11 @@ class TestContentHarmsScenarioBasic:
         mock_objective_target,
         mock_adversarial_target,
         mock_objective_scorer,
-        mock_seed_groups,
+        mock_all_harm_objectives,
     ):
         """Test initialization with custom seed dataset prefix."""
         mock_get_scorer.return_value = mock_objective_scorer
-        mock_get_objectives.return_value = {
-            "hate": mock_seed_groups("hate"),
-            "fairness": mock_seed_groups("fairness"),
-            "violence": mock_seed_groups("violence"),
-            "sexual": mock_seed_groups("sexual"),
-            "harassment": mock_seed_groups("harassment"),
-            "misinformation": mock_seed_groups("misinformation"),
-            "leakage": mock_seed_groups("leakage"),
-        }
+        mock_get_objectives.return_value = mock_all_harm_objectives
 
         scenario = ContentHarmsScenario(adversarial_chat=mock_adversarial_target)
 
@@ -332,19 +321,11 @@ class TestContentHarmsScenarioBasic:
         mock_objective_target,
         mock_adversarial_target,
         mock_objective_scorer,
-        mock_seed_groups,
+        mock_all_harm_objectives,
     ):
         """Test that initialization defaults to ALL strategy when none provided."""
         mock_get_scorer.return_value = mock_objective_scorer
-        mock_get_objectives.return_value = {
-            "hate": mock_seed_groups("hate"),
-            "fairness": mock_seed_groups("fairness"),
-            "violence": mock_seed_groups("violence"),
-            "sexual": mock_seed_groups("sexual"),
-            "harassment": mock_seed_groups("harassment"),
-            "misinformation": mock_seed_groups("misinformation"),
-            "leakage": mock_seed_groups("leakage"),
-        }
+        mock_get_objectives.return_value = mock_all_harm_objectives
 
         scenario = ContentHarmsScenario(adversarial_chat=mock_adversarial_target)
 
@@ -397,19 +378,11 @@ class TestContentHarmsScenarioBasic:
         mock_objective_target,
         mock_adversarial_target,
         mock_objective_scorer,
-        mock_seed_groups,
+        mock_all_harm_objectives,
     ):
         """Test initialization with max_retries parameter."""
         mock_get_scorer.return_value = mock_objective_scorer
-        mock_get_objectives.return_value = {
-            "hate": mock_seed_groups("hate"),
-            "fairness": mock_seed_groups("fairness"),
-            "violence": mock_seed_groups("violence"),
-            "sexual": mock_seed_groups("sexual"),
-            "harassment": mock_seed_groups("harassment"),
-            "misinformation": mock_seed_groups("misinformation"),
-            "leakage": mock_seed_groups("leakage"),
-        }
+        mock_get_objectives.return_value = mock_all_harm_objectives
 
         scenario = ContentHarmsScenario(adversarial_chat=mock_adversarial_target)
 
@@ -427,19 +400,11 @@ class TestContentHarmsScenarioBasic:
         mock_objective_target,
         mock_adversarial_target,
         mock_objective_scorer,
-        mock_seed_groups,
+        mock_all_harm_objectives,
     ):
         """Test that memory labels are properly stored."""
         mock_get_scorer.return_value = mock_objective_scorer
-        mock_get_objectives.return_value = {
-            "hate": mock_seed_groups("hate"),
-            "fairness": mock_seed_groups("fairness"),
-            "violence": mock_seed_groups("violence"),
-            "sexual": mock_seed_groups("sexual"),
-            "harassment": mock_seed_groups("harassment"),
-            "misinformation": mock_seed_groups("misinformation"),
-            "leakage": mock_seed_groups("leakage"),
-        }
+        mock_get_objectives.return_value = mock_all_harm_objectives
 
         memory_labels = {"test_run": "123", "category": "harm"}
 

--- a/tests/unit/test_prompt_normalizer.py
+++ b/tests/unit/test_prompt_normalizer.py
@@ -353,22 +353,24 @@ async def test_prompt_normalizer_send_prompt_batch_async_throws(
 
     normalizer = PromptNormalizer()
 
-    if max_requests_per_minute and batch_size != 1:
-        with pytest.raises(ValueError):
+    # Mock asyncio.sleep to avoid 6s delay in rate limiting test
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        if max_requests_per_minute and batch_size != 1:
+            with pytest.raises(ValueError):
+                results = await normalizer.send_prompt_batch_to_target_async(
+                    requests=[normalizer_request],
+                    target=prompt_target,
+                    batch_size=batch_size,
+                )
+        else:
             results = await normalizer.send_prompt_batch_to_target_async(
                 requests=[normalizer_request],
                 target=prompt_target,
                 batch_size=batch_size,
             )
-    else:
-        results = await normalizer.send_prompt_batch_to_target_async(
-            requests=[normalizer_request],
-            target=prompt_target,
-            batch_size=batch_size,
-        )
 
-        assert "S_G_V_s_b_G_8_=" in prompt_target.prompt_sent
-        assert len(results) == 1
+            assert "S_G_V_s_b_G_8_=" in prompt_target.prompt_sent
+            assert len(results) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### pre-commit jupyter build: (pre) 47 seconds ---> 1 second

Changed local validation to run a lightweight script that only checks _toc.yml and api.rst for errors, rather than building the full Jupyter Book website. Full website builds still run in CI. Set this to only run the full build if an environment variable is present.

### pre-commit check-links: (pre) 20 seconds ---> 12 seconds

Added parallelism when checking links across documentation files and increased the number of threads for concurrent link validation.

### make unit-test parall: (pre) 266 seconds ---> 109 seconds (parallel) 

Switched from sequential to parallel test execution using pytest -n 4. Tested with -n auto but found -n 4 more consistent and reliable. Fixed several tests to be compatible with parallel execution (addressed fixture scoping and shared state issues). However, this can vary more than sequential tests depending on laptop load. 

### updating slowest tests: (pre) 109 seconds parallel -> 96 seconds 

Mocked asyncio.sleep in tests that were waiting for rate limiting (6s), retry delays in translation converter (6s), and net utility retries (~3s). Added 2 lightweight integration tests to verify actual timing behavior (exponential backoff and rate limiting). The ~15s sequential savings translates to ~13s wall-time improvement with parallel execution due to work distribution across workers.