### PR TITLE
Preserve empty JSON schema metadata

### DIFF
--- a/pyrit/models/json_response_config.py
+++ b/pyrit/models/json_response_config.py
@@ -42,7 +42,7 @@ class _JsonResponseConfig:
             return cls(enabled=False)
 
         schema_val = metadata.get(_METADATAKEYS["JSON_SCHEMA"])
-        if schema_val:
+        if schema_val is not None:
             if isinstance(schema_val, str):
                 try:
                     schema = json.loads(schema_val) if schema_val else None

--- a/tests/unit/models/test_json_response_config.py
+++ b/tests/unit/models/test_json_response_config.py
@@ -55,6 +55,18 @@ def test_with_json_schema_object():
     assert config.strict is True
 
 
+def test_with_empty_json_schema_object():
+    metadata = {
+        "response_format": "json",
+        "json_schema": {},
+    }
+    config = _JsonResponseConfig.from_metadata(metadata=metadata)
+    assert config.enabled is True
+    assert config.schema == {}
+    assert config.schema_name == "CustomSchema"
+    assert config.strict is True
+
+
 def test_with_invalid_json_schema_string():
     metadata = {
         "response_format": "json",


### PR DESCRIPTION
## Summary
- preserve explicitly provided empty JSON schema objects in `_JsonResponseConfig.from_metadata()`
- add a regression test covering `json_schema={}` metadata

## Problem
`_JsonResponseConfig.from_metadata()` currently treats `json_schema={}` as falsy and falls through to the same branch as “no schema provided”. That means these two inputs behave differently even though they both represent an explicit empty schema:

- `json_schema="{}"` -> preserved as `{}`
- `json_schema={}` -> silently converted to `None`

This is an inconsistent metadata parsing bug rather than a validation decision, because the string and dict forms should not diverge like this.

## Testing
- `.venv/bin/pytest tests/unit/models/test_json_response_config.py -q`