### PR TITLE
 [DEMONSTRATION ONLY - WILL NOT BE MERGED!] Component Config / Registry Entry: A new alternative design to Identifiers

### DIFF
--- a/pyrit/identifiers/__init__.py
+++ b/pyrit/identifiers/__init__.py
@@ -15,6 +15,7 @@ from pyrit.identifiers.identifier import (
 )
 from pyrit.identifiers.scorer_identifier import ScorerIdentifier
 from pyrit.identifiers.target_identifier import TargetIdentifier
+from pyrit.identifiers.component_config import ComponentConfig, Configurable
 
 __all__ = [
     "class_name_to_snake_case",
@@ -27,4 +28,6 @@ __all__ = [
     "ScorerIdentifier",
     "snake_case_to_class_name",
     "TargetIdentifier",
+    "ComponentConfig",
+    "Configurable",
 ]

--- a/pyrit/identifiers/component_config.py
+++ b/pyrit/identifiers/component_config.py
@@ -33,11 +33,6 @@ from pyrit.identifiers.class_name_utils import class_name_to_snake_case
 logger = logging.getLogger(__name__)
 
 
-# ---------------------------------------------------------------------------
-# Pure utility functions
-# ---------------------------------------------------------------------------
-
-
 def config_hash(config_dict: Dict[str, Any]) -> str:
     """
     Compute a deterministic SHA256 hash from a config dictionary.
@@ -107,11 +102,6 @@ def _build_hash_dict(
     return hash_dict
 
 
-# ---------------------------------------------------------------------------
-# ComponentConfig — the frozen identity snapshot
-# ---------------------------------------------------------------------------
-
-
 @dataclass(frozen=True)
 class ComponentConfig:
     """
@@ -138,10 +128,6 @@ class ComponentConfig:
         pyrit_version (str): Version tag for storage. Not included in hash.
     """
 
-    # -------------------------------------------------------------------
-    # Serialization key constants
-    # -------------------------------------------------------------------
-
     KEY_CLASS_NAME: ClassVar[str] = "class_name"
     KEY_CLASS_MODULE: ClassVar[str] = "class_module"
     KEY_HASH: ClassVar[str] = "hash"
@@ -149,10 +135,6 @@ class ComponentConfig:
     KEY_CHILDREN: ClassVar[str] = "children"
     LEGACY_KEY_TYPE: ClassVar[str] = "__type__"
     LEGACY_KEY_MODULE: ClassVar[str] = "__module__"
-
-    # -------------------------------------------------------------------
-    # Fields
-    # -------------------------------------------------------------------
 
     class_name: str
     class_module: str
@@ -170,10 +152,6 @@ class ComponentConfig:
             children=self.children,
         )
         object.__setattr__(self, "hash", config_hash(hash_dict))
-
-    # -------------------------------------------------------------------
-    # Computed properties
-    # -------------------------------------------------------------------
 
     @property
     def short_hash(self) -> str:
@@ -207,10 +185,6 @@ class ComponentConfig:
         (e.g., "self_ask_scale_scorer::a1b2c3d4").
         """
         return f"{self.snake_class_name}::{self.short_hash}"
-
-    # -------------------------------------------------------------------
-    # Factory
-    # -------------------------------------------------------------------
 
     @classmethod
     def of(
@@ -250,10 +224,6 @@ class ComponentConfig:
             children=clean_children,
         )
 
-    # -------------------------------------------------------------------
-    # Normalization
-    # -------------------------------------------------------------------
-
     @classmethod
     def normalize(cls, value: Union[ComponentConfig, Dict[str, Any]]) -> ComponentConfig:
         """
@@ -278,10 +248,6 @@ class ComponentConfig:
         if isinstance(value, dict):
             return cls.from_dict(value)
         raise TypeError(f"Expected ComponentConfig or dict, got {type(value).__name__}")
-
-    # -------------------------------------------------------------------
-    # Serialization
-    # -------------------------------------------------------------------
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -382,10 +348,6 @@ class ComponentConfig:
 
         return config
 
-    # -------------------------------------------------------------------
-    # Display
-    # -------------------------------------------------------------------
-
     def __str__(self) -> str:
         """
         Return a human-readable string representation.
@@ -417,11 +379,6 @@ class ComponentConfig:
             parts.append(f"children=({children_str})")
         parts.append(f"hash={self.short_hash}")
         return f"ComponentConfig({', '.join(parts)})"
-
-
-# ---------------------------------------------------------------------------
-# Configurable — the ABC components implement
-# ---------------------------------------------------------------------------
 
 
 class Configurable(ABC):

--- a/pyrit/identifiers/component_config.py
+++ b/pyrit/identifiers/component_config.py
@@ -1,0 +1,469 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""
+Component configuration and identity system for PyRIT.
+
+A ComponentConfig is an immutable snapshot of a component's behavioral configuration,
+serving as both its identity and its storable representation.
+
+Design principles:
+    1. The config dict IS the identity — no wrapper hierarchy needed.
+    2. Hash is content-addressed from behavioral params only.
+    3. Children carry their own hashes — compositional by default.
+    4. Adding optional params with None default is backward-compatible (None values excluded).
+
+ComponentConfig also satisfies the registry metadata contract (has class_name, class_module,
+snake_class_name), so it can be used directly as metadata in instance registries like
+ScorerRegistry without a separate wrapper.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, ClassVar, Dict, List, Optional, Union
+
+import pyrit
+from pyrit.identifiers.class_name_utils import class_name_to_snake_case
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Pure utility functions
+# ---------------------------------------------------------------------------
+
+
+def config_hash(config_dict: Dict[str, Any]) -> str:
+    """
+    Compute a deterministic SHA256 hash from a config dictionary.
+
+    This is the single source of truth for identity hashing across the entire
+    system. The dict is serialized with sorted keys and compact separators to
+    ensure determinism.
+
+    Args:
+        config_dict (Dict[str, Any]): A JSON-serializable dictionary.
+
+    Returns:
+        str: Hex-encoded SHA256 hash string.
+
+    Raises:
+        TypeError: If config_dict contains values that are not JSON-serializable.
+    """
+    canonical = json.dumps(config_dict, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _build_hash_dict(
+    *,
+    class_name: str,
+    class_module: str,
+    params: Dict[str, Any],
+    children: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Build the canonical dictionary used for hash computation.
+
+    Children are represented by their hashes, not their full config.
+    A parent's hash changes when a child's behavioral config changes,
+    but the parent doesn't need to understand the child's internal structure.
+
+    Args:
+        class_name (str): The component's class name.
+        class_module (str): The component's module path.
+        params (Dict[str, Any]): Behavioral parameters (non-None values only).
+        children (Dict[str, Any]): Child name to ComponentConfig or list of ComponentConfig.
+
+    Returns:
+        Dict[str, Any]: The canonical dictionary for hashing.
+    """
+    hash_dict: Dict[str, Any] = {
+        ComponentConfig.KEY_CLASS_NAME: class_name,
+        ComponentConfig.KEY_CLASS_MODULE: class_module,
+    }
+
+    # Only include non-None params — adding an optional param with None default
+    # won't change existing hashes, making the schema backward-compatible.
+    for key, value in sorted(params.items()):
+        if value is not None:
+            hash_dict[key] = value
+
+    # Children contribute their hashes, not their full structure.
+    if children:
+        children_hashes: Dict[str, Any] = {}
+        for name, child in sorted(children.items()):
+            if isinstance(child, ComponentConfig):
+                children_hashes[name] = child.hash
+            elif isinstance(child, list):
+                children_hashes[name] = [c.hash for c in child if isinstance(c, ComponentConfig)]
+        if children_hashes:
+            hash_dict[ComponentConfig.KEY_CHILDREN] = children_hashes
+
+    return hash_dict
+
+
+# ---------------------------------------------------------------------------
+# ComponentConfig — the frozen identity snapshot
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ComponentConfig:
+    """
+    Immutable snapshot of a component's behavioral configuration.
+
+    A single type for all component identity — scorers, targets, converters, and
+    any future component types all produce a ComponentConfig with their relevant
+    params and children.
+
+    The hash is content-addressed: two ComponentConfigs with the same class, params,
+    and children produce the same hash. This enables deterministic metrics lookup,
+    DB deduplication, and registry keying.
+
+    Also usable as registry metadata for instance registries (e.g., ScorerRegistry)
+    because it exposes ``class_name``, ``snake_class_name``, and ``unique_name``.
+
+    Attributes:
+        class_name (str): Python class name (e.g., "SelfAskScaleScorer").
+        class_module (str): Full module path (e.g., "pyrit.score.self_ask_scale_scorer").
+        params (Dict[str, Any]): Behavioral parameters that affect output.
+        children (Dict[str, Union[ComponentConfig, List[ComponentConfig]]]): Named
+            child configs for compositional identity (e.g., a scorer's target).
+        hash (str): Content-addressed SHA256 hash computed from class, params, and children.
+        pyrit_version (str): Version tag for storage. Not included in hash.
+    """
+
+    # -------------------------------------------------------------------
+    # Serialization key constants
+    # -------------------------------------------------------------------
+
+    KEY_CLASS_NAME: ClassVar[str] = "class_name"
+    KEY_CLASS_MODULE: ClassVar[str] = "class_module"
+    KEY_HASH: ClassVar[str] = "hash"
+    KEY_PYRIT_VERSION: ClassVar[str] = "pyrit_version"
+    KEY_CHILDREN: ClassVar[str] = "children"
+    LEGACY_KEY_TYPE: ClassVar[str] = "__type__"
+    LEGACY_KEY_MODULE: ClassVar[str] = "__module__"
+
+    # -------------------------------------------------------------------
+    # Fields
+    # -------------------------------------------------------------------
+
+    class_name: str
+    class_module: str
+    params: Dict[str, Any] = field(default_factory=dict)
+    children: Dict[str, Union[ComponentConfig, List[ComponentConfig]]] = field(default_factory=dict)
+    hash: str = field(init=False, compare=False)
+    pyrit_version: str = field(default_factory=lambda: pyrit.__version__, compare=False)
+
+    def __post_init__(self) -> None:
+        """Compute the content-addressed hash at creation time."""
+        hash_dict = _build_hash_dict(
+            class_name=self.class_name,
+            class_module=self.class_module,
+            params=self.params,
+            children=self.children,
+        )
+        object.__setattr__(self, "hash", config_hash(hash_dict))
+
+    # -------------------------------------------------------------------
+    # Computed properties
+    # -------------------------------------------------------------------
+
+    @property
+    def short_hash(self) -> str:
+        """
+        Return the first 8 characters of the hash for display and logging.
+
+        This truncated hash provides sufficient uniqueness for human-readable
+        identification while keeping output concise. Used in string representations,
+        log messages, and registry keys.
+
+        Returns:
+            str: First 8 hex characters of the SHA256 hash.
+        """
+        return self.hash[:8]
+
+    @property
+    def snake_class_name(self) -> str:
+        """
+        Snake_case version of class_name (e.g., "self_ask_scale_scorer").
+
+        Used by registries for key derivation and CLI formatting.
+        """
+        return class_name_to_snake_case(self.class_name)
+
+    @property
+    def unique_name(self) -> str:
+        """
+        Globally unique display name: ``snake_class_name::short_hash``.
+
+        Used as the default registration key in instance registries
+        (e.g., "self_ask_scale_scorer::a1b2c3d4").
+        """
+        return f"{self.snake_class_name}::{self.short_hash}"
+
+    # -------------------------------------------------------------------
+    # Factory
+    # -------------------------------------------------------------------
+
+    @classmethod
+    def of(
+        cls,
+        obj: object,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        children: Optional[Dict[str, Union[ComponentConfig, List[ComponentConfig]]]] = None,
+    ) -> ComponentConfig:
+        """
+        Build a ComponentConfig from a live object instance.
+
+        This factory method extracts class_name and class_module from the object's
+        type automatically, making it the preferred way to create configs in
+        component implementations. None-valued params and children are filtered out
+        to ensure backward-compatible hashing.
+
+        Args:
+            obj (object): The live component instance whose type info will be captured.
+            params (Optional[Dict[str, Any]]): Behavioral parameters that affect the
+                component's output. Only include params that change behavior — exclude
+                operational settings like rate limits, retry counts, or logging config.
+            children (Optional[Dict[str, Union[ComponentConfig, List[ComponentConfig]]]]):
+                Named child component configs. Use for compositional components like
+                scorers that wrap other scorers or targets that chain converters.
+
+        Returns:
+            ComponentConfig: The frozen config snapshot with computed hash.
+        """
+        clean_params = {k: v for k, v in (params or {}).items() if v is not None}
+        clean_children = {k: v for k, v in (children or {}).items() if v is not None}
+
+        return cls(
+            class_name=obj.__class__.__name__,
+            class_module=obj.__class__.__module__,
+            params=clean_params,
+            children=clean_children,
+        )
+
+    # -------------------------------------------------------------------
+    # Normalization
+    # -------------------------------------------------------------------
+
+    @classmethod
+    def normalize(cls, value: Union[ComponentConfig, Dict[str, Any]]) -> ComponentConfig:
+        """
+        Normalize a value to a ComponentConfig instance.
+
+        Accepts either an existing ComponentConfig (returned as-is) or a dict
+        (reconstructed via from_dict). This supports code paths that may receive
+        either typed configs or raw dicts from database storage.
+
+        Args:
+            value (Union[ComponentConfig, Dict[str, Any]]): A ComponentConfig or
+                a dictionary representation.
+
+        Returns:
+            ComponentConfig: The normalized config instance.
+
+        Raises:
+            TypeError: If value is neither a ComponentConfig nor a dict.
+        """
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, dict):
+            return cls.from_dict(value)
+        raise TypeError(f"Expected ComponentConfig or dict, got {type(value).__name__}")
+
+    # -------------------------------------------------------------------
+    # Serialization
+    # -------------------------------------------------------------------
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize to a JSON-compatible dictionary for DB/JSONL storage.
+
+        Produces a flat structure where params are inlined at the top level alongside
+        class_name, class_module, hash, and pyrit_version. This maintains backward
+        compatibility with existing DB queries that access params directly
+        (e.g., ``scorer_class_identifier->>'scorer_type'``).
+
+        Children are recursively serialized into a nested "children" key.
+
+        Returns:
+            Dict[str, Any]: JSON-serializable dictionary suitable for database storage
+                or JSONL export.
+        """
+        result: Dict[str, Any] = {
+            self.KEY_CLASS_NAME: self.class_name,
+            self.KEY_CLASS_MODULE: self.class_module,
+            self.KEY_HASH: self.hash,
+            self.KEY_PYRIT_VERSION: self.pyrit_version,
+        }
+
+        for key, value in self.params.items():
+            result[key] = value
+
+        if self.children:
+            serialized_children: Dict[str, Any] = {}
+            for name, child in self.children.items():
+                if isinstance(child, ComponentConfig):
+                    serialized_children[name] = child.to_dict()
+                elif isinstance(child, list):
+                    serialized_children[name] = [c.to_dict() for c in child]
+            result[self.KEY_CHILDREN] = serialized_children
+
+        return result
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> ComponentConfig:
+        """
+        Deserialize from a stored dictionary.
+
+        Reconstructs a ComponentConfig from data previously saved via to_dict().
+        Handles both the current format (``class_name``/``class_module``) and legacy
+        format (``__type__``/``__module__``) for backward compatibility with
+        older database records.
+
+        The hash is always recomputed from the reconstructed params and children.
+        If the stored hash differs from the computed hash, a warning is logged
+        indicating possible schema drift.
+
+        Args:
+            data (Dict[str, Any]): Dictionary from DB/JSONL storage. The original
+                dict is not mutated; a copy is made internally.
+
+        Returns:
+            ComponentConfig: Reconstructed config with freshly computed hash.
+        """
+        data = dict(data)  # Don't mutate the input
+
+        # Handle legacy key mappings
+        class_name = (
+            data.pop(cls.KEY_CLASS_NAME, None) or data.pop(cls.LEGACY_KEY_TYPE, None) or "Unknown"
+        )
+        class_module = (
+            data.pop(cls.KEY_CLASS_MODULE, None) or data.pop(cls.LEGACY_KEY_MODULE, None) or "unknown"
+        )
+
+        stored_hash = data.pop(cls.KEY_HASH, None)
+        pyrit_version = data.pop(cls.KEY_PYRIT_VERSION, pyrit.__version__)
+
+        # Reconstruct children
+        children: Dict[str, Union[ComponentConfig, List[ComponentConfig]]] = {}
+        raw_children = data.pop(cls.KEY_CHILDREN, None)
+        if raw_children and isinstance(raw_children, dict):
+            for name, child_data in raw_children.items():
+                if isinstance(child_data, dict):
+                    children[name] = cls.from_dict(child_data)
+                elif isinstance(child_data, list):
+                    children[name] = [cls.from_dict(c) for c in child_data if isinstance(c, dict)]
+
+        # Everything remaining is a param
+        params = data
+
+        config = cls(
+            class_name=class_name,
+            class_module=class_module,
+            params=params,
+            children=children,
+            pyrit_version=pyrit_version,
+        )
+
+        if stored_hash and config.hash != stored_hash:
+            logger.warning(
+                f"Hash mismatch for {class_name}: stored={stored_hash[:8]}, "
+                f"computed={config.short_hash}. Schema may have changed."
+            )
+
+        return config
+
+    # -------------------------------------------------------------------
+    # Display
+    # -------------------------------------------------------------------
+
+    def __str__(self) -> str:
+        """
+        Return a human-readable string representation.
+
+        Format: ``ClassName::abcd1234`` (class name followed by short hash).
+        Suitable for log messages and user-facing output.
+
+        Returns:
+            str: Human-readable identifier string.
+        """
+        return f"{self.class_name}::{self.short_hash}"
+
+    def __repr__(self) -> str:
+        """
+        Return a detailed representation for debugging.
+
+        Includes class name, all params, children references, and the short hash.
+        Useful for inspecting config contents in debuggers or REPL sessions.
+
+        Returns:
+            str: Detailed debug string showing all config components.
+        """
+        params_str = ", ".join(f"{k}={v!r}" for k, v in sorted(self.params.items()))
+        children_str = ", ".join(f"{k}={v}" for k, v in sorted(self.children.items()))
+        parts = [f"class={self.class_name}"]
+        if params_str:
+            parts.append(f"params=({params_str})")
+        if children_str:
+            parts.append(f"children=({children_str})")
+        parts.append(f"hash={self.short_hash}")
+        return f"ComponentConfig({', '.join(parts)})"
+
+
+# ---------------------------------------------------------------------------
+# Configurable — the ABC components implement
+# ---------------------------------------------------------------------------
+
+
+class Configurable(ABC):
+    """
+    Abstract base class for components that describe their behavioral configuration.
+
+    Components implement ``_build_config()`` to return a frozen ComponentConfig
+    snapshot. The config is built lazily on first access and cached for the
+    component's lifetime.
+    """
+
+    _config: Optional[ComponentConfig] = None
+
+    @abstractmethod
+    def _build_config(self) -> ComponentConfig:
+        """
+        Build the behavioral configuration for this component.
+
+        Only include params that affect the component's behavior/output.
+        Exclude operational params (rate limits, retry config, logging settings).
+
+        Returns:
+            ComponentConfig: The frozen configuration snapshot.
+        """
+        ...
+
+    def get_config(self) -> ComponentConfig:
+        """
+        Get the component's configuration, building it lazily on first access.
+
+        The config is computed once via _build_config() and then cached for
+        subsequent calls. This ensures consistent identity throughout the
+        component's lifetime while deferring computation until actually needed.
+
+        Note:
+            Not thread-safe. If thread safety is required, subclasses should
+            implement appropriate synchronization.
+
+        Returns:
+            ComponentConfig: The frozen configuration snapshot representing
+                this component's behavioral identity.
+        """
+        if self._config is None:
+            self._config = self._build_config()
+        return self._config

--- a/pyrit/prompt_target/openai/openai_chat_target.py
+++ b/pyrit/prompt_target/openai/openai_chat_target.py
@@ -4,7 +4,7 @@
 import base64
 import json
 import logging
-from typing import Any, Dict, MutableSequence, Optional
+from typing import Any, ClassVar, Dict, MutableSequence, Optional
 
 from pyrit.common import convert_local_image_to_data_url
 from pyrit.exceptions import (
@@ -13,6 +13,7 @@ from pyrit.exceptions import (
     pyrit_target_retry,
 )
 from pyrit.identifiers import TargetIdentifier
+from pyrit.identifiers.component_config import ComponentConfig
 from pyrit.models import (
     ChatMessage,
     DataTypeSerializer,
@@ -61,6 +62,16 @@ class OpenAIChatTarget(OpenAITarget, PromptChatTarget):
         extra_body_parameters (dict): Additional parameters to send in the request body
 
     """
+
+    # Configuration key constants
+    CONFIG_KEY_TEMPERATURE: ClassVar[str] = "temperature"
+    CONFIG_KEY_TOP_P: ClassVar[str] = "top_p"
+    CONFIG_KEY_MAX_COMPLETION_TOKENS: ClassVar[str] = "max_completion_tokens"
+    CONFIG_KEY_MAX_TOKENS: ClassVar[str] = "max_tokens"
+    CONFIG_KEY_FREQUENCY_PENALTY: ClassVar[str] = "frequency_penalty"
+    CONFIG_KEY_PRESENCE_PENALTY: ClassVar[str] = "presence_penalty"
+    CONFIG_KEY_SEED: ClassVar[str] = "seed"
+    CONFIG_KEY_N: ClassVar[str] = "n"
 
     def __init__(
         self,
@@ -181,6 +192,26 @@ class OpenAIChatTarget(OpenAITarget, PromptChatTarget):
                 "presence_penalty": self._presence_penalty,
                 "seed": self._seed,
                 "n": self._n,
+            },
+        )
+    
+    def _build_config(self) -> ComponentConfig:
+        """
+        Build the behavioral configuration for this target.
+
+        Returns:
+            ComponentConfig: The frozen configuration snapshot.
+        """
+        return self._create_config(
+            params={
+                self.CONFIG_KEY_TEMPERATURE: self._temperature,
+                self.CONFIG_KEY_TOP_P: self._top_p,
+                self.CONFIG_KEY_MAX_COMPLETION_TOKENS: self._max_completion_tokens,
+                self.CONFIG_KEY_MAX_TOKENS: self._max_tokens,
+                self.CONFIG_KEY_FREQUENCY_PENALTY: self._frequency_penalty,
+                self.CONFIG_KEY_PRESENCE_PENALTY: self._presence_penalty,
+                self.CONFIG_KEY_SEED: self._seed,
+                self.CONFIG_KEY_N: self._n,
             },
         )
 

--- a/pyrit/registry/base.py
+++ b/pyrit/registry/base.py
@@ -8,11 +8,49 @@ This module contains types shared between class registries (which store Type[T])
 and instance registries (which store T instances).
 """
 
+from dataclasses import dataclass
 from typing import Any, Dict, Iterator, List, Optional, Protocol, TypeVar, runtime_checkable
+
+from pyrit.identifiers.class_name_utils import class_name_to_snake_case
 
 # Type variable for metadata (invariant for Protocol compatibility)
 MetadataT = TypeVar("MetadataT")
 
+
+@dataclass(frozen=True)
+class RegistryEntry:
+    """
+    Minimal base for class-level registry metadata.
+
+    Provides the common fields every registry metadata type needs for display,
+    lookup, and filtering in class registries (ScenarioRegistry, InitializerRegistry).
+
+    This is NOT for component instance identity — use ComponentConfig for that.
+    RegistryEntry describes a *class* for discovery and CLI listing;
+    ComponentConfig describes a *configured instance* for DB storage and hash-based lookup.
+
+    Subclasses (ScenarioMetadata, InitializerMetadata) add domain-specific fields
+    as frozen dataclass fields.
+
+    Attributes:
+        class_name (str): Python class name (e.g., "ContentHarmsScenario").
+        class_module (str): Full module path (e.g., "pyrit.scenario.scenarios.content_harms").
+        class_description (str): Human-readable description, typically from the class docstring.
+    """
+
+    class_name: str
+    class_module: str
+    class_description: str = ""
+
+    @property
+    def snake_class_name(self) -> str:
+        """
+        Snake_case version of class_name (e.g., "content_harms_scenario").
+
+        Used by CLI formatting and as registry display keys.
+        """
+        return class_name_to_snake_case(self.class_name)
+    
 
 @runtime_checkable
 class RegistryProtocol(Protocol[MetadataT]):

--- a/pyrit/registry/class_registries/base_class_registry.py
+++ b/pyrit/registry/class_registries/base_class_registry.py
@@ -19,9 +19,8 @@ Terminology:
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, Generic, Iterator, List, Optional, Type, TypeVar
 
-from pyrit.identifiers import Identifier
 from pyrit.identifiers.class_name_utils import class_name_to_snake_case
-from pyrit.registry.base import RegistryProtocol
+from pyrit.registry.base import RegistryEntry, RegistryProtocol
 
 # Type variable for the registered class type
 T = TypeVar("T")
@@ -183,7 +182,7 @@ class BaseClassRegistry(ABC, RegistryProtocol[MetadataT], Generic[T, MetadataT])
         """
         pass
 
-    def _build_base_metadata(self, name: str, entry: ClassEntry[T]) -> Identifier:
+    def _build_base_metadata(self, name: str, entry: ClassEntry[T]) -> RegistryEntry:
         """
         Build the common base metadata for a registered class.
 
@@ -195,7 +194,7 @@ class BaseClassRegistry(ABC, RegistryProtocol[MetadataT], Generic[T, MetadataT])
             entry: The ClassEntry containing the registered class.
 
         Returns:
-            An Identifier dataclass with common fields.
+            A RegistryEntry dataclass with common fields.
         """
         registered_class = entry.registered_class
 
@@ -206,8 +205,7 @@ class BaseClassRegistry(ABC, RegistryProtocol[MetadataT], Generic[T, MetadataT])
         else:
             description = entry.description or "No description available"
 
-        return Identifier(
-            identifier_type="class",
+        return RegistryEntry(
             class_name=registered_class.__name__,
             class_module=registered_class.__module__,
             class_description=description,

--- a/pyrit/registry/class_registries/initializer_registry.py
+++ b/pyrit/registry/class_registries/initializer_registry.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Optional
 
 from pyrit.identifiers import Identifier
+from pyrit.registry.base import RegistryEntry
 from pyrit.registry.class_registries.base_class_registry import (
     BaseClassRegistry,
     ClassEntry,
@@ -34,16 +35,21 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class InitializerMetadata(Identifier):
+class InitializerMetadata(RegistryEntry):
     """
     Metadata describing a registered PyRITInitializer class.
 
     Use get_class() to get the actual class.
     """
 
-    display_name: str
-    required_env_vars: tuple[str, ...]
-    execution_order: int
+    # Human-readable display name (e.g., "Objective Target Setup").
+    display_name: str = ""
+
+    # Environment variables required by the initializer.
+    required_env_vars: tuple[str, ...] = ()
+
+    # Execution order priority (lower = earlier).
+    execution_order: int = 100
 
 
 class InitializerRegistry(BaseClassRegistry["PyRITInitializer", InitializerMetadata]):
@@ -208,7 +214,6 @@ class InitializerRegistry(BaseClassRegistry["PyRITInitializer", InitializerMetad
         try:
             instance = initializer_class()
             return InitializerMetadata(
-                identifier_type="class",
                 class_name=initializer_class.__name__,
                 class_module=initializer_class.__module__,
                 class_description=instance.description,
@@ -219,7 +224,6 @@ class InitializerRegistry(BaseClassRegistry["PyRITInitializer", InitializerMetad
         except Exception as e:
             logger.warning(f"Failed to get metadata for {name}: {e}")
             return InitializerMetadata(
-                identifier_type="class",
                 class_name=initializer_class.__name__,
                 class_module=initializer_class.__module__,
                 class_description="Error loading initializer metadata",

--- a/pyrit/registry/class_registries/scenario_registry.py
+++ b/pyrit/registry/class_registries/scenario_registry.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Optional
 
 from pyrit.identifiers import Identifier
 from pyrit.identifiers.class_name_utils import class_name_to_snake_case
+from pyrit.registry.base import RegistryEntry
 from pyrit.registry.class_registries.base_class_registry import (
     BaseClassRegistry,
     ClassEntry,
@@ -33,18 +34,27 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class ScenarioMetadata(Identifier):
+class ScenarioMetadata(RegistryEntry):
     """
     Metadata describing a registered Scenario class.
 
     Use get_class() to get the actual class.
     """
 
-    default_strategy: str
-    all_strategies: tuple[str, ...]
-    aggregate_strategies: tuple[str, ...]
-    default_datasets: tuple[str, ...]
-    max_dataset_size: Optional[int]
+    # The default strategy name (e.g., "single_turn").
+    default_strategy: str = ""
+
+    # All available strategy names for this scenario.
+    all_strategies: tuple[str, ...] = ()
+
+    # Aggregate strategies that combine multiple attack approaches.
+    aggregate_strategies: tuple[str, ...] = ()
+
+    # Default dataset names used by this scenario.
+    default_datasets: tuple[str, ...] = ()
+
+    # Maximum number of items per dataset.
+    max_dataset_size: Optional[int] = None
 
 
 class ScenarioRegistry(BaseClassRegistry["Scenario", ScenarioMetadata]):
@@ -170,7 +180,6 @@ class ScenarioRegistry(BaseClassRegistry["Scenario", ScenarioMetadata]):
         max_dataset_size = dataset_config.max_dataset_size
 
         return ScenarioMetadata(
-            identifier_type="class",
             class_name=scenario_class.__name__,
             class_module=scenario_class.__module__,
             class_description=description,


### PR DESCRIPTION
# Simplify Component Identity: ComponentConfig + RegistryEntry

NOTE:
For demonstration purposes, this is additive, I did not remove any of the existing Identifier functionality. Components implement both `Identifiable` and `Configurable` for side-by-side comparison. For `RegistryEntry`, the metadata classes (`ScenarioMetadata`, `InitializerMetadata`) are swapped directly since they are ephemeral and never persisted to storage.


## Context

I was looking at the `Identifier` class and realized it's overly complex for what it does. It handles instance identity, registry metadata, hash computation with field exclusion annotations, serialization with storage truncation, and more, all in one class. It works, but the coupling it creates makes the codebase harder to change than it should be.

I started asking what if we split this into two small, focused types instead? That's what this PR does. Below I'll walk through the specific issues I found and how the new design addresses each one.

## Issue 1: Parents know the target's schema

This is the one that bothered me most. e.g. in `Scorer._create_identifier()`:

```python
# pyrit/score/scorer.py - _create_identifier()
target_info: Optional[Dict[str, Any]] = None
if prompt_target:
    target_id = prompt_target.get_identifier()
    target_info = {"class_name": target_id.class_name}
    if target_id.model_name:
        target_info["model_name"] = target_id.model_name
    if target_id.temperature is not None:
        target_info["temperature"] = target_id.temperature
    if target_id.top_p is not None:
        target_info["top_p"] = target_id.top_p
```

The scorer is reaching into the target's `TargetIdentifier` and cherry-picking fields it thinks are important (`model_name`, `temperature`, `top_p`). This is tight coupling, the scorer has to know the target's identity schema. If someone adds a field to `TargetIdentifier` that matters for behavior (say `max_tokens` or `frequency_penalty`), the scorer's identity won't reflect it unless someone also remembers to update this extraction logic.

And the extraction is lossy. The target has a full typed identifier with all its params; the scorer flattens it to a `Dict[str, Any]` with only the fields someone decided to copy over.

This isn't isolated to the scorer. The converter has the exact same coupling:

```python
# pyrit/prompt_converter/prompt_converter.py -  _create_identifier()
if converter_target:
    target_id = converter_target.get_identifier()
    target_info = {
        "class_name": target_id.class_name,
        "model_name": target_id.model_name,
        "temperature": target_id.temperature,
        "top_p": target_id.top_p,
    }
```

Same pattern, the parent reaches into the child's schema and cherry-picks the same four fields. Actually worse than the scorer version because it doesn't even check for `None` values. Any component that holds a reference to another component and wants to include it in its identity has to repeat this extraction logic.

**With ComponentConfig**, the scorer doesn't look inside the target at all:

```python
class SelfAskScaleScorer(FloatScaleScorer, Configurable):
    def _build_config(self) -> ComponentConfig:
        return self._create_config(
            params={
                self.CONFIG_KEY_SYSTEM_PROMPT: self._system_prompt,
                self.CONFIG_KEY_USER_PROMPT_TEMPLATE: "objective: {objective}\nresponse: {response}",
            },
            children={self.CONFIG_KEY_PROMPT_TARGET: self._prompt_target.get_config()},
        )
```

The target's entire config is captured as a child. The scorer's hash incorporates the target's hash, if the target's config changes (new model, different temperature, anything), the scorer's hash changes automatically. The scorer never needs to know what fields the target has.

## Issue 2: Hashing is implicit and annotation-driven

The current system uses field metadata annotations to control what gets hashed:

```python
# pyrit/identifiers/identifier.py
class _ExcludeFrom(Enum):
    HASH = "hash"
    STORAGE = "storage"

_EXPANSION_CATALOG: dict[_ExcludeFrom, set[_ExcludeFrom]] = {
    _ExcludeFrom.HASH: {_ExcludeFrom.HASH},
    _ExcludeFrom.STORAGE: {_ExcludeFrom.STORAGE, _ExcludeFrom.HASH},
}

# Then on each field:
class Identifier:
    class_description: str = field(metadata={_EXCLUDE: {_ExcludeFrom.STORAGE}})
    identifier_type: IdentifierType = field(metadata={_EXCLUDE: {_ExcludeFrom.STORAGE}})
    hash: str | None = field(default=None, compare=False, kw_only=True, metadata={_EXCLUDE: {_ExcludeFrom.HASH}})
    pyrit_version: str = field(default_factory=..., kw_only=True, metadata={_EXCLUDE: {_ExcludeFrom.HASH}})
```

And in the subclasses:

```python
class ScorerIdentifier(Identifier):
    system_prompt_template: Optional[str] = field(default=None, metadata={_MAX_STORAGE_LENGTH: 100})
    user_prompt_template: Optional[str] = field(default=None, metadata={_MAX_STORAGE_LENGTH: 100})
```

Then hash computation iterates over all fields and checks each one:

```python
def _compute_hash(self) -> str:
    hashable_dict = {
        f.name: getattr(self, f.name) for f in fields(self) if not _is_excluded_from_hash(f)
    }
```

This is clever, but it means that whether a field participates in hashing is determined by metadata on the field declaration, not by the structure of the data. When someone adds a new field to a subclass, they have to remember to annotate it correctly. There's no compiler error if you forget, the field just silently participates in (or is excluded from) the hash based on defaults.

The `_EXPANSION_CATALOG` adds another layer, `STORAGE` implicitly means `HASH` too, so `_ExcludeFrom.STORAGE` actually excludes from both storage and hashing. You have to understand this expansion system to reason about what any given field does.

**With ComponentConfig**, the separation is structural. There are only two buckets:

```python
@dataclass(frozen=True)
class ComponentConfig:
    class_name: str                    # hashed (part of identity)
    class_module: str                  # hashed
    params: Dict[str, Any]            # hashed - this IS the behavioral config
    children: Dict[str, ...]          # hashed (via child hashes)
    hash: str                         # NOT hashed (it's the output)
    pyrit_version: str                # NOT hashed (metadata for storage)
```

If it's in `params`, it gets hashed. If it's not, it doesn't. There is no annotation system, no expansion catalog, no per-field metadata to get wrong. You can't accidentally put a field in the wrong bucket because the buckets are different structural locations, not metadata flags.

## Issue 3: Registry metadata inherits identity machinery it never uses

`ScenarioMetadata` and `InitializerMetadata` extend `Identifier`:

```python
@dataclass(frozen=True)
class ScenarioMetadata(Identifier):
    default_strategy: str
    all_strategies: tuple[str, ...]
    aggregate_strategies: tuple[str, ...]
    default_datasets: tuple[str, ...]
    max_dataset_size: Optional[int]
```

Through this inheritance, `ScenarioMetadata` gets: `_compute_hash()`, `hash`, `unique_name`, `pyrit_version`, `to_dict()`, `from_dict()`, `identifier_type`, `_ExcludeFrom` field processing, `_MAX_STORAGE_LENGTH` truncation. None of these are ever called on `ScenarioMetadata` instances - the registry builds them on-the-fly for CLI display and filtering, then discards them.

This isn't just dead code on the instance. It's coupling. If someone changes how `Identifier._compute_hash()` works, or how `to_dict()` serializes, `ScenarioMetadata` is implicitly affected. The hash is still computed in `__post_init__` even though nobody reads it. If someone adds a field to `Identifier`, `ScenarioMetadata` inherits it. You can't tell from reading `ScenarioMetadata` which parts of `Identifier` it actually relies on.

The `_build_metadata` call sites also have to pass identity fields that are meaningless for class metadata:

```python
# ScenarioRegistry._build_metadata — current
return ScenarioMetadata(
    identifier_type="class",             # always "class", why is this a per-instance field?
    class_name=scenario_class.__name__,
    class_module=scenario_class.__module__,
    class_description=description,
    default_strategy=...,
    all_strategies=...,
    ...
)

# InitializerRegistry._build_metadata - current
return InitializerMetadata(
    identifier_type="class",             # same - always "class"
    class_name=initializer_class.__name__,
    class_module=initializer_class.__module__,
    class_description=instance.description,
    display_name=instance.name,
    required_env_vars=tuple(instance.required_env_vars),
    execution_order=instance.execution_order,
)
```

Every call passes `identifier_type="class"`. Every instance computes a hash that nobody reads. Every instance carries `pyrit_version` and `unique_name` that no consumer accesses. It's ceremony inherited from a base class designed for a different purpose.

**With RegistryEntry**, the base class has exactly what class registries need and nothing more:

```python
@dataclass(frozen=True)
class RegistryEntry:
    class_name: str
    class_module: str
    class_description: str = ""

    @property
    def snake_class_name(self) -> str:
        return class_name_to_snake_case(self.class_name)
```

The metadata classes inherit only what they use:

```python
# AFTER
@dataclass(frozen=True)
class ScenarioMetadata(RegistryEntry):
    default_strategy: str = ""
    all_strategies: tuple[str, ...] = ()
    aggregate_strategies: tuple[str, ...] = ()
    default_datasets: tuple[str, ...] = ()
    max_dataset_size: Optional[int] = None

@dataclass(frozen=True)
class InitializerMetadata(RegistryEntry):
    display_name: str = ""
    required_env_vars: tuple[str, ...] = ()
    execution_order: int = 100
```

And `_build_metadata` drops the dead fields:

```python
# ScenarioRegistry._build_metadata — new
return ScenarioMetadata(
    class_name=scenario_class.__name__,   # no identifier_type
    class_module=scenario_class.__module__,
    class_description=description,
    default_strategy=...,
    all_strategies=...,
    ...
)
```

`ScenarioMetadata(RegistryEntry)` inherits 3 fields and 1 property. No hash computation, no serialization machinery, no version tracking, no exclusion annotations. Changes to `ComponentConfig` hashing or serialization can't affect registry metadata because they don't share a base class.

Because these metadata classes are ephemeral, created by `_build_metadata` for CLI display and filtering, never persisted to a database, the base class swap is a direct replacement. No dual-implementation period needed, unlike the `Scorer`/`PromptTarget` migration where both `Identifiable` and `Configurable` must coexist while consumers migrate.

The downstream consumers are unaffected:
- CLI formatting (`format_scenario_metadata`, `format_initializer_metadata`) accesses `snake_class_name`, `class_name`, `class_description`, and domain-specific fields, all present on the new types.
- `_matches_filters` is duck-typed via `getattr` and works with both `Identifier` and `RegistryEntry`.
- `BaseClassRegistry`'s `MetadataT` bound changes from `Identifier` to `RegistryEntry`.

## Issue 4: Subclass-per-component is a typed schema for what's really an arbitrary param bag

We have `ScorerIdentifier`, `TargetIdentifier`, and `ConverterIdentifier`, each extending `Identifier` with their own fields. But look at what the subclasses actually add:

```python
# ScorerIdentifier adds:
scorer_type: ScoreType
system_prompt_template: Optional[str]
user_prompt_template: Optional[str]
sub_identifier: Optional[List["ScorerIdentifier"]]
target_info: Optional[Dict[str, Any]]
score_aggregator: Optional[str]
scorer_specific_params: Optional[Dict[str, Any]]    # an easy way to escape the data structure

# TargetIdentifier adds:
endpoint: str
model_name: str
temperature: Optional[float]
top_p: Optional[float]
max_requests_per_minute: Optional[int]
target_specific_params: Optional[Dict[str, Any]]    # an easy way to escape the data structure
```

These fields are the behavioral parameters of each component, which model, what temperature, which prompt template. They're configuration written once at construction, frozen, and then serialized to JSON or hashed. Nobody writes `identifier.scorer_type = "float_scale"` during a running attack.

The tell is the escape hatches. Both subclasses have a `*_specific_params: Optional[Dict[str, Any]]` field, an untyped dict for "everything else that doesn't fit the schema." `OpenAICompletionTarget` uses it for `max_tokens`, `frequency_penalty`, `presence_penalty`, and `n`:

```python
# pyrit/prompt_target/openai/openai_completion_target.py
def _build_identifier(self) -> TargetIdentifier:
    return self._create_identifier(
        temperature=self._temperature,
        top_p=self._top_p,
        target_specific_params={
            "max_tokens": self._max_tokens,
            "frequency_penalty": self._frequency_penalty,
            "presence_penalty": self._presence_penalty,
            "n": self._n,
        },
    )
```

Why do `temperature` and `top_p` get typed fields but `max_tokens` and `frequency_penalty` go into the untyped dict? There's no principled boundary, it's just which params someone happened to put on the base class first. The schema can't keep up with the variety of component params, so it falls back to a dict anyway.

And the main consumers interact with identifiers through the base-class surface:

```python
# ScoreEntry stores it as JSON
entry.scorer_class_identifier = json.dumps(scorer_id.to_dict())

# Metrics lookup compares hashes
scorer_hash = scorer.get_identifier().hash

# ScenarioResult stores it as a dict
self.objective_target_identifier = target.get_identifier()
```

The one exception is `ConsoleScorerPrinter`, which accesses subclass fields directly, `scorer_identifier.target_info`, `.score_aggregator`, `.sub_identifier`. But even there, `target_info` is already `Dict[str, Any]` accessed via `.get("model_name")`, and `scorer_specific_params` is iterated as a generic dict. It's half-typed at best. With `ComponentConfig` this becomes `config.params.get("score_aggregator")` and `config.children.get("sub_scorers", [])`, same access pattern, just through `params` and `children` instead of named fields.

Nobody branches on `isinstance(identifier, ScorerIdentifier)`. The subclass-specific fields are written once at construction, serialized into a JSON blob in the DB, and queried by string key (`scorer_class_identifier->>'scorer_type'`). The type information is erased at the consumption boundary.

When the fields are arbitrary component params, the subclasses already need untyped dict escape hatches, and the single consumer that does typed access is already half-untyped, the subclass hierarchy is providing a typed schema for data that doesn't benefit from one.

**With ComponentConfig**, this is explicit:

```python
# Scorer - params are whatever matters for this scorer
ComponentConfig.of(self, params={"scorer_type": ..., "system_prompt": ...}, children={"target": ...})

# Target - params are whatever matters for this target
ComponentConfig.of(self, params={"endpoint": ..., "model_name": ..., "temperature": ..., "max_tokens": ...})

# Converter - params are whatever matters for this converter
ComponentConfig.of(self, params={"converter_name": ..., "language": ...})
```

No escape hatch needed because the whole thing is a params dict. Components differ in what they put in `params`, not in what subclass they instantiate. Adding a new component type means implementing one method, no new `Identifier` subclass with its own `from_dict()` override.

## Issue 5: The Identifiable generic adds ceremony for no benefit

Components currently must declare their identifier type:

```python
class SelfAskScaleScorer(FloatScaleScorer, Identifiable[ScorerIdentifier]):
    def _build_identifier(self) -> ScorerIdentifier:
        return ScorerIdentifier(
            identifier_type="instance",
            class_name=self.__class__.__name__,
            class_module=self.__class__.__module__,
            class_description=" ".join(self.__class__.__doc__.split()) if self.__class__.__doc__ else "",
            ...
        )
```

The generic type parameter `[ScorerIdentifier]` looks like it gives type safety, but in practice callers almost always work with the result as a dict (`to_dict()`) or only access base-class fields (`hash`, `class_name`). The generic doesn't prevent misuse, it just adds boilerplate.

And every `_build_identifier` has to manually pass `class_name=self.__class__.__name__`, `class_module=self.__class__.__module__`, `class_description=...`, `identifier_type="instance"`, the same 4 lines repeated in every implementation.

**With Configurable**, the boilerplate is gone:

```python
class SelfAskScaleScorer(FloatScaleScorer, Configurable):
   def _build_config(self) -> ComponentConfig:
        return self._create_config(
            params={
                self.CONFIG_KEY_SYSTEM_PROMPT: self._system_prompt,
                self.CONFIG_KEY_USER_PROMPT_TEMPLATE: "objective: {objective}\nresponse: {response}",
            },
            children={self.CONFIG_KEY_PROMPT_TARGET: self._prompt_target.get_config()},
        )

   # base class create config
   def _create_config(
        self,
        *,
        params: Optional[Dict[str, Any]] = None,
        children: Optional[Dict[str, Union[ComponentConfig, List[ComponentConfig]]]] = None,
    ) -> ComponentConfig:
        all_params: Dict[str, Any] = {self.CONFIG_KEY_SCORER_TYPE: self.scorer_type}
        if params:
            all_params.update(params)

        return ComponentConfig.of(
             self,  # class_name and class_module extracted automatically
             params=all_params, 
             children=children
        )
```

`ComponentConfig.of(self)` extracts `class_name` and `class_module` from the object. No generic type parameter, no manual boilerplate fields.

---

## The new design

Two types, each with one job:

**ComponentConfig** - instance identity. A frozen dataclass with `(class_name, class_module, params, children, hash)`. Replaces `ScorerIdentifier`, `TargetIdentifier`, `ConverterIdentifier`, and `Identifiable[T]`.

**RegistryEntry** - class metadata. A frozen dataclass with `(class_name, class_module, class_description)` and a `snake_class_name` property. Replaces `Identifier` as the base for `ScenarioMetadata` and `InitializerMetadata`.

These two types share no base class. They're connected only by duck typing - `_matches_filters()` uses `getattr` and works with both. Changes to one side can't break the other.

## Summary of how each issue is resolved

| Issue | Current | New |
|---|---|---|
| Scorer/converter knows target's schema | Both manually extract `model_name`, `temperature`, `top_p` from `TargetIdentifier` | Child config carried as opaque `ComponentConfig`, hash flows automatically |
| Hash behavior hidden in field metadata | `_ExcludeFrom` enum, `_EXPANSION_CATALOG`, per-field `metadata={_EXCLUDE: ...}` | Structural: `params` gets hashed, everything else doesn't |
| Registry metadata inherits unused machinery | `ScenarioMetadata(Identifier)` inherits hash, serialization, exclusion logic, `identifier_type="class"` on every instance | `ScenarioMetadata(RegistryEntry)` inherits 3 fields and 1 property; direct swap since metadata is ephemeral |
| Subclass per component type | `ScorerIdentifier`, `TargetIdentifier`, `ConverterIdentifier` with typed schemas for arbitrary params (plus `*_specific_params` dict escape hatches) | One `ComponentConfig` type, components differ in params |
| Generic ABC boilerplate | `Identifiable[ScorerIdentifier]`, manual `class_name`/`class_module`/`identifier_type` | `Configurable` ABC, `ComponentConfig.of(self)` extracts class info |

## Other things worth noting

**Backward-compatible schema evolution.** Adding an optional param with `None` default doesn't change existing hashes because `None` values are excluded:

```python
config_v1 = ComponentConfig.of(self, params={"threshold": 0.8})
config_v2 = ComponentConfig.of(self, params={"threshold": 0.8, "new_param": None})
assert config_v1.hash == config_v2.hash
```

**DB backward compatibility.** `to_dict()` inlines params at top level, so existing queries like `scorer_class_identifier->>'scorer_type'` keep working. `from_dict()` handles legacy `__type__`/`__module__` keys.

**Open/Closed for new components.** Adding a new component type means implementing `_build_config()` and putting params in a dict. No new identifier subclass, no new `from_dict()` override.

## Architecture

The design separates instance identity from class metadata, with no shared base class between them:

```
INSTANCE IDENTITY                           CLASS METADATA
(DB storage, hashing, metrics)              (registries, CLI display)

ComponentConfig                             RegistryEntry
├── class_name                              ├── class_name
├── class_module                            ├── class_module
├── params: dict                            ├── class_description
├── children: dict                          └── snake_class_name (property)
├── hash (content-addressed)                    │
├── pyrit_version                               ├── ScenarioMetadata
├── snake_class_name (property)                 │   ├── default_strategy
├── unique_name (property)                      │   ├── all_strategies
└── short_hash (property)                       │   ├── aggregate_strategies
                                                │   ├── default_datasets
Configurable (ABC)                              │   └── max_dataset_size
├── _build_config()                             │
└── get_config() (cached)                       └── InitializerMetadata
                                                    ├── display_name
                                                    ├── required_env_vars
                                                    └── execution_order
```

**Why two unrelated types?** Because they have fundamentally different lifecycles and consumers:

| Concern | ComponentConfig | RegistryEntry |
|---------|----------------|---------------|
| Created when | Component is instantiated | `_build_metadata` called for CLI/listing |
| Persisted to DB | Yes (Score, MessagePiece, ScenarioResult) | No - ephemeral |
| Needs hashing | Yes - content-addressed identity | No |
| Needs serialization | Yes - `to_dict()`/`from_dict()` for DB roundtrip | No |
| Needs version tracking | Yes - `pyrit_version` for schema evolution | No |
| Connected via | `_matches_filters` uses `getattr` on both (duck-typed) | Same |

## Migration plan

Incremental, no big-bang:

1. **Add new types alongside existing** - `ComponentConfig`, `Configurable`, `RegistryEntry` added. Zero breakage, both systems coexist.
2. **Add `ComponentConfig.normalize()`** - classmethod that accepts `ComponentConfig | dict` and returns `ComponentConfig`, mirroring the existing `Identifier.normalize()` pattern. Needed because `MessagePiece` uses `.normalize()` to handle both typed identifiers and legacy dicts from the DB.
3. **Dual-implement on components** - scorers, targets, converters implement both `Configurable` and `Identifiable` temporarily, verify hashes match.
4. **Swap class registry metadata** - `ScenarioMetadata(Identifier)` → `ScenarioMetadata(RegistryEntry)`, `InitializerMetadata(Identifier)` -> `InitializerMetadata(RegistryEntry)`, `BaseClassRegistry`'s `MetadataT` bound: `Identifier` -> `RegistryEntry`. This is a direct replacement (no dual-implementation) because metadata objects are ephemeral, created by `_build_metadata` for CLI display, never persisted. The only code change in `_build_metadata` call sites is removing `identifier_type="class"`.
5. **Migrate `MessagePiece`** - this is the largest consumer surface. Three typed identifier fields (`converter_identifiers: List[ConverterIdentifier]`, `prompt_target_identifier: Optional[TargetIdentifier]`, `scorer_identifier: Optional[ScorerIdentifier]`) change to `ComponentConfig`. `PromptMemoryEntry.get_message_piece()` switches from `TargetIdentifier.from_dict()` / `ConverterIdentifier.from_dict()` to `ComponentConfig.from_dict()`.
6. **Migrate other consumers** - `ScenarioResult`, `Score`, `ConsoleScorerPrinter`, `ScorerRegistry`, `TargetRegistry`, metrics IO.
7. **Remove old types** - delete `Identifier` hierarchy, `Identifiable`, exclusion machinery.

**Deliberate simplification:** The current `_MAX_STORAGE_LENGTH` metadata truncates long prompt templates in `to_dict()` for storage display. `ComponentConfig` doesn't replicate this - if a UI or printer wants to truncate long values, that's a display concern, not an identity concern. The hash already uses full values in both designs.
