### PR TITLE
FIX env file loading including all directories on the way to the cwd (in reverse)

### DIFF
--- a/tests/unit/setup/test_initialization.py
+++ b/tests/unit/setup/test_initialization.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 import os
+import pathlib
 import tempfile
 from unittest import mock
 
@@ -9,7 +10,10 @@ import pytest
 
 from pyrit.common.apply_defaults import reset_default_values
 from pyrit.setup import IN_MEMORY, initialize_pyrit_async
-from pyrit.setup.initialization import _load_initializers_from_scripts
+from pyrit.setup.initialization import (
+    _find_project_root,
+    _load_initializers_from_scripts,
+)
 
 
 class TestLoadInitializersFromScripts:
@@ -104,3 +108,146 @@ class ScriptInit(PyRITInitializer):
         """Test that invalid memory type raises ValueError."""
         with pytest.raises(ValueError, match="is not a supported type"):
             await initialize_pyrit_async(memory_db_type="InvalidType")  # type: ignore
+
+
+class TestFindProjectRoot:
+    """Tests for _find_project_root function."""
+
+    def test_find_project_root_with_env_file(self):
+        """Test finding project root when .env file exists."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a directory structure: tmpdir/.env and tmpdir/subdir/
+            tmpdir_path = pathlib.Path(tmpdir)
+            env_file = tmpdir_path / ".env"
+            env_file.touch()
+
+            subdir = tmpdir_path / "subdir"
+            subdir.mkdir()
+
+            # Change to subdir and find root
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(subdir)
+                root = _find_project_root()
+                assert root == tmpdir_path
+            finally:
+                os.chdir(original_cwd)
+
+    def test_find_project_root_with_pyproject_toml(self):
+        """Test finding project root when pyproject.toml exists."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a directory structure with pyproject.toml
+            tmpdir_path = pathlib.Path(tmpdir)
+            pyproject = tmpdir_path / "pyproject.toml"
+            pyproject.touch()
+
+            subdir = tmpdir_path / "nested" / "dir"
+            subdir.mkdir(parents=True)
+
+            # Change to nested subdir and find root
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(subdir)
+                root = _find_project_root()
+                assert root == tmpdir_path
+            finally:
+                os.chdir(original_cwd)
+
+    def test_find_project_root_no_indicators_returns_cwd(self):
+        """Test that when no indicators are found, current working directory is returned."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a directory with no project indicators
+            tmpdir_path = pathlib.Path(tmpdir)
+            subdir = tmpdir_path / "subdir"
+            subdir.mkdir()
+
+            # Change to subdir - should return subdir itself as no indicators found
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(subdir)
+                root = _find_project_root()
+                assert root == subdir
+            finally:
+                os.chdir(original_cwd)
+
+    def test_find_project_root_multiple_indicators(self):
+        """Test finding project root when multiple indicators exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a directory structure with multiple indicators
+            tmpdir_path = pathlib.Path(tmpdir)
+            (tmpdir_path / ".env").touch()
+            (tmpdir_path / ".env.local").touch()
+
+            subdir = tmpdir_path / "src" / "module"
+            subdir.mkdir(parents=True)
+
+            # Change to nested subdir and find root
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(subdir)
+                root = _find_project_root()
+                assert root == tmpdir_path
+            finally:
+                os.chdir(original_cwd)
+
+
+class TestLoadEnvironmentFiles:
+    """Tests for _load_environment_files function."""
+
+    @mock.patch("pyrit.setup.initialization._find_project_root")
+    @mock.patch("dotenv.load_dotenv")
+    def test_load_env_file_exists(self, mock_load_dotenv, mock_find_root):
+        """Test loading .env file when it exists in project root."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = pathlib.Path(tmpdir)
+            mock_find_root.return_value = tmpdir_path
+
+            # Create .env file
+            env_file = tmpdir_path / ".env"
+            env_file.write_text("TEST_VAR=value")
+
+            from pyrit.setup.initialization import _load_environment_files
+
+            _load_environment_files()
+
+            # Verify load_dotenv was called with the correct path
+            calls = mock_load_dotenv.call_args_list
+            assert any(str(env_file) in str(call) for call in calls)
+
+    @mock.patch("pyrit.setup.initialization._find_project_root")
+    @mock.patch("dotenv.load_dotenv")
+    def test_load_env_local_file_exists(self, mock_load_dotenv, mock_find_root):
+        """Test loading .env.local file when it exists in project root."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = pathlib.Path(tmpdir)
+            mock_find_root.return_value = tmpdir_path
+
+            # Create both .env and .env.local files
+            env_file = tmpdir_path / ".env"
+            env_file.write_text("TEST_VAR=value")
+            env_local_file = tmpdir_path / ".env.local"
+            env_local_file.write_text("TEST_VAR=local_value")
+
+            from pyrit.setup.initialization import _load_environment_files
+
+            _load_environment_files()
+
+            # Verify both files were loaded
+            calls = mock_load_dotenv.call_args_list
+            assert any(str(env_file) in str(call) for call in calls)
+            assert any(str(env_local_file) in str(call) for call in calls)
+
+    @mock.patch("pyrit.setup.initialization._find_project_root")
+    @mock.patch("dotenv.load_dotenv")
+    def test_load_env_files_do_not_exist(self, mock_load_dotenv, mock_find_root):
+        """Test behavior when no .env files exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = pathlib.Path(tmpdir)
+            mock_find_root.return_value = tmpdir_path
+
+            from pyrit.setup.initialization import _load_environment_files
+
+            _load_environment_files()
+
+            # Should still call load_dotenv (with verbose=True fallback)
+            assert mock_load_dotenv.called


### PR DESCRIPTION

<!--- Please add one of the following as a prefix to the pull request title: -->
<!--- DOC for documentation changes -->
<!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
<!--- FIX for bug fixes -->
<!--- TEST for adding tests -->
<!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
<!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->

<!--- Note on BREAKING changes: If your PR includes a change that will require users to make a corresponding
change (e.g. naming changes), please list [BREAKING] in front of the above prefix in the PR title.
For example, [BREAKING] FEAT or [BREAKING] MAINT -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->
The installed version of PyRIT with wheel didn't recognize .env files in the local working directory (or parent dirs). This fixes that problem.
<!--- If you are considering making a contribution please open an issue first. -->
<!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
<!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->

<!--- If your change is BREAKING please include reasoning for why below. -->


## Tests and Documentation

<!--- Contributions require tests and documentation (if applicable). -->
<!--- Include a description of tests and documentation updated (if applicable) -->
validated with notebooks, pyrit_scan, pyrit_shell
<!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
<!--- Include how you/if ran JupyText here -->
<!--- This is described at: https://github.com/Azure/PyRIT/tree/main/doc  -->
