### PR TITLE
DOC GitHub Pages 404: use static HTML output for deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v3
       with:
-        path: "doc/_build/site"
+        path: "doc/_build/html"
     - name: Deploy to GitHub Pages
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       id: deployment

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ mypy:
 docs-build:
 	uv run python build_scripts/pydoc2json.py pyrit --submodules -o doc/_api/pyrit_all.json
 	uv run python build_scripts/gen_api_md.py
-	cd doc && uv run jupyter-book build --all
+	cd doc && uv run jupyter-book build --all --html
 	uv run ./build_scripts/generate_rss.py
 
 # Regenerate only the API reference pages (without building the full site)


### PR DESCRIPTION
JB2's default 'jupyter-book build' produces a SPA (JSON content + client-side rendering) that requires a web server. GitHub Pages serves static files and gets a 404 because there's no index.html.

Fix by adding --html flag which generates static HTML via server-side rendering, and update the artifact upload path from _build/site to _build/html.
