### PR TITLE
FIX GUI conversation switching during in-flight requests and sort ordering

### DIFF
--- a/frontend/src/components/Chat/ChatWindow.tsx
+++ b/frontend/src/components/Chat/ChatWindow.tsx
@@ -74,6 +74,10 @@ export default function ChatWindow({
       setIsPanelOpen(true)
     }
   }, [attackResultId, relatedConversationCount])
+  // Set by panel click to bypass the in-flight guard on the next useEffect cycle.
+  // This lets users switch to a sending conversation while still protecting
+  // optimistic messages when handleSend internally updates activeConversationId.
+  const forceLoadRef = useRef(false)
   // Always-current ref of the conversation being viewed so async callbacks can
   // check whether the user navigated away while a request was in-flight.
   const viewedConvRef = useRef(activeConversationId ?? conversationId)
@@ -126,9 +130,12 @@ export default function ChatWindow({
   // Reload messages when activeConversationId changes
   useEffect(() => {
     if (!attackResultId || !activeConversationId) { return }
-    // Skip loading if a send is already in-flight for this conversation —
-    // the send handler will update messages when it completes.
-    if (sendingConvIdsRef.current.has(activeConversationId)) { return }
+    // Allow user-initiated switches (forceLoadRef), but skip re-loading when
+    // handleSend internally updated activeConversationId during an in-flight
+    // send — the optimistic messages are already displayed.
+    const force = forceLoadRef.current
+    forceLoadRef.current = false
+    if (!force && sendingConvIdsRef.current.has(activeConversationId)) { return }
     loadConversation(attackResultId, activeConversationId)
   }, [activeConversationId, attackResultId, loadConversation])
 
@@ -143,6 +150,7 @@ export default function ChatWindow({
   // Handle conversation selection from the panel
   // For a different ID the useEffect handles loading; for same ID force a refresh
   const handlePanelSelectConversation = useCallback((convId: string) => {
+    forceLoadRef.current = true
     onSelectConversation(convId)
     if (convId === activeConversationId && attackResultId) {
       loadConversation(attackResultId, convId)

--- a/pyrit/backend/services/attack_service.py
+++ b/pyrit/backend/services/attack_service.py
@@ -390,6 +390,9 @@ class AttackService:
         for conv_id in active_conv_ids:
             stats = stats_map.get(conv_id)
             created_at = stats.created_at if stats else None
+            # SQLite returns naive datetimes — normalize to UTC (same pattern as _ensure_utc)
+            if created_at is not None and created_at.tzinfo is None:
+                created_at = created_at.replace(tzinfo=timezone.utc)
             conversations.append(
                 ConversationSummary(
                     conversation_id=conv_id,
@@ -399,10 +402,12 @@ class AttackService:
                 )
             )
 
-        # Sort all conversations by created_at (earliest first, None last)
-        conversations.sort(
-            key=lambda c: (c.created_at is None, c.created_at or datetime.min.replace(tzinfo=timezone.utc))
-        )
+        # Sort conversations by created_at (earliest first). In-flight conversations
+        # have no stored messages yet so created_at is None — treat them as the most
+        # recent (they were just created) so they sort after older conversations
+        # instead of jumping to an arbitrary position.
+        now = datetime.now(timezone.utc)
+        conversations.sort(key=lambda c: c.created_at or now)
 
         return AttackConversationsResponse(
             attack_result_id=attack_result_id,


### PR DESCRIPTION
   <!--- Please add one of the following as a prefix to the pull request title: -->
   <!--- DOC for documentation changes -->
   <!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
   <!--- FIX for bug fixes -->
   <!--- TEST for adding tests -->
   <!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
   <!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->
   
   <!--- Note on BREAKING changes: If your PR includes a change that will require users to make a corresponding
   change (e.g. naming changes), please list [BREAKING] in front of the above prefix in the PR title.
   For example, [BREAKING] FEAT or [BREAKING] MAINT -->
   
   ## Description
   <!--- Provide a general summary of your changes. -->
   <!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
   <!--- Tag people for whom this PR may be of interest using @<username>. -->
   
   <!--- If you are considering making a contribution please open an issue first. -->
   <!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
   <!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->
   
   <!--- If your change is BREAKING please include reasoning for why below. -->
   
   Fixes two bugs in the frontend conversation panel:
   
   1. **Conversation switching blocked during in-flight requests** — A `sendingConvIdsRef` guard in `ChatWindow.tsx`'s `useEffect` 
  prevented loading messages for any conversation with an active send. This was redundant since `loadConversation()` already handles in-flight conversations by appending in-flight user messages and a loading spinner. Removed the 3-line guard.
   
   2. **In-flight conversations jump position after first response** — `attack_service.py` sorts conversations by `created_at`, but 
  in-flight conversations have `created_at=None` (no stored messages yet), causing them to sort unpredictably. Additionally, SQLite raw queries return timezone-naive datetimes while the rest of the codebase uses UTC-aware datetimes, causing `TypeError` on comparison. 
  Fixed by normalizing naive timestamps to UTC in the sort loop and using `datetime.now(timezone.utc)` as a fallback for `None`, so in-flight conversations consistently sort to the end.
   
   ## Tests and Documentation
   
   <!--- Contributions require tests and documentation (if applicable). -->
   <!--- Include a description of tests and documentation updated (if applicable) -->
   
   <!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
   <!--- Include how you/if ran JupyText here -->
   <!--- This is described at: https://github.com/Azure/PyRIT/tree/main/doc  -->
   
   - All existing unit tests pass
   - Pre-commit hooks pass
   - Manually tested both fixes live:
     - Verified switching between conversations while a request is in-flight works correctly
     - Verified in-flight conversations stay at the bottom of the list consistently after the first response arrives
   - No new tests added — these are behavioral fixes to existing logic with no new API surface