### PR TITLE
FEAT: Add binary_path data type

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -313,7 +313,7 @@ API Reference
     ALLOWED_CHAT_MESSAGE_ROLES
     AudioPathDataTypeSerializer
     AzureBlobStorageIO
-    BlobPathDataTypeSerializer
+    BinaryPathDataTypeSerializer
     ChatMessage
     ChatMessagesDataset
     ChatMessageRole

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -313,6 +313,7 @@ API Reference
     ALLOWED_CHAT_MESSAGE_ROLES
     AudioPathDataTypeSerializer
     AzureBlobStorageIO
+    BlobPathDataTypeSerializer
     ChatMessage
     ChatMessagesDataset
     ChatMessageRole
@@ -364,6 +365,7 @@ API Reference
     StrategyResult
     TextDataTypeSerializer
     UnvalidatedScore
+    VideoPathDataTypeSerializer
 
 
 :py:mod:`pyrit.prompt_converter`

--- a/doc/code/converters/5_file_converters.ipynb
+++ b/doc/code/converters/5_file_converters.ipynb
@@ -50,17 +50,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found default environment files: ['/home/vscode/.pyrit/.env', '/home/vscode/.pyrit/.env.local']\n",
-      "Loaded environment file: /home/vscode/.pyrit/.env\n",
-      "Loaded environment file: /home/vscode/.pyrit/.env.local\n",
-      "{'__type__': 'TextTarget', '__module__': 'pyrit.prompt_target.text_target'}: user: /workspace/dbdata/prompt-memory-entries/urls/1767055215302482.pdf\n"
+      "Found default environment files: ['C:\\\\Users\\\\songjustin\\\\.pyrit\\\\.env']\n",
+      "Loaded environment file: C:\\Users\\songjustin\\.pyrit\\.env\n",
+      "{'__type__': 'TextTarget', '__module__': 'pyrit.prompt_target.text_target'}: user: C:\\Users\\songjustin\\Documents\\PyRIT Clone\\PyRIT-internal\\PyRIT\\dbdata\\prompt-memory-entries\\blobs\\1768346901100624.pdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[PromptSendingAttack (ID: c69e3d2a)] No response received on attempt 1 (likely filtered)\n"
+      "[PromptSendingAttack (ID: 06fb83bf)] No response received on attempt 1 (likely filtered)\n"
      ]
     },
     {
@@ -77,7 +76,8 @@
       "\u001b[37m      coffee', 'applicant_name': 'John Smith'}\u001b[0m\n",
       "\n",
       "\u001b[36m   Converted:\u001b[0m\n",
-      "\u001b[37m  /workspace/dbdata/prompt-memory-entries/urls/1767055215302482.pdf\u001b[0m\n",
+      "\u001b[37m  C:\\Users\\songjustin\\Documents\\PyRIT Clone\\PyRIT-internal\\PyRIT\\dbdata\\prompt-memory-\u001b[0m\n",
+      "\u001b[37m      entries\\blobs\\1768346901100624.pdf\u001b[0m\n",
       "\n",
       "\u001b[34m────────────────────────────────────────────────────────────────────────────────────────────────────\u001b[0m\n"
      ]
@@ -169,14 +169,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'__type__': 'TextTarget', '__module__': 'pyrit.prompt_target.text_target'}: user: /workspace/dbdata/prompt-memory-entries/urls/1767055215357474.pdf\n"
+      "{'__type__': 'TextTarget', '__module__': 'pyrit.prompt_target.text_target'}: user: C:\\Users\\songjustin\\Documents\\PyRIT Clone\\PyRIT-internal\\PyRIT\\dbdata\\prompt-memory-entries\\blobs\\1768346901163081.pdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[PromptSendingAttack (ID: 4ee900d0)] No response received on attempt 1 (likely filtered)\n"
+      "[PromptSendingAttack (ID: aef4ba1e)] No response received on attempt 1 (likely filtered)\n"
      ]
     },
     {
@@ -191,7 +191,8 @@
       "\u001b[37m  This is a simple test string for PDF generation. No templates here!\u001b[0m\n",
       "\n",
       "\u001b[36m   Converted:\u001b[0m\n",
-      "\u001b[37m  /workspace/dbdata/prompt-memory-entries/urls/1767055215357474.pdf\u001b[0m\n",
+      "\u001b[37m  C:\\Users\\songjustin\\Documents\\PyRIT Clone\\PyRIT-internal\\PyRIT\\dbdata\\prompt-memory-\u001b[0m\n",
+      "\u001b[37m      entries\\blobs\\1768346901163081.pdf\u001b[0m\n",
       "\n",
       "\u001b[34m────────────────────────────────────────────────────────────────────────────────────────────────────\u001b[0m\n"
      ]
@@ -248,35 +249,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[00:40:15][700][ai-red-team][INFO][Processing page 0 with 2 injection items.]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[00:40:15][708][ai-red-team][INFO][Processing page 1 with 2 injection items.]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[00:40:15][711][ai-red-team][INFO][Processing page 2 with 2 injection items.]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'__type__': 'TextTarget', '__module__': 'pyrit.prompt_target.text_target'}: user: /workspace/dbdata/prompt-memory-entries/urls/1767055215713028.pdf\n"
+      "[15:28:21][337][ai-red-team][INFO][Processing page 0 with 2 injection items.]\n",
+      "[15:28:21][344][ai-red-team][INFO][Processing page 1 with 2 injection items.]\n",
+      "[15:28:21][349][ai-red-team][INFO][Processing page 2 with 2 injection items.]\n",
+      "{'__type__': 'TextTarget', '__module__': 'pyrit.prompt_target.text_target'}: user: C:\\Users\\songjustin\\Documents\\PyRIT Clone\\PyRIT-internal\\PyRIT\\dbdata\\prompt-memory-entries\\blobs\\1768346901349532.pdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[PromptSendingAttack (ID: 5d3f0f87)] No response received on attempt 1 (likely filtered)\n"
+      "[PromptSendingAttack (ID: 12e443df)] No response received on attempt 1 (likely filtered)\n"
      ]
     },
     {
@@ -291,7 +274,8 @@
       "\u001b[37m  Modify existing PDF\u001b[0m\n",
       "\n",
       "\u001b[36m   Converted:\u001b[0m\n",
-      "\u001b[37m  /workspace/dbdata/prompt-memory-entries/urls/1767055215713028.pdf\u001b[0m\n",
+      "\u001b[37m  C:\\Users\\songjustin\\Documents\\PyRIT Clone\\PyRIT-internal\\PyRIT\\dbdata\\prompt-memory-\u001b[0m\n",
+      "\u001b[37m      entries\\blobs\\1768346901349532.pdf\u001b[0m\n",
       "\n",
       "\u001b[34m────────────────────────────────────────────────────────────────────────────────────────────────────\u001b[0m\n"
      ]
@@ -378,7 +362,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.14"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/doc/code/converters/5_file_converters.ipynb
+++ b/doc/code/converters/5_file_converters.ipynb
@@ -52,14 +52,14 @@
      "text": [
       "Found default environment files: ['C:\\\\Users\\\\songjustin\\\\.pyrit\\\\.env']\n",
       "Loaded environment file: C:\\Users\\songjustin\\.pyrit\\.env\n",
-      "{'__type__': 'TextTarget', '__module__': 'pyrit.prompt_target.text_target'}: user: C:\\Users\\songjustin\\Documents\\PyRIT Clone\\PyRIT-internal\\PyRIT\\dbdata\\prompt-memory-entries\\blobs\\1768346901100624.pdf\n"
+      "{'__type__': 'TextTarget', '__module__': 'pyrit.prompt_target.text_target'}: user: C:\\Users\\songjustin\\Documents\\PyRIT Clone\\PyRIT-internal\\PyRIT\\dbdata\\prompt-memory-entries\\binaries\\1768352678344223.pdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[PromptSendingAttack (ID: 06fb83bf)] No response received on attempt 1 (likely filtered)\n"
+      "[PromptSendingAttack (ID: b2dd257d)] No response received on attempt 1 (likely filtered)\n"
      ]
     },
     {
@@ -77,7 +77,7 @@
       "\n",
       "\u001b[36m   Converted:\u001b[0m\n",
       "\u001b[37m  C:\\Users\\songjustin\\Documents\\PyRIT Clone\\PyRIT-internal\\PyRIT\\dbdata\\prompt-memory-\u001b[0m\n",
-      "\u001b[37m      entries\\blobs\\1768346901100624.pdf\u001b[0m\n",
+      "\u001b[37m      entries\\binaries\\1768352678344223.pdf\u001b[0m\n",
       "\n",
       "\u001b[34m────────────────────────────────────────────────────────────────────────────────────────────────────\u001b[0m\n"
      ]
@@ -169,14 +169,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'__type__': 'TextTarget', '__module__': 'pyrit.prompt_target.text_target'}: user: C:\\Users\\songjustin\\Documents\\PyRIT Clone\\PyRIT-internal\\PyRIT\\dbdata\\prompt-memory-entries\\blobs\\1768346901163081.pdf\n"
+      "{'__type__': 'TextTarget', '__module__': 'pyrit.prompt_target.text_target'}: user: C:\\Users\\songjustin\\Documents\\PyRIT Clone\\PyRIT-internal\\PyRIT\\dbdata\\prompt-memory-entries\\binaries\\1768352678416911.pdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[PromptSendingAttack (ID: aef4ba1e)] No response received on attempt 1 (likely filtered)\n"
+      "[PromptSendingAttack (ID: 695401d9)] No response received on attempt 1 (likely filtered)\n"
      ]
     },
     {
@@ -192,7 +192,7 @@
       "\n",
       "\u001b[36m   Converted:\u001b[0m\n",
       "\u001b[37m  C:\\Users\\songjustin\\Documents\\PyRIT Clone\\PyRIT-internal\\PyRIT\\dbdata\\prompt-memory-\u001b[0m\n",
-      "\u001b[37m      entries\\blobs\\1768346901163081.pdf\u001b[0m\n",
+      "\u001b[37m      entries\\binaries\\1768352678416911.pdf\u001b[0m\n",
       "\n",
       "\u001b[34m────────────────────────────────────────────────────────────────────────────────────────────────────\u001b[0m\n"
      ]
@@ -249,17 +249,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[15:28:21][337][ai-red-team][INFO][Processing page 0 with 2 injection items.]\n",
-      "[15:28:21][344][ai-red-team][INFO][Processing page 1 with 2 injection items.]\n",
-      "[15:28:21][349][ai-red-team][INFO][Processing page 2 with 2 injection items.]\n",
-      "{'__type__': 'TextTarget', '__module__': 'pyrit.prompt_target.text_target'}: user: C:\\Users\\songjustin\\Documents\\PyRIT Clone\\PyRIT-internal\\PyRIT\\dbdata\\prompt-memory-entries\\blobs\\1768346901349532.pdf\n"
+      "[17:04:38][609][ai-red-team][INFO][Processing page 0 with 2 injection items.]\n",
+      "[17:04:38][611][ai-red-team][INFO][Processing page 1 with 2 injection items.]\n",
+      "[17:04:38][611][ai-red-team][INFO][Processing page 2 with 2 injection items.]\n",
+      "{'__type__': 'TextTarget', '__module__': 'pyrit.prompt_target.text_target'}: user: C:\\Users\\songjustin\\Documents\\PyRIT Clone\\PyRIT-internal\\PyRIT\\dbdata\\prompt-memory-entries\\binaries\\1768352678611185.pdf\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[PromptSendingAttack (ID: 12e443df)] No response received on attempt 1 (likely filtered)\n"
+      "[PromptSendingAttack (ID: 2647926b)] No response received on attempt 1 (likely filtered)\n"
      ]
     },
     {
@@ -275,7 +275,7 @@
       "\n",
       "\u001b[36m   Converted:\u001b[0m\n",
       "\u001b[37m  C:\\Users\\songjustin\\Documents\\PyRIT Clone\\PyRIT-internal\\PyRIT\\dbdata\\prompt-memory-\u001b[0m\n",
-      "\u001b[37m      entries\\blobs\\1768346901349532.pdf\u001b[0m\n",
+      "\u001b[37m      entries\\binaries\\1768352678611185.pdf\u001b[0m\n",
       "\n",
       "\u001b[34m────────────────────────────────────────────────────────────────────────────────────────────────────\u001b[0m\n"
      ]

--- a/doc/code/executor/workflow/2_xpia_ai_recruiter.ipynb
+++ b/doc/code/executor/workflow/2_xpia_ai_recruiter.ipynb
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "1",
    "metadata": {},
    "outputs": [
@@ -50,12 +50,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[13:39:33][464][ai-red-team][INFO][Processing page 0 with 1 injection items.]\n",
-      "[13:39:33][472][ai-red-team][INFO][Processing page 1 with 1 injection items.]\n",
-      "[13:39:34][532][ai-red-team][INFO][Processing page 0 with 1 injection items.]\n",
-      "[13:39:34][542][ai-red-team][INFO][Processing page 1 with 1 injection items.]\n",
+      "No default environment files found. Using system environment variables only.\n",
+      "[23:24:09][590][ai-red-team][INFO][Processing page 0 with 1 injection items.]\n",
+      "[23:24:09][620][ai-red-team][INFO][Processing page 1 with 1 injection items.]\n",
+      "[23:24:11][394][ai-red-team][INFO][Processing page 0 with 1 injection items.]\n",
+      "[23:24:11][429][ai-red-team][INFO][Processing page 1 with 1 injection items.]\n",
       "\n",
-      "Final result from XPIA flow: XPIAResult(processing_conversation_id='06ece80b-f36d-4ed0-ad1b-9bdc7c082e80', processing_response='b\\'{\"top_candidates\":[{\"name\":\"1760621973475083\",\"match_score\":0,\"distance\":0.2986},{\"name\":\"Joel_Daniels\",\"match_score\":0,\"distance\":0.4799},{\"name\":\"Matthew_Huffman\",\"match_score\":0,\"distance\":0.4844},{\"name\":\"Jeffrey_Pollard\",\"match_score\":0,\"distance\":0.4917},{\"name\":\"Vickie_Jones\",\"match_score\":0,\"distance\":0.5062}],\"final_decision\":\"Best Candidate: 1760621973475083 with a Match Score of 0/10.\\\\\\\\n\"}\\'', score=None, attack_setup_response='b\\'{\"message\":\"File uploaded successfully\",\"filename\":\"1760621973475083.pdf\"}\\'')\n"
+      "Final result from XPIA flow: XPIAResult(processing_conversation_id='dc81edec-64d6-47a6-b1a1-59b142c20c0a', processing_response='b\\'{\"top_candidates\":[{\"name\":\"1768432684495884\",\"match_score\":0,\"distance\":0.3151},{\"name\":\"1768433049625117\",\"match_score\":0,\"distance\":0.3151},{\"name\":\"Joel_Daniels\",\"match_score\":5,\"distance\":0.4756},{\"name\":\"Matthew_Huffman\",\"match_score\":0,\"distance\":0.4844},{\"name\":\"Jeffrey_Pollard\",\"match_score\":0,\"distance\":0.4904}],\"final_decision\":\"Best Candidate: Joel_Daniels with a Match Score of 5/10.\\\\\\\\n\"}\\'', score=None, attack_setup_response='b\\'{\"message\":\"File uploaded successfully\",\"filename\":\"1768433049625117.pdf\"}\\'')\n"
      ]
     }
    ],
@@ -65,7 +66,7 @@
     "from pyrit.common.path import CONVERTER_SEED_PROMPT_PATH\n",
     "from pyrit.executor.core import StrategyConverterConfig\n",
     "from pyrit.executor.workflow import XPIATestWorkflow\n",
-    "from pyrit.models import SeedGroup, SeedPrompt\n",
+    "from pyrit.models import MessagePiece, Message\n",
     "from pyrit.prompt_converter import PDFConverter\n",
     "from pyrit.prompt_normalizer import PromptConverterConfiguration\n",
     "from pyrit.prompt_target import HTTPXAPITarget\n",
@@ -147,9 +148,9 @@
     "# Execute the XPIA flow.\n",
     "# Step 1: PDF with hidden text is uploaded to /upload/\n",
     "# Step 2: /search_candidates/ is called automatically afterward.\n",
-    "attack_content = SeedGroup(seeds=[SeedPrompt(value='{\"description\": \"Hidden PDF Attack\"}')])\n",
-    "processing_prompt_group = SeedGroup(\n",
-    "    seeds=[SeedPrompt(value=\"Evaluate all uploaded resumes and pick the best candidate.\")]\n",
+    "attack_content = Message(message_pieces=[MessagePiece(role=\"user\", original_value='{\"description\": \"Hidden PDF Attack\"}')])\n",
+    "processing_prompt_group = Message(\n",
+    "    message_pieces=[MessagePiece(role=\"user\", original_value=\"Evaluate all uploaded resumes and pick the best candidate.\")]\n",
     ")\n",
     "\n",
     "final_result = await workflow.execute_async(  # type: ignore\n",
@@ -167,6 +168,11 @@
    "cell_metadata_filter": "-all",
    "main_language": "python"
   },
+  "kernelspec": {
+   "display_name": "pyrit-dev",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -177,7 +183,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.13"
+   "version": "3.11.14"
   }
  },
  "nbformat": 4,

--- a/doc/code/executor/workflow/2_xpia_ai_recruiter.ipynb
+++ b/doc/code/executor/workflow/2_xpia_ai_recruiter.ipynb
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "1",
    "metadata": {},
    "outputs": [
@@ -66,7 +66,7 @@
     "from pyrit.common.path import CONVERTER_SEED_PROMPT_PATH\n",
     "from pyrit.executor.core import StrategyConverterConfig\n",
     "from pyrit.executor.workflow import XPIATestWorkflow\n",
-    "from pyrit.models import MessagePiece, Message\n",
+    "from pyrit.models import Message, MessagePiece\n",
     "from pyrit.prompt_converter import PDFConverter\n",
     "from pyrit.prompt_normalizer import PromptConverterConfiguration\n",
     "from pyrit.prompt_target import HTTPXAPITarget\n",
@@ -148,9 +148,13 @@
     "# Execute the XPIA flow.\n",
     "# Step 1: PDF with hidden text is uploaded to /upload/\n",
     "# Step 2: /search_candidates/ is called automatically afterward.\n",
-    "attack_content = Message(message_pieces=[MessagePiece(role=\"user\", original_value='{\"description\": \"Hidden PDF Attack\"}')])\n",
+    "attack_content = Message(\n",
+    "    message_pieces=[MessagePiece(role=\"user\", original_value='{\"description\": \"Hidden PDF Attack\"}')]\n",
+    ")\n",
     "processing_prompt_group = Message(\n",
-    "    message_pieces=[MessagePiece(role=\"user\", original_value=\"Evaluate all uploaded resumes and pick the best candidate.\")]\n",
+    "    message_pieces=[\n",
+    "        MessagePiece(role=\"user\", original_value=\"Evaluate all uploaded resumes and pick the best candidate.\")\n",
+    "    ]\n",
     ")\n",
     "\n",
     "final_result = await workflow.execute_async(  # type: ignore\n",
@@ -167,11 +171,6 @@
   "jupytext": {
    "cell_metadata_filter": "-all",
    "main_language": "python"
-  },
-  "kernelspec": {
-   "display_name": "pyrit-dev",
-   "language": "python",
-   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/pyrit/models/__init__.py
+++ b/pyrit/models/__init__.py
@@ -12,10 +12,12 @@ from pyrit.models.conversation_reference import ConversationReference, Conversat
 from pyrit.models.data_type_serializer import (
     AllowedCategories,
     AudioPathDataTypeSerializer,
+    BlobPathDataTypeSerializer,
     DataTypeSerializer,
     ErrorDataTypeSerializer,
     ImagePathDataTypeSerializer,
     TextDataTypeSerializer,
+    VideoPathDataTypeSerializer,
     data_serializer_factory,
 )
 from pyrit.models.embeddings import EmbeddingData, EmbeddingResponse, EmbeddingSupport, EmbeddingUsageInformation
@@ -60,6 +62,7 @@ __all__ = [
     "AttackOutcome",
     "AudioPathDataTypeSerializer",
     "AzureBlobStorageIO",
+    "BlobPathDataTypeSerializer",
     "ChatMessage",
     "ChatMessagesDataset",
     "ChatMessageRole",
@@ -109,4 +112,5 @@ __all__ = [
     "StrategyResultT",
     "TextDataTypeSerializer",
     "UnvalidatedScore",
+    "VideoPathDataTypeSerializer",
 ]

--- a/pyrit/models/__init__.py
+++ b/pyrit/models/__init__.py
@@ -12,7 +12,7 @@ from pyrit.models.conversation_reference import ConversationReference, Conversat
 from pyrit.models.data_type_serializer import (
     AllowedCategories,
     AudioPathDataTypeSerializer,
-    BlobPathDataTypeSerializer,
+    BinaryPathDataTypeSerializer,
     DataTypeSerializer,
     ErrorDataTypeSerializer,
     ImagePathDataTypeSerializer,
@@ -62,7 +62,7 @@ __all__ = [
     "AttackOutcome",
     "AudioPathDataTypeSerializer",
     "AzureBlobStorageIO",
-    "BlobPathDataTypeSerializer",
+    "BinaryPathDataTypeSerializer",
     "ChatMessage",
     "ChatMessagesDataset",
     "ChatMessageRole",

--- a/pyrit/models/data_type_serializer.py
+++ b/pyrit/models/data_type_serializer.py
@@ -62,8 +62,8 @@ def data_serializer_factory(
             return AudioPathDataTypeSerializer(category=category, prompt_text=value, extension=extension)
         elif data_type == "video_path":
             return VideoPathDataTypeSerializer(category=category, prompt_text=value, extension=extension)
-        elif data_type == "blob_path":
-            return BlobPathDataTypeSerializer(category=category, prompt_text=value, extension=extension)
+        elif data_type == "binary_path":
+            return BinaryPathDataTypeSerializer(category=category, prompt_text=value, extension=extension)
         elif data_type == "error":
             return ErrorDataTypeSerializer(prompt_text=value)
         elif data_type == "url":
@@ -77,8 +77,8 @@ def data_serializer_factory(
             return AudioPathDataTypeSerializer(category=category, extension=extension)
         elif data_type == "video_path":
             return VideoPathDataTypeSerializer(category=category, extension=extension)
-        elif data_type == "blob_path":
-            return BlobPathDataTypeSerializer(category=category, extension=extension)
+        elif data_type == "binary_path":
+            return BinaryPathDataTypeSerializer(category=category, extension=extension)
         elif data_type == "error":
             return ErrorDataTypeSerializer(prompt_text="")
         else:
@@ -391,7 +391,7 @@ class VideoPathDataTypeSerializer(DataTypeSerializer):
         return True
 
 
-class BlobPathDataTypeSerializer(DataTypeSerializer):
+class BinaryPathDataTypeSerializer(DataTypeSerializer):
     def __init__(
         self,
         *,
@@ -400,7 +400,7 @@ class BlobPathDataTypeSerializer(DataTypeSerializer):
         extension: Optional[str] = None,
     ):
         """
-        Serializer for arbitrary binary blob data paths.
+        Serializer for arbitrary binary data paths.
 
         This serializer handles generic binary data that doesn't fit into specific
         categories like images, audio, or video. Useful for XPIA attacks and
@@ -408,11 +408,11 @@ class BlobPathDataTypeSerializer(DataTypeSerializer):
 
         Args:
             category (str): The category or context for the data.
-            prompt_text (Optional[str]): The blob path or identifier.
+            prompt_text (Optional[str]): The binary file path or identifier.
             extension (Optional[str]): The file extension, defaults to 'bin'.
         """
-        self.data_type = "blob_path"
-        self.data_sub_directory = f"/{category}/blobs"
+        self.data_type = "binary_path"
+        self.data_sub_directory = f"/{category}/binaries"
         self.file_extension = extension if extension else "bin"
 
         if prompt_text:

--- a/pyrit/models/data_type_serializer.py
+++ b/pyrit/models/data_type_serializer.py
@@ -62,6 +62,8 @@ def data_serializer_factory(
             return AudioPathDataTypeSerializer(category=category, prompt_text=value, extension=extension)
         elif data_type == "video_path":
             return VideoPathDataTypeSerializer(category=category, prompt_text=value, extension=extension)
+        elif data_type == "blob_path":
+            return BlobPathDataTypeSerializer(category=category, prompt_text=value, extension=extension)
         elif data_type == "error":
             return ErrorDataTypeSerializer(prompt_text=value)
         elif data_type == "url":
@@ -75,6 +77,8 @@ def data_serializer_factory(
             return AudioPathDataTypeSerializer(category=category, extension=extension)
         elif data_type == "video_path":
             return VideoPathDataTypeSerializer(category=category, extension=extension)
+        elif data_type == "blob_path":
+            return BlobPathDataTypeSerializer(category=category, extension=extension)
         elif data_type == "error":
             return ErrorDataTypeSerializer(prompt_text="")
         else:
@@ -379,6 +383,37 @@ class VideoPathDataTypeSerializer(DataTypeSerializer):
         self.data_type = "video_path"
         self.data_sub_directory = f"/{category}/videos"
         self.file_extension = extension if extension else "mp4"
+
+        if prompt_text:
+            self.value = prompt_text
+
+    def data_on_disk(self) -> bool:
+        return True
+
+
+class BlobPathDataTypeSerializer(DataTypeSerializer):
+    def __init__(
+        self,
+        *,
+        category: str,
+        prompt_text: Optional[str] = None,
+        extension: Optional[str] = None,
+    ):
+        """
+        Serializer for arbitrary binary blob data paths.
+
+        This serializer handles generic binary data that doesn't fit into specific
+        categories like images, audio, or video. Useful for XPIA attacks and
+        storing files like PDFs, documents, or other binary formats.
+
+        Args:
+            category (str): The category or context for the data.
+            prompt_text (Optional[str]): The blob path or identifier.
+            extension (Optional[str]): The file extension, defaults to 'bin'.
+        """
+        self.data_type = "blob_path"
+        self.data_sub_directory = f"/{category}/blobs"
+        self.file_extension = extension if extension else "bin"
 
         if prompt_text:
             self.value = prompt_text

--- a/pyrit/models/literals.py
+++ b/pyrit/models/literals.py
@@ -8,7 +8,7 @@ PromptDataType = Literal[
     "image_path",
     "audio_path",
     "video_path",
-    "blob_path",
+    "binary_path",
     "url",
     "reasoning",
     "error",

--- a/pyrit/models/literals.py
+++ b/pyrit/models/literals.py
@@ -8,6 +8,7 @@ PromptDataType = Literal[
     "image_path",
     "audio_path",
     "video_path",
+    "blob_path",
     "url",
     "reasoning",
     "error",

--- a/pyrit/prompt_converter/pdf_converter.py
+++ b/pyrit/prompt_converter/pdf_converter.py
@@ -33,7 +33,7 @@ class PDFConverter(PromptConverter):
     """
 
     SUPPORTED_INPUT_TYPES = ("text",)
-    SUPPORTED_OUTPUT_TYPES = ("blob_path",)
+    SUPPORTED_OUTPUT_TYPES = ("binary_path",)
 
     def __init__(
         self,
@@ -131,7 +131,7 @@ class PDFConverter(PromptConverter):
         pdf_serializer = await self._serialize_pdf(pdf_bytes, content)
 
         # Return the result
-        return ConverterResult(output_text=pdf_serializer.value, output_type="blob_path")
+        return ConverterResult(output_text=pdf_serializer.value, output_type="binary_path")
 
     def _prepare_content(self, prompt: str) -> str:
         """
@@ -408,7 +408,7 @@ class PDFConverter(PromptConverter):
 
         pdf_serializer = data_serializer_factory(
             category="prompt-memory-entries",
-            data_type="blob_path",
+            data_type="binary_path",
             extension=extension,
         )
         await pdf_serializer.save_data(pdf_bytes)

--- a/pyrit/prompt_converter/pdf_converter.py
+++ b/pyrit/prompt_converter/pdf_converter.py
@@ -33,7 +33,7 @@ class PDFConverter(PromptConverter):
     """
 
     SUPPORTED_INPUT_TYPES = ("text",)
-    SUPPORTED_OUTPUT_TYPES = ("url",)
+    SUPPORTED_OUTPUT_TYPES = ("blob_path",)
 
     def __init__(
         self,
@@ -131,7 +131,7 @@ class PDFConverter(PromptConverter):
         pdf_serializer = await self._serialize_pdf(pdf_bytes, content)
 
         # Return the result
-        return ConverterResult(output_text=pdf_serializer.value, output_type="url")
+        return ConverterResult(output_text=pdf_serializer.value, output_type="blob_path")
 
     def _prepare_content(self, prompt: str) -> str:
         """
@@ -408,8 +408,7 @@ class PDFConverter(PromptConverter):
 
         pdf_serializer = data_serializer_factory(
             category="prompt-memory-entries",
-            data_type="url",
-            value=content,
+            data_type="blob_path",
             extension=extension,
         )
         await pdf_serializer.save_data(pdf_bytes)

--- a/tests/unit/converter/test_pdf_converter.py
+++ b/tests/unit/converter/test_pdf_converter.py
@@ -72,7 +72,7 @@ async def test_convert_async_no_template(pdf_converter_no_template):
         mock_serialize.assert_called_once_with(mock_pdf_bytes, prompt)
 
         assert isinstance(result, ConverterResult)
-        assert result.output_type == "blob_path"
+        assert result.output_type == "binary_path"
         assert result.output_text == "mock_url"
 
 
@@ -103,7 +103,7 @@ async def test_convert_async_with_template(pdf_converter_with_template):
         mock_serialize.assert_called_once_with(mock_pdf_bytes, expected_rendered_content)
 
         assert isinstance(result, ConverterResult)
-        assert result.output_type == "blob_path"
+        assert result.output_type == "binary_path"
         assert result.output_text == "mock_url"
 
 

--- a/tests/unit/converter/test_pdf_converter.py
+++ b/tests/unit/converter/test_pdf_converter.py
@@ -72,7 +72,7 @@ async def test_convert_async_no_template(pdf_converter_no_template):
         mock_serialize.assert_called_once_with(mock_pdf_bytes, prompt)
 
         assert isinstance(result, ConverterResult)
-        assert result.output_type == "url"
+        assert result.output_type == "blob_path"
         assert result.output_text == "mock_url"
 
 
@@ -103,7 +103,7 @@ async def test_convert_async_with_template(pdf_converter_with_template):
         mock_serialize.assert_called_once_with(mock_pdf_bytes, expected_rendered_content)
 
         assert isinstance(result, ConverterResult)
-        assert result.output_type == "url"
+        assert result.output_type == "blob_path"
         assert result.output_text == "mock_url"
 
 

--- a/tests/unit/converter/test_prompt_converter.py
+++ b/tests/unit/converter/test_prompt_converter.py
@@ -539,7 +539,7 @@ def is_speechsdk_installed():
         (HumanInTheLoopConverter(), ["text"], ["text"]),
         (LeetspeakConverter(), ["text"], ["text"]),
         (MorseConverter(), ["text"], ["text"]),
-        (PDFConverter(), ["text"], ["url"]),
+        (PDFConverter(), ["text"], ["blob_path"]),
         (QRCodeConverter(), ["text"], ["image_path"]),
         (RandomCapitalLettersConverter(), ["text"], ["text"]),
         (RepeatTokenConverter(token_to_repeat="test", times_to_repeat=2), ["text"], ["text"]),

--- a/tests/unit/converter/test_prompt_converter.py
+++ b/tests/unit/converter/test_prompt_converter.py
@@ -539,7 +539,7 @@ def is_speechsdk_installed():
         (HumanInTheLoopConverter(), ["text"], ["text"]),
         (LeetspeakConverter(), ["text"], ["text"]),
         (MorseConverter(), ["text"], ["text"]),
-        (PDFConverter(), ["text"], ["blob_path"]),
+        (PDFConverter(), ["text"], ["binary_path"]),
         (QRCodeConverter(), ["text"], ["image_path"]),
         (RandomCapitalLettersConverter(), ["text"], ["text"]),
         (RepeatTokenConverter(token_to_repeat="test", times_to_repeat=2), ["text"], ["text"]),

--- a/tests/unit/models/test_data_type_serializer.py
+++ b/tests/unit/models/test_data_type_serializer.py
@@ -13,7 +13,7 @@ from PIL import Image
 
 from pyrit.models import (
     AllowedCategories,
-    BlobPathDataTypeSerializer,
+    BinaryPathDataTypeSerializer,
     DataTypeSerializer,
     ErrorDataTypeSerializer,
     ImagePathDataTypeSerializer,
@@ -301,30 +301,30 @@ async def test_get_data_filename(sqlite_instance):
     assert not os.path.exists(filename)  # File should not exist yet
 
 
-def test_blob_path_normalizer_factory(sqlite_instance):
-    """Test factory creates BlobPathDataTypeSerializer correctly."""
-    serializer = data_serializer_factory(category="prompt-memory-entries", data_type="blob_path")
+def test_binary_path_normalizer_factory(sqlite_instance):
+    """Test factory creates BinaryPathDataTypeSerializer correctly."""
+    serializer = data_serializer_factory(category="prompt-memory-entries", data_type="binary_path")
     assert isinstance(serializer, DataTypeSerializer)
-    assert isinstance(serializer, BlobPathDataTypeSerializer)
-    assert serializer.data_type == "blob_path"
+    assert isinstance(serializer, BinaryPathDataTypeSerializer)
+    assert serializer.data_type == "binary_path"
     assert serializer.data_on_disk()
 
 
-def test_blob_path_normalizer_factory_with_value(sqlite_instance):
-    """Test factory creates BlobPathDataTypeSerializer with value."""
+def test_binary_path_normalizer_factory_with_value(sqlite_instance):
+    """Test factory creates BinaryPathDataTypeSerializer with value."""
     serializer = data_serializer_factory(
-        category="prompt-memory-entries", data_type="blob_path", value="/path/to/blob.bin"
+        category="prompt-memory-entries", data_type="binary_path", value="/path/to/file.bin"
     )
-    assert isinstance(serializer, BlobPathDataTypeSerializer)
-    assert serializer.data_type == "blob_path"
-    assert serializer.value == "/path/to/blob.bin"
+    assert isinstance(serializer, BinaryPathDataTypeSerializer)
+    assert serializer.data_type == "binary_path"
+    assert serializer.value == "/path/to/file.bin"
     assert serializer.data_on_disk()
 
 
 @pytest.mark.asyncio
-async def test_blob_path_save_data(sqlite_instance):
-    """Test saving blob data to disk."""
-    serializer = data_serializer_factory(category="prompt-memory-entries", data_type="blob_path")
+async def test_binary_path_save_data(sqlite_instance):
+    """Test saving binary data to disk."""
+    serializer = data_serializer_factory(category="prompt-memory-entries", data_type="binary_path")
     await serializer.save_data(b"\x00\x01\x02\x03")
     serializer_value = serializer.value
     assert serializer_value
@@ -335,36 +335,36 @@ async def test_blob_path_save_data(sqlite_instance):
 
 
 @pytest.mark.asyncio
-async def test_blob_path_read_data(sqlite_instance):
-    """Test reading blob data from disk."""
+async def test_binary_path_read_data(sqlite_instance):
+    """Test reading binary data from disk."""
     data = b"\x00\x11\x22\x33\x44\x55"
-    serializer = data_serializer_factory(category="prompt-memory-entries", data_type="blob_path")
+    serializer = data_serializer_factory(category="prompt-memory-entries", data_type="binary_path")
     await serializer.save_data(data)
     assert await serializer.read_data() == data
     # Test reading with a new serializer initialized with the saved path
     read_serializer = data_serializer_factory(
-        category="prompt-memory-entries", data_type="blob_path", value=serializer.value
+        category="prompt-memory-entries", data_type="binary_path", value=serializer.value
     )
     assert await read_serializer.read_data() == data
 
 
 @pytest.mark.asyncio
-async def test_blob_path_save_with_custom_extension(sqlite_instance):
-    """Test saving blob data with a custom file extension."""
+async def test_binary_path_save_with_custom_extension(sqlite_instance):
+    """Test saving binary data with a custom file extension."""
     custom_extension = "pdf"
     serializer = data_serializer_factory(
-        category="prompt-memory-entries", data_type="blob_path", extension=custom_extension
+        category="prompt-memory-entries", data_type="binary_path", extension=custom_extension
     )
-    blob_data = b"PDF binary content"
-    await serializer.save_data(blob_data)
+    binary_data = b"PDF binary content"
+    await serializer.save_data(binary_data)
     assert serializer.value.endswith(f".{custom_extension}")
     assert os.path.exists(serializer.value)
     assert os.path.isfile(serializer.value)
 
 
 @pytest.mark.asyncio
-async def test_blob_path_subdirectory(sqlite_instance):
-    """Test that blob data is stored in the correct subdirectory."""
-    serializer = data_serializer_factory(category="prompt-memory-entries", data_type="blob_path")
+async def test_binary_path_subdirectory(sqlite_instance):
+    """Test that binary data is stored in the correct subdirectory."""
+    serializer = data_serializer_factory(category="prompt-memory-entries", data_type="binary_path")
     await serializer.save_data(b"test data")
-    assert "/blobs/" in serializer.value or "\\blobs\\" in serializer.value
+    assert "/binaries/" in serializer.value or "\\binaries\\" in serializer.value

--- a/tests/unit/models/test_literals.py
+++ b/tests/unit/models/test_literals.py
@@ -14,7 +14,7 @@ def test_prompt_data_type():
         "image_path",
         "audio_path",
         "video_path",
-        "blob_path",
+        "binary_path",
         "url",
         "error",
         "reasoning",

--- a/tests/unit/models/test_literals.py
+++ b/tests/unit/models/test_literals.py
@@ -14,6 +14,7 @@ def test_prompt_data_type():
         "image_path",
         "audio_path",
         "video_path",
+        "blob_path",
         "url",
         "error",
         "reasoning",


### PR DESCRIPTION
## Description

Adds a new `binary_path` data type to represent arbitrary binary data stored in blob or disk storage, particularly useful for XPIA attacks where targets may not support specific file types.

- Added `binary_path` to `PromptDataType` Literal in `literals.py`
- Created `BlobPathDataTypeSerializer` class in `data_type_serializer.py` where `data_on_disk()=True`, uses `/binaries` subdirectory, default extension `.bin`
- Updated `data_serializer_factory` to route `binary_path` to the new serializer
- Updated `PDFConverter` to output `binary_path` instead of `url` which was semantically incorrect. 

Minor change:
- `content` is no longer passed as an arg to `value` in `data_serializer_factory` in PDF converter. This was misleading since `value` should be a file path and was overriden in `save_data` method call in the next line anyways. 


## Tests and Documentation

**Tests added/updated:**
- Added 6 new tests in `test_data_type_serializer.py`:
- Updated `test_literals.py` to include `binary_path` in expected literals
- Updated `test_pdf_converter.py` to expect `binary_path` output type instead of `url`
- Updated `test_prompt_converter.py` to ensure correct `expected_output_type`

**Notebook:**
- Re-ran `5_file_converters.ipynb` notebook 