### PR TITLE
FIX make bash default and remove volume mount for venv in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -54,11 +54,12 @@ RUN groupadd $USERNAME \
     && useradd -g $USERNAME -m $USERNAME \
     && echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-# Create venv using uv
-RUN uv venv /opt/venv --python 3.11 \
- && chown -R vscode:vscode /opt/venv \
- && ls -la /opt/venv/bin/activate
-ENV PATH="/opt/venv/bin:$PATH"
+# Remove any existing venv and create fresh uv venv
+RUN rm -rf /opt/pyrit-dev \
+ && uv venv /opt/pyrit-dev --python 3.11 \
+ && chown -R vscode:vscode /opt/pyrit-dev \
+ && ls -la /opt/pyrit-dev/bin/activate
+ENV PATH="/opt/pyrit-dev/bin:$PATH"
 
 # Pre-create common user caches and fix permissions
 RUN mkdir -p /home/vscode/.cache/pre-commit \
@@ -74,8 +75,8 @@ RUN mkdir -p /home/vscode/.cache/pre-commit \
 USER vscode
 # Create bash configuration files and activate the venv in bash sessions
 RUN touch /home/vscode/.bashrc /home/vscode/.bash_profile \
- && echo "[ -f /opt/venv/bin/activate ] && source /opt/venv/bin/activate" >> /home/vscode/.bashrc \
- && echo "[ -f /opt/venv/bin/activate ] && source /opt/venv/bin/activate" >> /home/vscode/.bash_profile
+ && echo "[ -f /opt/pyrit-dev/bin/activate ] && source /opt/pyrit-dev/bin/activate" >> /home/vscode/.bashrc \
+ && echo "[ -f /opt/pyrit-dev/bin/activate ] && source /opt/pyrit-dev/bin/activate" >> /home/vscode/.bash_profile
 
 # Configure Git for better performance with bind mounts
 RUN git config --global core.preloadindex true \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
   "customizations": {
     "vscode": {
       "settings": {
-        "python.defaultInterpreterPath": "/opt/venv/bin/python",
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "python.defaultInterpreterPath": "/opt/pyrit-dev/bin/python",
         "python.analysis.extraPaths": [
           "/workspace"
         ],
@@ -32,7 +33,7 @@
           "pyrit/**"
         ],
         "python.analysis.exclude": [
-          "/opt/venv/**",
+          "/opt/pyrit-dev/**",
           "**/.venv/**",
           "**/site-packages/**",
           "**/doc/**",

--- a/.devcontainer/devcontainer_setup.sh
+++ b/.devcontainer/devcontainer_setup.sh
@@ -38,8 +38,8 @@ if [ -f "$HASH_FILE" ]; then
     chmod 666 "$HASH_FILE"
 fi
 
-uv venv /opt/venv --python 3.11 \
-    && . /opt/venv/bin/activate
+# Activate the uv venv created in the Dockerfile
+source /opt/pyrit-dev/bin/activate
 
 # Compute current hash
 CURRENT_HASH=$(sha256sum /workspace/pyproject.toml | awk '{print $1}')

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,7 +11,6 @@ services:
           memory: "16G"
     volumes:
       - ..:/workspace:delegated
-      - pyrit-env:/opt/venv:cached
       - pip-cache:/home/vscode/.cache/pip:cached
       - uv-cache:/home/vscode/.cache/uv:cached
       - precommit-cache:/home/vscode/.cache/pre-commit:cached
@@ -24,7 +23,6 @@ services:
     command: "sleep infinity"
 
 volumes:
-  pyrit-env:
   pip-cache:
   uv-cache:
   precommit-cache:


### PR DESCRIPTION

<!--- Please add one of the following as a prefix to the pull request title: -->
<!--- DOC for documentation changes -->
<!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
<!--- FIX for bug fixes -->
<!--- TEST for adding tests -->
<!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
<!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->

<!--- Note on BREAKING changes: If your PR includes a change that will require users to make a corresponding
change (e.g. naming changes), please list [BREAKING] in front of the above prefix in the PR title.
For example, [BREAKING] FEAT or [BREAKING] MAINT -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->
Short summary: When creating a new terminal this should now immediately be `/bin/bash` with activated `pyrit-dev` venv.

Longer version: Currently, if you rebuild the devcontainer it won't run /bin/bash so you'll be in a very annoying shell where you can't even hit the up key and get the last command. So that's one part. 
 
The more crucial part is that the venv didn't work. uv is meant to install the venv in /opt/venv and @hannahwestra25 and I couldn't fathom what happens to it that `/opt/venv/bin/activate` isn't there after it is rebuilt as devcontainer. I even ran all the commands from the Dockerfile manually on the base image and it was very much there! Turns out the configuration has this line `- pyrit-env:/opt/venv:cached` which overrides that directory and that's why the activate script was gone whenever the container was done setting up. So I removed that. For clarity, I also renamed the venv from name `venv` to `pyrit-dev` which was the name of the conda env we had before. There are plenty of `venv` and `.venv` directories floating around as it is 
<!--- If you are considering making a contribution please open an issue first. -->
<!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
<!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->

<!--- If your change is BREAKING please include reasoning for why below. -->


## Tests and Documentation

<!--- Contributions require tests and documentation (if applicable). -->
<!--- Include a description of tests and documentation updated (if applicable) -->
validated locally
<!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
<!--- Include how you/if ran JupyText here -->
<!--- This is described at: https://github.com/Azure/PyRIT/tree/main/doc  -->
