### PR TITLE
FIX Preserve silent when loading config overrides

### DIFF
--- a/pyrit/setup/configuration_loader.py
+++ b/pyrit/setup/configuration_loader.py
@@ -224,6 +224,7 @@ class ConfigurationLoader(YamlLoadable):
             "initializers": [],
             "initialization_scripts": None,  # None = use defaults
             "env_files": None,  # None = use defaults
+            "silent": False,
         }
 
         # 1. Try loading default config file if it exists
@@ -239,6 +240,7 @@ class ConfigurationLoader(YamlLoadable):
                 # Preserve None vs [] distinction from config file
                 config_data["initialization_scripts"] = default_config.initialization_scripts
                 config_data["env_files"] = default_config.env_files
+                config_data["silent"] = default_config.silent
                 if default_config.operator:
                     config_data["operator"] = default_config.operator
                 if default_config.operation:
@@ -259,6 +261,7 @@ class ConfigurationLoader(YamlLoadable):
             # Preserve None vs [] distinction from config file
             config_data["initialization_scripts"] = explicit_config.initialization_scripts
             config_data["env_files"] = explicit_config.env_files
+            config_data["silent"] = explicit_config.silent
             if explicit_config.operator:
                 config_data["operator"] = explicit_config.operator
             if explicit_config.operation:

--- a/tests/unit/setup/test_configuration_loader.py
+++ b/tests/unit/setup/test_configuration_loader.py
@@ -504,3 +504,22 @@ initializers:
             assert config._initializer_configs[0].name == "cli_init"
         finally:
             config_path.unlink()
+
+    @mock.patch("pyrit.setup.configuration_loader.DEFAULT_CONFIG_PATH")
+    def test_load_with_overrides_preserves_silent_from_config_file(self, mock_default_path):
+        """Test that load_with_overrides preserves the silent flag from config files."""
+        mock_default_path.exists.return_value = False
+
+        yaml_content = """
+memory_db_type: sqlite
+silent: true
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            config_path = pathlib.Path(f.name)
+
+        try:
+            config = ConfigurationLoader.load_with_overrides(config_file=config_path)
+            assert config.silent is True
+        finally:
+            config_path.unlink()


### PR DESCRIPTION
## Summary
- preserve the `silent` flag when `ConfigurationLoader.load_with_overrides()` reads default or explicit config files
- add regression coverage for config-file-backed `silent: true` values

## Problem
`ConfigurationLoader.load_with_overrides()` merges `memory_db_type`, `initializers`, `initialization_scripts`, and `env_files` from configuration files, but it drops the `silent` field entirely.

As a result, config files that set `silent: true` are loaded with `silent=False`, so initialization output is not suppressed even though the configuration explicitly requests it.

## Testing
- `.venv/bin/pytest tests/unit/setup/test_configuration_loader.py -q`