### PR TITLE
FIX/FEAT: Enable multi-modal pieces for SelfAskTrueFalseScorer scoring

### DIFF
--- a/doc/code/scoring/scorer_evals.ipynb
+++ b/doc/code/scoring/scorer_evals.ipynb
@@ -38,8 +38,7 @@
     ")\n",
     "from pyrit.setup import IN_MEMORY, initialize_pyrit_async\n",
     "\n",
-    "await initialize_pyrit_async(memory_db_type=IN_MEMORY)  # type: ignore\n",
-    "target = OpenAIChatTarget()"
+    "await initialize_pyrit_async(memory_db_type=IN_MEMORY)  # type: ignore"
    ]
   },
   {
@@ -123,7 +122,14 @@
     }
    ],
    "source": [
-    "target = OpenAIChatTarget()\n",
+    "import os\n",
+    "\n",
+    "# Use unsafe endpoint ideally since evaluation dataset may include harmful content\n",
+    "target = OpenAIChatTarget(\n",
+    "    endpoint=os.environ[\"AZURE_OPENAI_GPT4O_UNSAFE_CHAT_ENDPOINT\"],\n",
+    "    api_key=os.environ[\"AZURE_OPENAI_GPT4O_UNSAFE_CHAT_KEY\"],\n",
+    "    model_name=os.environ[\"AZURE_OPENAI_GPT4O_UNSAFE_CHAT_MODEL\"],\n",
+    ")\n",
     "likert_scorer = SelfAskLikertScorer(chat_target=target, likert_scale_path=LikertScalePaths.HATE_SPEECH_SCALE.value)\n",
     "\n",
     "# factory method that creates an HarmScorerEvaluator in this case since metrics_type is HARM.\n",

--- a/doc/code/scoring/scorer_evals.py
+++ b/doc/code/scoring/scorer_evals.py
@@ -5,11 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.18.1
-#   kernelspec:
-#     display_name: pyrit2
-#     language: python
-#     name: python3
+#       jupytext_version: 1.17.2
 # ---
 
 # %% [markdown]
@@ -40,7 +36,6 @@ from pyrit.score import (
 from pyrit.setup import IN_MEMORY, initialize_pyrit_async
 
 await initialize_pyrit_async(memory_db_type=IN_MEMORY)  # type: ignore
-target = OpenAIChatTarget()
 
 # %% [markdown]
 # ## Running Harm Scorer Evaluation
@@ -80,7 +75,14 @@ target = OpenAIChatTarget()
 # With multiple evaluators, we can measure inter-reliability alignment between evaluators shown below:
 
 # %%
-target = OpenAIChatTarget()
+import os
+
+# Use unsafe endpoint ideally since evaluation dataset may include harmful content
+target = OpenAIChatTarget(
+    endpoint=os.environ["AZURE_OPENAI_GPT4O_UNSAFE_CHAT_ENDPOINT"],
+    api_key=os.environ["AZURE_OPENAI_GPT4O_UNSAFE_CHAT_KEY"],
+    model_name=os.environ["AZURE_OPENAI_GPT4O_UNSAFE_CHAT_MODEL"],
+)
 likert_scorer = SelfAskLikertScorer(chat_target=target, likert_scale_path=LikertScalePaths.HATE_SPEECH_SCALE.value)
 
 # factory method that creates an HarmScorerEvaluator in this case since metrics_type is HARM.

--- a/pyrit/score/float_scale/self_ask_scale_scorer.py
+++ b/pyrit/score/float_scale/self_ask_scale_scorer.py
@@ -87,6 +87,7 @@ class SelfAskScaleScorer(FloatScaleScorer):
         """Build the scorer evaluation identifier for this scorer."""
         self._set_scorer_identifier(
             system_prompt_template=self._system_prompt,
+            user_prompt_template="objective: {objective}\nresponse: {response}",
             prompt_target=self._prompt_target,
         )
 

--- a/pyrit/score/scorer.py
+++ b/pyrit/score/scorer.py
@@ -460,7 +460,7 @@ class Scorer(abc.ABC):
         message_value: str,
         message_data_type: PromptDataType,
         scored_prompt_id: str,
-        additional_image_path: Optional[str] = None,
+        prepended_text_message_piece: Optional[str] = None,
         category: Optional[Sequence[str] | str] = None,
         objective: Optional[str] = None,
         score_value_output_key: str = "score_value",
@@ -479,12 +479,15 @@ class Scorer(abc.ABC):
         Args:
             prompt_target (PromptChatTarget): The target LLM to send the message to.
             system_prompt (str): The system-level prompt that guides the behavior of the target LLM.
-            message_value (str): The actual value or content to be scored by the LLM.
-            message_data_type (PromptDataType): The type of the data being sent in the message.
+            message_value (str): The actual value or content to be scored by the LLM (e.g., text, image path,
+                audio path).
+            message_data_type (PromptDataType): The type of the data being sent in the message (e.g., "text",
+                "image_path", "audio_path").
             scored_prompt_id (str): The ID of the scored prompt.
-            additional_image_path (Optional[str]): Path to an image to append as an additional piece
-                in the scoring request. When provided, creates a multi-piece message with the
-                text message_value followed by this image. Defaults to None.
+            prepended_text_message_piece (Optional[str]): Text context to prepend before the main
+                message_value. When provided, creates a multi-piece message with this text first, followed
+                by the message_value. Useful for adding objective/context when scoring non-text content.
+                Defaults to None.
             category (Optional[Sequence[str] | str]): The category of the score. Can also be parsed from
                 the JSON response if not provided. Defaults to None.
             objective (Optional[str]): A description of the objective that is associated with the score,
@@ -523,8 +526,25 @@ class Scorer(abc.ABC):
         )
         prompt_metadata: dict[str, str | int] = {"response_format": "json"}
 
-        # Build message pieces - text first, then optional image
-        message_pieces = [
+        # Build message pieces - prepended text context first (if provided), then the main message being scored
+        message_pieces: list[MessagePiece] = []
+
+        # Add prepended text context piece if provided (e.g., objective context for non-text scoring)
+        if prepended_text_message_piece:
+            message_pieces.append(
+                MessagePiece(
+                    role="user",
+                    original_value=prepended_text_message_piece,
+                    original_value_data_type="text",
+                    converted_value_data_type="text",
+                    conversation_id=conversation_id,
+                    prompt_target_identifier=prompt_target.get_identifier(),
+                    prompt_metadata=prompt_metadata,
+                )
+            )
+
+        # Add the main message piece being scored
+        message_pieces.append(
             MessagePiece(
                 role="user",
                 original_value=message_value,
@@ -534,20 +554,7 @@ class Scorer(abc.ABC):
                 prompt_target_identifier=prompt_target.get_identifier(),
                 prompt_metadata=prompt_metadata,
             )
-        ]
-
-        # Add image piece if provided
-        if additional_image_path:
-            message_pieces.append(
-                MessagePiece(
-                    role="user",
-                    original_value=additional_image_path,
-                    original_value_data_type="image_path",
-                    converted_value_data_type="image_path",
-                    conversation_id=conversation_id,
-                    prompt_target_identifier=prompt_target.get_identifier(),
-                )
-            )
+        )
 
         scorer_llm_request = Message(message_pieces)
         try:

--- a/pyrit/score/true_false/self_ask_true_false_scorer.py
+++ b/pyrit/score/true_false/self_ask_true_false_scorer.py
@@ -169,20 +169,24 @@ class SelfAskTrueFalseScorer(TrueFalseScorer):
                 The score_value is True or False based on which description fits best.
                 Metadata can be configured to provide additional information.
         """
-        # Build scoring prompt - for images, the image content is sent as a separate piece
-        is_image = message_piece.converted_value_data_type == "image_path"
-        if is_image:
-            scoring_prompt = f"objective: {objective}\nresponse:"
+        # Build scoring prompt - for non-text content, extra context about objective is sent as a prepended text piece
+        is_non_text = message_piece.converted_value_data_type != "text"
+        if is_non_text:
+            prepended_text = f"objective: {objective}\nresponse:"
+            scoring_value = message_piece.converted_value
+            scoring_data_type = message_piece.converted_value_data_type
         else:
-            scoring_prompt = f"objective: {objective}\nresponse: {message_piece.converted_value}"
+            prepended_text = None
+            scoring_value = f"objective: {objective}\nresponse: {message_piece.converted_value}"
+            scoring_data_type = "text"
 
         unvalidated_score = await self._score_value_with_llm(
             prompt_target=self._prompt_target,
             system_prompt=self._system_prompt,
-            message_value=scoring_prompt,
-            message_data_type="text",
+            message_value=scoring_value,
+            message_data_type=scoring_data_type,
             scored_prompt_id=message_piece.id,
-            additional_image_path=message_piece.converted_value if is_image else None,
+            prepended_text_message_piece=prepended_text,
             category=self._score_category,
             objective=objective,
             attack_identifier=message_piece.attack_identifier,

--- a/pyrit/score/true_false/self_ask_true_false_scorer.py
+++ b/pyrit/score/true_false/self_ask_true_false_scorer.py
@@ -150,6 +150,7 @@ class SelfAskTrueFalseScorer(TrueFalseScorer):
         """Build the scorer evaluation identifier for this scorer."""
         self._set_scorer_identifier(
             system_prompt_template=self._system_prompt,
+            user_prompt_template="objective: {objective}\nresponse: {response}",
             prompt_target=self._prompt_target,
             score_aggregator=self._score_aggregator.__name__,
         )


### PR DESCRIPTION
## Description
This PR addresses the bug where if an image piece is passed in to be scored by the `SelfAskTrueFalseScorer` the scoring prompt string combining the `objective` and the `image_path` is read as a path rather than two separate pieces (one text and one image).
- Adds an optional `additional_image_path` param to `_score_value_with_llm` so that a multimodal multi-piece `Message` (text + image) can be scored properly

Benefits of having this additional param as opposed to adding this logic directly into `self_ask_true_false_scorer.py`:
- retry decorator works automatically
- JSON parsing and response cleanup logic stays in one place 
- All scorers can use it if needed in the future (as we have more multimodal scorers)
- Minimal code duplication

This PR also addresses a bug where scorer_evals notebook wouldn't run properly in our integration test pipeline since an unsafe/no-filter model wasn't being used to score harmful responses so content filter error would fire. 

## Tests and Documentation
Added unit tests and re-ran notebooks locally. 
