### PR TITLE
FIX fix permission denied error when creating env

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,6 @@ FROM --platform=linux/amd64 ghcr.io/astral-sh/uv:python3.11-bookworm-slim
 
 # Makes installation faster
 ENV UV_COMPILE_BYTECODE=1
-ENV UV_SYSTEM_PYTHON=1
 
 SHELL ["/bin/bash", "-c"]
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,6 +34,7 @@
         ],
         "python.analysis.exclude": [
           "/opt/pyrit-dev/**",
+          "**/.venv/**",
           "**/site-packages/**",
           "**/doc/**",
           "**/tests/**",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,7 +34,6 @@
         ],
         "python.analysis.exclude": [
           "/opt/pyrit-dev/**",
-          "**/.venv/**",
           "**/site-packages/**",
           "**/doc/**",
           "**/tests/**",


### PR DESCRIPTION

## Description
remove UV_SYSTEM_PROMPT which was causing the environment to install packages system wide (ie usr/local) which requires root permissions rather than vscode.


## Tests and Documentation
tested manually
