### PR TITLE
MAINT Enable ruff C4 (flake8-comprehensions) rules and fix all violations

### DIFF
--- a/build_scripts/check_links.py
+++ b/build_scripts/check_links.py
@@ -189,7 +189,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     total_urls = sum(len(urls) for urls in file_urls.values())
-    unique_urls = len(set(url for urls in file_urls.values() for url in urls))
+    unique_urls = len({url for urls in file_urls.values() for url in urls})
     print(f"Checking {unique_urls} unique URL(s) across {len(file_urls)} file(s) (total: {total_urls})...")
 
     all_broken_urls = check_all_links_parallel(file_urls, max_workers=30)

--- a/doc/generate_docs/pct_to_ipynb.py
+++ b/doc/generate_docs/pct_to_ipynb.py
@@ -62,7 +62,7 @@ def main():
         if file in processed_files:
             print(f"Skipping already processed file: {file}")
             continue
-        if any([skip_file in file for skip_file in skip_files]):
+        if any(skip_file in file for skip_file in skip_files):
             print(f"Skipping configured skipped file: {file}")
             continue
         print(f"Processing {file}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,6 +246,7 @@ fixable = [
     "YTT",
 ]
 select = [
+    "C4",  # https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
     "CPY001",  # missing-copyright-notice
     "D",  # https://docs.astral.sh/ruff/rules/#pydocstyle-d
     "DOC",  # https://docs.astral.sh/ruff/rules/#pydoclint-doc

--- a/pyrit/analytics/text_matching.py
+++ b/pyrit/analytics/text_matching.py
@@ -131,14 +131,14 @@ class ApproximateTextMatching(TextMatching):
         text_str = text if self._case_sensitive else text.lower()
 
         # Generate all n-grams from target
-        target_ngrams = set([target_str[i : i + self._n] for i in range(len(target_str) - (self._n - 1))])
+        target_ngrams = {target_str[i : i + self._n] for i in range(len(target_str) - (self._n - 1))}
 
         # Safety check: if no n-grams were generated, return 0.0
         if not target_ngrams:
             return 0.0
 
         # Count how many target n-grams are found in text
-        matching_ngrams = sum([int(ngram in text_str) for ngram in target_ngrams])
+        matching_ngrams = sum(int(ngram in text_str) for ngram in target_ngrams)
 
         # Calculate proportion of matching n-grams
         score = matching_ngrams / len(target_ngrams)

--- a/pyrit/auxiliary_attacks/gcg/attack/base/attack_manager.py
+++ b/pyrit/auxiliary_attacks/gcg/attack/base/attack_manager.py
@@ -299,7 +299,7 @@ class AttackPrompt:
             gen_config.max_new_tokens = self.test_new_toks
         gen_str = self.generate_str(model, gen_config).strip()
         logger.info(gen_str)
-        jailbroken = not any([prefix in gen_str for prefix in self.test_prefixes])
+        jailbroken = not any(prefix in gen_str for prefix in self.test_prefixes)
         em = self.target in gen_str
         return jailbroken, int(em)
 
@@ -329,7 +329,7 @@ class AttackPrompt:
                 for control in test_controls
             ]
             pad_tok = 0
-            while pad_tok in self.input_ids or any([pad_tok in ids for ids in test_ids]):
+            while pad_tok in self.input_ids or any(pad_tok in ids for ids in test_ids):
                 pad_tok += 1
             nested_ids = torch.nested.nested_tensor(test_ids)
             test_ids = torch.nested.to_padded_tensor(nested_ids, pad_tok, (len(test_ids), max_len))
@@ -521,7 +521,7 @@ class PromptManager:
         return [prompt.test_loss(model) for prompt in self._prompts]
 
     def grad(self, model: Any) -> torch.Tensor:
-        return sum([prompt.grad(model) for prompt in self._prompts])  # type: ignore[return-value, unused-ignore]
+        return sum(prompt.grad(model) for prompt in self._prompts)  # type: ignore[return-value, unused-ignore]
 
     def logits(self, model: Any, test_controls: Any = None, return_ids: bool = False) -> Any:
         vals = [prompt.logits(model, test_controls, return_ids) for prompt in self._prompts]
@@ -1564,7 +1564,7 @@ class EvaluateAttack:
 
                     curr_jb, curr_em = [], []
                     for gen_str, target in zip(all_outputs, targets):
-                        jailbroken = not any([prefix in gen_str for prefix in self.test_prefixes])
+                        jailbroken = not any(prefix in gen_str for prefix in self.test_prefixes)
                         em = target in gen_str
                         curr_jb.append(jailbroken)
                         curr_em.append(em)
@@ -1704,7 +1704,7 @@ def get_workers(params: Any, eval: bool = False) -> tuple[list[ModelWorker], lis
     conv_templates = []
     for conv in raw_conv_templates:
         if conv.name == "zero_shot":
-            conv.roles = tuple(["### " + r for r in conv.roles])
+            conv.roles = tuple("### " + r for r in conv.roles)
             conv.sep = "\n"
         elif conv.name == "llama-2":
             conv.sep2 = conv.sep2.strip()

--- a/pyrit/auxiliary_attacks/gcg/attack/gcg/gcg_attack.py
+++ b/pyrit/auxiliary_attacks/gcg/attack/gcg/gcg_attack.py
@@ -206,17 +206,13 @@ class GCGMultiPromptAttack(MultiPromptAttack):
                         worker(self.prompts[k][i], "logits", worker.model, cand, return_ids=True)
                     logits, ids = zip(*[worker.results.get() for worker in self.workers])
                     loss[j * batch_size : (j + 1) * batch_size] += sum(
-                        [
-                            target_weight * self.prompts[k][i].target_loss(logit, id).mean(dim=-1).to(main_device)
-                            for k, (logit, id) in enumerate(zip(logits, ids))
-                        ]
+                        target_weight * self.prompts[k][i].target_loss(logit, id).mean(dim=-1).to(main_device)
+                        for k, (logit, id) in enumerate(zip(logits, ids))
                     )
                     if control_weight != 0:
                         loss[j * batch_size : (j + 1) * batch_size] += sum(
-                            [
-                                control_weight * self.prompts[k][i].control_loss(logit, id).mean(dim=-1).to(main_device)
-                                for k, (logit, id) in enumerate(zip(logits, ids))
-                            ]
+                            control_weight * self.prompts[k][i].control_loss(logit, id).mean(dim=-1).to(main_device)
+                            for k, (logit, id) in enumerate(zip(logits, ids))
                         )
                     del logits, ids
                     gc.collect()

--- a/pyrit/backend/mappers/attack_mappers.py
+++ b/pyrit/backend/mappers/attack_mappers.py
@@ -51,7 +51,7 @@ def attack_result_to_summary(
     Returns:
         AttackSummary DTO ready for the API response.
     """
-    message_count = len(set(p.sequence for p in pieces))
+    message_count = len({p.sequence for p in pieces})
     last_preview = _get_preview_from_pieces(pieces)
 
     created_str = ar.metadata.get("created_at")

--- a/pyrit/common/csv_helper.py
+++ b/pyrit/common/csv_helper.py
@@ -13,7 +13,7 @@ def read_csv(file: IO[Any]) -> List[Dict[str, str]]:
         List[Dict[str, str]]: Parsed CSV rows as dictionaries.
     """
     reader = csv.DictReader(file)
-    return [row for row in reader]
+    return list(reader)
 
 
 def write_csv(file: IO[Any], examples: List[Dict[str, str]]) -> None:

--- a/pyrit/common/json_helper.py
+++ b/pyrit/common/json_helper.py
@@ -33,7 +33,7 @@ def read_jsonl(file: IO[Any]) -> List[Dict[str, str]]:
     Returns:
         List[Dict[str, str]]: Parsed JSONL content.
     """
-    return list(json.loads(line) for line in file)
+    return [json.loads(line) for line in file]
 
 
 def write_jsonl(file: IO[Any], examples: List[Dict[str, str]]) -> None:

--- a/pyrit/datasets/seed_datasets/remote/harmbench_multimodal_dataset.py
+++ b/pyrit/datasets/seed_datasets/remote/harmbench_multimodal_dataset.py
@@ -70,9 +70,9 @@ class _HarmBenchMultimodalDataset(_RemoteDatasetLoader):
         # Validate categories if provided
         if categories is not None:
             valid_categories = {category.value for category in SemanticCategory}
-            invalid_categories = (
-                set(cat.value if isinstance(cat, SemanticCategory) else cat for cat in categories) - valid_categories
-            )
+            invalid_categories = {
+                cat.value if isinstance(cat, SemanticCategory) else cat for cat in categories
+            } - valid_categories
             if invalid_categories:
                 raise ValueError(f"Invalid semantic categories: {', '.join(invalid_categories)}")
 

--- a/pyrit/datasets/seed_datasets/remote/pku_safe_rlhf_dataset.py
+++ b/pyrit/datasets/seed_datasets/remote/pku_safe_rlhf_dataset.py
@@ -119,7 +119,7 @@ class _PKUSafeRLHFDataset(_RemoteDatasetLoader):
                         value=item["prompt"],
                         data_type="text",
                         dataset_name=self.dataset_name,
-                        harm_categories=sorted(list(harm_categories)),
+                        harm_categories=sorted(harm_categories),
                         description=(
                             "This is a Hugging Face dataset that labels a prompt and 2 responses categorizing "
                             "their helpfulness or harmfulness. Only the 'prompt' column is extracted."

--- a/pyrit/datasets/seed_datasets/remote/vlsu_multimodal_dataset.py
+++ b/pyrit/datasets/seed_datasets/remote/vlsu_multimodal_dataset.py
@@ -86,9 +86,9 @@ class _VLSUMultimodalDataset(_RemoteDatasetLoader):
         # Validate categories if provided
         if categories is not None:
             valid_categories = {category.value for category in VLSUCategory}
-            invalid_categories = (
-                set(cat.value if isinstance(cat, VLSUCategory) else cat for cat in categories) - valid_categories
-            )
+            invalid_categories = {
+                cat.value if isinstance(cat, VLSUCategory) else cat for cat in categories
+            } - valid_categories
             if invalid_categories:
                 raise ValueError(f"Invalid VLSU categories: {', '.join(invalid_categories)}")
 

--- a/pyrit/datasets/seed_datasets/seed_dataset_provider.py
+++ b/pyrit/datasets/seed_datasets/seed_dataset_provider.py
@@ -102,7 +102,7 @@ class SeedDatasetProvider(ABC):
                 dataset_names.add(provider.dataset_name)
             except Exception as e:
                 raise ValueError(f"Could not get dataset name from {provider_class.__name__}: {e}")
-        return sorted(list(dataset_names))
+        return sorted(dataset_names)
 
     @classmethod
     async def fetch_datasets_async(

--- a/pyrit/memory/memory_interface.py
+++ b/pyrit/memory/memory_interface.py
@@ -1088,7 +1088,7 @@ class MemoryInterface(abc.ABC):
             # Determine the prompt group ID.
             # It should either be set uniformly or generated if not set.
             # Inconsistent prompt group IDs will raise an error.
-            group_id_set = set(seed.prompt_group_id for seed in prompt_group.seeds)
+            group_id_set = {seed.prompt_group_id for seed in prompt_group.seeds}
             if len(group_id_set) > 1:
                 raise ValueError(
                     f"""Inconsistent 'prompt_group_id' attribute between members of the

--- a/pyrit/memory/sqlite_memory.py
+++ b/pyrit/memory/sqlite_memory.py
@@ -176,7 +176,7 @@ class SQLiteMemory(MemoryInterface, metaclass=Singleton):
 
         # Create SQL condition using SQLAlchemy's text() with bindparams
         # Note: We do NOT convert values to string here, to allow integer comparison in JSON
-        return text(json_conditions).bindparams(**{key: value for key, value in metadata.items()})
+        return text(json_conditions).bindparams(**dict(metadata.items()))
 
     def add_message_pieces_to_memory(self, *, message_pieces: Sequence[MessagePiece]) -> None:
         """

--- a/pyrit/prompt_converter/template_segment_converter.py
+++ b/pyrit/prompt_converter/template_segment_converter.py
@@ -62,7 +62,7 @@ class TemplateSegmentConverter(PromptConverter):
         # Validate all parameters exist in the template value by attempting to render with empty values
         try:
             # Create a dict with empty values for all parameters
-            empty_values = {param: "" for param in self.prompt_template.parameters}
+            empty_values = dict.fromkeys(self.prompt_template.parameters, "")
             # This will raise ValueError if any parameter is missing
             self.prompt_template.render_template_value(**empty_values)
         except ValueError as e:

--- a/pyrit/prompt_normalizer/prompt_normalizer.py
+++ b/pyrit/prompt_normalizer/prompt_normalizer.py
@@ -79,7 +79,7 @@ class PromptNormalizer:
             Message: The response received from the target.
         """
         # Validates that the MessagePieces in the Message are part of the same sequence
-        if len(set(piece.sequence for piece in message.message_pieces)) > 1:
+        if len({piece.sequence for piece in message.message_pieces}) > 1:
             raise ValueError("All MessagePieces in the Message must have the same sequence.")
 
         # Prepare the request by updating conversation ID, labels, and attack identifier

--- a/pyrit/score/float_scale/plagiarism_scorer.py
+++ b/pyrit/score/float_scale/plagiarism_scorer.py
@@ -123,7 +123,7 @@ class PlagiarismScorer(FloatScaleScorer):
         Returns:
             set: Set of n-gram tuples.
         """
-        return set(tuple(tokens[i : i + n]) for i in range(len(tokens) - n + 1))
+        return {tuple(tokens[i : i + n]) for i in range(len(tokens) - n + 1)}
 
     def _plagiarism_score(
         self,

--- a/tests/unit/datasets/test_vlsu_multimodal_dataset.py
+++ b/tests/unit/datasets/test_vlsu_multimodal_dataset.py
@@ -208,7 +208,7 @@ class TestVLSUMultimodalDataset:
             assert len(dataset.seeds) == 4  # 2 pairs of text + image
 
             # Get unique group_ids
-            group_ids = set(s.prompt_group_id for s in dataset.seeds)
+            group_ids = {s.prompt_group_id for s in dataset.seeds}
             assert len(group_ids) == 2  # Two different pairs
 
             # Verify each pair has one text and one image

--- a/tests/unit/memory/test_memory_exporter.py
+++ b/tests/unit/memory/test_memory_exporter.py
@@ -31,7 +31,7 @@ def read_file(file_path, export_type):
     elif export_type == "csv":
         with open(file_path, "r", newline="") as f:
             reader = csv.DictReader(f)
-            return [row for row in reader]
+            return list(reader)
     else:
         raise ValueError(f"Invalid export type: {export_type}")
 

--- a/tests/unit/target/test_playwright_copilot_target.py
+++ b/tests/unit/target/test_playwright_copilot_target.py
@@ -183,7 +183,7 @@ class TestPlaywrightCopilotTarget:
         assert mock_page.locator.call_count == 2
         # Check that both calls were with the same selector
         expected_calls = [call("#test-input"), call("#test-input")]
-        actual_locator_calls = [call_args for call_args in mock_page.locator.call_args_list]
+        actual_locator_calls = list(mock_page.locator.call_args_list)
         assert actual_locator_calls == expected_calls
 
         mock_locator.click.assert_awaited_once()

--- a/tests/unit/target/test_prompt_shield_target.py
+++ b/tests/unit/target/test_prompt_shield_target.py
@@ -86,7 +86,7 @@ async def test_prompt_shield_document_parsing(
 @pytest.mark.asyncio
 async def test_prompt_shield_response_validation(promptshield_target: PromptShieldTarget):
     # This tests handling both an empty request and an empty response
-    promptshield_target._validate_response(request_body=dict(), response_body=dict())
+    promptshield_target._validate_response(request_body={}, response_body={})
 
 
 def test_api_key_authentication():


### PR DESCRIPTION
Simplify comprehensions and collection constructors:
- Replace unnecessary generator expressions with direct set/list literals
- Remove unnecessary comprehensions in function calls (any, all, sorted, etc.)
- Simplify identity comprehensions (e.g., [x for x in y] -> list(y))
- Replace dict()/list()/tuple() calls with literal syntax
- Remove unnecessary double-cast/process calls
