### PR TITLE
Fix explicit SAS token handling in AzureBlobStorageIO

### DIFF
--- a/pyrit/models/storage_io.py
+++ b/pyrit/models/storage_io.py
@@ -192,6 +192,7 @@ class AzureBlobStorageIO(StorageIO):
         AZURE_STORAGE_ACCOUNT_SAS_TOKEN environment variable or the init sas_token parameter, it will be used
         for authentication. Otherwise, a delegation SAS token will be created using Entra ID authentication.
         """
+        sas_token = self._sas_token
         if not self._sas_token:
             logger.info("SAS token not provided. Creating a delegation SAS token using Entra ID authentication.")
             sas_token = await AzureStorageAuth.get_sas_token(self._container_url)

--- a/tests/unit/models/test_storage_io.py
+++ b/tests/unit/models/test_storage_io.py
@@ -130,6 +130,26 @@ async def test_azure_blob_storage_io_write_file():
 
 
 @pytest.mark.asyncio
+async def test_azure_blob_storage_io_create_container_client_uses_explicit_sas_token():
+    container_url = "https://youraccount.blob.core.windows.net/yourcontainer"
+    sas_token = "explicit-sas-token"
+    azure_blob_storage_io = AzureBlobStorageIO(container_url=container_url, sas_token=sas_token)
+
+    mock_container_client = AsyncMock()
+
+    with (
+        patch("pyrit.models.storage_io.AzureStorageAuth.get_sas_token", new_callable=AsyncMock) as mock_get_sas_token,
+        patch("pyrit.models.storage_io.AsyncContainerClient.from_container_url", return_value=mock_container_client)
+        as mock_from_container_url,
+    ):
+        await azure_blob_storage_io._create_container_client_async()
+
+    mock_get_sas_token.assert_not_awaited()
+    mock_from_container_url.assert_called_once_with(container_url=container_url, credential=sas_token)
+    assert azure_blob_storage_io._client_async is mock_container_client
+
+
+@pytest.mark.asyncio
 async def test_azure_storage_io_path_exists(azure_blob_storage_io):
     azure_blob_storage_io._client_async = AsyncMock()
 

--- a/tests/unit/models/test_storage_io.py
+++ b/tests/unit/models/test_storage_io.py
@@ -139,8 +139,9 @@ async def test_azure_blob_storage_io_create_container_client_uses_explicit_sas_t
 
     with (
         patch("pyrit.models.storage_io.AzureStorageAuth.get_sas_token", new_callable=AsyncMock) as mock_get_sas_token,
-        patch("pyrit.models.storage_io.AsyncContainerClient.from_container_url", return_value=mock_container_client)
-        as mock_from_container_url,
+        patch(
+            "pyrit.models.storage_io.AsyncContainerClient.from_container_url", return_value=mock_container_client
+        ) as mock_from_container_url,
     ):
         await azure_blob_storage_io._create_container_client_async()
 


### PR DESCRIPTION
## Summary

This fixes a bug in `AzureBlobStorageIO._create_container_client_async()` when an explicit `sas_token` is provided during initialization.

## Problem

`AzureBlobStorageIO` is documented to accept either:
- an explicit SAS token passed into the constructor, or
- a delegated SAS token generated through `AzureStorageAuth`

In practice, the implementation only assigned the local `sas_token` variable inside the fallback branch. When `self._sas_token` was already set, the fallback branch was skipped and `AsyncContainerClient.from_container_url(..., credential=sas_token)` raised `UnboundLocalError` because `sas_token` had never been initialized.

That means callers using the explicit SAS token path could not create the async container client successfully.

## Fix

- initialize the local `sas_token` variable from `self._sas_token`
- keep the existing delegated SAS fallback only for the missing-token path
- add a regression test that verifies:
  - the explicit token is passed through to `AsyncContainerClient.from_container_url`
  - `AzureStorageAuth.get_sas_token()` is not called when an explicit token is already available

## Validation

Ran:

```bash
uv run --extra dev pytest tests/unit/models/test_storage_io.py -q
```

Result:

```text
14 passed in 0.04s
```
