### PR TITLE
Fix multiline JSON extraction in exceptions helpers

### DIFF
--- a/pyrit/exceptions/exceptions_helpers.py
+++ b/pyrit/exceptions/exceptions_helpers.py
@@ -121,8 +121,8 @@ def extract_json_from_string(response_msg: str) -> str:
             continue
 
         try:
-            _, end_index = decoder.raw_decode(response_msg[index:])
-            return response_msg[index : index + end_index]
+            _, end_index = decoder.raw_decode(response_msg, idx=index)
+            return response_msg[index:end_index]
         except json.JSONDecodeError:
             continue
 

--- a/pyrit/exceptions/exceptions_helpers.py
+++ b/pyrit/exceptions/exceptions_helpers.py
@@ -115,10 +115,16 @@ def extract_json_from_string(response_msg: str) -> str:
         str: The extracted JSON string if found, otherwise the original string.
 
     """
-    json_pattern = re.compile(r"\{.*\}|\[.*\]")
-    match = json_pattern.search(response_msg)
-    if match:
-        return match.group(0)
+    decoder = json.JSONDecoder()
+    for index, char in enumerate(response_msg):
+        if char not in "[{":
+            continue
+
+        try:
+            _, end_index = decoder.raw_decode(response_msg[index:])
+            return response_msg[index : index + end_index]
+        except json.JSONDecodeError:
+            continue
 
     return response_msg
 

--- a/tests/unit/exceptions/test_exceptions_helpers.py
+++ b/tests/unit/exceptions/test_exceptions_helpers.py
@@ -59,6 +59,10 @@ def test_remove_end_md_json(input_str, expected_output):
         ("No JSON here", "No JSON here"),
         ('jsn\n{"key": "value"}\n```', '{"key": "value"}'),
         ('Some text before JSON {"a": [1,2,3], "b": {"c": 4}} some text after JSON', '{"a": [1,2,3], "b": {"c": 4}}'),
+        (
+            'Some text before JSON {\n  "key": "value",\n  "nested": {"enabled": true}\n} some text after JSON',
+            '{\n  "key": "value",\n  "nested": {"enabled": true}\n}',
+        ),
     ],
 )
 def test_extract_json_from_string(input_str, expected_output):


### PR DESCRIPTION
## Summary

This updates `extract_json_from_string()` to correctly extract multiline JSON payloads from larger strings.

## Problem

`extract_json_from_string()` currently relies on a regex:

```python
re.compile(r"\{.*\}|\[.*\]")
```

That has two problems for real model output:

1. `.` does not match newlines by default, so multiline JSON objects and arrays are not matched as a whole.
2. When the outer JSON spans multiple lines but contains a nested single-line object, the regex can skip the outer payload and return the nested fragment instead.

In practice, this means helper code can extract the wrong JSON fragment from valid responses that include explanatory text plus a pretty-printed JSON body.

## Fix

Replace the regex-based extraction with `json.JSONDecoder().raw_decode()` scanning logic:

- scan for candidate `{` / `[` starting positions
- attempt to decode a JSON object or array from each candidate position
- return the first complete decodable payload

This preserves existing behavior for single-line JSON while fixing multiline extraction and avoiding nested-fragment false matches.

## Tests

Added a regression test covering a multiline JSON object embedded in surrounding text.

Validation command:

```bash
uv run --extra dev pytest tests/unit/exceptions/test_exceptions_helpers.py -q
```

Validation result:

```text
31 passed in 0.04s
```
