### PR TITLE
Ignore blank lines when reading JSONL

### DIFF
--- a/pyrit/common/json_helper.py
+++ b/pyrit/common/json_helper.py
@@ -33,7 +33,7 @@ def read_jsonl(file: IO[Any]) -> list[dict[str, str]]:
     Returns:
         List[Dict[str, str]]: Parsed JSONL content.
     """
-    return [json.loads(line) for line in file]
+    return [json.loads(line) for line in file if line.strip()]
 
 
 def write_jsonl(file: IO[Any], examples: list[dict[str, str]]) -> None:

--- a/tests/unit/common/test_json_helper.py
+++ b/tests/unit/common/test_json_helper.py
@@ -1,0 +1,14 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from io import StringIO
+
+from pyrit.common.json_helper import read_jsonl
+
+
+def test_read_jsonl_ignores_blank_lines():
+    file = StringIO('{"prompt": "first"}\n\n{"prompt": "second"}\n')
+
+    result = read_jsonl(file)
+
+    assert result == [{"prompt": "first"}, {"prompt": "second"}]


### PR DESCRIPTION
## Summary

This makes `read_jsonl()` tolerate blank lines in JSONL input.

## Problem

`read_jsonl()` currently does a direct `json.loads(line)` for every line in the file.

That means a JSONL file with an empty line or a whitespace-only separator fails immediately with `JSONDecodeError`, even when every non-empty line is valid JSON.

In practice, blank lines are common in generated or hand-edited JSONL files, especially at the end of a file or between entries during review.

## Fix

Skip blank / whitespace-only lines before decoding:

```python
json.loads(line) for line in file if line.strip()
```

This preserves the existing behavior for valid JSONL records while making the reader robust to common formatting noise.

## Tests

Added regression coverage for a JSONL stream containing a blank line between two valid entries.

Validation command:

```bash
.venv/bin/pytest tests/unit/common/test_json_helper.py -q
```

Validation result:

```text
1 passed in 0.01s
```
