### PR TITLE
FIX Preserve quoted shell arguments in run parsing

### DIFF
--- a/pyrit/cli/_cli_args.py
+++ b/pyrit/cli/_cli_args.py
@@ -18,6 +18,7 @@ import dataclasses
 import inspect
 import json
 import logging
+import shlex
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -533,7 +534,7 @@ def parse_run_arguments(*, args_string: str) -> dict[str, Any]:
     Raises:
         ValueError: If parsing or validation fails.
     """
-    parts = args_string.split()
+    parts = shlex.split(args_string)
 
     if not parts:
         raise ValueError("No scenario name provided")
@@ -558,7 +559,7 @@ def parse_list_targets_arguments(*, args_string: str) -> dict[str, Any]:
     Raises:
         ValueError: If parsing or validation fails.
     """
-    parts = args_string.split()
+    parts = shlex.split(args_string)
     return _parse_shell_arguments(parts=parts, arg_specs=_LIST_TARGETS_ARG_SPECS)
 
 

--- a/tests/unit/cli/test_frontend_core.py
+++ b/tests/unit/cli/test_frontend_core.py
@@ -710,8 +710,8 @@ class TestParseRunArguments:
         assert result["max_retries"] == 3
 
     def test_parse_run_arguments_with_memory_labels(self):
-        """Test parsing with memory-labels."""
-        result = frontend_core.parse_run_arguments(args_string='test_scenario --memory-labels {"key":"value"}')
+        """Test parsing with memory-labels (JSON must be quoted in shell mode)."""
+        result = frontend_core.parse_run_arguments(args_string="""test_scenario --memory-labels '{"key":"value"}'""")
 
         assert result["memory_labels"] == {"key": "value"}
 
@@ -728,6 +728,35 @@ class TestParseRunArguments:
         )
 
         assert result["initialization_scripts"] == ["script1.py", "script2.py"]
+
+    def test_parse_run_arguments_with_quoted_paths(self):
+        """Test parsing quoted paths with spaces for shell mode."""
+        result = frontend_core.parse_run_arguments(
+            args_string='test_scenario --initialization-scripts "/tmp/my script.py" --strategies s1'
+        )
+
+        assert result["initialization_scripts"] == ["/tmp/my script.py"]
+        assert result["scenario_strategies"] == ["s1"]
+
+    def test_parse_run_arguments_with_quoted_memory_labels(self):
+        """Test parsing quoted JSON for memory-labels in shell mode."""
+        result = frontend_core.parse_run_arguments(
+            args_string="""test_scenario --memory-labels '{"experiment": "test 1"}'"""
+        )
+
+        assert result["memory_labels"] == {"experiment": "test 1"}
+
+    def test_parse_run_arguments_with_short_strategies_after_initializers(self):
+        """Test that -s is treated as a flag after multi-value initializers."""
+        result = frontend_core.parse_run_arguments(args_string="test_scenario --initializers init1 -s s1 s2")
+
+        assert result["initializers"] == ["init1"]
+        assert result["scenario_strategies"] == ["s1", "s2"]
+
+    def test_parse_run_arguments_unterminated_quote_raises(self):
+        """Test that unterminated quotes raise ValueError."""
+        with pytest.raises(ValueError):
+            frontend_core.parse_run_arguments(args_string='test_scenario --initialization-scripts "/tmp/my script.py')
 
     def test_parse_run_arguments_complex(self):
         """Test parsing complex argument combination."""


### PR DESCRIPTION
## Summary

Replace naive `str.split()` with `shlex.split()` in `parse_run_arguments()` and `parse_list_targets_arguments()` so that quoted shell arguments are correctly tokenized.

> **Note:** This PR was substantially reworked from the original submission. The key changes from the original:
> - Uses stdlib `shlex.split()` (1 import + 2 call-site changes) instead of a 50-line hand-rolled tokenizer
> - Targets the correct file (`pyrit/cli/_cli_args.py`) after the codebase was refactored since the original PR
> - The `-s` flag-swallowing bug was already fixed in the `_parse_shell_arguments` refactor, so only a regression test was added for that

## Problem

`pyrit shell` forwards the raw `run ...` line into `parse_run_arguments()`, which splits on whitespace with `str.split()`. This breaks any argument that contains spaces inside quotes:

- `--initialization-scripts "/tmp/my script.py"`
- `--memory-labels '{"experiment": "test 1"}'`

## Solution

Replace `args_string.split()` with `shlex.split(args_string)` which handles quoting, escaping, and unterminated-quote detection out of the box.

**Breaking change:** unquoted JSON like `--memory-labels {"key":"value"}` must now be quoted as `--memory-labels '{"key":"value"}'`. This matches standard shell behavior.

## Testing

- `pytest tests/unit/cli/test_frontend_core.py -q` (114 tests pass)
- `pytest tests/unit/cli/test_pyrit_shell.py -q` (54 tests pass)

New test cases:
- Quoted paths with spaces
- Quoted JSON with spaces in values
- `-s` short flag after `--initializers` (regression)
- Unterminated quote raises `ValueError`