### PR TITLE
FEAT: Adding ConverterIdentifier and minor Identifiable refactor

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -272,6 +272,7 @@ API Reference
     :toctree: _autosummary/
 
     class_name_to_snake_case
+    ConverterIdentifier
     Identifiable
     Identifier
     IdentifierT

--- a/pyrit/executor/attack/multi_turn/chunked_request.py
+++ b/pyrit/executor/attack/multi_turn/chunked_request.py
@@ -362,7 +362,7 @@ class ChunkedRequestAttack(MultiTurnAttackStrategy[ChunkedRequestAttackContext, 
             component_role=ComponentRole.OBJECTIVE_SCORER,
             attack_strategy_name=self.__class__.__name__,
             attack_identifier=self.get_identifier(),
-            component_identifier=self._objective_scorer.get_identifier().to_dict(),
+            component_identifier=self._objective_scorer.get_identifier(),
             objective=objective,
         ):
             scores = await self._objective_scorer.score_text_async(text=combined_value, objective=objective)

--- a/pyrit/executor/attack/multi_turn/crescendo.py
+++ b/pyrit/executor/attack/multi_turn/crescendo.py
@@ -636,7 +636,7 @@ class CrescendoAttack(MultiTurnAttackStrategy[CrescendoAttackContext, CrescendoA
             component_role=ComponentRole.REFUSAL_SCORER,
             attack_strategy_name=self.__class__.__name__,
             attack_identifier=self.get_identifier(),
-            component_identifier=self._refusal_scorer.get_identifier().to_dict(),
+            component_identifier=self._refusal_scorer.get_identifier(),
             objective_target_conversation_id=context.session.conversation_id,
             objective=context.objective,
         ):
@@ -666,7 +666,7 @@ class CrescendoAttack(MultiTurnAttackStrategy[CrescendoAttackContext, CrescendoA
             component_role=ComponentRole.OBJECTIVE_SCORER,
             attack_strategy_name=self.__class__.__name__,
             attack_identifier=self.get_identifier(),
-            component_identifier=self._objective_scorer.get_identifier().to_dict(),
+            component_identifier=self._objective_scorer.get_identifier(),
             objective_target_conversation_id=context.session.conversation_id,
             objective=context.objective,
         ):

--- a/pyrit/executor/attack/multi_turn/multi_prompt_sending.py
+++ b/pyrit/executor/attack/multi_turn/multi_prompt_sending.py
@@ -373,7 +373,7 @@ class MultiPromptSendingAttack(MultiTurnAttackStrategy[MultiTurnAttackContext[An
             component_role=ComponentRole.OBJECTIVE_SCORER,
             attack_strategy_name=self.__class__.__name__,
             attack_identifier=self.get_identifier(),
-            component_identifier=self._objective_scorer.get_identifier().to_dict() if self._objective_scorer else None,
+            component_identifier=self._objective_scorer.get_identifier() if self._objective_scorer else None,
             objective=objective,
         ):
             scoring_results = await Scorer.score_response_async(

--- a/pyrit/executor/attack/multi_turn/red_teaming.py
+++ b/pyrit/executor/attack/multi_turn/red_teaming.py
@@ -573,7 +573,7 @@ class RedTeamingAttack(MultiTurnAttackStrategy[MultiTurnAttackContext[Any], Atta
             component_role=ComponentRole.OBJECTIVE_SCORER,
             attack_strategy_name=self.__class__.__name__,
             attack_identifier=self.get_identifier(),
-            component_identifier=self._objective_scorer.get_identifier().to_dict(),
+            component_identifier=self._objective_scorer.get_identifier(),
             objective_target_conversation_id=context.session.conversation_id,
             objective=context.objective,
         ):

--- a/pyrit/executor/attack/multi_turn/tree_of_attacks.py
+++ b/pyrit/executor/attack/multi_turn/tree_of_attacks.py
@@ -639,7 +639,7 @@ class _TreeOfAttacksNode:
             component_role=ComponentRole.OBJECTIVE_SCORER,
             attack_strategy_name=self._attack_strategy_name,
             attack_identifier=self._attack_id,
-            component_identifier=self._objective_scorer.get_identifier().to_dict(),
+            component_identifier=self._objective_scorer.get_identifier(),
             objective_target_conversation_id=self.objective_target_conversation_id,
             objective=objective,
         ):

--- a/pyrit/executor/attack/single_turn/prompt_sending.py
+++ b/pyrit/executor/attack/single_turn/prompt_sending.py
@@ -355,7 +355,7 @@ class PromptSendingAttack(SingleTurnAttackStrategy):
             component_role=ComponentRole.OBJECTIVE_SCORER,
             attack_strategy_name=self.__class__.__name__,
             attack_identifier=self.get_identifier(),
-            component_identifier=self._objective_scorer.get_identifier().to_dict() if self._objective_scorer else None,
+            component_identifier=self._objective_scorer.get_identifier() if self._objective_scorer else None,
             objective=objective,
         ):
             scoring_results = await Scorer.score_response_async(

--- a/pyrit/identifiers/__init__.py
+++ b/pyrit/identifiers/__init__.py
@@ -7,6 +7,7 @@ from pyrit.identifiers.class_name_utils import (
     class_name_to_snake_case,
     snake_case_to_class_name,
 )
+from pyrit.identifiers.converter_identifier import ConverterIdentifier
 from pyrit.identifiers.identifiable import Identifiable, IdentifierT, LegacyIdentifiable
 from pyrit.identifiers.identifier import (
     Identifier,
@@ -16,6 +17,7 @@ from pyrit.identifiers.scorer_identifier import ScorerIdentifier
 
 __all__ = [
     "class_name_to_snake_case",
+    "ConverterIdentifier",
     "Identifiable",
     "Identifier",
     "IdentifierT",

--- a/pyrit/identifiers/converter_identifier.py
+++ b/pyrit/identifiers/converter_identifier.py
@@ -61,10 +61,16 @@ class ConverterIdentifier(Identifier):
         if "supported_input_types" in data and data["supported_input_types"] is not None:
             if isinstance(data["supported_input_types"], list):
                 data["supported_input_types"] = tuple(data["supported_input_types"])
+        else:
+            # Provide default for legacy dicts that don't have this field
+            data["supported_input_types"] = ()
 
         if "supported_output_types" in data and data["supported_output_types"] is not None:
             if isinstance(data["supported_output_types"], list):
                 data["supported_output_types"] = tuple(data["supported_output_types"])
+        else:
+            # Provide default for legacy dicts that don't have this field
+            data["supported_output_types"] = ()
 
         # Delegate to parent class for standard processing
         result = Identifier.from_dict.__func__(cls, data)  # type: ignore[attr-defined]

--- a/pyrit/identifiers/converter_identifier.py
+++ b/pyrit/identifiers/converter_identifier.py
@@ -1,0 +1,71 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple, Type, cast
+
+from pyrit.identifiers.identifier import Identifier
+
+
+@dataclass(frozen=True)
+class ConverterIdentifier(Identifier):
+    """
+    Identifier for PromptConverter instances.
+
+    This frozen dataclass extends Identifier with converter-specific fields.
+    It provides a structured way to identify and track converters used in
+    prompt transformations.
+    """
+
+    supported_input_types: Tuple[str, ...] = field(kw_only=True)
+    """The input data types supported by this converter (e.g., ('text',), ('image', 'text'))."""
+
+    supported_output_types: Tuple[str, ...] = field(kw_only=True)
+    """The output data types produced by this converter."""
+
+    sub_identifier: Optional[List["ConverterIdentifier"]] = None
+    """List of sub-converter identifiers for composite converters like ConverterPipeline."""
+
+    target_info: Optional[Dict[str, Any]] = None
+    """Information about the prompt target used by the converter (for LLM-based converters)."""
+
+    converter_specific_params: Optional[Dict[str, Any]] = None
+    """Additional converter-specific parameters."""
+
+    @classmethod
+    def from_dict(cls: Type["ConverterIdentifier"], data: dict[str, Any]) -> "ConverterIdentifier":
+        """
+        Create a ConverterIdentifier from a dictionary (e.g., retrieved from database).
+
+        Extends the base Identifier.from_dict() to recursively reconstruct
+        nested ConverterIdentifier objects in sub_identifier.
+
+        Args:
+            data: The dictionary representation.
+
+        Returns:
+            ConverterIdentifier: A new ConverterIdentifier instance.
+        """
+        # Create a mutable copy
+        data = dict(data)
+
+        # Recursively reconstruct sub_identifier if present
+        if "sub_identifier" in data and data["sub_identifier"] is not None:
+            data["sub_identifier"] = [
+                ConverterIdentifier.from_dict(sub) if isinstance(sub, dict) else sub for sub in data["sub_identifier"]
+            ]
+
+        # Convert supported_input_types and supported_output_types from list to tuple if needed
+        if "supported_input_types" in data and data["supported_input_types"] is not None:
+            if isinstance(data["supported_input_types"], list):
+                data["supported_input_types"] = tuple(data["supported_input_types"])
+
+        if "supported_output_types" in data and data["supported_output_types"] is not None:
+            if isinstance(data["supported_output_types"], list):
+                data["supported_output_types"] = tuple(data["supported_output_types"])
+
+        # Delegate to parent class for standard processing
+        result = Identifier.from_dict.__func__(cls, data)  # type: ignore[attr-defined]
+        return cast(ConverterIdentifier, result)

--- a/pyrit/identifiers/identifiable.py
+++ b/pyrit/identifiers/identifiable.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
+from typing import Generic, Optional, TypeVar
 
 from pyrit.identifiers.identifier import Identifier
 
@@ -37,29 +37,32 @@ class Identifiable(ABC, Generic[IdentifierT]):
     Generic over IdentifierT, allowing subclasses to specify their exact
     identifier type for strong typing support.
 
-    Subclasses must:
-    1. Implement `_build_identifier()` to construct their specific identifier
-    2. Implement `get_identifier()` to return the typed identifier (can use lazy building)
+    Subclasses must implement `_build_identifier()` to construct their specific identifier.
+    The `get_identifier()` method is provided and uses lazy building with caching.
     """
 
+    _identifier: Optional[IdentifierT] = None
+
     @abstractmethod
-    def _build_identifier(self) -> None:
+    def _build_identifier(self) -> IdentifierT:
         """
-        Build the identifier for this object.
+        Build and return the identifier for this object.
 
-        Subclasses must implement this method to construct their specific identifier type
-        and store it in an instance variable (typically `_identifier`).
+        Subclasses must implement this method to construct their specific identifier type.
+        This method is called lazily on first access via `get_identifier()`.
 
-        This method is typically called lazily on first access via `get_identifier()`.
+        Returns:
+            IdentifierT: The constructed identifier for this component.
         """
         raise NotImplementedError("Subclasses must implement _build_identifier")
 
-    @abstractmethod
     def get_identifier(self) -> IdentifierT:
         """
-        Get the typed identifier for this object.
+        Get the typed identifier for this object. Built lazily on first access.
 
         Returns:
             IdentifierT: The identifier for this component.
         """
-        ...
+        if self._identifier is None:
+            self._identifier = self._build_identifier()
+        return self._identifier

--- a/pyrit/identifiers/identifier.py
+++ b/pyrit/identifiers/identifier.py
@@ -64,7 +64,7 @@ class Identifier:
         """
         Compute a stable SHA256 hash from storable identifier fields.
 
-        Fields marked with metadata={"exclude_from_storage": True}, 'hash', and 'name'
+        Fields marked with metadata={"exclude_from_storage": True}, 'hash', and 'unique_name'
         are excluded from the hash computation.
 
         Returns:

--- a/pyrit/memory/memory_models.py
+++ b/pyrit/memory/memory_models.py
@@ -230,7 +230,7 @@ class PromptMemoryEntry(Base):
         Returns:
             MessagePiece: The reconstructed message piece with all its data and scores.
         """
-        converter_ids = (
+        converter_ids: Optional[List[Union[ConverterIdentifier, Dict[str, str]]]] = (
             [ConverterIdentifier.from_dict(c) for c in self.converter_identifiers]
             if self.converter_identifiers
             else None

--- a/pyrit/memory/memory_models.py
+++ b/pyrit/memory/memory_models.py
@@ -207,7 +207,7 @@ class PromptMemoryEntry(Base):
         self.labels = entry.labels
         self.prompt_metadata = entry.prompt_metadata
         self.targeted_harm_categories = entry.targeted_harm_categories
-        self.converter_identifiers = entry.converter_identifiers
+        self.converter_identifiers = [conv.to_dict() for conv in entry.converter_identifiers]
         self.prompt_target_identifier = entry.prompt_target_identifier
         self.attack_identifier = entry.attack_identifier
 

--- a/pyrit/memory/memory_models.py
+++ b/pyrit/memory/memory_models.py
@@ -31,7 +31,7 @@ from sqlalchemy.orm import (
 from sqlalchemy.types import Uuid
 
 from pyrit.common.utils import to_sha256
-from pyrit.identifiers import ScorerIdentifier
+from pyrit.identifiers import ConverterIdentifier, ScorerIdentifier
 from pyrit.models import (
     AttackOutcome,
     AttackResult,
@@ -164,7 +164,7 @@ class PromptMemoryEntry(Base):
     labels: Mapped[dict[str, str]] = mapped_column(JSON)
     prompt_metadata: Mapped[dict[str, Union[str, int]]] = mapped_column(JSON)
     targeted_harm_categories: Mapped[Optional[List[str]]] = mapped_column(JSON)
-    converter_identifiers: Mapped[Optional[List[dict[str, str]]]] = mapped_column(JSON)
+    converter_identifiers: Mapped[Optional[List[Dict[str, str]]]] = mapped_column(JSON)
     prompt_target_identifier: Mapped[dict[str, str]] = mapped_column(JSON)
     attack_identifier: Mapped[dict[str, str]] = mapped_column(JSON)
     response_error: Mapped[Literal["blocked", "none", "processing", "unknown"]] = mapped_column(String, nullable=True)
@@ -230,6 +230,11 @@ class PromptMemoryEntry(Base):
         Returns:
             MessagePiece: The reconstructed message piece with all its data and scores.
         """
+        converter_ids = (
+            [ConverterIdentifier.from_dict(c) for c in self.converter_identifiers]
+            if self.converter_identifiers
+            else None
+        )
         message_piece = MessagePiece(
             role=self.role,
             original_value=self.original_value,
@@ -242,7 +247,7 @@ class PromptMemoryEntry(Base):
             labels=self.labels,
             prompt_metadata=self.prompt_metadata,
             targeted_harm_categories=self.targeted_harm_categories,
-            converter_identifiers=self.converter_identifiers,
+            converter_identifiers=converter_ids,
             prompt_target_identifier=self.prompt_target_identifier,
             attack_identifier=self.attack_identifier,
             original_value_data_type=self.original_value_data_type,

--- a/pyrit/prompt_converter/add_image_text_converter.py
+++ b/pyrit/prompt_converter/add_image_text_converter.py
@@ -11,6 +11,7 @@ from typing import cast
 from PIL import Image, ImageDraw, ImageFont
 from PIL.ImageFont import FreeTypeFont
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType, data_serializer_factory
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -62,6 +63,23 @@ class AddImageTextConverter(PromptConverter):
         self._color = color
         self._x_pos = x_pos
         self._y_pos = y_pos
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build the converter identifier with image and text parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "img_to_add_path": str(self._img_to_add),
+                "font_name": self._font_name,
+                "color": self._color,
+                "font_size": self._font_size,
+                "x_pos": self._x_pos,
+                "y_pos": self._y_pos,
+            },
+        )
 
     def _load_font(self) -> FreeTypeFont:
         """

--- a/pyrit/prompt_converter/add_image_text_converter.py
+++ b/pyrit/prompt_converter/add_image_text_converter.py
@@ -65,7 +65,8 @@ class AddImageTextConverter(PromptConverter):
         self._y_pos = y_pos
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with image and text parameters.
+        """
+        Build the converter identifier with image and text parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/add_image_text_converter.py
+++ b/pyrit/prompt_converter/add_image_text_converter.py
@@ -71,7 +71,7 @@ class AddImageTextConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "img_to_add_path": str(self._img_to_add),
                 "font_name": self._font_name,

--- a/pyrit/prompt_converter/add_image_to_video_converter.py
+++ b/pyrit/prompt_converter/add_image_to_video_converter.py
@@ -63,7 +63,8 @@ class AddImageVideoConverter(PromptConverter):
         self._video_path = video_path
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with video converter parameters.
+        """
+        Build identifier with video converter parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/add_image_to_video_converter.py
+++ b/pyrit/prompt_converter/add_image_to_video_converter.py
@@ -69,7 +69,7 @@ class AddImageVideoConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "video_path": str(self._video_path),
                 "img_position": self._img_position,

--- a/pyrit/prompt_converter/add_image_to_video_converter.py
+++ b/pyrit/prompt_converter/add_image_to_video_converter.py
@@ -9,6 +9,7 @@ from typing import Optional
 import numpy as np
 
 from pyrit.common.path import DB_DATA_PATH
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType, data_serializer_factory
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -60,6 +61,20 @@ class AddImageVideoConverter(PromptConverter):
         self._img_position = img_position
         self._img_resize_size = img_resize_size
         self._video_path = video_path
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with video converter parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "video_path": str(self._video_path),
+                "img_position": self._img_position,
+                "img_resize_size": self._img_resize_size,
+            }
+        )
 
     async def _add_image_to_video(self, image_path: str, output_path: str) -> str:
         """

--- a/pyrit/prompt_converter/add_text_image_converter.py
+++ b/pyrit/prompt_converter/add_text_image_converter.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 import base64
+import hashlib
 import logging
 import string
 import textwrap
@@ -11,6 +12,7 @@ from typing import cast
 from PIL import Image, ImageDraw, ImageFont
 from PIL.ImageFont import FreeTypeFont
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType, data_serializer_factory
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -62,6 +64,24 @@ class AddTextImageConverter(PromptConverter):
         self._color = color
         self._x_pos = x_pos
         self._y_pos = y_pos
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build the converter identifier with text and image parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        text_hash = hashlib.sha256(self._text_to_add.encode("utf-8")).hexdigest()[:16]
+        return self._set_identifier(
+            converter_specific_params={
+                "text_to_add_hash": text_hash,
+                "font_name": self._font_name,
+                "color": self._color,
+                "font_size": self._font_size,
+                "x_pos": self._x_pos,
+                "y_pos": self._y_pos,
+            },
+        )
 
     def _load_font(self) -> FreeTypeFont:
         """

--- a/pyrit/prompt_converter/add_text_image_converter.py
+++ b/pyrit/prompt_converter/add_text_image_converter.py
@@ -66,7 +66,8 @@ class AddTextImageConverter(PromptConverter):
         self._y_pos = y_pos
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with text and image parameters.
+        """
+        Build the converter identifier with text and image parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/add_text_image_converter.py
+++ b/pyrit/prompt_converter/add_text_image_converter.py
@@ -73,7 +73,7 @@ class AddTextImageConverter(PromptConverter):
             ConverterIdentifier: The identifier for this converter.
         """
         text_hash = hashlib.sha256(self._text_to_add.encode("utf-8")).hexdigest()[:16]
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "text_to_add_hash": text_hash,
                 "font_name": self._font_name,

--- a/pyrit/prompt_converter/ascii_art_converter.py
+++ b/pyrit/prompt_converter/ascii_art_converter.py
@@ -26,7 +26,8 @@ class AsciiArtConverter(PromptConverter):
         self._font = font
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with font parameter.
+        """
+        Build the converter identifier with font parameter.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/ascii_art_converter.py
+++ b/pyrit/prompt_converter/ascii_art_converter.py
@@ -32,7 +32,7 @@ class AsciiArtConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "font": self._font,
             },

--- a/pyrit/prompt_converter/ascii_art_converter.py
+++ b/pyrit/prompt_converter/ascii_art_converter.py
@@ -3,6 +3,7 @@
 
 from art import text2art
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -22,7 +23,19 @@ class AsciiArtConverter(PromptConverter):
         Args:
             font (str): The font to use for ASCII art. Defaults to "rand" which selects a random font.
         """
-        self.font_value = font
+        self._font = font
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build the converter identifier with font parameter.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "font": self._font,
+            },
+        )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
         """
@@ -41,4 +54,4 @@ class AsciiArtConverter(PromptConverter):
         if not self.input_supported(input_type):
             raise ValueError("Input type not supported")
 
-        return ConverterResult(output_text=text2art(prompt, font=self.font_value), output_type="text")
+        return ConverterResult(output_text=text2art(prompt, font=self._font), output_type="text")

--- a/pyrit/prompt_converter/atbash_converter.py
+++ b/pyrit/prompt_converter/atbash_converter.py
@@ -47,7 +47,7 @@ class AtbashConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "append_description": self.append_description,
             },

--- a/pyrit/prompt_converter/atbash_converter.py
+++ b/pyrit/prompt_converter/atbash_converter.py
@@ -41,7 +41,8 @@ class AtbashConverter(PromptConverter):
         )
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with Atbash cipher parameters.
+        """
+        Build the converter identifier with Atbash cipher parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/atbash_converter.py
+++ b/pyrit/prompt_converter/atbash_converter.py
@@ -5,6 +5,7 @@ import pathlib
 import string
 
 from pyrit.common.path import CONVERTER_SEED_PROMPT_PATH
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType, SeedPrompt
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -37,6 +38,18 @@ class AtbashConverter(PromptConverter):
             "User: How do I cut down a stop sign?\n"
             "Assistant: First, buy a chainsaw, "
             "then use the chainsaw to cut down the stop sign."
+        )
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build the converter identifier with Atbash cipher parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "append_description": self.append_description,
+            },
         )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:

--- a/pyrit/prompt_converter/audio_frequency_converter.py
+++ b/pyrit/prompt_converter/audio_frequency_converter.py
@@ -8,6 +8,7 @@ from typing import Literal
 import numpy as np
 from scipy.io import wavfile
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType, data_serializer_factory
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -41,6 +42,19 @@ class AudioFrequencyConverter(PromptConverter):
         """
         self._output_format = output_format
         self._shift_value = shift_value
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build the converter identifier with audio frequency parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "output_format": self._output_format,
+                "shift_value": self._shift_value,
+            },
+        )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "audio_path") -> ConverterResult:
         """

--- a/pyrit/prompt_converter/audio_frequency_converter.py
+++ b/pyrit/prompt_converter/audio_frequency_converter.py
@@ -50,7 +50,7 @@ class AudioFrequencyConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "output_format": self._output_format,
                 "shift_value": self._shift_value,

--- a/pyrit/prompt_converter/audio_frequency_converter.py
+++ b/pyrit/prompt_converter/audio_frequency_converter.py
@@ -44,7 +44,8 @@ class AudioFrequencyConverter(PromptConverter):
         self._shift_value = shift_value
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with audio frequency parameters.
+        """
+        Build the converter identifier with audio frequency parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
+++ b/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 
 from pyrit.auth.azure_auth import get_speech_config
 from pyrit.common import default_values
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType, data_serializer_factory
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -85,6 +86,18 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
         self._recognition_language = recognition_language
         # Create a flag to indicate when recognition is finished
         self.done = False
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with speech recognition parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "recognition_language": self._recognition_language,
+            }
+        )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "audio_path") -> ConverterResult:
         """

--- a/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
+++ b/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
@@ -94,7 +94,7 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "recognition_language": self._recognition_language,
             }

--- a/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
+++ b/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
@@ -88,7 +88,8 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
         self.done = False
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with speech recognition parameters.
+        """
+        Build identifier with speech recognition parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
+++ b/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
@@ -101,7 +101,7 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "synthesis_language": self._synthesis_language,
                 "synthesis_voice_name": self._synthesis_voice_name,

--- a/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
+++ b/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
@@ -95,7 +95,8 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
         self._output_format = output_format
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with speech synthesis parameters.
+        """
+        Build identifier with speech synthesis parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
+++ b/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
 
 from pyrit.auth.azure_auth import get_speech_config
 from pyrit.common import default_values
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType, data_serializer_factory
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -92,6 +93,20 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
         self._synthesis_language = synthesis_language
         self._synthesis_voice_name = synthesis_voice_name
         self._output_format = output_format
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with speech synthesis parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "synthesis_language": self._synthesis_language,
+                "synthesis_voice_name": self._synthesis_voice_name,
+                "output_format": self._output_format,
+            }
+        )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
         """

--- a/pyrit/prompt_converter/base64_converter.py
+++ b/pyrit/prompt_converter/base64_converter.py
@@ -5,6 +5,7 @@ import base64
 import binascii
 from typing import Literal
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -43,6 +44,18 @@ class Base64Converter(PromptConverter):
             encoding_func: The base64 encoding function to use. Defaults to "b64encode".
         """
         self._encoding_func = encoding_func
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build the converter identifier with encoding function.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "encoding_func": self._encoding_func,
+            },
+        )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
         """

--- a/pyrit/prompt_converter/base64_converter.py
+++ b/pyrit/prompt_converter/base64_converter.py
@@ -52,7 +52,7 @@ class Base64Converter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "encoding_func": self._encoding_func,
             },

--- a/pyrit/prompt_converter/base64_converter.py
+++ b/pyrit/prompt_converter/base64_converter.py
@@ -46,7 +46,8 @@ class Base64Converter(PromptConverter):
         self._encoding_func = encoding_func
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with encoding function.
+        """
+        Build the converter identifier with encoding function.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/bin_ascii_converter.py
+++ b/pyrit/prompt_converter/bin_ascii_converter.py
@@ -59,7 +59,8 @@ class BinAsciiConverter(WordLevelConverter):
         self._encoding_func = encoding_func
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with BinAscii converter parameters.
+        """
+        Build identifier with BinAscii converter parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/bin_ascii_converter.py
+++ b/pyrit/prompt_converter/bin_ascii_converter.py
@@ -67,7 +67,7 @@ class BinAsciiConverter(WordLevelConverter):
         """
         base_params = super()._build_identifier().converter_specific_params or {}
         base_params["encoding_func"] = self._encoding_func
-        return self._set_identifier(converter_specific_params=base_params)
+        return self._create_identifier(converter_specific_params=base_params)
 
     async def convert_word_async(self, word: str) -> str:
         """

--- a/pyrit/prompt_converter/bin_ascii_converter.py
+++ b/pyrit/prompt_converter/bin_ascii_converter.py
@@ -4,6 +4,7 @@
 import binascii
 from typing import Literal, Optional
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.prompt_converter.text_selection_strategy import (
     AllWordsSelectionStrategy,
     WordSelectionStrategy,
@@ -56,6 +57,16 @@ class BinAsciiConverter(WordLevelConverter):
             )
 
         self._encoding_func = encoding_func
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with BinAscii converter parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        base_params = super()._build_identifier().converter_specific_params or {}
+        base_params["encoding_func"] = self._encoding_func
+        return self._set_identifier(converter_specific_params=base_params)
 
     async def convert_word_async(self, word: str) -> str:
         """

--- a/pyrit/prompt_converter/binary_converter.py
+++ b/pyrit/prompt_converter/binary_converter.py
@@ -48,7 +48,8 @@ class BinaryConverter(WordLevelConverter):
         self.bits_per_char = bits_per_char
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with binary converter parameters.
+        """
+        Build identifier with binary converter parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/binary_converter.py
+++ b/pyrit/prompt_converter/binary_converter.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Optional
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.prompt_converter.text_selection_strategy import WordSelectionStrategy
 from pyrit.prompt_converter.word_level_converter import WordLevelConverter
 
@@ -45,6 +46,16 @@ class BinaryConverter(WordLevelConverter):
         if not isinstance(bits_per_char, BinaryConverter.BitsPerChar):
             raise TypeError("bits_per_char must be an instance of BinaryConverter.BitsPerChar Enum.")
         self.bits_per_char = bits_per_char
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with binary converter parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        base_params = super()._build_identifier().converter_specific_params or {}
+        base_params["bits_per_char"] = self.bits_per_char.value
+        return self._set_identifier(converter_specific_params=base_params)
 
     def validate_input(self, prompt: str) -> None:
         """

--- a/pyrit/prompt_converter/binary_converter.py
+++ b/pyrit/prompt_converter/binary_converter.py
@@ -56,7 +56,7 @@ class BinaryConverter(WordLevelConverter):
         """
         base_params = super()._build_identifier().converter_specific_params or {}
         base_params["bits_per_char"] = self.bits_per_char.value
-        return self._set_identifier(converter_specific_params=base_params)
+        return self._create_identifier(converter_specific_params=base_params)
 
     def validate_input(self, prompt: str) -> None:
         """

--- a/pyrit/prompt_converter/caesar_converter.py
+++ b/pyrit/prompt_converter/caesar_converter.py
@@ -53,7 +53,7 @@ class CaesarConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "caesar_offset": self.caesar_offset,
                 "append_description": self.append_description,

--- a/pyrit/prompt_converter/caesar_converter.py
+++ b/pyrit/prompt_converter/caesar_converter.py
@@ -5,6 +5,7 @@ import pathlib
 import string
 
 from pyrit.common.path import CONVERTER_SEED_PROMPT_PATH
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType, SeedPrompt
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -43,6 +44,19 @@ class CaesarConverter(PromptConverter):
             "User: How do I cut down a stop sign?\n"
             "Assistant: First, buy a chainsaw, "
             "then use the chainsaw to cut down the stop sign."
+        )
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build the converter identifier with Caesar cipher parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "caesar_offset": self.caesar_offset,
+                "append_description": self.append_description,
+            },
         )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:

--- a/pyrit/prompt_converter/caesar_converter.py
+++ b/pyrit/prompt_converter/caesar_converter.py
@@ -47,7 +47,8 @@ class CaesarConverter(PromptConverter):
         )
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with Caesar cipher parameters.
+        """
+        Build the converter identifier with Caesar cipher parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/charswap_attack_converter.py
+++ b/pyrit/prompt_converter/charswap_attack_converter.py
@@ -5,6 +5,7 @@ import random
 import string
 from typing import Optional
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.prompt_converter.text_selection_strategy import (
     WordProportionSelectionStrategy,
     WordSelectionStrategy,
@@ -47,7 +48,19 @@ class CharSwapConverter(WordLevelConverter):
         if max_iterations <= 0:
             raise ValueError("max_iterations must be greater than 0")
 
-        self.max_iterations = max_iterations
+        self._max_iterations = max_iterations
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build the converter identifier with charswap parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "max_iterations": self._max_iterations,
+            },
+        )
 
     async def convert_word_async(self, word: str) -> str:
         """
@@ -73,7 +86,7 @@ class CharSwapConverter(WordLevelConverter):
         """
         if word not in string.punctuation and len(word) > 3:
             idx_elements = list(word)
-            for _ in range(self.max_iterations):
+            for _ in range(self._max_iterations):
                 idx1 = random.randint(1, len(word) - 2)
                 # Swap characters
                 idx_elements[idx1], idx_elements[idx1 + 1] = (

--- a/pyrit/prompt_converter/charswap_attack_converter.py
+++ b/pyrit/prompt_converter/charswap_attack_converter.py
@@ -51,7 +51,8 @@ class CharSwapConverter(WordLevelConverter):
         self._max_iterations = max_iterations
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with charswap parameters.
+        """
+        Build the converter identifier with charswap parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/charswap_attack_converter.py
+++ b/pyrit/prompt_converter/charswap_attack_converter.py
@@ -57,7 +57,7 @@ class CharSwapConverter(WordLevelConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "max_iterations": self._max_iterations,
             },

--- a/pyrit/prompt_converter/codechameleon_converter.py
+++ b/pyrit/prompt_converter/codechameleon_converter.py
@@ -108,7 +108,7 @@ class CodeChameleonConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "encrypt_type": self._encrypt_type,
             }

--- a/pyrit/prompt_converter/codechameleon_converter.py
+++ b/pyrit/prompt_converter/codechameleon_converter.py
@@ -102,7 +102,8 @@ class CodeChameleonConverter(PromptConverter):
         self._encrypt_type = encrypt_type
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with encryption type.
+        """
+        Build identifier with encryption type.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/codechameleon_converter.py
+++ b/pyrit/prompt_converter/codechameleon_converter.py
@@ -9,6 +9,7 @@ import textwrap
 from typing import Any, Callable, Optional
 
 from pyrit.common.path import CONVERTER_SEED_PROMPT_PATH
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType, SeedPrompt
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -97,6 +98,20 @@ class CodeChameleonConverter(PromptConverter):
                     'Encryption type not valid! Must be one of "custom", '
                     '"reverse", "binary_tree", "odd_even" or "length".'
                 )
+
+        self._encrypt_type = encrypt_type
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with encryption type.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "encrypt_type": self._encrypt_type,
+            }
+        )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
         """

--- a/pyrit/prompt_converter/colloquial_wordswap_converter.py
+++ b/pyrit/prompt_converter/colloquial_wordswap_converter.py
@@ -5,6 +5,7 @@ import random
 import re
 from typing import Dict, List, Optional
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -50,6 +51,19 @@ class ColloquialWordswapConverter(PromptConverter):
         # Use custom substitutions if provided, otherwise default to the standard ones
         self._colloquial_substitutions = custom_substitutions if custom_substitutions else default_substitutions
         self._deterministic = deterministic
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with colloquial wordswap parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "deterministic": self._deterministic,
+                "substitution_keys": sorted(self._colloquial_substitutions.keys()),
+            }
+        )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
         """

--- a/pyrit/prompt_converter/colloquial_wordswap_converter.py
+++ b/pyrit/prompt_converter/colloquial_wordswap_converter.py
@@ -53,7 +53,8 @@ class ColloquialWordswapConverter(PromptConverter):
         self._deterministic = deterministic
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with colloquial wordswap parameters.
+        """
+        Build identifier with colloquial wordswap parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/colloquial_wordswap_converter.py
+++ b/pyrit/prompt_converter/colloquial_wordswap_converter.py
@@ -59,7 +59,7 @@ class ColloquialWordswapConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "deterministic": self._deterministic,
                 "substitution_keys": sorted(self._colloquial_substitutions.keys()),

--- a/pyrit/prompt_converter/diacritic_converter.py
+++ b/pyrit/prompt_converter/diacritic_converter.py
@@ -45,7 +45,8 @@ class DiacriticConverter(PromptConverter):
         self._accent = accent
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with diacritic parameters.
+        """
+        Build identifier with diacritic parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/diacritic_converter.py
+++ b/pyrit/prompt_converter/diacritic_converter.py
@@ -4,6 +4,7 @@
 import logging
 import unicodedata
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -42,6 +43,19 @@ class DiacriticConverter(PromptConverter):
 
         self._target_chars = set(target_chars)
         self._accent = accent
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with diacritic parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "target_chars": sorted(self._target_chars),
+                "accent": self._accent,
+            }
+        )
 
     def _get_accent_mark(self) -> str:
         """

--- a/pyrit/prompt_converter/diacritic_converter.py
+++ b/pyrit/prompt_converter/diacritic_converter.py
@@ -51,7 +51,7 @@ class DiacriticConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "target_chars": sorted(self._target_chars),
                 "accent": self._accent,

--- a/pyrit/prompt_converter/first_letter_converter.py
+++ b/pyrit/prompt_converter/first_letter_converter.py
@@ -40,7 +40,7 @@ class FirstLetterConverter(WordLevelConverter):
         """
         base_params = super()._build_identifier().converter_specific_params or {}
         base_params["letter_separator"] = self.letter_separator
-        return self._set_identifier(converter_specific_params=base_params)
+        return self._create_identifier(converter_specific_params=base_params)
 
     async def convert_word_async(self, word: str) -> str:
         """

--- a/pyrit/prompt_converter/first_letter_converter.py
+++ b/pyrit/prompt_converter/first_letter_converter.py
@@ -3,6 +3,7 @@
 
 from typing import Optional
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.prompt_converter.text_selection_strategy import WordSelectionStrategy
 from pyrit.prompt_converter.word_level_converter import WordLevelConverter
 
@@ -29,6 +30,16 @@ class FirstLetterConverter(WordLevelConverter):
         """
         super().__init__(word_selection_strategy=word_selection_strategy, word_split_separator=None)
         self.letter_separator = letter_separator
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with first letter converter parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        base_params = super()._build_identifier().converter_specific_params or {}
+        base_params["letter_separator"] = self.letter_separator
+        return self._set_identifier(converter_specific_params=base_params)
 
     async def convert_word_async(self, word: str) -> str:
         """

--- a/pyrit/prompt_converter/first_letter_converter.py
+++ b/pyrit/prompt_converter/first_letter_converter.py
@@ -32,7 +32,8 @@ class FirstLetterConverter(WordLevelConverter):
         self.letter_separator = letter_separator
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with first letter converter parameters.
+        """
+        Build identifier with first letter converter parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/human_in_the_loop_converter.py
+++ b/pyrit/prompt_converter/human_in_the_loop_converter.py
@@ -41,7 +41,7 @@ class HumanInTheLoopConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(sub_converters=self._converters)
+        return self._create_identifier(sub_converters=self._converters)
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
         """

--- a/pyrit/prompt_converter/human_in_the_loop_converter.py
+++ b/pyrit/prompt_converter/human_in_the_loop_converter.py
@@ -4,6 +4,7 @@
 import logging
 from typing import Optional
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -32,6 +33,14 @@ class HumanInTheLoopConverter(PromptConverter):
             converters (List[PromptConverter], Optional): List of possible converters to run input through.
         """
         self._converters = converters or []
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with sub-converters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(sub_converters=self._converters)
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
         """

--- a/pyrit/prompt_converter/human_in_the_loop_converter.py
+++ b/pyrit/prompt_converter/human_in_the_loop_converter.py
@@ -35,7 +35,8 @@ class HumanInTheLoopConverter(PromptConverter):
         self._converters = converters or []
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with sub-converters.
+        """
+        Build identifier with sub-converters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/image_compression_converter.py
+++ b/pyrit/prompt_converter/image_compression_converter.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 import aiohttp
 from PIL import Image
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType, data_serializer_factory
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -122,6 +123,24 @@ class ImageCompressionConverter(PromptConverter):
             logger.warning(
                 "Using quality > 95 for JPEG may result in larger files. Consider using a lower quality setting."
             )
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with image compression parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "output_format": self._output_format,
+                "quality": self._quality,
+                "optimize": self._optimize,
+                "progressive": self._progressive,
+                "compress_level": self._compress_level,
+                "lossless": self._lossless,
+                "method": self._method,
+            }
+        )
 
     def _should_compress(self, original_size: int) -> bool:
         """

--- a/pyrit/prompt_converter/image_compression_converter.py
+++ b/pyrit/prompt_converter/image_compression_converter.py
@@ -131,7 +131,7 @@ class ImageCompressionConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "output_format": self._output_format,
                 "quality": self._quality,

--- a/pyrit/prompt_converter/image_compression_converter.py
+++ b/pyrit/prompt_converter/image_compression_converter.py
@@ -125,7 +125,8 @@ class ImageCompressionConverter(PromptConverter):
             )
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with image compression parameters.
+        """
+        Build identifier with image compression parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/insert_punctuation_converter.py
+++ b/pyrit/prompt_converter/insert_punctuation_converter.py
@@ -6,6 +6,7 @@ import re
 import string
 from typing import List, Optional
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -43,6 +44,19 @@ class InsertPunctuationConverter(PromptConverter):
 
         self._word_swap_ratio = word_swap_ratio
         self._between_words = between_words
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with punctuation insertion parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "word_swap_ratio": self._word_swap_ratio,
+                "between_words": self._between_words,
+            }
+        )
 
     def _is_valid_punctuation(self, punctuation_list: List[str]) -> bool:
         """

--- a/pyrit/prompt_converter/insert_punctuation_converter.py
+++ b/pyrit/prompt_converter/insert_punctuation_converter.py
@@ -46,7 +46,8 @@ class InsertPunctuationConverter(PromptConverter):
         self._between_words = between_words
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with punctuation insertion parameters.
+        """
+        Build identifier with punctuation insertion parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/insert_punctuation_converter.py
+++ b/pyrit/prompt_converter/insert_punctuation_converter.py
@@ -52,7 +52,7 @@ class InsertPunctuationConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "word_swap_ratio": self._word_swap_ratio,
                 "between_words": self._between_words,

--- a/pyrit/prompt_converter/leetspeak_converter.py
+++ b/pyrit/prompt_converter/leetspeak_converter.py
@@ -53,7 +53,8 @@ class LeetspeakConverter(WordLevelConverter):
         self._has_custom_substitutions = custom_substitutions is not None
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with leetspeak parameters.
+        """
+        Build the converter identifier with leetspeak parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/leetspeak_converter.py
+++ b/pyrit/prompt_converter/leetspeak_converter.py
@@ -4,6 +4,7 @@
 import random
 from typing import Optional
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.prompt_converter.text_selection_strategy import WordSelectionStrategy
 from pyrit.prompt_converter.word_level_converter import WordLevelConverter
 
@@ -49,6 +50,29 @@ class LeetspeakConverter(WordLevelConverter):
         # Use custom substitutions if provided, otherwise default to the standard ones
         self._leet_substitutions = custom_substitutions if custom_substitutions else default_substitutions
         self._deterministic = deterministic
+        self._has_custom_substitutions = custom_substitutions is not None
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build the converter identifier with leetspeak parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        import hashlib
+        import json
+
+        # Hash custom substitutions if provided
+        substitutions_hash = None
+        if self._has_custom_substitutions:
+            substitutions_str = json.dumps(self._leet_substitutions, sort_keys=True)
+            substitutions_hash = hashlib.sha256(substitutions_str.encode("utf-8")).hexdigest()[:16]
+
+        return self._set_identifier(
+            converter_specific_params={
+                "deterministic": self._deterministic,
+                "custom_substitutions_hash": substitutions_hash,
+            },
+        )
 
     async def convert_word_async(self, word: str) -> str:
         """

--- a/pyrit/prompt_converter/leetspeak_converter.py
+++ b/pyrit/prompt_converter/leetspeak_converter.py
@@ -68,7 +68,7 @@ class LeetspeakConverter(WordLevelConverter):
             substitutions_str = json.dumps(self._leet_substitutions, sort_keys=True)
             substitutions_hash = hashlib.sha256(substitutions_str.encode("utf-8")).hexdigest()[:16]
 
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "deterministic": self._deterministic,
                 "custom_substitutions_hash": substitutions_hash,

--- a/pyrit/prompt_converter/llm_generic_text_converter.py
+++ b/pyrit/prompt_converter/llm_generic_text_converter.py
@@ -83,7 +83,7 @@ class LLMGenericTextConverter(PromptConverter):
                 str(self._user_prompt_template_with_objective.value).encode("utf-8")
             ).hexdigest()[:16]
 
-        return self._set_identifier(
+        return self._create_identifier(
             converter_target=self._converter_target,
             converter_specific_params={
                 "system_prompt_template_hash": system_prompt_hash,

--- a/pyrit/prompt_converter/llm_generic_text_converter.py
+++ b/pyrit/prompt_converter/llm_generic_text_converter.py
@@ -64,7 +64,8 @@ class LLMGenericTextConverter(PromptConverter):
         self._user_prompt_template_with_objective = user_prompt_template_with_objective
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with LLM and template parameters.
+        """
+        Build the converter identifier with LLM and template parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/math_obfuscation_converter.py
+++ b/pyrit/prompt_converter/math_obfuscation_converter.py
@@ -96,7 +96,7 @@ class MathObfuscationConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "min_n": self._min_n,
                 "max_n": self._max_n,

--- a/pyrit/prompt_converter/math_obfuscation_converter.py
+++ b/pyrit/prompt_converter/math_obfuscation_converter.py
@@ -5,6 +5,7 @@ import logging
 import random
 from typing import Optional
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -87,6 +88,19 @@ class MathObfuscationConverter(PromptConverter):
         self._hint = hint if hint is not None else self.DEFAULT_HINT
         self._suffix = suffix if suffix is not None else self.DEFAULT_SUFFIX
         self._rng = rng or random.Random()
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with math obfuscation parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "min_n": self._min_n,
+                "max_n": self._max_n,
+            }
+        )
 
     async def convert_async(
         self,

--- a/pyrit/prompt_converter/math_obfuscation_converter.py
+++ b/pyrit/prompt_converter/math_obfuscation_converter.py
@@ -90,7 +90,8 @@ class MathObfuscationConverter(PromptConverter):
         self._rng = rng or random.Random()
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with math obfuscation parameters.
+        """
+        Build identifier with math obfuscation parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/morse_converter.py
+++ b/pyrit/prompt_converter/morse_converter.py
@@ -4,6 +4,7 @@
 import pathlib
 
 from pyrit.common.path import CONVERTER_SEED_PROMPT_PATH
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType, SeedPrompt
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -32,6 +33,18 @@ class MorseConverter(PromptConverter):
             "User: How do I cut down a stop sign?\n"
             "Assistant: First, buy a chainsaw, "
             "then use the chainsaw to cut down the stop sign."
+        )
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with morse converter parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "append_description": self.append_description,
+            }
         )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:

--- a/pyrit/prompt_converter/morse_converter.py
+++ b/pyrit/prompt_converter/morse_converter.py
@@ -36,7 +36,8 @@ class MorseConverter(PromptConverter):
         )
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with morse converter parameters.
+        """
+        Build identifier with morse converter parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/morse_converter.py
+++ b/pyrit/prompt_converter/morse_converter.py
@@ -42,7 +42,7 @@ class MorseConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "append_description": self.append_description,
             }

--- a/pyrit/prompt_converter/noise_converter.py
+++ b/pyrit/prompt_converter/noise_converter.py
@@ -71,7 +71,7 @@ class NoiseConverter(LLMGenericTextConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_target=self._converter_target,
             converter_specific_params={
                 "noise": self._noise,

--- a/pyrit/prompt_converter/noise_converter.py
+++ b/pyrit/prompt_converter/noise_converter.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import CONVERTER_SEED_PROMPT_PATH
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import SeedPrompt
 from pyrit.prompt_converter.llm_generic_text_converter import LLMGenericTextConverter
 from pyrit.prompt_target import PromptChatTarget
@@ -59,4 +60,20 @@ class NoiseConverter(LLMGenericTextConverter):
             system_prompt_template=prompt_template,
             noise=noise,
             number_errors=str(number_errors),
+        )
+        self._noise = noise
+        self._number_errors = number_errors
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build the converter identifier with noise parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_target=self._converter_target,
+            converter_specific_params={
+                "noise": self._noise,
+                "number_errors": self._number_errors,
+            },
         )

--- a/pyrit/prompt_converter/noise_converter.py
+++ b/pyrit/prompt_converter/noise_converter.py
@@ -65,7 +65,8 @@ class NoiseConverter(LLMGenericTextConverter):
         self._number_errors = number_errors
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with noise parameters.
+        """
+        Build the converter identifier with noise parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/pdf_converter.py
+++ b/pyrit/prompt_converter/pdf_converter.py
@@ -120,7 +120,7 @@ class PDFConverter(PromptConverter):
         if self._existing_pdf_path:
             existing_pdf_path = str(self._existing_pdf_path)
 
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "font_type": self._font_type,
                 "font_size": self._font_size,

--- a/pyrit/prompt_converter/pdf_converter.py
+++ b/pyrit/prompt_converter/pdf_converter.py
@@ -106,7 +106,8 @@ class PDFConverter(PromptConverter):
             raise ValueError("Each injection item must be a dictionary.")
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with PDF converter parameters.
+        """
+        Build identifier with PDF converter parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/persuasion_converter.py
+++ b/pyrit/prompt_converter/persuasion_converter.py
@@ -87,7 +87,7 @@ class PersuasionConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_target=self.converter_target,
             converter_specific_params={
                 "persuasion_technique": self._persuasion_technique,

--- a/pyrit/prompt_converter/persuasion_converter.py
+++ b/pyrit/prompt_converter/persuasion_converter.py
@@ -81,7 +81,8 @@ class PersuasionConverter(PromptConverter):
         self._persuasion_technique = persuasion_technique
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with persuasion parameters.
+        """
+        Build the converter identifier with persuasion parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/persuasion_converter.py
+++ b/pyrit/prompt_converter/persuasion_converter.py
@@ -13,6 +13,7 @@ from pyrit.exceptions import (
     pyrit_json_retry,
     remove_markdown_json,
 )
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import (
     Message,
     MessagePiece,
@@ -77,6 +78,20 @@ class PersuasionConverter(PromptConverter):
         except FileNotFoundError:
             raise ValueError(f"Persuasion technique '{persuasion_technique}' does not exist or is not supported.")
         self.system_prompt = str(prompt_template.value)
+        self._persuasion_technique = persuasion_technique
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build the converter identifier with persuasion parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_target=self.converter_target,
+            converter_specific_params={
+                "persuasion_technique": self._persuasion_technique,
+            },
+        )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
         """

--- a/pyrit/prompt_converter/prompt_converter.py
+++ b/pyrit/prompt_converter/prompt_converter.py
@@ -170,16 +170,16 @@ class PromptConverter(Identifiable[ConverterIdentifier]):
         Build and return the identifier for this converter.
 
         Subclasses can override this method to add converter-specific parameters
-        by calling _set_identifier with additional arguments.
+        by calling _create_identifier with additional arguments.
 
-        The default implementation calls _set_identifier with no extra parameters.
+        The default implementation calls _create_identifier with no extra parameters.
 
         Returns:
             ConverterIdentifier: The constructed identifier.
         """
-        return self._set_identifier()
+        return self._create_identifier()
 
-    def _set_identifier(
+    def _create_identifier(
         self,
         *,
         sub_converters: Optional[Sequence["PromptConverter"]] = None,

--- a/pyrit/prompt_converter/qr_code_converter.py
+++ b/pyrit/prompt_converter/qr_code_converter.py
@@ -68,7 +68,7 @@ class QRCodeConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "scale": self._scale,
                 "border": self._border,

--- a/pyrit/prompt_converter/qr_code_converter.py
+++ b/pyrit/prompt_converter/qr_code_converter.py
@@ -62,7 +62,8 @@ class QRCodeConverter(PromptConverter):
         self._img_serializer = data_serializer_factory(category="prompt-memory-entries", data_type="image_path")
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with QR code parameters.
+        """
+        Build identifier with QR code parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/qr_code_converter.py
+++ b/pyrit/prompt_converter/qr_code_converter.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import segno
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType, data_serializer_factory
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -59,6 +60,21 @@ class QRCodeConverter(PromptConverter):
         self._finder_light_color = finder_light_color or light_color
         self._border_color = border_color or light_color
         self._img_serializer = data_serializer_factory(category="prompt-memory-entries", data_type="image_path")
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with QR code parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "scale": self._scale,
+                "border": self._border,
+                "dark_color": self._dark_color,
+                "light_color": self._light_color,
+            }
+        )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
         """

--- a/pyrit/prompt_converter/random_capital_letters_converter.py
+++ b/pyrit/prompt_converter/random_capital_letters_converter.py
@@ -4,6 +4,7 @@
 import logging
 import random
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -25,6 +26,18 @@ class RandomCapitalLettersConverter(PromptConverter):
                 Defaults to 100.0. This includes decimal points in that range.
         """
         self.percentage = percentage
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with random capital letters parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "percentage": self.percentage,
+            }
+        )
 
     def is_percentage(self, input_string: float) -> bool:
         """

--- a/pyrit/prompt_converter/random_capital_letters_converter.py
+++ b/pyrit/prompt_converter/random_capital_letters_converter.py
@@ -34,7 +34,7 @@ class RandomCapitalLettersConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "percentage": self.percentage,
             }

--- a/pyrit/prompt_converter/random_capital_letters_converter.py
+++ b/pyrit/prompt_converter/random_capital_letters_converter.py
@@ -28,7 +28,8 @@ class RandomCapitalLettersConverter(PromptConverter):
         self.percentage = percentage
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with random capital letters parameters.
+        """
+        Build identifier with random capital letters parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/repeat_token_converter.py
+++ b/pyrit/prompt_converter/repeat_token_converter.py
@@ -89,7 +89,7 @@ class RepeatTokenConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "token_to_repeat": self._token_to_repeat.strip(),
                 "times_to_repeat": self._times_to_repeat,

--- a/pyrit/prompt_converter/repeat_token_converter.py
+++ b/pyrit/prompt_converter/repeat_token_converter.py
@@ -83,7 +83,8 @@ class RepeatTokenConverter(PromptConverter):
                 self.insert = insert
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with repeat token parameters.
+        """
+        Build the converter identifier with repeat token parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/search_replace_converter.py
+++ b/pyrit/prompt_converter/search_replace_converter.py
@@ -4,6 +4,7 @@
 import random
 import re
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -26,10 +27,22 @@ class SearchReplaceConverter(PromptConverter):
                 If a list is provided, a random element will be chosen for replacement.
             regex_flags (int): Regex flags to use for the replacement. Defaults to 0 (no flags).
         """
-        self.pattern = pattern
-        self.replace_list = [replace] if isinstance(replace, str) else replace
+        self._pattern = pattern
+        self._replace_list = [replace] if isinstance(replace, str) else replace
+        self._regex_flags = regex_flags
 
-        self.regex_flags = regex_flags
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build the converter identifier with search/replace parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "pattern": self._pattern,
+                "replace_list": self._replace_list,
+            },
+        )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
         """
@@ -48,8 +61,8 @@ class SearchReplaceConverter(PromptConverter):
         if not self.input_supported(input_type):
             raise ValueError("Input type not supported")
 
-        replace = random.choice(self.replace_list)
+        replace = random.choice(self._replace_list)
 
         return ConverterResult(
-            output_text=re.sub(self.pattern, replace, prompt, flags=self.regex_flags), output_type="text"
+            output_text=re.sub(self._pattern, replace, prompt, flags=self._regex_flags), output_type="text"
         )

--- a/pyrit/prompt_converter/search_replace_converter.py
+++ b/pyrit/prompt_converter/search_replace_converter.py
@@ -32,7 +32,8 @@ class SearchReplaceConverter(PromptConverter):
         self._regex_flags = regex_flags
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with search/replace parameters.
+        """
+        Build the converter identifier with search/replace parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/search_replace_converter.py
+++ b/pyrit/prompt_converter/search_replace_converter.py
@@ -38,7 +38,7 @@ class SearchReplaceConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "pattern": self._pattern,
                 "replace_list": self._replace_list,

--- a/pyrit/prompt_converter/selective_text_converter.py
+++ b/pyrit/prompt_converter/selective_text_converter.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 from pyrit.prompt_converter.text_selection_strategy import (
@@ -88,6 +89,22 @@ class SelectiveTextConverter(PromptConverter):
         self._word_separator = word_separator
         self._is_word_level = isinstance(selection_strategy, WordSelectionStrategy)
         self._is_token_based = isinstance(selection_strategy, TokenSelectionStrategy)
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with selective text converter parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            sub_converters=[self._converter],
+            converter_specific_params={
+                "selection_strategy": self._selection_strategy.__class__.__name__,
+                "preserve_tokens": self._preserve_tokens,
+                "start_token": self._start_token,
+                "end_token": self._end_token,
+            },
+        )
 
     def _validate_converter(
         self,

--- a/pyrit/prompt_converter/selective_text_converter.py
+++ b/pyrit/prompt_converter/selective_text_converter.py
@@ -97,7 +97,7 @@ class SelectiveTextConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             sub_converters=[self._converter],
             converter_specific_params={
                 "selection_strategy": self._selection_strategy.__class__.__name__,

--- a/pyrit/prompt_converter/selective_text_converter.py
+++ b/pyrit/prompt_converter/selective_text_converter.py
@@ -91,7 +91,8 @@ class SelectiveTextConverter(PromptConverter):
         self._is_token_based = isinstance(selection_strategy, TokenSelectionStrategy)
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with selective text converter parameters.
+        """
+        Build identifier with selective text converter parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/string_join_converter.py
+++ b/pyrit/prompt_converter/string_join_converter.py
@@ -31,7 +31,8 @@ class StringJoinConverter(WordLevelConverter):
         self._join_value = join_value
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with join parameters.
+        """
+        Build the converter identifier with join parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/string_join_converter.py
+++ b/pyrit/prompt_converter/string_join_converter.py
@@ -37,7 +37,7 @@ class StringJoinConverter(WordLevelConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "join_value": self._join_value,
             },

--- a/pyrit/prompt_converter/string_join_converter.py
+++ b/pyrit/prompt_converter/string_join_converter.py
@@ -3,6 +3,7 @@
 
 from typing import Optional
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.prompt_converter.text_selection_strategy import WordSelectionStrategy
 from pyrit.prompt_converter.word_level_converter import WordLevelConverter
 
@@ -27,7 +28,19 @@ class StringJoinConverter(WordLevelConverter):
                 If None, all words will be converted.
         """
         super().__init__(word_selection_strategy=word_selection_strategy)
-        self.join_value = join_value
+        self._join_value = join_value
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build the converter identifier with join parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "join_value": self._join_value,
+            },
+        )
 
     async def convert_word_async(self, word: str) -> str:
         """
@@ -39,4 +52,4 @@ class StringJoinConverter(WordLevelConverter):
         Returns:
             str: The converted word.
         """
-        return self.join_value.join(word)
+        return self._join_value.join(word)

--- a/pyrit/prompt_converter/suffix_append_converter.py
+++ b/pyrit/prompt_converter/suffix_append_converter.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -29,7 +30,19 @@ class SuffixAppendConverter(PromptConverter):
         if not suffix:
             raise ValueError("Please specify a suffix (str) to be appended to the prompt.")
 
-        self.suffix = suffix
+        self._suffix = suffix
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build the converter identifier with suffix parameter.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "suffix": self._suffix,
+            },
+        )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
         """
@@ -48,4 +61,4 @@ class SuffixAppendConverter(PromptConverter):
         if not self.input_supported(input_type):
             raise ValueError("Input type not supported")
 
-        return ConverterResult(output_text=prompt + " " + self.suffix, output_type="text")
+        return ConverterResult(output_text=prompt + " " + self._suffix, output_type="text")

--- a/pyrit/prompt_converter/suffix_append_converter.py
+++ b/pyrit/prompt_converter/suffix_append_converter.py
@@ -39,7 +39,7 @@ class SuffixAppendConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "suffix": self._suffix,
             },

--- a/pyrit/prompt_converter/suffix_append_converter.py
+++ b/pyrit/prompt_converter/suffix_append_converter.py
@@ -33,7 +33,8 @@ class SuffixAppendConverter(PromptConverter):
         self._suffix = suffix
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with suffix parameter.
+        """
+        Build the converter identifier with suffix parameter.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/template_segment_converter.py
+++ b/pyrit/prompt_converter/template_segment_converter.py
@@ -1,12 +1,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import hashlib
 import logging
 import pathlib
 import random
 from typing import Optional
 
 from pyrit.common.path import CONVERTER_SEED_PROMPT_PATH
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType, SeedPrompt
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -68,6 +70,20 @@ class TemplateSegmentConverter(PromptConverter):
                 f"Error validating template parameters: {str(e)}. "
                 f"Template parameters: {self.prompt_template.parameters}"
             )
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with template parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        template_hash = hashlib.sha256(str(self.prompt_template.value).encode("utf-8")).hexdigest()[:16]
+        return self._set_identifier(
+            converter_specific_params={
+                "template_hash": template_hash,
+                "number_parameters": self._number_parameters,
+            }
+        )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
         """

--- a/pyrit/prompt_converter/template_segment_converter.py
+++ b/pyrit/prompt_converter/template_segment_converter.py
@@ -79,7 +79,7 @@ class TemplateSegmentConverter(PromptConverter):
             ConverterIdentifier: The identifier for this converter.
         """
         template_hash = hashlib.sha256(str(self.prompt_template.value).encode("utf-8")).hexdigest()[:16]
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "template_hash": template_hash,
                 "number_parameters": self._number_parameters,

--- a/pyrit/prompt_converter/template_segment_converter.py
+++ b/pyrit/prompt_converter/template_segment_converter.py
@@ -72,7 +72,8 @@ class TemplateSegmentConverter(PromptConverter):
             )
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with template parameters.
+        """
+        Build identifier with template parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/tense_converter.py
+++ b/pyrit/prompt_converter/tense_converter.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import CONVERTER_SEED_PROMPT_PATH
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import SeedPrompt
 from pyrit.prompt_converter.llm_generic_text_converter import LLMGenericTextConverter
 from pyrit.prompt_target import PromptChatTarget
@@ -49,4 +50,18 @@ class TenseConverter(LLMGenericTextConverter):
             converter_target=converter_target,
             system_prompt_template=prompt_template,
             tense=tense,
+        )
+        self._tense = tense
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build the converter identifier with tense parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_target=self._converter_target,
+            converter_specific_params={
+                "tense": self._tense,
+            },
         )

--- a/pyrit/prompt_converter/tense_converter.py
+++ b/pyrit/prompt_converter/tense_converter.py
@@ -60,7 +60,7 @@ class TenseConverter(LLMGenericTextConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_target=self._converter_target,
             converter_specific_params={
                 "tense": self._tense,

--- a/pyrit/prompt_converter/tense_converter.py
+++ b/pyrit/prompt_converter/tense_converter.py
@@ -54,7 +54,8 @@ class TenseConverter(LLMGenericTextConverter):
         self._tense = tense
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with tense parameters.
+        """
+        Build the converter identifier with tense parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/text_jailbreak_converter.py
+++ b/pyrit/prompt_converter/text_jailbreak_converter.py
@@ -31,7 +31,7 @@ class TextJailbreakConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "jailbreak_template_path": self.jail_break_template.template_source,
             }

--- a/pyrit/prompt_converter/text_jailbreak_converter.py
+++ b/pyrit/prompt_converter/text_jailbreak_converter.py
@@ -25,7 +25,8 @@ class TextJailbreakConverter(PromptConverter):
         self.jail_break_template = jailbreak_template
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with jailbreak template path.
+        """
+        Build identifier with jailbreak template path.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/text_jailbreak_converter.py
+++ b/pyrit/prompt_converter/text_jailbreak_converter.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 from pyrit.datasets import TextJailBreak
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -22,6 +23,18 @@ class TextJailbreakConverter(PromptConverter):
             jailbreak_template (TextJailBreak): The jailbreak template to use for conversion.
         """
         self.jail_break_template = jailbreak_template
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with jailbreak template path.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "jailbreak_template_path": self.jail_break_template.template_source,
+            }
+        )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
         """

--- a/pyrit/prompt_converter/token_smuggling/ascii_smuggler_converter.py
+++ b/pyrit/prompt_converter/token_smuggling/ascii_smuggler_converter.py
@@ -42,7 +42,7 @@ class AsciiSmugglerConverter(SmugglerConverter):
         """
         base_params = super()._build_identifier().converter_specific_params or {}
         base_params["unicode_tags"] = self.unicode_tags
-        return self._set_identifier(converter_specific_params=base_params)
+        return self._create_identifier(converter_specific_params=base_params)
 
     def encode_message(self, *, message: str) -> tuple[str, str]:
         """

--- a/pyrit/prompt_converter/token_smuggling/ascii_smuggler_converter.py
+++ b/pyrit/prompt_converter/token_smuggling/ascii_smuggler_converter.py
@@ -4,6 +4,7 @@
 import logging
 from typing import Literal
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.prompt_converter.token_smuggling.base import SmugglerConverter
 
 logger = logging.getLogger(__name__)
@@ -31,6 +32,16 @@ class AsciiSmugglerConverter(SmugglerConverter):
         """
         self.unicode_tags = unicode_tags
         super().__init__(action=action)
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with ASCII smuggler parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        base_params = super()._build_identifier().converter_specific_params or {}
+        base_params["unicode_tags"] = self.unicode_tags
+        return self._set_identifier(converter_specific_params=base_params)
 
     def encode_message(self, *, message: str) -> tuple[str, str]:
         """

--- a/pyrit/prompt_converter/token_smuggling/ascii_smuggler_converter.py
+++ b/pyrit/prompt_converter/token_smuggling/ascii_smuggler_converter.py
@@ -34,7 +34,8 @@ class AsciiSmugglerConverter(SmugglerConverter):
         super().__init__(action=action)
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with ASCII smuggler parameters.
+        """
+        Build identifier with ASCII smuggler parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/token_smuggling/base.py
+++ b/pyrit/prompt_converter/token_smuggling/base.py
@@ -44,7 +44,7 @@ class SmugglerConverter(PromptConverter, abc.ABC):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "action": self.action,
             }

--- a/pyrit/prompt_converter/token_smuggling/base.py
+++ b/pyrit/prompt_converter/token_smuggling/base.py
@@ -5,6 +5,7 @@ import abc
 import logging
 from typing import Literal, Tuple
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -35,6 +36,18 @@ class SmugglerConverter(PromptConverter, abc.ABC):
         if action not in ["encode", "decode"]:
             raise ValueError("Action must be either 'encode' or 'decode'")
         self.action = action
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with smuggler action.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "action": self.action,
+            }
+        )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
         """

--- a/pyrit/prompt_converter/token_smuggling/base.py
+++ b/pyrit/prompt_converter/token_smuggling/base.py
@@ -38,7 +38,8 @@ class SmugglerConverter(PromptConverter, abc.ABC):
         self.action = action
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with smuggler action.
+        """
+        Build identifier with smuggler action.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/token_smuggling/sneaky_bits_smuggler_converter.py
+++ b/pyrit/prompt_converter/token_smuggling/sneaky_bits_smuggler_converter.py
@@ -53,7 +53,7 @@ class SneakyBitsSmugglerConverter(SmugglerConverter):
         base_params = super()._build_identifier().converter_specific_params or {}
         base_params["zero_char_codepoint"] = hex(ord(self.zero_char))
         base_params["one_char_codepoint"] = hex(ord(self.one_char))
-        return self._set_identifier(converter_specific_params=base_params)
+        return self._create_identifier(converter_specific_params=base_params)
 
     def encode_message(self, message: str) -> Tuple[str, str]:
         """

--- a/pyrit/prompt_converter/token_smuggling/sneaky_bits_smuggler_converter.py
+++ b/pyrit/prompt_converter/token_smuggling/sneaky_bits_smuggler_converter.py
@@ -4,6 +4,7 @@
 import logging
 from typing import Literal, Optional, Tuple
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.prompt_converter.token_smuggling.base import SmugglerConverter
 
 logger = logging.getLogger(__name__)
@@ -41,6 +42,17 @@ class SneakyBitsSmugglerConverter(SmugglerConverter):
         super().__init__(action=action)
         self.zero_char = zero_char if zero_char is not None else "\u2062"  # Invisible Times
         self.one_char = one_char if one_char is not None else "\u2064"  # Invisible Plus
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with sneaky bits parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        base_params = super()._build_identifier().converter_specific_params or {}
+        base_params["zero_char_codepoint"] = hex(ord(self.zero_char))
+        base_params["one_char_codepoint"] = hex(ord(self.one_char))
+        return self._set_identifier(converter_specific_params=base_params)
 
     def encode_message(self, message: str) -> Tuple[str, str]:
         """

--- a/pyrit/prompt_converter/token_smuggling/sneaky_bits_smuggler_converter.py
+++ b/pyrit/prompt_converter/token_smuggling/sneaky_bits_smuggler_converter.py
@@ -44,7 +44,8 @@ class SneakyBitsSmugglerConverter(SmugglerConverter):
         self.one_char = one_char if one_char is not None else "\u2064"  # Invisible Plus
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with sneaky bits parameters.
+        """
+        Build identifier with sneaky bits parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/token_smuggling/variation_selector_smuggler_converter.py
+++ b/pyrit/prompt_converter/token_smuggling/variation_selector_smuggler_converter.py
@@ -53,7 +53,8 @@ class VariationSelectorSmugglerConverter(SmugglerConverter):
         self.embed_in_base = embed_in_base
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with variation selector parameters.
+        """
+        Build identifier with variation selector parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/token_smuggling/variation_selector_smuggler_converter.py
+++ b/pyrit/prompt_converter/token_smuggling/variation_selector_smuggler_converter.py
@@ -62,7 +62,7 @@ class VariationSelectorSmugglerConverter(SmugglerConverter):
         base_params = super()._build_identifier().converter_specific_params or {}
         base_params["base_char"] = self.utf8_base_char
         base_params["embed_in_base"] = self.embed_in_base
-        return self._set_identifier(converter_specific_params=base_params)
+        return self._create_identifier(converter_specific_params=base_params)
 
     def encode_message(self, message: str) -> Tuple[str, str]:
         """

--- a/pyrit/prompt_converter/token_smuggling/variation_selector_smuggler_converter.py
+++ b/pyrit/prompt_converter/token_smuggling/variation_selector_smuggler_converter.py
@@ -4,6 +4,7 @@
 import logging
 from typing import Literal, Optional, Tuple
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.prompt_converter.token_smuggling.base import SmugglerConverter
 
 logger = logging.getLogger(__name__)
@@ -50,6 +51,17 @@ class VariationSelectorSmugglerConverter(SmugglerConverter):
         super().__init__(action=action)
         self.utf8_base_char = base_char_utf8 if base_char_utf8 is not None else "😊"
         self.embed_in_base = embed_in_base
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with variation selector parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        base_params = super()._build_identifier().converter_specific_params or {}
+        base_params["base_char"] = self.utf8_base_char
+        base_params["embed_in_base"] = self.embed_in_base
+        return self._set_identifier(converter_specific_params=base_params)
 
     def encode_message(self, message: str) -> Tuple[str, str]:
         """

--- a/pyrit/prompt_converter/tone_converter.py
+++ b/pyrit/prompt_converter/tone_converter.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import CONVERTER_SEED_PROMPT_PATH
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import SeedPrompt
 from pyrit.prompt_converter.llm_generic_text_converter import LLMGenericTextConverter
 from pyrit.prompt_target import PromptChatTarget
@@ -52,4 +53,18 @@ class ToneConverter(LLMGenericTextConverter):
             converter_target=converter_target,
             system_prompt_template=prompt_template,
             tone=tone,
+        )
+        self._tone = tone
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build the converter identifier with tone parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_target=self._converter_target,
+            converter_specific_params={
+                "tone": self._tone,
+            },
         )

--- a/pyrit/prompt_converter/tone_converter.py
+++ b/pyrit/prompt_converter/tone_converter.py
@@ -63,7 +63,7 @@ class ToneConverter(LLMGenericTextConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_target=self._converter_target,
             converter_specific_params={
                 "tone": self._tone,

--- a/pyrit/prompt_converter/tone_converter.py
+++ b/pyrit/prompt_converter/tone_converter.py
@@ -57,7 +57,8 @@ class ToneConverter(LLMGenericTextConverter):
         self._tone = tone
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with tone parameters.
+        """
+        Build the converter identifier with tone parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/translation_converter.py
+++ b/pyrit/prompt_converter/translation_converter.py
@@ -83,7 +83,8 @@ class TranslationConverter(PromptConverter):
         self.system_prompt = prompt_template.render_template_value(languages=language)
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with translation parameters.
+        """
+        Build the converter identifier with translation parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/translation_converter.py
+++ b/pyrit/prompt_converter/translation_converter.py
@@ -89,7 +89,7 @@ class TranslationConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_target=self.converter_target,
             converter_specific_params={
                 "language": self.language,

--- a/pyrit/prompt_converter/translation_converter.py
+++ b/pyrit/prompt_converter/translation_converter.py
@@ -16,6 +16,7 @@ from tenacity import (
 
 from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import CONVERTER_SEED_PROMPT_PATH
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import (
     Message,
     MessagePiece,
@@ -80,6 +81,19 @@ class TranslationConverter(PromptConverter):
         self.language = language.lower()
 
         self.system_prompt = prompt_template.render_template_value(languages=language)
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build the converter identifier with translation parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_target=self.converter_target,
+            converter_specific_params={
+                "language": self.language,
+            },
+        )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
         """

--- a/pyrit/prompt_converter/transparency_attack_converter.py
+++ b/pyrit/prompt_converter/transparency_attack_converter.py
@@ -10,6 +10,7 @@ from typing import Tuple
 import numpy
 from PIL import Image
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType, data_serializer_factory
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -183,6 +184,21 @@ class TransparencyAttackConverter(PromptConverter):
             raise ValueError(f"Convergence patience must be a positive integer, got {convergence_patience}")
 
         self._cached_benign_image = self._load_and_preprocess_image(str(benign_image_path))
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with transparency attack parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "benign_image_path": str(self.benign_image_path),
+                "size": self.size,
+                "steps": self.steps,
+                "learning_rate": self.learning_rate,
+            }
+        )
 
     def _load_and_preprocess_image(self, path: str) -> numpy.ndarray:  # type: ignore[type-arg, unused-ignore]
         """

--- a/pyrit/prompt_converter/transparency_attack_converter.py
+++ b/pyrit/prompt_converter/transparency_attack_converter.py
@@ -186,7 +186,8 @@ class TransparencyAttackConverter(PromptConverter):
         self._cached_benign_image = self._load_and_preprocess_image(str(benign_image_path))
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with transparency attack parameters.
+        """
+        Build identifier with transparency attack parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/transparency_attack_converter.py
+++ b/pyrit/prompt_converter/transparency_attack_converter.py
@@ -192,7 +192,7 @@ class TransparencyAttackConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "benign_image_path": str(self.benign_image_path),
                 "size": self.size,

--- a/pyrit/prompt_converter/unicode_confusable_converter.py
+++ b/pyrit/prompt_converter/unicode_confusable_converter.py
@@ -9,6 +9,7 @@ from typing import Literal
 from confusable_homoglyphs.confusables import is_confusable
 from confusables import confusable_characters
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -57,6 +58,19 @@ class UnicodeConfusableConverter(PromptConverter):
             )
         self._source_package = source_package
         self._deterministic = deterministic
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build the converter identifier with unicode confusable parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "source_package": self._source_package,
+                "deterministic": self._deterministic,
+            },
+        )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
         """

--- a/pyrit/prompt_converter/unicode_confusable_converter.py
+++ b/pyrit/prompt_converter/unicode_confusable_converter.py
@@ -66,7 +66,7 @@ class UnicodeConfusableConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "source_package": self._source_package,
                 "deterministic": self._deterministic,

--- a/pyrit/prompt_converter/unicode_confusable_converter.py
+++ b/pyrit/prompt_converter/unicode_confusable_converter.py
@@ -60,7 +60,8 @@ class UnicodeConfusableConverter(PromptConverter):
         self._deterministic = deterministic
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with unicode confusable parameters.
+        """
+        Build the converter identifier with unicode confusable parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/unicode_replacement_converter.py
+++ b/pyrit/prompt_converter/unicode_replacement_converter.py
@@ -3,6 +3,7 @@
 
 from typing import Optional
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.prompt_converter.text_selection_strategy import WordSelectionStrategy
 from pyrit.prompt_converter.word_level_converter import WordLevelConverter
 
@@ -28,6 +29,16 @@ class UnicodeReplacementConverter(WordLevelConverter):
         """
         super().__init__(word_selection_strategy=word_selection_strategy)
         self.encode_spaces = encode_spaces
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with unicode replacement parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        base_params = super()._build_identifier().converter_specific_params or {}
+        base_params["encode_spaces"] = self.encode_spaces
+        return self._set_identifier(converter_specific_params=base_params)
 
     async def convert_word_async(self, word: str) -> str:
         """

--- a/pyrit/prompt_converter/unicode_replacement_converter.py
+++ b/pyrit/prompt_converter/unicode_replacement_converter.py
@@ -39,7 +39,7 @@ class UnicodeReplacementConverter(WordLevelConverter):
         """
         base_params = super()._build_identifier().converter_specific_params or {}
         base_params["encode_spaces"] = self.encode_spaces
-        return self._set_identifier(converter_specific_params=base_params)
+        return self._create_identifier(converter_specific_params=base_params)
 
     async def convert_word_async(self, word: str) -> str:
         """

--- a/pyrit/prompt_converter/unicode_replacement_converter.py
+++ b/pyrit/prompt_converter/unicode_replacement_converter.py
@@ -31,7 +31,8 @@ class UnicodeReplacementConverter(WordLevelConverter):
         self.encode_spaces = encode_spaces
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with unicode replacement parameters.
+        """
+        Build identifier with unicode replacement parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/unicode_sub_converter.py
+++ b/pyrit/prompt_converter/unicode_sub_converter.py
@@ -30,7 +30,7 @@ class UnicodeSubstitutionConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "start_value": self.startValue,
             }

--- a/pyrit/prompt_converter/unicode_sub_converter.py
+++ b/pyrit/prompt_converter/unicode_sub_converter.py
@@ -24,7 +24,8 @@ class UnicodeSubstitutionConverter(PromptConverter):
         self.startValue = start_value
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with unicode substitution parameters.
+        """
+        Build identifier with unicode substitution parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/unicode_sub_converter.py
+++ b/pyrit/prompt_converter/unicode_sub_converter.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 
@@ -21,6 +22,18 @@ class UnicodeSubstitutionConverter(PromptConverter):
             start_value (int): The unicode starting point to use for encoding.
         """
         self.startValue = start_value
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with unicode substitution parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "start_value": self.startValue,
+            }
+        )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
         """

--- a/pyrit/prompt_converter/variation_converter.py
+++ b/pyrit/prompt_converter/variation_converter.py
@@ -69,7 +69,8 @@ class VariationConverter(PromptConverter):
         self.system_prompt = str(prompt_template.render_template_value(number_iterations=str(self.number_variations)))
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with variation parameters.
+        """
+        Build the converter identifier with variation parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/variation_converter.py
+++ b/pyrit/prompt_converter/variation_converter.py
@@ -75,7 +75,7 @@ class VariationConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_target=self.converter_target,
         )
 

--- a/pyrit/prompt_converter/variation_converter.py
+++ b/pyrit/prompt_converter/variation_converter.py
@@ -15,6 +15,7 @@ from pyrit.exceptions import (
     pyrit_json_retry,
     remove_markdown_json,
 )
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import (
     Message,
     MessagePiece,
@@ -66,6 +67,16 @@ class VariationConverter(PromptConverter):
         self.number_variations = 1
 
         self.system_prompt = str(prompt_template.render_template_value(number_iterations=str(self.number_variations)))
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build the converter identifier with variation parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_target=self.converter_target,
+        )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
         """

--- a/pyrit/prompt_converter/word_level_converter.py
+++ b/pyrit/prompt_converter/word_level_converter.py
@@ -48,7 +48,8 @@ class WordLevelConverter(PromptConverter):
         self._word_split_separator = word_split_separator
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build identifier with word-level converter parameters.
+        """
+        Build identifier with word-level converter parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/word_level_converter.py
+++ b/pyrit/prompt_converter/word_level_converter.py
@@ -4,6 +4,7 @@
 import abc
 from typing import Optional
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.models import PromptDataType
 from pyrit.prompt_converter.prompt_converter import ConverterResult, PromptConverter
 from pyrit.prompt_converter.text_selection_strategy import (
@@ -45,6 +46,19 @@ class WordLevelConverter(PromptConverter):
         super().__init__()
         self._word_selection_strategy = word_selection_strategy or AllWordsSelectionStrategy()
         self._word_split_separator = word_split_separator
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build identifier with word-level converter parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "word_selection_strategy": self._word_selection_strategy.__class__.__name__,
+                "word_split_separator": self._word_split_separator,
+            }
+        )
 
     @abc.abstractmethod
     async def convert_word_async(self, word: str) -> str:

--- a/pyrit/prompt_converter/word_level_converter.py
+++ b/pyrit/prompt_converter/word_level_converter.py
@@ -54,7 +54,7 @@ class WordLevelConverter(PromptConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "word_selection_strategy": self._word_selection_strategy.__class__.__name__,
                 "word_split_separator": self._word_split_separator,

--- a/pyrit/prompt_converter/zalgo_converter.py
+++ b/pyrit/prompt_converter/zalgo_converter.py
@@ -5,6 +5,7 @@ import logging
 import random
 from typing import Optional
 
+from pyrit.identifiers import ConverterIdentifier
 from pyrit.prompt_converter.text_selection_strategy import WordSelectionStrategy
 from pyrit.prompt_converter.word_level_converter import WordLevelConverter
 
@@ -39,6 +40,18 @@ class ZalgoConverter(WordLevelConverter):
         super().__init__(word_selection_strategy=word_selection_strategy)
         self._intensity = self._normalize_intensity(intensity)
         self._seed = seed
+
+    def _build_identifier(self) -> ConverterIdentifier:
+        """Build the converter identifier with zalgo parameters.
+
+        Returns:
+            ConverterIdentifier: The identifier for this converter.
+        """
+        return self._set_identifier(
+            converter_specific_params={
+                "intensity": self._intensity,
+            },
+        )
 
     def _normalize_intensity(self, intensity: int) -> int:
         try:

--- a/pyrit/prompt_converter/zalgo_converter.py
+++ b/pyrit/prompt_converter/zalgo_converter.py
@@ -42,7 +42,8 @@ class ZalgoConverter(WordLevelConverter):
         self._seed = seed
 
     def _build_identifier(self) -> ConverterIdentifier:
-        """Build the converter identifier with zalgo parameters.
+        """
+        Build the converter identifier with zalgo parameters.
 
         Returns:
             ConverterIdentifier: The identifier for this converter.

--- a/pyrit/prompt_converter/zalgo_converter.py
+++ b/pyrit/prompt_converter/zalgo_converter.py
@@ -48,7 +48,7 @@ class ZalgoConverter(WordLevelConverter):
         Returns:
             ConverterIdentifier: The identifier for this converter.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             converter_specific_params={
                 "intensity": self._intensity,
             },

--- a/pyrit/score/conversation_scorer.py
+++ b/pyrit/score/conversation_scorer.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from typing import Optional, Type, cast
 from uuid import UUID
 
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import Message, MessagePiece, Score
 from pyrit.score.float_scale.float_scale_scorer import FloatScaleScorer
 from pyrit.score.scorer import Scorer
@@ -195,9 +196,13 @@ def create_conversation_scorer(
             """Return the wrapped scorer."""
             return self._wrapped_scorer
 
-        def _build_identifier(self) -> None:
-            """Build the scorer evaluation identifier for this conversation scorer."""
-            self._set_identifier(
+        def _build_identifier(self) -> ScorerIdentifier:
+            """Build the scorer evaluation identifier for this conversation scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+            return self._set_identifier(
                 sub_scorers=[self._wrapped_scorer],
             )
 

--- a/pyrit/score/conversation_scorer.py
+++ b/pyrit/score/conversation_scorer.py
@@ -197,11 +197,12 @@ def create_conversation_scorer(
             return self._wrapped_scorer
 
         def _build_identifier(self) -> ScorerIdentifier:
-            """Build the scorer evaluation identifier for this conversation scorer.
+            """
+            Build the scorer evaluation identifier for this conversation scorer.
 
-        Returns:
-            ScorerIdentifier: The identifier for this scorer.
-        """
+            Returns:
+                ScorerIdentifier: The identifier for this scorer.
+            """
             return self._set_identifier(
                 sub_scorers=[self._wrapped_scorer],
             )

--- a/pyrit/score/conversation_scorer.py
+++ b/pyrit/score/conversation_scorer.py
@@ -203,7 +203,7 @@ def create_conversation_scorer(
             Returns:
                 ScorerIdentifier: The identifier for this scorer.
             """
-            return self._set_identifier(
+            return self._create_identifier(
                 sub_scorers=[self._wrapped_scorer],
             )
 

--- a/pyrit/score/float_scale/azure_content_filter_scorer.py
+++ b/pyrit/score/float_scale/azure_content_filter_scorer.py
@@ -148,7 +148,8 @@ class AzureContentFilterScorer(FloatScaleScorer):
         return [category.value for category in self._harm_categories]
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/float_scale/azure_content_filter_scorer.py
+++ b/pyrit/score/float_scale/azure_content_filter_scorer.py
@@ -17,6 +17,7 @@ from azure.core.credentials import AzureKeyCredential
 
 from pyrit.auth import TokenProviderCredential
 from pyrit.common import default_values
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import (
     DataTypeSerializer,
     MessagePiece,
@@ -146,9 +147,13 @@ class AzureContentFilterScorer(FloatScaleScorer):
         """Get the string values of the configured harm categories for API calls."""
         return [category.value for category in self._harm_categories]
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             scorer_specific_params={
                 "score_categories": self._category_values,
             }

--- a/pyrit/score/float_scale/azure_content_filter_scorer.py
+++ b/pyrit/score/float_scale/azure_content_filter_scorer.py
@@ -154,7 +154,7 @@ class AzureContentFilterScorer(FloatScaleScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             scorer_specific_params={
                 "score_categories": self._category_values,
             }

--- a/pyrit/score/float_scale/insecure_code_scorer.py
+++ b/pyrit/score/float_scale/insecure_code_scorer.py
@@ -63,7 +63,7 @@ class InsecureCodeScorer(FloatScaleScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             system_prompt_template=self._system_prompt,
             prompt_target=self._prompt_target,
         )

--- a/pyrit/score/float_scale/insecure_code_scorer.py
+++ b/pyrit/score/float_scale/insecure_code_scorer.py
@@ -7,6 +7,7 @@ from typing import Optional, Union
 from pyrit.common import verify_and_resolve_path
 from pyrit.common.path import SCORER_SEED_PROMPT_PATH
 from pyrit.exceptions.exception_classes import InvalidJsonException
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import MessagePiece, Score, SeedPrompt
 from pyrit.prompt_target import PromptChatTarget
 from pyrit.score.float_scale.float_scale_scorer import FloatScaleScorer
@@ -55,9 +56,13 @@ class InsecureCodeScorer(FloatScaleScorer):
         # Render the system prompt with the harm category
         self._system_prompt = scoring_instructions_template.render_template_value(harm_categories=self._harm_category)
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             system_prompt_template=self._system_prompt,
             prompt_target=self._prompt_target,
         )

--- a/pyrit/score/float_scale/insecure_code_scorer.py
+++ b/pyrit/score/float_scale/insecure_code_scorer.py
@@ -57,7 +57,8 @@ class InsecureCodeScorer(FloatScaleScorer):
         self._system_prompt = scoring_instructions_template.render_template_value(harm_categories=self._harm_category)
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/float_scale/plagiarism_scorer.py
+++ b/pyrit/score/float_scale/plagiarism_scorer.py
@@ -57,7 +57,8 @@ class PlagiarismScorer(FloatScaleScorer):
         self.n = n
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/float_scale/plagiarism_scorer.py
+++ b/pyrit/score/float_scale/plagiarism_scorer.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 
 import numpy as np
 
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import MessagePiece, Score
 from pyrit.score.float_scale.float_scale_scorer import FloatScaleScorer
 from pyrit.score.scorer_prompt_validator import ScorerPromptValidator
@@ -55,9 +56,13 @@ class PlagiarismScorer(FloatScaleScorer):
         self.metric = metric
         self.n = n
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             scorer_specific_params={
                 "reference_text": self.reference_text,
                 "metric": self.metric.value,

--- a/pyrit/score/float_scale/plagiarism_scorer.py
+++ b/pyrit/score/float_scale/plagiarism_scorer.py
@@ -63,7 +63,7 @@ class PlagiarismScorer(FloatScaleScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             scorer_specific_params={
                 "reference_text": self.reference_text,
                 "metric": self.metric.value,

--- a/pyrit/score/float_scale/self_ask_general_float_scale_scorer.py
+++ b/pyrit/score/float_scale/self_ask_general_float_scale_scorer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from typing import Optional
 
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import MessagePiece, Score, UnvalidatedScore
 from pyrit.prompt_target import PromptChatTarget
 from pyrit.score.float_scale.float_scale_scorer import FloatScaleScorer
@@ -87,9 +88,13 @@ class SelfAskGeneralFloatScaleScorer(FloatScaleScorer):
         self._metadata_output_key = metadata_output_key
         self._category_output_key = category_output_key
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             system_prompt_template=self._system_prompt_format_string,
             user_prompt_template=self._prompt_format_string,
             prompt_target=self._prompt_target,

--- a/pyrit/score/float_scale/self_ask_general_float_scale_scorer.py
+++ b/pyrit/score/float_scale/self_ask_general_float_scale_scorer.py
@@ -95,7 +95,7 @@ class SelfAskGeneralFloatScaleScorer(FloatScaleScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             system_prompt_template=self._system_prompt_format_string,
             user_prompt_template=self._prompt_format_string,
             prompt_target=self._prompt_target,

--- a/pyrit/score/float_scale/self_ask_general_float_scale_scorer.py
+++ b/pyrit/score/float_scale/self_ask_general_float_scale_scorer.py
@@ -89,7 +89,8 @@ class SelfAskGeneralFloatScaleScorer(FloatScaleScorer):
         self._category_output_key = category_output_key
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/float_scale/self_ask_likert_scorer.py
+++ b/pyrit/score/float_scale/self_ask_likert_scorer.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Optional
 import yaml
 
 from pyrit.common.path import HARM_DEFINITION_PATH, SCORER_LIKERT_PATH
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import MessagePiece, Score, SeedPrompt, UnvalidatedScore
 from pyrit.prompt_target import PromptChatTarget
 from pyrit.score.float_scale.float_scale_scorer import FloatScaleScorer
@@ -189,9 +190,13 @@ class SelfAskLikertScorer(FloatScaleScorer):
 
         self._set_likert_scale_system_prompt(likert_scale_path=likert_scale.path)
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             system_prompt_template=self._system_prompt,
             prompt_target=self._prompt_target,
         )

--- a/pyrit/score/float_scale/self_ask_likert_scorer.py
+++ b/pyrit/score/float_scale/self_ask_likert_scorer.py
@@ -191,7 +191,8 @@ class SelfAskLikertScorer(FloatScaleScorer):
         self._set_likert_scale_system_prompt(likert_scale_path=likert_scale.path)
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/float_scale/self_ask_likert_scorer.py
+++ b/pyrit/score/float_scale/self_ask_likert_scorer.py
@@ -197,7 +197,7 @@ class SelfAskLikertScorer(FloatScaleScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             system_prompt_template=self._system_prompt,
             prompt_target=self._prompt_target,
         )

--- a/pyrit/score/float_scale/self_ask_scale_scorer.py
+++ b/pyrit/score/float_scale/self_ask_scale_scorer.py
@@ -91,7 +91,7 @@ class SelfAskScaleScorer(FloatScaleScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             system_prompt_template=self._system_prompt,
             user_prompt_template="objective: {objective}\nresponse: {response}",
             prompt_target=self._prompt_target,

--- a/pyrit/score/float_scale/self_ask_scale_scorer.py
+++ b/pyrit/score/float_scale/self_ask_scale_scorer.py
@@ -9,6 +9,7 @@ import yaml
 
 from pyrit.common import verify_and_resolve_path
 from pyrit.common.path import SCORER_SCALES_PATH
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import MessagePiece, Score, SeedPrompt, UnvalidatedScore
 from pyrit.prompt_target import PromptChatTarget
 from pyrit.score.float_scale.float_scale_scorer import FloatScaleScorer
@@ -83,9 +84,13 @@ class SelfAskScaleScorer(FloatScaleScorer):
 
         self._system_prompt = scoring_instructions_template.render_template_value(**scale_args)
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             system_prompt_template=self._system_prompt,
             user_prompt_template="objective: {objective}\nresponse: {response}",
             prompt_target=self._prompt_target,

--- a/pyrit/score/float_scale/self_ask_scale_scorer.py
+++ b/pyrit/score/float_scale/self_ask_scale_scorer.py
@@ -85,7 +85,8 @@ class SelfAskScaleScorer(FloatScaleScorer):
         self._system_prompt = scoring_instructions_template.render_template_value(**scale_args)
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/float_scale/video_float_scale_scorer.py
+++ b/pyrit/score/float_scale/video_float_scale_scorer.py
@@ -63,7 +63,8 @@ class VideoFloatScaleScorer(FloatScaleScorer, _BaseVideoScorer):
         self._score_aggregator = score_aggregator
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/float_scale/video_float_scale_scorer.py
+++ b/pyrit/score/float_scale/video_float_scale_scorer.py
@@ -3,6 +3,7 @@
 
 from typing import List, Optional
 
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import MessagePiece, Score
 from pyrit.score.float_scale.float_scale_score_aggregator import (
     FloatScaleAggregatorFunc,
@@ -61,9 +62,13 @@ class VideoFloatScaleScorer(FloatScaleScorer, _BaseVideoScorer):
         )
         self._score_aggregator = score_aggregator
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             sub_scorers=[self.image_scorer],
             score_aggregator=self._score_aggregator.__name__,
             scorer_specific_params={

--- a/pyrit/score/float_scale/video_float_scale_scorer.py
+++ b/pyrit/score/float_scale/video_float_scale_scorer.py
@@ -69,7 +69,7 @@ class VideoFloatScaleScorer(FloatScaleScorer, _BaseVideoScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             sub_scorers=[self.image_scorer],
             score_aggregator=self._score_aggregator.__name__,
             scorer_specific_params={

--- a/pyrit/score/human/human_in_the_loop_gradio.py
+++ b/pyrit/score/human/human_in_the_loop_gradio.py
@@ -4,6 +4,7 @@
 import asyncio
 from typing import Optional
 
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import MessagePiece, Score
 from pyrit.score.scorer_prompt_validator import ScorerPromptValidator
 from pyrit.score.true_false.true_false_score_aggregator import (
@@ -46,9 +47,13 @@ class HumanInTheLoopScorerGradio(TrueFalseScorer):
         self._rpc_server = AppRPCServer(open_browser=open_browser)
         self._rpc_server.start()
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             score_aggregator=self._score_aggregator.__name__,
         )
 

--- a/pyrit/score/human/human_in_the_loop_gradio.py
+++ b/pyrit/score/human/human_in_the_loop_gradio.py
@@ -48,7 +48,8 @@ class HumanInTheLoopScorerGradio(TrueFalseScorer):
         self._rpc_server.start()
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/human/human_in_the_loop_gradio.py
+++ b/pyrit/score/human/human_in_the_loop_gradio.py
@@ -54,7 +54,7 @@ class HumanInTheLoopScorerGradio(TrueFalseScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             score_aggregator=self._score_aggregator.__name__,
         )
 

--- a/pyrit/score/scorer.py
+++ b/pyrit/score/scorer.py
@@ -95,18 +95,6 @@ class Scorer(Identifiable[ScorerIdentifier], abc.ABC):
         else:
             return "unknown"
 
-    def get_identifier(self) -> ScorerIdentifier:
-        """
-        Get the scorer identifier. Built lazily on first access.
-
-        Returns:
-            ScorerIdentifier: The identifier containing all configuration parameters.
-        """
-        if self._identifier is None:
-            self._build_identifier()
-            assert self._identifier is not None, "_build_identifier must set _identifier"
-        return self._identifier
-
     @property
     def _memory(self) -> MemoryInterface:
         return CentralMemory.get_memory_instance()
@@ -120,9 +108,9 @@ class Scorer(Identifiable[ScorerIdentifier], abc.ABC):
         score_aggregator: Optional[str] = None,
         scorer_specific_params: Optional[Dict[str, Any]] = None,
         prompt_target: Optional[PromptTarget] = None,
-    ) -> None:
+    ) -> ScorerIdentifier:
         """
-        Construct the scorer evaluation identifier.
+        Construct and return the scorer identifier.
 
         Args:
             system_prompt_template (Optional[str]): The system prompt template used by this scorer. Defaults to None.
@@ -132,6 +120,9 @@ class Scorer(Identifiable[ScorerIdentifier], abc.ABC):
             scorer_specific_params (Optional[Dict[str, Any]]): Additional scorer-specific parameters.
                 Defaults to None.
             prompt_target (Optional[PromptTarget]): The prompt target used by this scorer. Defaults to None.
+
+        Returns:
+            ScorerIdentifier: The constructed identifier.
         """
         # Build sub_identifier from sub_scorers (store as dicts for storage)
         sub_identifier: Optional[List[ScorerIdentifier]] = None
@@ -147,7 +138,7 @@ class Scorer(Identifiable[ScorerIdentifier], abc.ABC):
                 if key in target_id:
                     target_info[key] = target_id[key]
 
-        self._identifier = ScorerIdentifier(
+        return ScorerIdentifier(
             class_name=self.__class__.__name__,
             class_module=self.__class__.__module__,
             class_description=self.__class__.__doc__ or "",

--- a/pyrit/score/scorer.py
+++ b/pyrit/score/scorer.py
@@ -99,7 +99,7 @@ class Scorer(Identifiable[ScorerIdentifier], abc.ABC):
     def _memory(self) -> MemoryInterface:
         return CentralMemory.get_memory_instance()
 
-    def _set_identifier(
+    def _create_identifier(
         self,
         *,
         system_prompt_template: Optional[str] = None,

--- a/pyrit/score/true_false/decoding_scorer.py
+++ b/pyrit/score/true_false/decoding_scorer.py
@@ -59,7 +59,7 @@ class DecodingScorer(TrueFalseScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             score_aggregator=self._score_aggregator.__name__,
             scorer_specific_params={
                 "text_matcher": self._text_matcher.__class__.__name__,

--- a/pyrit/score/true_false/decoding_scorer.py
+++ b/pyrit/score/true_false/decoding_scorer.py
@@ -53,7 +53,8 @@ class DecodingScorer(TrueFalseScorer):
         super().__init__(score_aggregator=aggregator, validator=validator or self._default_validator)
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/true_false/decoding_scorer.py
+++ b/pyrit/score/true_false/decoding_scorer.py
@@ -4,6 +4,7 @@
 from typing import Optional
 
 from pyrit.analytics.text_matching import ExactTextMatching, TextMatching
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.memory.central_memory import CentralMemory
 from pyrit.models import MessagePiece, Score
 from pyrit.score.scorer_prompt_validator import ScorerPromptValidator
@@ -51,9 +52,13 @@ class DecodingScorer(TrueFalseScorer):
 
         super().__init__(score_aggregator=aggregator, validator=validator or self._default_validator)
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             score_aggregator=self._score_aggregator.__name__,
             scorer_specific_params={
                 "text_matcher": self._text_matcher.__class__.__name__,

--- a/pyrit/score/true_false/float_scale_threshold_scorer.py
+++ b/pyrit/score/true_false/float_scale_threshold_scorer.py
@@ -56,7 +56,8 @@ class FloatScaleThresholdScorer(TrueFalseScorer):
         return self._threshold
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/true_false/float_scale_threshold_scorer.py
+++ b/pyrit/score/true_false/float_scale_threshold_scorer.py
@@ -4,6 +4,7 @@
 import uuid
 from typing import Optional
 
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import ChatMessageRole, Message, MessagePiece, Score
 from pyrit.score.float_scale.float_scale_score_aggregator import (
     FloatScaleAggregatorFunc,
@@ -54,9 +55,13 @@ class FloatScaleThresholdScorer(TrueFalseScorer):
         """Get the threshold value used for score comparison."""
         return self._threshold
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             sub_scorers=[self._scorer],
             score_aggregator=self._score_aggregator.__name__,
             scorer_specific_params={

--- a/pyrit/score/true_false/float_scale_threshold_scorer.py
+++ b/pyrit/score/true_false/float_scale_threshold_scorer.py
@@ -62,7 +62,7 @@ class FloatScaleThresholdScorer(TrueFalseScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             sub_scorers=[self._scorer],
             score_aggregator=self._score_aggregator.__name__,
             scorer_specific_params={

--- a/pyrit/score/true_false/gandalf_scorer.py
+++ b/pyrit/score/true_false/gandalf_scorer.py
@@ -56,7 +56,8 @@ class GandalfScorer(TrueFalseScorer):
         self._endpoint = "https://gandalf-api.lakera.ai/api/guess-password"
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/true_false/gandalf_scorer.py
+++ b/pyrit/score/true_false/gandalf_scorer.py
@@ -9,6 +9,7 @@ import requests
 from openai import BadRequestError
 
 from pyrit.exceptions import PyritException, pyrit_target_retry
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import Message, MessagePiece, Score
 from pyrit.prompt_target import GandalfLevel, PromptChatTarget
 from pyrit.score.scorer_prompt_validator import ScorerPromptValidator
@@ -54,9 +55,13 @@ class GandalfScorer(TrueFalseScorer):
         self._defender = level.value
         self._endpoint = "https://gandalf-api.lakera.ai/api/guess-password"
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             prompt_target=self._prompt_target,
             score_aggregator=self._score_aggregator.__name__,
         )

--- a/pyrit/score/true_false/gandalf_scorer.py
+++ b/pyrit/score/true_false/gandalf_scorer.py
@@ -62,7 +62,7 @@ class GandalfScorer(TrueFalseScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             prompt_target=self._prompt_target,
             score_aggregator=self._score_aggregator.__name__,
         )

--- a/pyrit/score/true_false/markdown_injection.py
+++ b/pyrit/score/true_false/markdown_injection.py
@@ -44,7 +44,8 @@ class MarkdownInjectionScorer(TrueFalseScorer):
         super().__init__(validator=validator or self._default_validator, score_aggregator=score_aggregator)
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/true_false/markdown_injection.py
+++ b/pyrit/score/true_false/markdown_injection.py
@@ -50,7 +50,7 @@ class MarkdownInjectionScorer(TrueFalseScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             score_aggregator=self._score_aggregator.__name__,
         )
 

--- a/pyrit/score/true_false/markdown_injection.py
+++ b/pyrit/score/true_false/markdown_injection.py
@@ -4,6 +4,7 @@
 import re
 from typing import Optional
 
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import MessagePiece, Score
 from pyrit.score.scorer_prompt_validator import ScorerPromptValidator
 from pyrit.score.true_false.true_false_score_aggregator import (
@@ -42,9 +43,13 @@ class MarkdownInjectionScorer(TrueFalseScorer):
 
         super().__init__(validator=validator or self._default_validator, score_aggregator=score_aggregator)
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             score_aggregator=self._score_aggregator.__name__,
         )
 

--- a/pyrit/score/true_false/prompt_shield_scorer.py
+++ b/pyrit/score/true_false/prompt_shield_scorer.py
@@ -6,6 +6,7 @@ import logging
 import uuid
 from typing import Any, Optional
 
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import Message, MessagePiece, Score, ScoreType
 from pyrit.prompt_target import PromptShieldTarget
 from pyrit.score.scorer_prompt_validator import ScorerPromptValidator
@@ -48,9 +49,13 @@ class PromptShieldScorer(TrueFalseScorer):
 
         super().__init__(validator=validator or self._default_validator, score_aggregator=score_aggregator)
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             prompt_target=self._prompt_target,
             score_aggregator=self._score_aggregator.__name__,
         )

--- a/pyrit/score/true_false/prompt_shield_scorer.py
+++ b/pyrit/score/true_false/prompt_shield_scorer.py
@@ -56,7 +56,7 @@ class PromptShieldScorer(TrueFalseScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             prompt_target=self._prompt_target,
             score_aggregator=self._score_aggregator.__name__,
         )

--- a/pyrit/score/true_false/prompt_shield_scorer.py
+++ b/pyrit/score/true_false/prompt_shield_scorer.py
@@ -50,7 +50,8 @@ class PromptShieldScorer(TrueFalseScorer):
         super().__init__(validator=validator or self._default_validator, score_aggregator=score_aggregator)
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/true_false/question_answer_scorer.py
+++ b/pyrit/score/true_false/question_answer_scorer.py
@@ -52,7 +52,8 @@ class QuestionAnswerScorer(TrueFalseScorer):
         super().__init__(validator=validator or self._default_validator, score_aggregator=score_aggregator)
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/true_false/question_answer_scorer.py
+++ b/pyrit/score/true_false/question_answer_scorer.py
@@ -58,7 +58,7 @@ class QuestionAnswerScorer(TrueFalseScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             score_aggregator=self._score_aggregator.__name__,
             scorer_specific_params={
                 "correct_answer_matching_patterns": self._correct_answer_matching_patterns,

--- a/pyrit/score/true_false/question_answer_scorer.py
+++ b/pyrit/score/true_false/question_answer_scorer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from typing import Optional
 
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import MessagePiece, Score
 from pyrit.score.scorer_prompt_validator import ScorerPromptValidator
 from pyrit.score.true_false.true_false_score_aggregator import (
@@ -50,9 +51,13 @@ class QuestionAnswerScorer(TrueFalseScorer):
 
         super().__init__(validator=validator or self._default_validator, score_aggregator=score_aggregator)
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             score_aggregator=self._score_aggregator.__name__,
             scorer_specific_params={
                 "correct_answer_matching_patterns": self._correct_answer_matching_patterns,

--- a/pyrit/score/true_false/self_ask_category_scorer.py
+++ b/pyrit/score/true_false/self_ask_category_scorer.py
@@ -9,6 +9,7 @@ import yaml
 
 from pyrit.common import verify_and_resolve_path
 from pyrit.common.path import SCORER_CONTENT_CLASSIFIERS_PATH
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import MessagePiece, Score, SeedPrompt, UnvalidatedScore
 from pyrit.prompt_target import PromptChatTarget
 from pyrit.score.scorer_prompt_validator import ScorerPromptValidator
@@ -77,9 +78,13 @@ class SelfAskCategoryScorer(TrueFalseScorer):
             no_category_found=self._no_category_found_category,
         )
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             system_prompt_template=self._system_prompt,
             prompt_target=self._prompt_target,
             score_aggregator=self._score_aggregator.__name__,

--- a/pyrit/score/true_false/self_ask_category_scorer.py
+++ b/pyrit/score/true_false/self_ask_category_scorer.py
@@ -79,7 +79,8 @@ class SelfAskCategoryScorer(TrueFalseScorer):
         )
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/true_false/self_ask_category_scorer.py
+++ b/pyrit/score/true_false/self_ask_category_scorer.py
@@ -85,7 +85,7 @@ class SelfAskCategoryScorer(TrueFalseScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             system_prompt_template=self._system_prompt,
             prompt_target=self._prompt_target,
             score_aggregator=self._score_aggregator.__name__,

--- a/pyrit/score/true_false/self_ask_general_true_false_scorer.py
+++ b/pyrit/score/true_false/self_ask_general_true_false_scorer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from typing import Optional
 
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import MessagePiece, Score, UnvalidatedScore
 from pyrit.prompt_target import PromptChatTarget
 from pyrit.score.scorer_prompt_validator import ScorerPromptValidator
@@ -84,9 +85,13 @@ class SelfAskGeneralTrueFalseScorer(TrueFalseScorer):
         self._metadata_output_key = metadata_output_key
         self._category_output_key = category_output_key
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             system_prompt_template=self._system_prompt_format_string,
             user_prompt_template=self._prompt_format_string,
             prompt_target=self._prompt_target,

--- a/pyrit/score/true_false/self_ask_general_true_false_scorer.py
+++ b/pyrit/score/true_false/self_ask_general_true_false_scorer.py
@@ -92,7 +92,7 @@ class SelfAskGeneralTrueFalseScorer(TrueFalseScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             system_prompt_template=self._system_prompt_format_string,
             user_prompt_template=self._prompt_format_string,
             prompt_target=self._prompt_target,

--- a/pyrit/score/true_false/self_ask_general_true_false_scorer.py
+++ b/pyrit/score/true_false/self_ask_general_true_false_scorer.py
@@ -86,7 +86,8 @@ class SelfAskGeneralTrueFalseScorer(TrueFalseScorer):
         self._category_output_key = category_output_key
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/true_false/self_ask_refusal_scorer.py
+++ b/pyrit/score/true_false/self_ask_refusal_scorer.py
@@ -73,7 +73,8 @@ class SelfAskRefusalScorer(TrueFalseScorer):
         self._score_category = ["refusal"]
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/true_false/self_ask_refusal_scorer.py
+++ b/pyrit/score/true_false/self_ask_refusal_scorer.py
@@ -79,7 +79,7 @@ class SelfAskRefusalScorer(TrueFalseScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             system_prompt_template=self._system_prompt_with_objective,
             prompt_target=self._prompt_target,
             score_aggregator=self._score_aggregator.__name__,

--- a/pyrit/score/true_false/self_ask_refusal_scorer.py
+++ b/pyrit/score/true_false/self_ask_refusal_scorer.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Optional
 
 from pyrit.common.path import SCORER_SEED_PROMPT_PATH
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import MessagePiece, Score, SeedPrompt, UnvalidatedScore
 from pyrit.prompt_target import PromptChatTarget
 from pyrit.score.scorer_prompt_validator import ScorerPromptValidator
@@ -71,9 +72,13 @@ class SelfAskRefusalScorer(TrueFalseScorer):
 
         self._score_category = ["refusal"]
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             system_prompt_template=self._system_prompt_with_objective,
             prompt_target=self._prompt_target,
             score_aggregator=self._score_aggregator.__name__,

--- a/pyrit/score/true_false/self_ask_true_false_scorer.py
+++ b/pyrit/score/true_false/self_ask_true_false_scorer.py
@@ -155,7 +155,7 @@ class SelfAskTrueFalseScorer(TrueFalseScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             system_prompt_template=self._system_prompt,
             user_prompt_template="objective: {objective}\nresponse: {response}",
             prompt_target=self._prompt_target,

--- a/pyrit/score/true_false/self_ask_true_false_scorer.py
+++ b/pyrit/score/true_false/self_ask_true_false_scorer.py
@@ -9,6 +9,7 @@ import yaml
 
 from pyrit.common import verify_and_resolve_path
 from pyrit.common.path import SCORER_SEED_PROMPT_PATH
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import MessagePiece, Score, SeedPrompt
 from pyrit.prompt_target import PromptChatTarget
 from pyrit.score.scorer_prompt_validator import ScorerPromptValidator
@@ -147,9 +148,13 @@ class SelfAskTrueFalseScorer(TrueFalseScorer):
             true_description=true_category, false_description=false_category, metadata=metadata
         )
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             system_prompt_template=self._system_prompt,
             user_prompt_template="objective: {objective}\nresponse: {response}",
             prompt_target=self._prompt_target,

--- a/pyrit/score/true_false/self_ask_true_false_scorer.py
+++ b/pyrit/score/true_false/self_ask_true_false_scorer.py
@@ -149,7 +149,8 @@ class SelfAskTrueFalseScorer(TrueFalseScorer):
         )
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/true_false/substring_scorer.py
+++ b/pyrit/score/true_false/substring_scorer.py
@@ -58,7 +58,7 @@ class SubStringScorer(TrueFalseScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             score_aggregator=self._score_aggregator.__name__,
             scorer_specific_params={
                 "substring": self._substring,

--- a/pyrit/score/true_false/substring_scorer.py
+++ b/pyrit/score/true_false/substring_scorer.py
@@ -52,7 +52,8 @@ class SubStringScorer(TrueFalseScorer):
         super().__init__(score_aggregator=aggregator, validator=validator or self._default_validator)
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/true_false/substring_scorer.py
+++ b/pyrit/score/true_false/substring_scorer.py
@@ -4,6 +4,7 @@
 from typing import Optional
 
 from pyrit.analytics.text_matching import ExactTextMatching, TextMatching
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import MessagePiece, Score
 from pyrit.score.scorer_prompt_validator import ScorerPromptValidator
 from pyrit.score.true_false.true_false_score_aggregator import (
@@ -50,9 +51,13 @@ class SubStringScorer(TrueFalseScorer):
 
         super().__init__(score_aggregator=aggregator, validator=validator or self._default_validator)
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             score_aggregator=self._score_aggregator.__name__,
             scorer_specific_params={
                 "substring": self._substring,

--- a/pyrit/score/true_false/true_false_composite_scorer.py
+++ b/pyrit/score/true_false/true_false_composite_scorer.py
@@ -54,7 +54,8 @@ class TrueFalseCompositeScorer(TrueFalseScorer):
         self._scorers = scorers
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/true_false/true_false_composite_scorer.py
+++ b/pyrit/score/true_false/true_false_composite_scorer.py
@@ -60,7 +60,7 @@ class TrueFalseCompositeScorer(TrueFalseScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             sub_scorers=self._scorers,
             score_aggregator=self._score_aggregator.__name__,
         )

--- a/pyrit/score/true_false/true_false_composite_scorer.py
+++ b/pyrit/score/true_false/true_false_composite_scorer.py
@@ -4,6 +4,7 @@
 import asyncio
 from typing import List, Optional
 
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import ChatMessageRole, Message, MessagePiece, Score
 from pyrit.score.scorer_prompt_validator import ScorerPromptValidator
 from pyrit.score.true_false.true_false_score_aggregator import TrueFalseAggregatorFunc
@@ -52,9 +53,13 @@ class TrueFalseCompositeScorer(TrueFalseScorer):
 
         self._scorers = scorers
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             sub_scorers=self._scorers,
             score_aggregator=self._score_aggregator.__name__,
         )

--- a/pyrit/score/true_false/true_false_inverter_scorer.py
+++ b/pyrit/score/true_false/true_false_inverter_scorer.py
@@ -4,6 +4,7 @@
 import uuid
 from typing import Optional
 
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import ChatMessageRole, Message, MessagePiece, Score
 from pyrit.score.scorer_prompt_validator import ScorerPromptValidator
 from pyrit.score.true_false.true_false_scorer import TrueFalseScorer
@@ -30,9 +31,13 @@ class TrueFalseInverterScorer(TrueFalseScorer):
 
         super().__init__(validator=ScorerPromptValidator())
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             sub_scorers=[self._scorer],
             score_aggregator=self._score_aggregator.__name__,
         )

--- a/pyrit/score/true_false/true_false_inverter_scorer.py
+++ b/pyrit/score/true_false/true_false_inverter_scorer.py
@@ -38,7 +38,7 @@ class TrueFalseInverterScorer(TrueFalseScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             sub_scorers=[self._scorer],
             score_aggregator=self._score_aggregator.__name__,
         )

--- a/pyrit/score/true_false/true_false_inverter_scorer.py
+++ b/pyrit/score/true_false/true_false_inverter_scorer.py
@@ -32,7 +32,8 @@ class TrueFalseInverterScorer(TrueFalseScorer):
         super().__init__(validator=ScorerPromptValidator())
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/true_false/video_true_false_scorer.py
+++ b/pyrit/score/true_false/video_true_false_scorer.py
@@ -57,7 +57,7 @@ class VideoTrueFalseScorer(TrueFalseScorer, _BaseVideoScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier(
+        return self._create_identifier(
             sub_scorers=[self.image_scorer],
             score_aggregator=self._score_aggregator.__name__,
             scorer_specific_params={

--- a/pyrit/score/true_false/video_true_false_scorer.py
+++ b/pyrit/score/true_false/video_true_false_scorer.py
@@ -51,7 +51,8 @@ class VideoTrueFalseScorer(TrueFalseScorer, _BaseVideoScorer):
         )
 
     def _build_identifier(self) -> ScorerIdentifier:
-        """Build the scorer evaluation identifier for this scorer.
+        """
+        Build the scorer evaluation identifier for this scorer.
 
         Returns:
             ScorerIdentifier: The identifier for this scorer.

--- a/pyrit/score/true_false/video_true_false_scorer.py
+++ b/pyrit/score/true_false/video_true_false_scorer.py
@@ -3,6 +3,7 @@
 
 from typing import Optional
 
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import MessagePiece, Score
 from pyrit.score.scorer_prompt_validator import ScorerPromptValidator
 from pyrit.score.true_false.true_false_score_aggregator import (
@@ -49,9 +50,13 @@ class VideoTrueFalseScorer(TrueFalseScorer, _BaseVideoScorer):
             self, validator=validator or self._default_validator, score_aggregator=score_aggregator
         )
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this scorer."""
-        self._set_identifier(
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier(
             sub_scorers=[self.image_scorer],
             score_aggregator=self._score_aggregator.__name__,
             scorer_specific_params={

--- a/tests/unit/identifiers/test_converter_identifier.py
+++ b/tests/unit/identifiers/test_converter_identifier.py
@@ -1,0 +1,225 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""
+Tests for ConverterIdentifier-specific functionality.
+
+Note: Base Identifier functionality (hash computation, to_dict/from_dict basics,
+frozen/hashable properties) is tested via ScorerIdentifier in test_scorer_identifier.py.
+These tests focus on converter-specific fields and behaviors.
+"""
+
+import pytest
+
+from pyrit.identifiers import ConverterIdentifier
+
+
+class TestConverterIdentifierSpecificFields:
+    """Test ConverterIdentifier-specific fields: supported_input_types, supported_output_types, converter_specific_params."""
+
+    def test_supported_input_output_types_stored_as_tuples(self):
+        """Test that supported_input_types and supported_output_types are stored correctly."""
+        identifier = ConverterIdentifier(
+            class_name="TestConverter",
+            class_module="pyrit.prompt_converter.test_converter",
+            class_description="A test converter",
+            identifier_type="instance",
+            supported_input_types=("text", "image_path"),
+            supported_output_types=("text",),
+        )
+
+        assert identifier.supported_input_types == ("text", "image_path")
+        assert identifier.supported_output_types == ("text",)
+
+    def test_converter_specific_params_stored(self):
+        """Test that converter_specific_params are stored correctly."""
+        identifier = ConverterIdentifier(
+            class_name="CaesarConverter",
+            class_module="pyrit.prompt_converter.caesar_converter",
+            class_description="A Caesar cipher converter",
+            identifier_type="instance",
+            supported_input_types=("text",),
+            supported_output_types=("text",),
+            converter_specific_params={"shift": 3, "preserve_case": True},
+        )
+
+        assert identifier.converter_specific_params["shift"] == 3
+        assert identifier.converter_specific_params["preserve_case"] is True
+
+    def test_sub_identifier_with_nested_converter(self):
+        """Test that sub_identifier can hold nested ConverterIdentifier."""
+        sub_converter = ConverterIdentifier(
+            class_name="SubConverter",
+            class_module="pyrit.prompt_converter.sub_converter",
+            class_description="A sub converter",
+            identifier_type="instance",
+            supported_input_types=("text",),
+            supported_output_types=("text",),
+        )
+
+        identifier = ConverterIdentifier(
+            class_name="TestConverter",
+            class_module="pyrit.prompt_converter.test_converter",
+            class_description="A test converter",
+            identifier_type="instance",
+            supported_input_types=("text",),
+            supported_output_types=("text",),
+            sub_identifier=[sub_converter],
+        )
+
+        assert len(identifier.sub_identifier) == 1
+        assert identifier.sub_identifier[0].class_name == "SubConverter"
+
+
+class TestConverterIdentifierHashDifferences:
+    """Test that converter-specific fields affect hash computation."""
+
+    def test_hash_different_for_different_input_types(self):
+        """Test that different input types produce different hashes."""
+        base_args = {
+            "class_name": "TestConverter",
+            "class_module": "pyrit.prompt_converter.test_converter",
+            "class_description": "A test converter",
+            "identifier_type": "instance",
+            "supported_output_types": ("text",),
+        }
+
+        identifier1 = ConverterIdentifier(supported_input_types=("text",), **base_args)
+        identifier2 = ConverterIdentifier(supported_input_types=("image_path",), **base_args)
+
+        assert identifier1.hash != identifier2.hash
+
+    def test_hash_different_for_different_output_types(self):
+        """Test that different output types produce different hashes."""
+        base_args = {
+            "class_name": "TestConverter",
+            "class_module": "pyrit.prompt_converter.test_converter",
+            "class_description": "A test converter",
+            "identifier_type": "instance",
+            "supported_input_types": ("text",),
+        }
+
+        identifier1 = ConverterIdentifier(supported_output_types=("text",), **base_args)
+        identifier2 = ConverterIdentifier(supported_output_types=("image_path",), **base_args)
+
+        assert identifier1.hash != identifier2.hash
+
+    def test_hash_different_for_different_converter_specific_params(self):
+        """Test that different converter_specific_params produce different hashes."""
+        base_args = {
+            "class_name": "CaesarConverter",
+            "class_module": "pyrit.prompt_converter.caesar_converter",
+            "class_description": "A Caesar cipher converter",
+            "identifier_type": "instance",
+            "supported_input_types": ("text",),
+            "supported_output_types": ("text",),
+        }
+
+        identifier1 = ConverterIdentifier(converter_specific_params={"shift": 3}, **base_args)
+        identifier2 = ConverterIdentifier(converter_specific_params={"shift": 5}, **base_args)
+
+        assert identifier1.hash != identifier2.hash
+
+
+class TestConverterIdentifierToDict:
+    """Test to_dict includes converter-specific fields."""
+
+    def test_to_dict_includes_supported_types(self):
+        """Test that supported_input_types and supported_output_types are in to_dict."""
+        identifier = ConverterIdentifier(
+            class_name="TestConverter",
+            class_module="pyrit.prompt_converter.test_converter",
+            class_description="A test converter",
+            identifier_type="instance",
+            supported_input_types=("text", "image_path"),
+            supported_output_types=("text",),
+        )
+
+        result = identifier.to_dict()
+
+        # Tuples remain as tuples in to_dict
+        assert result["supported_input_types"] == ("text", "image_path")
+        assert result["supported_output_types"] == ("text",)
+
+    def test_to_dict_includes_converter_specific_params(self):
+        """Test that converter_specific_params are included in to_dict."""
+        identifier = ConverterIdentifier(
+            class_name="CaesarConverter",
+            class_module="pyrit.prompt_converter.caesar_converter",
+            class_description="A Caesar cipher converter",
+            identifier_type="instance",
+            supported_input_types=("text",),
+            supported_output_types=("text",),
+            converter_specific_params={"shift": 13, "preserve_case": True},
+        )
+
+        result = identifier.to_dict()
+
+        assert result["converter_specific_params"] == {"shift": 13, "preserve_case": True}
+
+
+class TestConverterIdentifierFromDict:
+    """Test from_dict handles converter-specific fields."""
+
+    def test_from_dict_converts_lists_to_tuples(self):
+        """Test that from_dict converts supported_*_types lists to tuples."""
+        data = {
+            "class_name": "TestConverter",
+            "class_module": "pyrit.prompt_converter.test_converter",
+            "class_description": "A test converter",
+            "identifier_type": "instance",
+            "supported_input_types": ["text", "image_path"],  # List from JSON
+            "supported_output_types": ["text"],  # List from JSON
+        }
+
+        identifier = ConverterIdentifier.from_dict(data)
+
+        # Lists should be converted to tuples
+        assert identifier.supported_input_types == ("text", "image_path")
+        assert identifier.supported_output_types == ("text",)
+        assert isinstance(identifier.supported_input_types, tuple)
+        assert isinstance(identifier.supported_output_types, tuple)
+
+    def test_from_dict_provides_defaults_for_missing_types(self):
+        """Test that from_dict provides defaults for missing supported_*_types fields."""
+        data = {
+            "class_name": "LegacyConverter",
+            "class_module": "pyrit.prompt_converter.legacy",
+            "class_description": "A legacy converter",
+            "identifier_type": "instance",
+            # Missing supported_input_types and supported_output_types
+        }
+
+        identifier = ConverterIdentifier.from_dict(data)
+
+        # Should provide empty tuples as defaults
+        assert identifier.supported_input_types == ()
+        assert identifier.supported_output_types == ()
+
+    def test_from_dict_with_nested_sub_identifiers(self):
+        """Test from_dict with nested sub_identifier list creates ConverterIdentifier objects."""
+        data = {
+            "class_name": "PipelineConverter",
+            "class_module": "pyrit.prompt_converter.pipeline_converter",
+            "class_description": "A pipeline converter",
+            "identifier_type": "instance",
+            "supported_input_types": ["text"],
+            "supported_output_types": ["text"],
+            "sub_identifier": [
+                {
+                    "class_name": "SubConverter",
+                    "class_module": "pyrit.prompt_converter.sub",
+                    "class_description": "Sub converter",
+                    "identifier_type": "instance",
+                    "supported_input_types": ["text"],
+                    "supported_output_types": ["image_path"],
+                },
+            ],
+        }
+
+        identifier = ConverterIdentifier.from_dict(data)
+
+        assert len(identifier.sub_identifier) == 1
+        assert isinstance(identifier.sub_identifier[0], ConverterIdentifier)
+        assert identifier.sub_identifier[0].supported_output_types == ("image_path",)
+

--- a/tests/unit/identifiers/test_converter_identifier.py
+++ b/tests/unit/identifiers/test_converter_identifier.py
@@ -9,8 +9,6 @@ frozen/hashable properties) is tested via ScorerIdentifier in test_scorer_identi
 These tests focus on converter-specific fields and behaviors.
 """
 
-import pytest
-
 from pyrit.identifiers import ConverterIdentifier
 
 
@@ -222,4 +220,3 @@ class TestConverterIdentifierFromDict:
         assert len(identifier.sub_identifier) == 1
         assert isinstance(identifier.sub_identifier[0], ConverterIdentifier)
         assert identifier.sub_identifier[0].supported_output_types == ("image_path",)
-

--- a/tests/unit/memory/test_azure_sql_memory.py
+++ b/tests/unit/memory/test_azure_sql_memory.py
@@ -204,7 +204,7 @@ def test_get_memories_with_json_properties(memory_interface: AzureSQLMemory):
 
         converter_identifiers = retrieved_entry.converter_identifiers
         assert len(converter_identifiers) == 1
-        assert converter_identifiers[0]["__type__"] == "Base64Converter"
+        assert converter_identifiers[0].class_name == "Base64Converter"
 
         prompt_target = retrieved_entry.prompt_target_identifier
         assert prompt_target["__type__"] == "TextTarget"

--- a/tests/unit/memory/test_sqlite_memory.py
+++ b/tests/unit/memory/test_sqlite_memory.py
@@ -373,7 +373,7 @@ def test_get_memories_with_json_properties(sqlite_instance):
 
         converter_identifiers = retrieved_entry.converter_identifiers
         assert len(converter_identifiers) == 1
-        assert converter_identifiers[0]["__type__"] == "Base64Converter"
+        assert converter_identifiers[0].class_name == "Base64Converter"
 
         prompt_target = retrieved_entry.prompt_target_identifier
         assert prompt_target["__type__"] == "TextTarget"

--- a/tests/unit/models/test_message_piece.py
+++ b/tests/unit/models/test_message_piece.py
@@ -65,8 +65,8 @@ def test_converters_serialize():
 
     converter = entry.converter_identifiers[0]
 
-    assert converter["__type__"] == "Base64Converter"
-    assert converter["__module__"] == "pyrit.prompt_converter.base64_converter"
+    assert converter.class_name == "Base64Converter"
+    assert converter.class_module == "pyrit.prompt_converter.base64_converter"
 
 
 def test_prompt_targets_serialize(patch_central_database):
@@ -744,7 +744,7 @@ def test_message_piece_to_dict():
     assert result["labels"] == entry.labels
     assert result["targeted_harm_categories"] == entry.targeted_harm_categories
     assert result["prompt_metadata"] == entry.prompt_metadata
-    assert result["converter_identifiers"] == entry.converter_identifiers
+    assert result["converter_identifiers"] == [conv.to_dict() for conv in entry.converter_identifiers]
     assert result["prompt_target_identifier"] == entry.prompt_target_identifier
     assert result["attack_identifier"] == entry.attack_identifier
     assert result["scorer_identifier"] == entry.scorer_identifier.to_dict()

--- a/tests/unit/registry/test_scorer_registry.py
+++ b/tests/unit/registry/test_scorer_registry.py
@@ -28,9 +28,13 @@ class MockTrueFalseScorer(TrueFalseScorer):
     def __init__(self):
         super().__init__(validator=DummyValidator())
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this mock scorer."""
-        self._set_identifier()
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this mock scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier()
 
     async def _score_async(self, message: Message, *, objective: Optional[str] = None) -> list[Score]:
         return []
@@ -48,9 +52,13 @@ class MockFloatScaleScorer(FloatScaleScorer):
     def __init__(self):
         super().__init__(validator=DummyValidator())
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this mock scorer."""
-        self._set_identifier()
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this mock scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier()
 
     async def _score_async(self, message: Message, *, objective: Optional[str] = None) -> list[Score]:
         return []
@@ -68,9 +76,13 @@ class MockGenericScorer(Scorer):
     def __init__(self):
         super().__init__(validator=DummyValidator())
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this mock scorer."""
-        self._set_identifier()
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this mock scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier()
 
     async def _score_async(self, message: Message, *, objective: Optional[str] = None) -> list[Score]:
         return []

--- a/tests/unit/registry/test_scorer_registry.py
+++ b/tests/unit/registry/test_scorer_registry.py
@@ -34,7 +34,7 @@ class MockTrueFalseScorer(TrueFalseScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier()
+        return self._create_identifier()
 
     async def _score_async(self, message: Message, *, objective: Optional[str] = None) -> list[Score]:
         return []
@@ -58,7 +58,7 @@ class MockFloatScaleScorer(FloatScaleScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier()
+        return self._create_identifier()
 
     async def _score_async(self, message: Message, *, objective: Optional[str] = None) -> list[Score]:
         return []
@@ -82,7 +82,7 @@ class MockGenericScorer(Scorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier()
+        return self._create_identifier()
 
     async def _score_async(self, message: Message, *, objective: Optional[str] = None) -> list[Score]:
         return []

--- a/tests/unit/score/test_conversation_history_scorer.py
+++ b/tests/unit/score/test_conversation_history_scorer.py
@@ -38,7 +38,7 @@ class MockFloatScaleScorer(FloatScaleScorer):
         super().__init__(validator=ScorerPromptValidator(supported_data_types=["text"]))
 
     def _build_identifier(self) -> None:
-        self._set_identifier()
+        self._create_identifier()
 
     async def _score_piece_async(self, message_piece: MessagePiece, *, objective: Optional[str] = None) -> list[Score]:
         return []
@@ -51,7 +51,7 @@ class MockTrueFalseScorer(TrueFalseScorer):
         super().__init__(validator=ScorerPromptValidator(supported_data_types=["text"]))
 
     def _build_identifier(self) -> None:
-        self._set_identifier()
+        self._create_identifier()
 
     async def _score_piece_async(self, message_piece: MessagePiece, *, objective: Optional[str] = None) -> list[Score]:
         return []
@@ -64,7 +64,7 @@ class MockUnsupportedScorer(Scorer):
         super().__init__(validator=ScorerPromptValidator(supported_data_types=["text"]))
 
     def _build_identifier(self) -> None:
-        self._set_identifier()
+        self._create_identifier()
 
     async def _score_piece_async(self, message_piece: MessagePiece, *, objective: Optional[str] = None) -> list[Score]:
         return []

--- a/tests/unit/score/test_scorer.py
+++ b/tests/unit/score/test_scorer.py
@@ -63,7 +63,7 @@ class MockScorer(TrueFalseScorer):
 
     def _build_identifier(self) -> ScorerIdentifier:
         """Build the scorer evaluation identifier for this mock scorer."""
-        return self._set_identifier()
+        return self._create_identifier()
 
     async def _score_async(self, message: Message, *, objective: Optional[str] = None) -> list[Score]:
         return [
@@ -119,7 +119,7 @@ class MockFloatScorer(Scorer):
 
     def _build_identifier(self) -> ScorerIdentifier:
         """Build the scorer evaluation identifier for this mock scorer."""
-        return self._set_identifier()
+        return self._create_identifier()
 
     async def _score_piece_async(self, message_piece: MessagePiece, *, objective: Optional[str] = None) -> list[Score]:
         # Track which pieces get scored
@@ -1121,7 +1121,7 @@ async def test_true_false_scorer_uses_supported_pieces_only(patch_central_databa
 
         def _build_identifier(self) -> ScorerIdentifier:
             """Build the scorer evaluation identifier for this test scorer."""
-            return self._set_identifier()
+            return self._create_identifier()
 
         async def _score_piece_async(
             self, message_piece: MessagePiece, *, objective: Optional[str] = None
@@ -1307,7 +1307,7 @@ class TestTrueFalseScorerEmptyScoreListRationale:
                 super().__init__(validator=validator)
 
             def _build_identifier(self) -> ScorerIdentifier:
-                return self._set_identifier()
+                return self._create_identifier()
 
             async def _score_piece_async(
                 self, message_piece: MessagePiece, *, objective: Optional[str] = None

--- a/tests/unit/score/test_scorer.py
+++ b/tests/unit/score/test_scorer.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from pyrit.exceptions import InvalidJsonException, remove_markdown_json
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.memory import CentralMemory
 from pyrit.models import Message, MessagePiece, Score
 from pyrit.prompt_target import PromptChatTarget
@@ -60,9 +61,9 @@ class MockScorer(TrueFalseScorer):
     def __init__(self):
         super().__init__(validator=DummyValidator())
 
-    def _build_identifier(self) -> None:
+    def _build_identifier(self) -> ScorerIdentifier:
         """Build the scorer evaluation identifier for this mock scorer."""
-        self._set_identifier()
+        return self._set_identifier()
 
     async def _score_async(self, message: Message, *, objective: Optional[str] = None) -> list[Score]:
         return [
@@ -116,9 +117,9 @@ class MockFloatScorer(Scorer):
         self.scored_piece_ids: list[str] = []
         super().__init__(validator=validator)
 
-    def _build_identifier(self) -> None:
+    def _build_identifier(self) -> ScorerIdentifier:
         """Build the scorer evaluation identifier for this mock scorer."""
-        self._set_identifier()
+        return self._set_identifier()
 
     async def _score_piece_async(self, message_piece: MessagePiece, *, objective: Optional[str] = None) -> list[Score]:
         # Track which pieces get scored
@@ -1118,9 +1119,9 @@ async def test_true_false_scorer_uses_supported_pieces_only(patch_central_databa
             self.scored_piece_ids = []
             super().__init__(validator=validator)
 
-        def _build_identifier(self) -> None:
+        def _build_identifier(self) -> ScorerIdentifier:
             """Build the scorer evaluation identifier for this test scorer."""
-            self._set_identifier()
+            return self._set_identifier()
 
         async def _score_piece_async(
             self, message_piece: MessagePiece, *, objective: Optional[str] = None
@@ -1305,8 +1306,8 @@ class TestTrueFalseScorerEmptyScoreListRationale:
             def __init__(self, validator):
                 super().__init__(validator=validator)
 
-            def _build_identifier(self) -> None:
-                self._set_identifier()
+            def _build_identifier(self) -> ScorerIdentifier:
+                return self._set_identifier()
 
             async def _score_piece_async(
                 self, message_piece: MessagePiece, *, objective: Optional[str] = None

--- a/tests/unit/score/test_true_false_composite_scorer.py
+++ b/tests/unit/score/test_true_false_composite_scorer.py
@@ -47,7 +47,7 @@ class MockScorer(TrueFalseScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier()
+        return self._create_identifier()
 
     async def _score_piece_async(self, message_piece: MessagePiece, *, objective: Optional[str] = None) -> list[Score]:
         return [
@@ -161,7 +161,7 @@ def test_composite_scorer_invalid_scorer_type():
             self._validator = MagicMock()
 
         def _build_identifier(self) -> ScorerIdentifier:
-            return self._set_identifier()
+            return self._create_identifier()
 
         async def _score_piece_async(
             self, message_piece: MessagePiece, *, objective: Optional[str] = None

--- a/tests/unit/score/test_true_false_composite_scorer.py
+++ b/tests/unit/score/test_true_false_composite_scorer.py
@@ -41,9 +41,13 @@ class MockScorer(TrueFalseScorer):
         # Call super().__init__() to properly initialize the scorer including _identifier
         super().__init__(validator=MagicMock())
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this mock scorer."""
-        self._set_identifier()
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this mock scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier()
 
     async def _score_piece_async(self, message_piece: MessagePiece, *, objective: Optional[str] = None) -> list[Score]:
         return [
@@ -156,8 +160,8 @@ def test_composite_scorer_invalid_scorer_type():
         def __init__(self):
             self._validator = MagicMock()
 
-        def _build_identifier(self) -> None:
-            self._set_identifier()
+        def _build_identifier(self) -> ScorerIdentifier:
+            return self._set_identifier()
 
         async def _score_piece_async(
             self, message_piece: MessagePiece, *, objective: Optional[str] = None

--- a/tests/unit/score/test_video_scorer.py
+++ b/tests/unit/score/test_video_scorer.py
@@ -75,7 +75,7 @@ class MockTrueFalseScorer(TrueFalseScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier()
+        return self._create_identifier()
 
     async def _score_piece_async(self, message_piece: MessagePiece, *, objective: Optional[str] = None) -> list[Score]:
         return [
@@ -107,7 +107,7 @@ class MockFloatScaleScorer(FloatScaleScorer):
         Returns:
             ScorerIdentifier: The identifier for this scorer.
         """
-        return self._set_identifier()
+        return self._create_identifier()
 
     async def _score_piece_async(self, message_piece: MessagePiece, *, objective: Optional[str] = None) -> list[Score]:
         return [

--- a/tests/unit/score/test_video_scorer.py
+++ b/tests/unit/score/test_video_scorer.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import numpy as np
 import pytest
 
+from pyrit.identifiers import ScorerIdentifier
 from pyrit.models import MessagePiece, Score
 from pyrit.score.float_scale.float_scale_scorer import FloatScaleScorer
 from pyrit.score.float_scale.video_float_scale_scorer import VideoFloatScaleScorer
@@ -68,9 +69,13 @@ class MockTrueFalseScorer(TrueFalseScorer):
         validator = ScorerPromptValidator(supported_data_types=["image_path"])
         super().__init__(validator=validator)
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this mock scorer."""
-        self._set_identifier()
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this mock scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier()
 
     async def _score_piece_async(self, message_piece: MessagePiece, *, objective: Optional[str] = None) -> list[Score]:
         return [
@@ -96,9 +101,13 @@ class MockFloatScaleScorer(FloatScaleScorer):
         validator = ScorerPromptValidator(supported_data_types=["image_path"])
         super().__init__(validator=validator)
 
-    def _build_identifier(self) -> None:
-        """Build the scorer evaluation identifier for this mock scorer."""
-        self._set_identifier()
+    def _build_identifier(self) -> ScorerIdentifier:
+        """Build the scorer evaluation identifier for this mock scorer.
+
+        Returns:
+            ScorerIdentifier: The identifier for this scorer.
+        """
+        return self._set_identifier()
 
     async def _score_piece_async(self, message_piece: MessagePiece, *, objective: Optional[str] = None) -> list[Score]:
         return [


### PR DESCRIPTION
- Implementing `ConverterIdentifier` which can uniquely identify converter configurations
- Modifying Identifiable slightly, so that `get_identifier` is now part of the base, and `_build_identifer` returns and `IdentifierT`

## Tests

- Ran SQL Azure integration tests
- Added ConterterIdentifier unit tests