### PR TITLE
MAINT: Add permissions to docker_build workflow

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -12,6 +12,9 @@ on:
       - "release/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -153,6 +156,8 @@ jobs:
     name: Test Import (local)
     runs-on: ubuntu-latest
     needs: build-production-local
+    permissions:
+      contents: read
     steps:
       - name: Download production image
         uses: actions/download-artifact@v4
@@ -170,6 +175,8 @@ jobs:
     name: Test GUI (local)
     runs-on: ubuntu-latest
     needs: build-production-local
+    permissions:
+      contents: read
     steps:
       - name: Download production image
         uses: actions/download-artifact@v4
@@ -207,6 +214,8 @@ jobs:
     name: Test Jupyter (local)
     runs-on: ubuntu-latest
     needs: build-production-local
+    permissions:
+      contents: read
     steps:
       - name: Download production image
         uses: actions/download-artifact@v4
@@ -239,6 +248,8 @@ jobs:
     name: Test Import (PyPI)
     runs-on: ubuntu-latest
     needs: build-production-pypi
+    permissions:
+      contents: read
     steps:
       - name: Download production image
         uses: actions/download-artifact@v4
@@ -256,6 +267,8 @@ jobs:
     name: Test GUI (PyPI)
     runs-on: ubuntu-latest
     needs: build-production-pypi
+    permissions:
+      contents: read
     steps:
       - name: Download production image
         uses: actions/download-artifact@v4
@@ -291,6 +304,8 @@ jobs:
     name: Test Jupyter (PyPI)
     runs-on: ubuntu-latest
     needs: build-production-pypi
+    permissions:
+      contents: read
     steps:
       - name: Download production image
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Description

Adds explicit `permissions` blocks to the `docker_build.yml` GitHub Actions workflow following the [principle of least privilege](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-the-permissions-key).

**Top-level `permissions: contents: read`** ensures the GITHUB_TOKEN defaults to read-only across all jobs, even newly added ones. **Job-level `permissions: contents: read`** added to the 6 test jobs that were missing them:
- `test-local-import`, `test-local-gui`, `test-local-jupyter`
- `test-pypi-import`, `test-pypi-gui`, `test-pypi-jupyter`

The 3 build jobs (`build-devcontainer`, `build-production-local`, `build-production-pypi`) already had job-level permissions and remain unchanged.

Without a top-level `permissions` block, the workflow inherits the repository default token permissions (often `write-all`). If any step is compromised, the token has broader access than needed. All jobs in this workflow only require `contents: read`.

## Tests and Documentation

No test or documentation changes needed. This is a CI workflow configuration change only. The workflow YAML is syntactically valid and the permissions are consistent across all jobs.