### PR TITLE
Fix non-Windows UI startup checks

### DIFF
--- a/pyrit/ui/app.py
+++ b/pyrit/ui/app.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import sys
 import traceback
+import ctypes
 
 GLOBAL_MUTEX_NAME = "PyRIT-Gradio"
 
@@ -29,8 +30,6 @@ def create_mutex() -> bool:
     if sys.platform != "win32":
         return True
 
-    import ctypes.wintypes  # noqa: F401
-
     ctypes.windll.kernel32.CreateMutexW(None, False, GLOBAL_MUTEX_NAME)
     last_error = ctypes.windll.kernel32.GetLastError()
     return bool(last_error != 183)  # ERROR_ALREADY_EXISTS
@@ -39,8 +38,6 @@ def create_mutex() -> bool:
 def is_app_running() -> bool:
     if sys.platform != "win32":
         return False
-
-    import ctypes.wintypes  # noqa: F401
 
     SYNCHRONIZE = 0x00100000
     mutex = ctypes.windll.kernel32.OpenMutexW(SYNCHRONIZE, False, GLOBAL_MUTEX_NAME)

--- a/pyrit/ui/app.py
+++ b/pyrit/ui/app.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import traceback
 import ctypes
+import ctypes
 
 GLOBAL_MUTEX_NAME = "PyRIT-Gradio"
 
@@ -29,8 +30,6 @@ def launch_app(open_browser: bool = False) -> None:
 def create_mutex() -> bool:
     if sys.platform != "win32":
         return True
-
-    ctypes.windll.kernel32.CreateMutexW(None, False, GLOBAL_MUTEX_NAME)
     last_error = ctypes.windll.kernel32.GetLastError()
     return bool(last_error != 183)  # ERROR_ALREADY_EXISTS
 
@@ -40,8 +39,6 @@ def is_app_running() -> bool:
         return False
 
     SYNCHRONIZE = 0x00100000
-    mutex = ctypes.windll.kernel32.OpenMutexW(SYNCHRONIZE, False, GLOBAL_MUTEX_NAME)
-    if not mutex:
         return False
 
     # Close the handle to the mutex

--- a/pyrit/ui/app.py
+++ b/pyrit/ui/app.py
@@ -25,9 +25,20 @@ def launch_app(open_browser: bool = False) -> None:
         subprocess.Popen([python_path, current_path, str(open_browser)])
 
 
+def create_mutex() -> bool:
+    if sys.platform != "win32":
+        return True
+
+    import ctypes.wintypes  # noqa: F401
+
+    ctypes.windll.kernel32.CreateMutexW(None, False, GLOBAL_MUTEX_NAME)
+    last_error = ctypes.windll.kernel32.GetLastError()
+    return bool(last_error != 183)  # ERROR_ALREADY_EXISTS
+
+
 def is_app_running() -> bool:
     if sys.platform != "win32":
-        raise NotImplementedError("This function is only supported on Windows.")
+        return False
 
     import ctypes.wintypes  # noqa: F401
 
@@ -42,17 +53,6 @@ def is_app_running() -> bool:
 
 
 if __name__ == "__main__":
-
-    def create_mutex() -> bool:
-        if sys.platform != "win32":
-            raise NotImplementedError("This function is only supported on Windows.")
-
-        # TODO make sure to add cross-platform support for this.
-        import ctypes.wintypes
-
-        ctypes.windll.kernel32.CreateMutexW(None, False, GLOBAL_MUTEX_NAME)
-        last_error = ctypes.windll.kernel32.GetLastError()
-        return bool(last_error != 183)  # ERROR_ALREADY_EXISTS
 
     if not create_mutex():
         print("Gradio UI is already running.")

--- a/tests/unit/ui/test_app.py
+++ b/tests/unit/ui/test_app.py
@@ -1,0 +1,16 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from pyrit.ui import app as ui_app
+
+
+def test_is_app_running_returns_false_on_non_windows(monkeypatch):
+    monkeypatch.setattr(ui_app.sys, "platform", "linux")
+
+    assert ui_app.is_app_running() is False
+
+
+def test_create_mutex_returns_true_on_non_windows(monkeypatch):
+    monkeypatch.setattr(ui_app.sys, "platform", "linux")
+
+    assert ui_app.create_mutex() is True


### PR DESCRIPTION
## Summary

This fixes the deprecated Gradio UI startup path on non-Windows platforms.

## Problem

`pyrit.ui.app` currently treats the Windows mutex logic as mandatory in two places:

- `is_app_running()` raises `NotImplementedError` on non-Windows platforms
- the `__main__` startup path defines a nested `create_mutex()` helper that also raises `NotImplementedError` on non-Windows platforms

That creates two failure modes on Linux/macOS:

1. `AppRPCServer.start()` calls `is_app_running()` before launching the UI, so the RPC path fails during the probe step.
2. Even if the process is launched directly, the child process fails immediately in the `__main__` block before it can start the Gradio app.

## Fix

- move `create_mutex()` to module scope so the startup guard is reusable and testable
- make `create_mutex()` a no-op that returns `True` on non-Windows platforms
- make `is_app_running()` return `False` on non-Windows platforms instead of raising

This preserves the existing Windows mutex-based single-instance behavior while allowing non-Windows platforms to proceed through the UI startup path.

## Tests

Added unit coverage for the non-Windows behavior:

- `is_app_running()` returns `False`
- `create_mutex()` returns `True`

Validation command:

```bash
uv run --extra dev pytest tests/unit/ui/test_app.py -q
```

Validation result:

```text
2 passed, 1 warning in 0.04s
```

The warning is the existing deprecation warning for `pyrit.ui`.
