### PR TITLE
Ignore blank lines when reading TXT prompts

### DIFF
--- a/pyrit/common/text_helper.py
+++ b/pyrit/common/text_helper.py
@@ -11,7 +11,7 @@ def read_txt(file: IO[Any]) -> list[dict[str, str]]:
     Returns:
         List[Dict[str, str]]: Parsed TXT content.
     """
-    return [{"prompt": line.strip()} for line in file.readlines()]
+    return [{"prompt": line.strip()} for line in file.readlines() if line.strip()]
 
 
 def write_txt(file: IO[Any], examples: list[dict[str, str]]) -> None:

--- a/tests/unit/common/test_text_helper.py
+++ b/tests/unit/common/test_text_helper.py
@@ -1,0 +1,12 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from io import StringIO
+
+from pyrit.common.text_helper import read_txt
+
+
+def test_read_txt_ignores_blank_lines():
+    file = StringIO("first prompt\n\n   \nsecond prompt\n")
+
+    assert read_txt(file) == [{"prompt": "first prompt"}, {"prompt": "second prompt"}]


### PR DESCRIPTION
## Summary
- skip blank and whitespace-only lines when parsing TXT prompt files
- add a regression test covering mixed prompt and blank lines

## Problem
`pyrit.common.text_helper.read_txt()` currently turns every input line into a prompt entry after `strip()`. This means blank lines are loaded as `{"prompt": ""}`, which silently injects empty prompts into TXT-backed datasets.

## Testing
- `.venv/bin/pytest tests/unit/common/test_text_helper.py -q`