### PR TITLE
Preserve URL case in HTTP target requests

### DIFF
--- a/pyrit/prompt_target/http_target/http_target.py
+++ b/pyrit/prompt_target/http_target/http_target.py
@@ -280,7 +280,6 @@ class HTTPTarget(PromptTarget):
         headers_dict: dict[str, str],
     ) -> str:
         # If path is already a full URL, return it as is
-        path = path.lower()
         if path.startswith(("http://", "https://")):
             return path
 

--- a/tests/unit/target/test_http_target.py
+++ b/tests/unit/target/test_http_target.py
@@ -93,12 +93,12 @@ def test_parse_raw_http_request_ignores_content_length(patch_central_database):
 
 def test_parse_raw_http_respects_url_path(patch_central_database):
     request1 = (
-        "POST https://diffsite.com/test/ HTTP/1.1\nHost: example.com\nContent-Type: "
+        "POST https://diffsite.com/Test/Path?Token=AbC123 HTTP/1.1\nHost: example.com\nContent-Type: "
         "application/json\nContent-Length: 100\n\n"
     )
     target = HTTPTarget(http_request=request1)
     headers, _, url, _, _ = target.parse_raw_http_request(request1)
-    assert url == "https://diffsite.com/test/"
+    assert url == "https://diffsite.com/Test/Path?Token=AbC123"
 
     # The host header should still be example.com
     assert headers == {"host": "example.com", "content-type": "application/json"}

--- a/tests/unit/target/test_http_target_parsing.py
+++ b/tests/unit/target/test_http_target_parsing.py
@@ -59,6 +59,17 @@ def test_parse_raw_http_request(mock_http_target):
     assert version == "HTTP/1.1"
 
 
+def test_parse_raw_http_request_preserves_relative_url_case(sqlite_instance):
+    request = "GET /CaseSensitive/Run?token=AbC123&Mode=Keep HTTP/1.1\nHost: Example.COM\n\n"
+    target = HTTPTarget(http_request=request)
+
+    _, _, url, method, version = target.parse_raw_http_request(request)
+
+    assert url == "https://Example.COM/CaseSensitive/Run?token=AbC123&Mode=Keep"
+    assert method == "GET"
+    assert version == "HTTP/1.1"
+
+
 def test_parse_regex_response_no_match():
     mock_response = MagicMock()
     mock_response.content = b"<html><body>No match here</body></html>"


### PR DESCRIPTION
## Summary
- preserve the original path/query casing when `HTTPTarget` builds a request URL
- add regression coverage for both relative request targets and already-absolute URLs

## Problem
`HTTPTarget._infer_full_url_from_host()` lowercases the entire request target before checking whether it is already an absolute URL. That means any case-sensitive path or query string is rewritten before the request is sent.

Examples that currently change unexpectedly:
- `/CaseSensitive/Run?token=AbC123&Mode=Keep`
- `https://diffsite.com/Test/Path?Token=AbC123`

Both should be forwarded exactly as supplied in the raw HTTP request.

## Testing
- `.venv/bin/pytest tests/unit/target/test_http_target.py -q`
- `.venv/bin/pytest tests/unit/target/test_http_target_parsing.py -q`