### PR TITLE
Support CRLF raw HTTP requests in HTTPTarget

### DIFF
--- a/pyrit/prompt_target/http_target/http_target.py
+++ b/pyrit/prompt_target/http_target/http_target.py
@@ -237,11 +237,11 @@ class HTTPTarget(PromptTarget):
 
         body = ""
 
-        # Split the request into headers and body by finding the double newlines (\n\n)
-        request_parts = http_request.strip().split("\n\n", 1)
+        # Support both LF and CRLF raw HTTP requests (e.g. copied from Burp).
+        request_parts = re.split(r"\r?\n\r?\n", http_request.strip(), maxsplit=1)
 
         # Parse out the header components
-        header_lines = request_parts[0].strip().split("\n")
+        header_lines = request_parts[0].strip().splitlines()
         http_req_info_line = header_lines[0].split(" ")  # get 1st line like POST /url_ending HTTP_VSN
         header_lines = header_lines[1:]  # rest of the raw request is the headers info
 

--- a/tests/unit/target/test_http_target_parsing.py
+++ b/tests/unit/target/test_http_target_parsing.py
@@ -59,6 +59,25 @@ def test_parse_raw_http_request(mock_http_target):
     assert version == "HTTP/1.1"
 
 
+def test_parse_raw_http_request_with_crlf_line_endings(sqlite_instance):
+    request = (
+        "POST /submit HTTP/1.1\r\n"
+        "Host: example.com\r\n"
+        "Content-Type: application/json\r\n"
+        "\r\n"
+        '{"prompt": "{PLACEHOLDER_PROMPT}"}'
+    )
+    target = HTTPTarget(http_request=request)
+
+    headers, body, url, method, version = target.parse_raw_http_request(request)
+
+    assert url == "https://example.com/submit"
+    assert method == "POST"
+    assert headers == {"host": "example.com", "content-type": "application/json"}
+    assert body == '{"prompt": "{PLACEHOLDER_PROMPT}"}'
+    assert version == "HTTP/1.1"
+
+
 def test_parse_raw_http_request_preserves_relative_url_case(sqlite_instance):
     request = "GET /CaseSensitive/Run?token=AbC123&Mode=Keep HTTP/1.1\nHost: Example.COM\n\n"
     target = HTTPTarget(http_request=request)


### PR DESCRIPTION
## Summary
- support CRLF-delimited raw HTTP requests in `HTTPTarget.parse_raw_http_request()`
- normalize header splitting so copied requests from tools like Burp parse correctly
- add regression coverage for CRLF raw HTTP request input

## Problem
`HTTPTarget.parse_raw_http_request()` currently splits raw requests on `"\n\n"` and header lines on `"\n"`.

That works for LF-only input, but raw HTTP requests copied from tools commonly use CRLF line endings. With CRLF input, the current parser fails to split headers and body correctly and leaves carriage returns embedded in header lines.

In practice, valid raw HTTP requests can fail to parse even though the content is otherwise correct.

## Testing
- `.venv/bin/pytest tests/unit/target/test_http_target_parsing.py -q`