### PR TITLE
Fail fast on unknown shell run arguments

### DIFF
--- a/pyrit/cli/frontend_core.py
+++ b/pyrit/cli/frontend_core.py
@@ -969,7 +969,6 @@ def parse_run_arguments(*, args_string: str) -> dict[str, Any]:
             result["max_dataset_size"] = validate_integer(parts[i], name="--max-dataset-size", min_value=1)
             i += 1
         else:
-            logger.warning(f"Unknown argument: {parts[i]}")
-            i += 1
+            raise ValueError(f"Unknown argument: {parts[i]}")
 
     return result

--- a/tests/unit/cli/test_frontend_core.py
+++ b/tests/unit/cli/test_frontend_core.py
@@ -684,6 +684,11 @@ class TestParseRunArguments:
         with pytest.raises(ValueError, match="requires a value"):
             frontend_core.parse_run_arguments(args_string="test_scenario --max-concurrency")
 
+    def test_parse_run_arguments_unknown_argument_raises(self):
+        """Test parsing with an unknown argument fails fast."""
+        with pytest.raises(ValueError, match=r"Unknown argument: --bogus"):
+            frontend_core.parse_run_arguments(args_string="test_scenario --bogus 123 --max-retries 2")
+
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("patch_central_database")


### PR DESCRIPTION
## Summary
- reject unknown `pyrit_shell run` arguments instead of logging a warning and continuing
- keep the existing shell error path so invalid `run` input is shown to the user immediately
- add regression coverage for unknown shell run arguments

## Problem
`parse_run_arguments()` currently logs unknown tokens and keeps parsing. In shell mode that means a typo can be silently ignored while the rest of the command still runs.

For example:
- `run demo --bogus 123 --max-retries 2`

currently logs warnings for `--bogus` and `123`, but still returns a parsed command with `max_retries=2`.

That turns invalid CLI input into a silent partial execution instead of a clear parse error.

## Testing
- `.venv/bin/pytest tests/unit/cli/test_frontend_core.py -q`
- `.venv/bin/pytest tests/unit/cli/test_pyrit_shell.py -q -k parse_error`