### PR TITLE
FIX enable b64_json response_format param for old image targets

### DIFF
--- a/pyrit/prompt_target/openai/openai_image_target.py
+++ b/pyrit/prompt_target/openai/openai_image_target.py
@@ -139,20 +139,20 @@ class OpenAIImageTarget(OpenAITarget):
 
         Returns:
             Message: Constructed message with image path.
-        
+
         Note:
             PyRIT expects base64-encoded images. Some models (like dall-e) return URLs by default,
             while others (like gpt-image-1) always return base64. This method detects the format
             and adapts automatically.
         """
         image_data = response.data[0]
-        
+
         # Try to get base64 data first (preferred format)
-        b64_data = getattr(image_data, 'b64_json', None)
-        
+        b64_data = getattr(image_data, "b64_json", None)
+
         if not b64_data:
             # Check if URL format was returned instead
-            image_url = getattr(image_data, 'url', None)
+            image_url = getattr(image_data, "url", None)
             if image_url:
                 # Model returned URL instead of base64 - set flag and retry
                 logger.info(

--- a/pyrit/prompt_target/openai/openai_image_target.py
+++ b/pyrit/prompt_target/openai/openai_image_target.py
@@ -63,6 +63,9 @@ class OpenAIImageTarget(OpenAITarget):
         self.quality = quality
         self.style = style
         self.image_size = image_size
+        # Flag to track if we need to explicitly request b64_json format
+        # Will be set to True if the model returns URLs instead of base64
+        self._requires_response_format = False
 
         super().__init__(*args, **kwargs)
 
@@ -110,6 +113,10 @@ class OpenAIImageTarget(OpenAITarget):
             "size": self.image_size,
         }
 
+        # Add response_format if we've detected the model returns URLs by default
+        if self._requires_response_format:
+            image_generation_args["response_format"] = "b64_json"
+
         if self.quality:
             image_generation_args["quality"] = self.quality
         if self.style:
@@ -132,13 +139,33 @@ class OpenAIImageTarget(OpenAITarget):
 
         Returns:
             Message: Constructed message with image path.
+        
+        Note:
+            PyRIT expects base64-encoded images. Some models (like dall-e) return URLs by default,
+            while others (like gpt-image-1) always return base64. This method detects the format
+            and adapts automatically.
         """
-        # Extract base64 image data from response
-        b64_data = response.data[0].b64_json
-
-        # Handle empty response using retry
+        image_data = response.data[0]
+        
+        # Try to get base64 data first (preferred format)
+        b64_data = getattr(image_data, 'b64_json', None)
+        
         if not b64_data:
-            raise EmptyResponseException(message="The image generation returned an empty response.")
+            # Check if URL format was returned instead
+            image_url = getattr(image_data, 'url', None)
+            if image_url:
+                # Model returned URL instead of base64 - set flag and retry
+                logger.info(
+                    "Image model returned URL instead of base64. "
+                    "Setting flag to request b64_json format in future calls."
+                )
+                self._requires_response_format = True
+                raise EmptyResponseException(
+                    message="Image was returned as URL instead of base64. Retrying with response_format parameter."
+                )
+            else:
+                # Neither URL nor base64 - truly empty response
+                raise EmptyResponseException(message="The image generation returned an empty response.")
 
         # Save the image and get the file path
         data = data_serializer_factory(category="prompt-memory-entries", data_type="image_path")

--- a/tests/integration/targets/test_targets_and_secrets.py
+++ b/tests/integration/targets/test_targets_and_secrets.py
@@ -284,7 +284,12 @@ async def test_connect_openai_completion(sqlite_instance):
     [
         ("OPENAI_IMAGE_ENDPOINT1", "OPENAI_IMAGE_API_KEY1", "OPENAI_IMAGE_MODEL1", True),  # DALL-E-3
         ("OPENAI_IMAGE_ENDPOINT2", "OPENAI_IMAGE_API_KEY2", "OPENAI_IMAGE_MODEL2", False),  # gpt-image-1
-        ("PLATFORM_OPENAI_IMAGE_ENDPOINT", "PLATFORM_OPENAI_IMAGE_KEY", "PLATFORM_OPENAI_IMAGE_MODEL", True),  # DALL-E-3
+        (
+            "PLATFORM_OPENAI_IMAGE_ENDPOINT",
+            "PLATFORM_OPENAI_IMAGE_KEY",
+            "PLATFORM_OPENAI_IMAGE_MODEL",
+            True,
+        ),  # DALL-E-3
     ],
 )
 async def test_connect_image(sqlite_instance, endpoint, api_key, model_name, is_dalle_model):

--- a/tests/integration/targets/test_targets_and_secrets.py
+++ b/tests/integration/targets/test_targets_and_secrets.py
@@ -280,14 +280,14 @@ async def test_connect_openai_completion(sqlite_instance):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("endpoint", "api_key", "model_name"),
+    ("endpoint", "api_key", "model_name", "is_dalle_model"),
     [
-        ("OPENAI_IMAGE_ENDPOINT1", "OPENAI_IMAGE_API_KEY1", "OPENAI_IMAGE_MODEL1"),
-        ("OPENAI_IMAGE_ENDPOINT2", "OPENAI_IMAGE_API_KEY2", "OPENAI_IMAGE_MODEL2"),
-        ("PLATFORM_OPENAI_IMAGE_ENDPOINT", "PLATFORM_OPENAI_IMAGE_KEY", "PLATFORM_OPENAI_IMAGE_MODEL"),
+        ("OPENAI_IMAGE_ENDPOINT1", "OPENAI_IMAGE_API_KEY1", "OPENAI_IMAGE_MODEL1", True),  # DALL-E-3
+        ("OPENAI_IMAGE_ENDPOINT2", "OPENAI_IMAGE_API_KEY2", "OPENAI_IMAGE_MODEL2", False),  # gpt-image-1
+        ("PLATFORM_OPENAI_IMAGE_ENDPOINT", "PLATFORM_OPENAI_IMAGE_KEY", "PLATFORM_OPENAI_IMAGE_MODEL", True),  # DALL-E-3
     ],
 )
-async def test_connect_image(sqlite_instance, endpoint, api_key, model_name):
+async def test_connect_image(sqlite_instance, endpoint, api_key, model_name, is_dalle_model):
     endpoint_value = _get_required_env_var(endpoint)
     api_key_value = _get_required_env_var(api_key)
     model_name_value = os.getenv(model_name) if model_name else ""
@@ -298,7 +298,32 @@ async def test_connect_image(sqlite_instance, endpoint, api_key, model_name):
         model_name=model_name_value,
     )
 
-    await _assert_can_send_prompt(target, check_if_llm_interpreted_request=False)
+    # Verify the flag starts as False
+    assert target._requires_response_format is False
+
+    image_prompt = "A simple test image of a raccoon"
+    attack = PromptSendingAttack(objective_target=target)
+    result = await attack.execute_async(objective=image_prompt)
+
+    # For image generation, verify we got a successful response
+    assert result.last_response is not None
+    assert result.last_response.converted_value is not None
+    assert (
+        result.last_response.response_error == "none"
+    ), f"Expected successful response, got error: {result.last_response.response_error}"
+
+    # Validate we got a valid image file path
+    image_path = Path(result.last_response.converted_value)
+    assert image_path.exists(), f"Image file not found at path: {image_path}"
+    assert image_path.is_file(), f"Path exists but is not a file: {image_path}"
+
+    # Verify the adaptive response_format flag behavior
+    # DALL-E models return URLs by default, so flag should be set to True after first call
+    # gpt-image-1 always returns base64, so flag should remain False
+    if is_dalle_model:
+        assert target._requires_response_format is True, "DALL-E model should set response_format flag to True"
+    else:
+        assert target._requires_response_format is False, "gpt-image-1 should keep response_format flag as False"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/target/test_image_target.py
+++ b/tests/unit/target/test_image_target.py
@@ -313,27 +313,27 @@ async def test_send_prompt_async_url_response_triggers_retry(
         mock_generate.side_effect = [mock_response_url, mock_response_b64]
 
         resp = await image_target.send_prompt_async(message=Message([request]))
-        
+
         # Should have called generate twice (initial + retry)
         assert mock_generate.call_count == 2
-        
+
         # First call should NOT have response_format
         first_call_kwargs = mock_generate.call_args_list[0][1]
         assert "response_format" not in first_call_kwargs
-        
+
         # Second call should have response_format set to b64_json
         second_call_kwargs = mock_generate.call_args_list[1][1]
         assert second_call_kwargs["response_format"] == "b64_json"
-        
+
         # Should have successfully returned the image
         assert len(resp) == 1
         path = resp[0].message_pieces[0].original_value
         assert os.path.isfile(path)
-        
+
         with open(path, "r") as file:
             data = file.read()
             assert data == "hello"
-        
+
         os.remove(path)
 
 
@@ -365,7 +365,7 @@ async def test_send_prompt_async_url_response_sets_flag(
     with patch.object(image_target._async_client.images, "generate", new_callable=AsyncMock) as mock_generate:
         mock_generate.side_effect = [mock_response_url, mock_response_b64]
         await image_target.send_prompt_async(message=Message([request]))
-        
+
         # After handling URL response, flag should be True
         assert image_target._requires_response_format is True
 
@@ -389,8 +389,7 @@ async def test_send_prompt_async_uses_response_format_when_flag_set(
     with patch.object(image_target._async_client.images, "generate", new_callable=AsyncMock) as mock_generate:
         mock_generate.return_value = mock_response
         await image_target.send_prompt_async(message=Message([request]))
-        
+
         # Should include response_format in the call
         call_kwargs = mock_generate.call_args[1]
         assert call_kwargs["response_format"] == "b64_json"
-


### PR DESCRIPTION
<!--- Please add one of the following as a prefix to the pull request title: -->
<!--- DOC for documentation changes -->
<!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
<!--- FIX for bug fixes -->
<!--- TEST for adding tests -->
<!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
<!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->

<!--- Note on BREAKING changes: If your PR includes a change that will require users to make a corresponding
change (e.g. naming changes), please list [BREAKING] in front of the above prefix in the PR title.
For example, [BREAKING] FEAT or [BREAKING] MAINT -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->
#1194 introduced a bug for DALL-E-3 only when we don't pass `response_format`

<img width="657" height="106" alt="image" src="https://github.com/user-attachments/assets/c6e1718e-4b4a-4ac3-998d-9f69aaec6aae" />

Now, we capture this error and retry in the following turn. Eventually, these older targets will likely disappear and we can remove this special case.
<!--- If you are considering making a contribution please open an issue first. -->
<!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
<!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->

<!--- If your change is BREAKING please include reasoning for why below. -->


## Tests and Documentation

<!--- Contributions require tests and documentation (if applicable). -->
<!--- Include a description of tests and documentation updated (if applicable) -->
Added additional tests to capture such problems in the future.
<!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
<!--- Include how you/if ran JupyText here -->
<!--- This is described at: https://github.com/Azure/PyRIT/tree/main/doc  -->
