### PR TITLE
FIX GUI promote conversation to main feature working

### DIFF
--- a/frontend/e2e/flows.spec.ts
+++ b/frontend/e2e/flows.spec.ts
@@ -712,12 +712,8 @@ for (const variant of TARGET_VARIANTS) {
       const starBtn = page.getByTestId(`star-btn-${newConversationId}`);
       await expect(starBtn).toBeVisible({ timeout: 5_000 });
 
-      // Promote via backend API directly (UI handler targets a mismatched path)
-      const promoteResp = await request.post(
-        `/api/attacks/${encodeURIComponent(attackResultId)}/update-main-conversation`,
-        { data: { conversation_id: newConversationId } },
-      );
-      expect(promoteResp.ok()).toBeTruthy();
+      // Promote via the UI star button (tests the full click → API → refresh flow)
+      await starBtn.click();
 
       await expect
         .poll(
@@ -889,17 +885,10 @@ for (const variant of TARGET_VARIANTS) {
         timeout: 5_000,
       });
 
-      // Verify star button is visible but promote via API directly
-      // (UI handler targets a mismatched endpoint path)
-      await expect(
-        page.getByTestId(`star-btn-${branchConversationId}`),
-      ).toBeVisible({ timeout: 5_000 });
-
-      const promoteResp = await request.post(
-        `/api/attacks/${encodeURIComponent(attackResultId)}/update-main-conversation`,
-        { data: { conversation_id: branchConversationId } },
-      );
-      expect(promoteResp.ok()).toBeTruthy();
+      // Promote via the UI star button (tests the full click → API → refresh flow)
+      const starBtn = page.getByTestId(`star-btn-${branchConversationId}`);
+      await expect(starBtn).toBeVisible({ timeout: 5_000 });
+      await starBtn.click();
 
       await expect
         .poll(

--- a/frontend/src/components/Chat/ChatWindow.tsx
+++ b/frontend/src/components/Chat/ChatWindow.tsx
@@ -391,6 +391,7 @@ export default function ChatWindow({
 
     try {
       await attacksApi.changeMainConversation(attackResultId, convId)
+      setPanelRefreshKey(k => k + 1)
     } catch (err) {
       console.error('Failed to change main conversation:', err)
     }
@@ -528,7 +529,12 @@ export default function ChatWindow({
           onNewConversation={handleNewConversation}
           onChangeMainConversation={handleChangeMainConversation}
           onClose={() => setIsPanelOpen(false)}
-          locked={!activeTarget || isOperatorLocked || isCrossTargetLocked}
+          lockedReason={
+            !activeTarget ? 'Configure a target to enable this action.'
+            : isOperatorLocked ? 'Cannot modify — attack belongs to a different operator.'
+            : isCrossTargetLocked ? 'Cannot modify — attack was created with a different target.'
+            : undefined
+          }
           refreshKey={panelRefreshKey}
         />
       )}

--- a/frontend/src/components/Chat/ConversationPanel.tsx
+++ b/frontend/src/components/Chat/ConversationPanel.tsx
@@ -30,8 +30,8 @@ interface ConversationPanelProps {
   onNewConversation: () => void
   onChangeMainConversation: (conversationId: string) => void
   onClose: () => void
-  /** When true, disable mutating actions (new conversation, promote to main) */
-  locked?: boolean
+  /** When set, disables mutating actions (new conversation, promote to main) and explains why. */
+  lockedReason?: string
   /** Increment to trigger a conversation list refresh (e.g. after sending a message) */
   refreshKey?: number
 }
@@ -43,7 +43,7 @@ export default function ConversationPanel({
   onNewConversation,
   onChangeMainConversation,
   onClose,
-  locked,
+  lockedReason,
   refreshKey,
 }: ConversationPanelProps) {
   const styles = useConversationPanelStyles()
@@ -107,13 +107,13 @@ export default function ConversationPanel({
           )}
         </div>
         <div style={{ display: 'flex', gap: tokens.spacingHorizontalXXS }}>
-          <Tooltip content={locked ? 'Cannot modify — attack is locked' : 'New Conversation'} relationship="label">
+          <Tooltip content={lockedReason ?? 'New Conversation'} relationship="label">
             <Button
               appearance="subtle"
               size="small"
               icon={<AddRegular />}
               onClick={onNewConversation}
-              disabled={!attackResultId || locked}
+              disabled={!attackResultId || !!lockedReason}
               data-testid="new-conversation-btn"
             />
           </Tooltip>
@@ -184,14 +184,14 @@ export default function ConversationPanel({
                   <Tooltip
                     content={conv.conversation_id === mainConversationId
                       ? 'This is the main conversation.'
-                      : 'Promote to main conversation.'}
+                      : lockedReason ?? 'Promote to main conversation.'}
                     relationship="description"
                   >
                     <Button
                       appearance="subtle"
                       size="small"
                       icon={conv.conversation_id === mainConversationId ? <StarFilled /> : <StarRegular />}
-                      disabled={conv.conversation_id === mainConversationId || locked}
+                      disabled={conv.conversation_id === mainConversationId || !!lockedReason}
                       onClick={(e) => {
                         e.stopPropagation()
                         if (conv.conversation_id !== mainConversationId) {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -155,7 +155,7 @@ export const attacksApi = {
     conversationId: string
   ): Promise<ChangeMainConversationResponse> => {
     const response = await apiClient.post(
-      `/attacks/${encodeURIComponent(attackResultId)}/change-main-conversation`,
+      `/attacks/${encodeURIComponent(attackResultId)}/update-main-conversation`,
       { conversation_id: conversationId }
     )
     return response.data


### PR DESCRIPTION

   <!--- Please add one of the following as a prefix to the pull request title: -->
   <!--- DOC for documentation changes -->
   <!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
   <!--- FIX for bug fixes -->
   <!--- TEST for adding tests -->
   <!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
   <!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->
   
   <!--- Note on BREAKING changes: If your PR includes a change that will require users to make a corresponding
   change (e.g. naming changes), please list [BREAKING] in front of the above prefix in the PR title.
   For example, [BREAKING] FEAT or [BREAKING] MAINT -->
   
   ## Description
   <!--- Provide a general summary of your changes. -->
   <!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
   <!--- Tag people for whom this PR may be of interest using @<username>. -->
   
   <!--- If you are considering making a contribution please open an issue first. -->
   <!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
   <!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->
   
   <!--- If your change is BREAKING please include reasoning for why below. -->
   
   The star button in the Conversation Panel (used to promote a conversation to "main") was non-functional due to three compounding issues:
   
   1. **URL mismatch** — The frontend called `/attacks/{id}/change-main-conversation` but the backend route is 
  `/attacks/{id}/update-main-conversation`. The API call silently 404'd and the error was swallowed by the catch block.
   2. **No UI refresh** — After a successful promote, the conversation panel did not refresh, so the star icons stayed stale until 
  navigating away and back.
   3. **No explanation for disabled state** — When the star was disabled (target mismatch or operator locking), the tooltip still said "Promote to main conversation." with no indication of why the promotion was being blocked. There is now a message stating which promotion condition is blocking (no target set, mismatched conversation, different operator)
   
   ### Changes
   
   - **`frontend/src/services/api.ts`** — Fix endpoint URL from `change-main-conversation` to `update-main-conversation`
   - **`frontend/src/components/Chat/ChatWindow.tsx`** — Add `setPanelRefreshKey` after successful promote; replace boolean `locked` 
  prop with `lockedReason` string carrying contextual messages
   - **`frontend/src/components/Chat/ConversationPanel.tsx`** — Update prop interface and tooltips to display specific lock reasons
   - **`frontend/e2e/flows.spec.ts`** — Update two seeded E2E tests to click the star button via UI instead of calling the backend API 
  directly (removing workaround for the URL mismatch)
   
   ## Tests and Documentation
   
   <!--- Contributions require tests and documentation (if applicable). -->
   <!--- Include a description of tests and documentation updated (if applicable) -->
   
   <!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
   <!--- Include how you/if ran JupyText here -->
   <!--- This is described at: https://github.com/Azure/PyRIT/tree/main/doc  -->
   
   - All 407 frontend unit tests pass (`npx jest`)
   - Updated E2E tests in `flows.spec.ts`: "should change main conversation" and "full lifecycle" now test the full UI click → API → 
  refresh flow instead of bypassing the frontend with direct API calls
   - Manually verified: star click returns 200 in DevTools, star icons update immediately, contextual tooltips display correct lock 
  reason for each disabled state
   - JupyText: N/A — no notebook or documentation changes