### PR TITLE
FEAT: Adding pyrit_version to identifiers

### DIFF
--- a/pyrit/identifiers/identifier.py
+++ b/pyrit/identifiers/identifier.py
@@ -46,11 +46,14 @@ class _ExcludeFrom(Enum):
         Returns:
             set[_ExcludeFrom]: The complete set of exclusions including implied ones.
         """
-        _EXPANSION_CATALOG: dict[_ExcludeFrom, set[_ExcludeFrom]] = {
-            _ExcludeFrom.HASH: {_ExcludeFrom.HASH},
-            _ExcludeFrom.STORAGE: {_ExcludeFrom.STORAGE, _ExcludeFrom.HASH},
-        }
         return _EXPANSION_CATALOG[self]
+
+
+# Lookup table for exclusion expansion - defined after enum so values exist
+_EXPANSION_CATALOG: dict[_ExcludeFrom, set[_ExcludeFrom]] = {
+    _ExcludeFrom.HASH: {_ExcludeFrom.HASH},
+    _ExcludeFrom.STORAGE: {_ExcludeFrom.STORAGE, _ExcludeFrom.HASH},
+}
 
 
 def _expand_exclusions(exclude_set: set[_ExcludeFrom]) -> set[_ExcludeFrom]:
@@ -277,28 +280,6 @@ class Identifier:
         filtered_data = {k: v for k, v in data.items() if k in valid_fields}
 
         return cls(**filtered_data)
-
-    def with_pyrit_version(self: T, version: str) -> T:
-        """
-        Create a copy of this Identifier with a different pyrit_version.
-
-        Since Identifier is frozen, this returns a new instance with all the same
-        field values except for pyrit_version which is set to the provided value.
-
-        Args:
-            version: The pyrit_version to set on the new instance.
-
-        Returns:
-            A new Identifier instance with the updated pyrit_version.
-        """
-        # Get all current field values
-        current_data = self.to_dict()
-        # Override pyrit_version
-        current_data["pyrit_version"] = version
-        # Add back fields excluded from storage that are needed for from_dict
-        current_data["class_description"] = self.class_description
-        current_data["identifier_type"] = self.identifier_type
-        return type(self).from_dict(current_data)
 
     @classmethod
     def normalize(cls: Type[T], value: T | dict[str, Any]) -> T:

--- a/pyrit/identifiers/identifier.py
+++ b/pyrit/identifiers/identifier.py
@@ -104,7 +104,7 @@ class Identifier:
     hash: str | None = field(default=None, compare=False, kw_only=True, metadata={_EXCLUDE: {_ExcludeFrom.HASH}})
 
     # {full_snake_case}::{hash[:8]}
-    unique_name: str = field(init=False, metadata={_EXCLUDE: {_ExcludeFrom.HASH, _ExcludeFrom.STORAGE}})  
+    unique_name: str = field(init=False, metadata={_EXCLUDE: {_ExcludeFrom.HASH, _ExcludeFrom.STORAGE}})
 
     # Version field - stored but not hashed (allows version tracking without affecting identity)
     pyrit_version: str = field(
@@ -237,6 +237,28 @@ class Identifier:
         filtered_data = {k: v for k, v in data.items() if k in valid_fields}
 
         return cls(**filtered_data)
+
+    def with_pyrit_version(self: T, version: str) -> T:
+        """
+        Create a copy of this Identifier with a different pyrit_version.
+
+        Since Identifier is frozen, this returns a new instance with all the same
+        field values except for pyrit_version which is set to the provided value.
+
+        Args:
+            version: The pyrit_version to set on the new instance.
+
+        Returns:
+            A new Identifier instance with the updated pyrit_version.
+        """
+        # Get all current field values
+        current_data = self.to_dict()
+        # Override pyrit_version
+        current_data["pyrit_version"] = version
+        # Add back fields excluded from storage that are needed for from_dict
+        current_data["class_description"] = self.class_description
+        current_data["identifier_type"] = self.identifier_type
+        return type(self).from_dict(current_data)
 
     @classmethod
     def normalize(cls: Type[T], value: T | dict[str, Any]) -> T:

--- a/pyrit/identifiers/identifier.py
+++ b/pyrit/identifiers/identifier.py
@@ -5,17 +5,73 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import asdict, dataclass, field, fields, is_dataclass
+from dataclasses import Field, asdict, dataclass, field, fields, is_dataclass
+from enum import Enum
 from typing import Any, Literal, Type, TypeVar
 
+import pyrit
 from pyrit.common.deprecation import print_deprecation_message
 from pyrit.identifiers.class_name_utils import class_name_to_snake_case
 
 IdentifierType = Literal["class", "instance"]
 
+
+class _ExcludeFrom(Enum):
+    """
+    Enum specifying what a field should be excluded from.
+
+    Used as values in the _EXCLUDE metadata set for dataclass fields.
+
+    Values:
+        HASH: Exclude the field from hash computation (field is still stored).
+        STORAGE: Exclude the field from storage (implies HASH - field is also excluded from hash).
+    """
+
+    HASH = "hash"
+    STORAGE = "storage"
+
+
 # Metadata keys for field configuration
-EXCLUDE_FROM_STORAGE = "exclude_from_storage"
-MAX_STORAGE_LENGTH = "max_storage_length"
+# _EXCLUDE is a metadata key whose value is a set of _ExcludeFrom enum values.
+# Examples:
+#   field(metadata={_EXCLUDE: {_ExcludeFrom.HASH}})  # Stored but not hashed
+#   field(metadata={_EXCLUDE: {_ExcludeFrom.HASH, _ExcludeFrom.STORAGE}})  # Not stored and not hashed
+_EXCLUDE = "exclude"
+_MAX_STORAGE_LENGTH = "max_storage_length"
+
+
+def _is_excluded_from_hash(f: Field[Any]) -> bool:
+    """
+    Check if a field should be excluded from hash computation.
+
+    A field is excluded from hash if it has _EXCLUDE metadata containing
+    _ExcludeFrom.HASH or _ExcludeFrom.STORAGE.
+
+    Args:
+        f: A dataclass field object.
+
+    Returns:
+        True if the field should be excluded from hash computation.
+    """
+    exclude_set = f.metadata.get(_EXCLUDE, set())
+    return _ExcludeFrom.HASH in exclude_set or _ExcludeFrom.STORAGE in exclude_set
+
+
+def _is_excluded_from_storage(f: Field[Any]) -> bool:
+    """
+    Check if a field should be excluded from storage.
+
+    A field is excluded from storage if it has _EXCLUDE metadata containing _ExcludeFrom.STORAGE.
+
+    Args:
+        f: A dataclass field object.
+
+    Returns:
+        True if the field should be excluded from storage.
+    """
+    exclude_set = f.metadata.get(_EXCLUDE, set())
+    return _ExcludeFrom.STORAGE in exclude_set
+
 
 T = TypeVar("T", bound="Identifier")
 
@@ -39,14 +95,19 @@ class Identifier:
     class_name: str  # The actual class name, equivalent to __type__ (e.g., "SelfAskRefusalScorer")
     class_module: str  # The module path, equivalent to __module__ (e.g., "pyrit.score.self_ask_refusal_scorer")
 
-    # Fields excluded from storage
-    class_description: str = field(metadata={EXCLUDE_FROM_STORAGE: True})
-    identifier_type: IdentifierType = field(metadata={EXCLUDE_FROM_STORAGE: True})
+    # Fields excluded from storage and hash
+    class_description: str = field(metadata={_EXCLUDE: {_ExcludeFrom.HASH, _ExcludeFrom.STORAGE}})
+    identifier_type: IdentifierType = field(metadata={_EXCLUDE: {_ExcludeFrom.HASH, _ExcludeFrom.STORAGE}})
 
     # Auto-computed fields
-    snake_class_name: str = field(init=False, metadata={EXCLUDE_FROM_STORAGE: True})
-    hash: str | None = field(default=None, compare=False, kw_only=True)
-    unique_name: str = field(init=False)  # Unique identifier: {full_snake_case}::{hash[:8]}
+    snake_class_name: str = field(init=False, metadata={_EXCLUDE: {_ExcludeFrom.HASH, _ExcludeFrom.STORAGE}})
+    hash: str | None = field(default=None, compare=False, kw_only=True, metadata={_EXCLUDE: {_ExcludeFrom.HASH}})
+    unique_name: str = field(init=False, metadata={_EXCLUDE: {_ExcludeFrom.HASH}})  # {full_snake_case}::{hash[:8]}
+
+    # Version field - stored but not hashed (allows version tracking without affecting identity)
+    pyrit_version: str = field(
+        default_factory=lambda: pyrit.__version__, kw_only=True, metadata={_EXCLUDE: {_ExcludeFrom.HASH}}
+    )
 
     def __post_init__(self) -> None:
         """Compute derived fields: snake_class_name, hash, and unique_name."""
@@ -54,26 +115,24 @@ class Identifier:
         # 1. Compute snake_class_name
         object.__setattr__(self, "snake_class_name", class_name_to_snake_case(self.class_name))
         # 2. Compute hash only if not already provided (e.g., from from_dict)
-        if self.hash is None:
-            object.__setattr__(self, "hash", self._compute_hash())
+        computed_hash = self.hash if self.hash is not None else self._compute_hash()
+        object.__setattr__(self, "hash", computed_hash)
         # 3. Compute unique_name: full snake_case :: hash prefix
         full_snake = class_name_to_snake_case(self.class_name)
-        object.__setattr__(self, "unique_name", f"{full_snake}::{self.hash[:8]}")
+        object.__setattr__(self, "unique_name", f"{full_snake}::{computed_hash[:8]}")
 
     def _compute_hash(self) -> str:
         """
-        Compute a stable SHA256 hash from storable identifier fields.
+        Compute a stable SHA256 hash from identifier fields not excluded from hashing.
 
-        Fields marked with metadata={"exclude_from_storage": True}, 'hash', and 'unique_name'
-        are excluded from the hash computation.
+        Fields are excluded from hash computation if they have:
+        metadata={_EXCLUDE: {_ExcludeFrom.HASH}} or metadata={_EXCLUDE: {_ExcludeFrom.HASH, _ExcludeFrom.STORAGE}}
 
         Returns:
             A hex string of the SHA256 hash.
         """
         hashable_dict: dict[str, Any] = {
-            f.name: getattr(self, f.name)
-            for f in fields(self)
-            if f.name not in ("hash", "unique_name") and not f.metadata.get(EXCLUDE_FROM_STORAGE, False)
+            f.name: getattr(self, f.name) for f in fields(self) if not _is_excluded_from_hash(f)
         }
         config_json = json.dumps(hashable_dict, sort_keys=True, separators=(",", ":"), default=_dataclass_encoder)
         return hashlib.sha256(config_json.encode("utf-8")).hexdigest()
@@ -93,10 +152,10 @@ class Identifier:
         """
         result: dict[str, Any] = {}
         for f in fields(self):
-            if f.metadata.get(EXCLUDE_FROM_STORAGE, False):
+            if _is_excluded_from_storage(f):
                 continue
             value = getattr(self, f.name)
-            max_len = f.metadata.get(MAX_STORAGE_LENGTH)
+            max_len = f.metadata.get(_MAX_STORAGE_LENGTH)
             if max_len is not None and isinstance(value, str) and len(value) > max_len:
                 truncated = value[:max_len]
                 field_hash = hashlib.sha256(value.encode()).hexdigest()[:16]
@@ -116,12 +175,6 @@ class Identifier:
     def from_dict(cls: Type[T], data: dict[str, Any]) -> T:
         """
         Create an Identifier from a dictionary (e.g., retrieved from database).
-
-        This handles:
-        - Legacy '__type__' key mapping to 'class_name'
-        - Legacy 'type' key mapping to 'class_name' (with deprecation warning)
-        - Legacy '__module__' key mapping to 'class_module'
-        - Ignoring unknown fields not present in the dataclass
 
         Note:
             For fields with max_storage_length, stored values may be truncated

--- a/pyrit/identifiers/identifier.py
+++ b/pyrit/identifiers/identifier.py
@@ -102,7 +102,9 @@ class Identifier:
     # Auto-computed fields
     snake_class_name: str = field(init=False, metadata={_EXCLUDE: {_ExcludeFrom.HASH, _ExcludeFrom.STORAGE}})
     hash: str | None = field(default=None, compare=False, kw_only=True, metadata={_EXCLUDE: {_ExcludeFrom.HASH}})
-    unique_name: str = field(init=False, metadata={_EXCLUDE: {_ExcludeFrom.HASH}})  # {full_snake_case}::{hash[:8]}
+
+    # {full_snake_case}::{hash[:8]}
+    unique_name: str = field(init=False, metadata={_EXCLUDE: {_ExcludeFrom.HASH, _ExcludeFrom.STORAGE}})  
 
     # Version field - stored but not hashed (allows version tracking without affecting identity)
     pyrit_version: str = field(

--- a/pyrit/identifiers/scorer_identifier.py
+++ b/pyrit/identifiers/scorer_identifier.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Type, cast
 
-from pyrit.identifiers.identifier import MAX_STORAGE_LENGTH, Identifier
+from pyrit.identifiers.identifier import _MAX_STORAGE_LENGTH, Identifier
 from pyrit.models.score import ScoreType
 
 
@@ -22,10 +22,10 @@ class ScorerIdentifier(Identifier):
     scorer_type: ScoreType = "unknown"
     """The type of scorer ("true_false", "float_scale", or "unknown")."""
 
-    system_prompt_template: Optional[str] = field(default=None, metadata={MAX_STORAGE_LENGTH: 100})
+    system_prompt_template: Optional[str] = field(default=None, metadata={_MAX_STORAGE_LENGTH: 100})
     """The system prompt template used by the scorer. Truncated for storage if > 100 characters."""
 
-    user_prompt_template: Optional[str] = field(default=None, metadata={MAX_STORAGE_LENGTH: 100})
+    user_prompt_template: Optional[str] = field(default=None, metadata={_MAX_STORAGE_LENGTH: 100})
     """The user prompt template used by the scorer. Truncated for storage if > 100 characters."""
 
     sub_identifier: Optional[List["ScorerIdentifier"]] = None

--- a/pyrit/memory/memory_models.py
+++ b/pyrit/memory/memory_models.py
@@ -243,10 +243,10 @@ class PromptMemoryEntry(Base):
         converter_ids: Optional[List[Union[ConverterIdentifier, Dict[str, str]]]] = None
         stored_version = self.pyrit_version or LEGACY_PYRIT_VERSION
         if self.converter_identifiers:
-            converter_ids = []
-            for c in self.converter_identifiers:
-                converter = ConverterIdentifier.from_dict(c)
-                converter_ids.append(converter.with_pyrit_version(stored_version))
+            converter_ids = [
+                ConverterIdentifier.from_dict({**c, "pyrit_version": stored_version})
+                for c in self.converter_identifiers
+            ]
         message_piece = MessagePiece(
             role=self.role,
             original_value=self.original_value,
@@ -374,8 +374,9 @@ class ScoreEntry(Base):
         scorer_identifier = None
         stored_version = self.pyrit_version or LEGACY_PYRIT_VERSION
         if self.scorer_class_identifier:
-            scorer_identifier = ScorerIdentifier.from_dict(self.scorer_class_identifier)
-            scorer_identifier = scorer_identifier.with_pyrit_version(stored_version)
+            scorer_identifier = ScorerIdentifier.from_dict(
+                {**self.scorer_class_identifier, "pyrit_version": stored_version}
+            )
         return Score(
             id=self.id,
             score_value=self.score_value,
@@ -947,8 +948,9 @@ class ScenarioResultEntry(Base):
         # Convert dict back to ScorerIdentifier with the stored pyrit_version
         scorer_identifier = None
         if self.objective_scorer_identifier:
-            scorer_identifier = ScorerIdentifier.from_dict(self.objective_scorer_identifier)
-            scorer_identifier = scorer_identifier.with_pyrit_version(stored_version)
+            scorer_identifier = ScorerIdentifier.from_dict(
+                {**self.objective_scorer_identifier, "pyrit_version": stored_version}
+            )
 
         return ScenarioResult(
             id=self.id,

--- a/tests/unit/identifiers/test_identifiers.py
+++ b/tests/unit/identifiers/test_identifiers.py
@@ -194,14 +194,16 @@ class TestIdentifierStorage:
         storage_dict = identifier.to_dict()
 
         # Should include storable fields
-        assert "unique_name" in storage_dict
         assert "class_name" in storage_dict
         assert "class_module" in storage_dict
         assert "hash" in storage_dict
+        assert "pyrit_version" in storage_dict
 
-        # Should exclude non-storable fields
+        # Should exclude non-storable fields (marked with _ExcludeFrom.STORAGE)
         assert "class_description" not in storage_dict
         assert "identifier_type" not in storage_dict
+        assert "snake_class_name" not in storage_dict
+        assert "unique_name" not in storage_dict
 
     def test_to_dict_values_match(self):
         """Test that to_dict values match the original identifier."""
@@ -213,8 +215,10 @@ class TestIdentifierStorage:
         )
         storage_dict = identifier.to_dict()
 
-        # unique_name is auto-computed
-        assert storage_dict["unique_name"] == identifier.unique_name
+        # unique_name and snake_class_name are excluded from storage
+        assert "unique_name" not in storage_dict
+        assert "snake_class_name" not in storage_dict
+        # Stored fields match
         assert storage_dict["class_name"] == "MyScorer"
         assert storage_dict["class_module"] == "pyrit.score.my_scorer"
         assert storage_dict["hash"] == identifier.hash

--- a/tests/unit/identifiers/test_scorer_identifier.py
+++ b/tests/unit/identifiers/test_scorer_identifier.py
@@ -162,7 +162,8 @@ class TestScorerIdentifierToDict:
         assert result["class_name"] == "TestScorer"
         assert result["class_module"] == "pyrit.score.test_scorer"
         assert result["hash"] == identifier.hash
-        assert result["unique_name"] == identifier.unique_name
+        # unique_name is excluded from storage (has _ExcludeFrom.STORAGE metadata)
+        assert "unique_name" not in result
         # class_description and identifier_type should be excluded
         assert "class_description" not in result
         assert "identifier_type" not in result


### PR DESCRIPTION
In our original `scorer_identifier`, I explicitly removed `pyrit_version` from the identifier because we don't want it as part of the hash (e.g. if the `pyrit_version` changes, we don't want to have to re-calculate scorer metrics).

Now that we have more robust general `Identifiers`, this PR adds it back.

Also added tests and refactored for readability (clearly separating hashes and storage metadata exclusion keys).