### PR TITLE
MAINT: Fixing Retry configuration so it works from .env

### DIFF
--- a/tests/unit/exceptions/test_exceptions.py
+++ b/tests/unit/exceptions/test_exceptions.py
@@ -3,6 +3,9 @@
 
 import json
 import logging
+import os
+
+from tenacity import RetryError
 
 from pyrit.exceptions import (
     BadRequestException,
@@ -11,6 +14,7 @@ from pyrit.exceptions import (
     MissingPromptPlaceholderException,
     PyritException,
     RateLimitException,
+    pyrit_custom_result_retry,
 )
 
 
@@ -97,3 +101,148 @@ def test_remove_markdown_json_exception(caplog):
         result = ex.process_exception()
     assert json.loads(result) == {"status_code": 500, "message": "Invalid JSON Response"}
     assert "InvalidJsonException encountered: Status Code: 500, Message: Invalid JSON Response" in caplog.text
+
+
+class TestRetryDecoratorsRespectRuntimeEnvVars:
+    """
+    Tests that retry decorators read environment variables at runtime, not at decoration time.
+
+    This is critical because users set RETRY_MAX_NUM_ATTEMPTS in their .env file, which is
+    loaded by initialize_pyrit_async() AFTER pyrit modules are imported. If decorators
+    captured the env var value at import time, the .env settings would be ignored.
+    """
+
+    def test_pyrit_target_retry_respects_runtime_env_var(self):
+        """Test that pyrit_target_retry reads RETRY_MAX_NUM_ATTEMPTS at runtime."""
+        import os
+
+        from pyrit.exceptions import EmptyResponseException, pyrit_target_retry
+
+        call_count = 0
+
+        @pyrit_target_retry
+        def failing_function():
+            nonlocal call_count
+            call_count += 1
+            raise EmptyResponseException()
+
+        # Change the env var AFTER the decorator has been applied
+        original_value = os.environ.get("RETRY_MAX_NUM_ATTEMPTS")
+        os.environ["RETRY_MAX_NUM_ATTEMPTS"] = "3"
+
+        try:
+            failing_function()
+        except EmptyResponseException:
+            pass  # Expected
+
+        # Restore original value
+        if original_value is not None:
+            os.environ["RETRY_MAX_NUM_ATTEMPTS"] = original_value
+
+        # Should have retried 3 times (the runtime value), not the value at decoration time
+        assert call_count == 3, (
+            f"Expected 3 attempts based on runtime RETRY_MAX_NUM_ATTEMPTS, but got {call_count}. "
+            "This suggests the decorator is reading the env var at decoration time, not runtime."
+        )
+
+    def test_pyrit_json_retry_respects_runtime_env_var(self):
+        """Test that pyrit_json_retry reads RETRY_MAX_NUM_ATTEMPTS at runtime."""
+        import os
+
+        from pyrit.exceptions import InvalidJsonException, pyrit_json_retry
+
+        call_count = 0
+
+        @pyrit_json_retry
+        def failing_function():
+            nonlocal call_count
+            call_count += 1
+            raise InvalidJsonException()
+
+        # Change the env var AFTER the decorator has been applied
+        original_value = os.environ.get("RETRY_MAX_NUM_ATTEMPTS")
+        os.environ["RETRY_MAX_NUM_ATTEMPTS"] = "4"
+
+        try:
+            failing_function()
+        except InvalidJsonException:
+            pass  # Expected
+
+        # Restore original value
+        if original_value is not None:
+            os.environ["RETRY_MAX_NUM_ATTEMPTS"] = original_value
+
+        # Should have retried 4 times (the runtime value)
+        assert call_count == 4, (
+            f"Expected 4 attempts based on runtime RETRY_MAX_NUM_ATTEMPTS, but got {call_count}. "
+            "This suggests the decorator is reading the env var at decoration time, not runtime."
+        )
+
+    def test_pyrit_placeholder_retry_respects_runtime_env_var(self):
+        """Test that pyrit_placeholder_retry reads RETRY_MAX_NUM_ATTEMPTS at runtime."""
+        import os
+
+        from pyrit.exceptions import (
+            MissingPromptPlaceholderException,
+            pyrit_placeholder_retry,
+        )
+
+        call_count = 0
+
+        @pyrit_placeholder_retry
+        def failing_function():
+            nonlocal call_count
+            call_count += 1
+            raise MissingPromptPlaceholderException()
+
+        # Change the env var AFTER the decorator has been applied
+        original_value = os.environ.get("RETRY_MAX_NUM_ATTEMPTS")
+        os.environ["RETRY_MAX_NUM_ATTEMPTS"] = "3"
+
+        try:
+            failing_function()
+        except MissingPromptPlaceholderException:
+            pass  # Expected
+
+        # Restore original value
+        if original_value is not None:
+            os.environ["RETRY_MAX_NUM_ATTEMPTS"] = original_value
+
+        # Should have retried 3 times (the runtime value)
+        assert call_count == 3, (
+            f"Expected 3 attempts based on runtime RETRY_MAX_NUM_ATTEMPTS, but got {call_count}. "
+            "This suggests the decorator is reading the env var at decoration time, not runtime."
+        )
+
+    def test_pyrit_custom_result_retry_respects_runtime_env_var(self):
+        """Test that pyrit_custom_result_retry reads CUSTOM_RESULT_RETRY_MAX_NUM_ATTEMPTS at runtime."""
+
+        call_count = 0
+
+        def should_retry(result):
+            return result == "retry"
+
+        @pyrit_custom_result_retry(retry_function=should_retry)
+        def failing_function():
+            nonlocal call_count
+            call_count += 1
+            return "retry"
+
+        # Change the env var AFTER the decorator has been applied
+        original_value = os.environ.get("CUSTOM_RESULT_RETRY_MAX_NUM_ATTEMPTS")
+        os.environ["CUSTOM_RESULT_RETRY_MAX_NUM_ATTEMPTS"] = "3"
+
+        try:
+            failing_function()
+        except RetryError:
+            pass  # Expected when all retries exhausted
+
+        # Restore original value
+        if original_value is not None:
+            os.environ["CUSTOM_RESULT_RETRY_MAX_NUM_ATTEMPTS"] = original_value
+
+        # Should have retried 3 times (the runtime value)
+        assert call_count == 3, (
+            f"Expected 3 attempts based on runtime CUSTOM_RESULT_RETRY_MAX_NUM_ATTEMPTS, but got {call_count}. "
+            "This suggests the decorator is reading the env var at decoration time, not runtime."
+        )


### PR DESCRIPTION
[this PR](https://github.com/Azure/PyRIT/pull/1172/files) happened because @romanlutz (correctly) pointed out globals are a bad practice. I remembered them not working otherwise, but I had a tough time remembering the circumstances.

Now I remember, because my PR above broke it! To repro, add this to a .env file

```
RETRY_MAX_NUM_ATTEMPTS=1
```

And if you run a notebook, it will still retry 10 times (or whatever your environment variable was set to before running pyrit).

Because it was loaded at initialization time, the .env file loading was not respected. And in fact, it did work with the globals, but no longer does. But with this fix, the exceptions class dynamically gets the number and avoids globals :)