### PR TITLE
FIX: Add arm64 Support for `devcontainer`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/python:3.11
+FROM mcr.microsoft.com/devcontainers/python:3.11
 
 # Makes installation faster
 ENV UV_COMPILE_BYTECODE=1
@@ -32,15 +32,12 @@ RUN apt-get update && apt-get install -y \
  && curl -sL https://packages.microsoft.com/keys/microsoft.asc \
       | gpg --dearmor \
       > /usr/share/keyrings/microsoft-archive-keyring.gpg \
- && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/debian/12/prod bookworm main" \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/debian/12/prod bookworm main" \
       > /etc/apt/sources.list.d/microsoft.list \
  && apt-get update \
- && ACCEPT_EULA=Y apt-get install -y \
-      msodbcsql18 \
-      mssql-tools \
-      unixodbc-dev \
+ && ACCEPT_EULA=Y apt-get install -y msodbcsql18 mssql-tools18 \
  && apt-get install -y azure-cli \
- && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> /etc/profile.d/sqltools.sh \
+ && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> /etc/profile.d/sqltools.sh \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,5 @@
 services:
   devcontainer:
-    platform: linux/amd64
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile


### PR DESCRIPTION
## Description

Fixes the devcontainer to support both amd64 and arm64 architectures. Previously, the Dockerfile and docker-compose.yml hardcoded `linux/amd64`, which caused issues on ARM-based machines.

### Changes

- **Removed `--platform=linux/amd64`** from the `FROM` instruction in `.devcontainer/Dockerfile` so Docker uses the host's native architecture.
- **Removed `platform: linux/amd64`** from `.devcontainer/docker-compose.yml`.
- **Made the Microsoft apt repo arch-aware** by replacing the hardcoded `arch=amd64` with `arch=$(dpkg --print-architecture)`.
- **Updated `mssql-tools` to `mssql-tools18`**, which adds arm64 support (the older `mssql-tools` package was amd64-only). Removed the redundant `unixodbc-dev` install (already installed in the earlier `apt-get` block).

## Tests and Documentation

- No test or documentation changes required; this is an infrastructure/devcontainer-only change.
- Verified the devcontainer builds and starts successfully on arm64.