### PR TITLE
 Fix: Eval hash mismatch due to parameter truncation in DB storage

### DIFF
--- a/pyrit/identifiers/component_identifier.py
+++ b/pyrit/identifiers/component_identifier.py
@@ -128,23 +128,52 @@ class ComponentIdentifier:
     #: Named child identifiers for compositional identity (e.g., a scorer's target).
     children: dict[str, Union[ComponentIdentifier, list[ComponentIdentifier]]] = field(default_factory=dict)
     #: Content-addressed SHA256 hash computed from class, params, and children.
-    hash: str = field(init=False, compare=False)
+    #: When ``None`` (the default), it is computed automatically in ``__post_init__``.
+    #: Pass an explicit value to preserve a pre-computed hash (e.g. from DB storage
+    #: where params may have been truncated).
+    hash: Optional[str] = field(default=None, compare=False)
     #: Version tag for storage. Not included in hash.
     pyrit_version: str = field(default_factory=lambda: pyrit.__version__, compare=False)
     #: Evaluation hash. Computed by EvaluationIdentifier subclasses (e.g. ScorerEvaluationIdentifier)
     #: and attached to the identifier so it is always available via ``to_dict()``.
     #: Survives DB round-trips even when param values are truncated.
-    eval_hash: Optional[str] = field(default=None, init=False, compare=False)
+    eval_hash: Optional[str] = field(default=None, compare=False)
 
     def __post_init__(self) -> None:
-        """Compute the content-addressed hash at creation time."""
-        hash_dict = _build_hash_dict(
+        """Compute the content-addressed hash at creation time if not already provided."""
+        if self.hash is None:
+            hash_dict = _build_hash_dict(
+                class_name=self.class_name,
+                class_module=self.class_module,
+                params=self.params,
+                children=self.children,
+            )
+            object.__setattr__(self, "hash", config_hash(hash_dict))
+
+    def with_eval_hash(self, eval_hash: str) -> ComponentIdentifier:
+        """
+        Return a new frozen ComponentIdentifier with ``eval_hash`` set.
+
+        The original ``hash`` is preserved (important for identifiers
+        reconstructed from truncated DB data where recomputation would
+        produce a wrong hash).
+
+        Args:
+            eval_hash: The evaluation hash to attach.
+
+        Returns:
+            A new ComponentIdentifier identical to this one but with
+            ``eval_hash`` set to the given value.
+        """
+        return ComponentIdentifier(
             class_name=self.class_name,
             class_module=self.class_module,
             params=self.params,
             children=self.children,
+            hash=self.hash,
+            pyrit_version=self.pyrit_version,
+            eval_hash=eval_hash,
         )
-        object.__setattr__(self, "hash", config_hash(hash_dict))
 
     @property
     def short_hash(self) -> str:
@@ -332,7 +361,7 @@ class ComponentIdentifier:
         class_module = data.pop(cls.KEY_CLASS_MODULE, None) or data.pop(cls.LEGACY_KEY_MODULE, None) or "unknown"
 
         stored_hash = data.pop(cls.KEY_HASH, None)
-        restored_eval_hash = data.pop(cls.KEY_EVAL_HASH, None)
+        stored_eval_hash = data.pop(cls.KEY_EVAL_HASH, None)
         pyrit_version = data.pop(cls.KEY_PYRIT_VERSION, pyrit.__version__)
 
         # Reconstruct children
@@ -341,24 +370,15 @@ class ComponentIdentifier:
         # Everything remaining is a param
         params = data
 
-        identifier = cls(
+        return cls(
             class_name=class_name,
             class_module=class_module,
             params=params,
             children=children,
+            hash=stored_hash,
             pyrit_version=pyrit_version,
+            eval_hash=stored_eval_hash,
         )
-
-        # Preserve stored hash if available — the stored hash was computed from
-        # untruncated data and is the correct identity. Recomputing from
-        # potentially truncated DB values would produce a wrong hash.
-        if stored_hash:
-            object.__setattr__(identifier, "hash", stored_hash)
-
-        if restored_eval_hash:
-            object.__setattr__(identifier, "eval_hash", restored_eval_hash)
-
-        return identifier
 
     def get_child(self, key: str) -> Optional[ComponentIdentifier]:
         """

--- a/pyrit/identifiers/component_identifier.py
+++ b/pyrit/identifiers/component_identifier.py
@@ -113,6 +113,7 @@ class ComponentIdentifier:
     KEY_CLASS_NAME: ClassVar[str] = "class_name"
     KEY_CLASS_MODULE: ClassVar[str] = "class_module"
     KEY_HASH: ClassVar[str] = "hash"
+    KEY_EVAL_HASH: ClassVar[str] = "eval_hash"
     KEY_PYRIT_VERSION: ClassVar[str] = "pyrit_version"
     KEY_CHILDREN: ClassVar[str] = "children"
     LEGACY_KEY_TYPE: ClassVar[str] = "__type__"
@@ -130,6 +131,10 @@ class ComponentIdentifier:
     hash: str = field(init=False, compare=False)
     #: Version tag for storage. Not included in hash.
     pyrit_version: str = field(default_factory=lambda: pyrit.__version__, compare=False)
+    #: Evaluation hash preserved from DB round-trip. Computed before truncation and
+    #: stored alongside the identity so that EvaluationIdentifier can use it directly
+    #: instead of recomputing from potentially truncated params.
+    stored_eval_hash: Optional[str] = field(default=None, init=False, compare=False)
 
     def __post_init__(self) -> None:
         """Compute the content-addressed hash at creation time."""
@@ -231,7 +236,7 @@ class ComponentIdentifier:
             return cls.from_dict(value)
         raise TypeError(f"Expected ComponentIdentifier or dict, got {type(value).__name__}")
 
-    def to_dict(self, *, max_value_length: Optional[int] = None) -> dict[str, Any]:
+    def to_dict(self, *, max_value_length: Optional[int] = None, eval_hash: Optional[str] = None) -> dict[str, Any]:
         """
         Serialize to a JSON-compatible dictionary for DB/JSONL storage.
 
@@ -246,6 +251,10 @@ class ComponentIdentifier:
                 DB storage where column sizes may be limited. The truncation applies
                 only to param values, not to structural keys like class_name or hash.
                 The limit is propagated to children. Defaults to None (no truncation).
+            eval_hash (Optional[str]): If provided, the evaluation hash is included in
+                the serialized dict. This should be computed before truncation so that
+                it can be recovered via ``from_dict()`` even when param values are
+                truncated. Defaults to None (no eval_hash stored).
 
         Returns:
             Dict[str, Any]: JSON-serializable dictionary suitable for database storage
@@ -257,6 +266,11 @@ class ComponentIdentifier:
             self.KEY_HASH: self.hash,
             self.KEY_PYRIT_VERSION: self.pyrit_version,
         }
+
+        # Include eval_hash if explicitly provided or if preserved from a prior round-trip
+        effective_eval_hash = eval_hash if eval_hash is not None else self.stored_eval_hash
+        if effective_eval_hash is not None:
+            result[self.KEY_EVAL_HASH] = effective_eval_hash
 
         for key, value in self.params.items():
             result[key] = self._truncate_value(value=value, max_length=max_value_length)
@@ -324,6 +338,7 @@ class ComponentIdentifier:
         class_module = data.pop(cls.KEY_CLASS_MODULE, None) or data.pop(cls.LEGACY_KEY_MODULE, None) or "unknown"
 
         stored_hash = data.pop(cls.KEY_HASH, None)
+        stored_eval_hash = data.pop(cls.KEY_EVAL_HASH, None)
         pyrit_version = data.pop(cls.KEY_PYRIT_VERSION, pyrit.__version__)
 
         # Reconstruct children
@@ -345,6 +360,11 @@ class ComponentIdentifier:
         # potentially truncated DB values would produce a wrong hash.
         if stored_hash:
             object.__setattr__(identifier, "hash", stored_hash)
+
+        # Preserve stored eval_hash if available — computed before truncation
+        # so that EvaluationIdentifier can use it directly.
+        if stored_eval_hash:
+            object.__setattr__(identifier, "stored_eval_hash", stored_eval_hash)
 
         return identifier
 

--- a/pyrit/identifiers/component_identifier.py
+++ b/pyrit/identifiers/component_identifier.py
@@ -131,10 +131,10 @@ class ComponentIdentifier:
     hash: str = field(init=False, compare=False)
     #: Version tag for storage. Not included in hash.
     pyrit_version: str = field(default_factory=lambda: pyrit.__version__, compare=False)
-    #: Evaluation hash preserved from DB round-trip. Computed before truncation and
-    #: stored alongside the identity so that EvaluationIdentifier can use it directly
-    #: instead of recomputing from potentially truncated params.
-    stored_eval_hash: Optional[str] = field(default=None, init=False, compare=False)
+    #: Evaluation hash. Computed by EvaluationIdentifier subclasses (e.g. ScorerEvaluationIdentifier)
+    #: and attached to the identifier so it is always available via ``to_dict()``.
+    #: Survives DB round-trips even when param values are truncated.
+    eval_hash: Optional[str] = field(default=None, init=False, compare=False)
 
     def __post_init__(self) -> None:
         """Compute the content-addressed hash at creation time."""
@@ -236,7 +236,7 @@ class ComponentIdentifier:
             return cls.from_dict(value)
         raise TypeError(f"Expected ComponentIdentifier or dict, got {type(value).__name__}")
 
-    def to_dict(self, *, max_value_length: Optional[int] = None, eval_hash: Optional[str] = None) -> dict[str, Any]:
+    def to_dict(self, *, max_value_length: Optional[int] = None) -> dict[str, Any]:
         """
         Serialize to a JSON-compatible dictionary for DB/JSONL storage.
 
@@ -251,10 +251,6 @@ class ComponentIdentifier:
                 DB storage where column sizes may be limited. The truncation applies
                 only to param values, not to structural keys like class_name or hash.
                 The limit is propagated to children. Defaults to None (no truncation).
-            eval_hash (Optional[str]): If provided, the evaluation hash is included in
-                the serialized dict. This should be computed before truncation so that
-                it can be recovered via ``from_dict()`` even when param values are
-                truncated. Defaults to None (no eval_hash stored).
 
         Returns:
             Dict[str, Any]: JSON-serializable dictionary suitable for database storage
@@ -267,10 +263,8 @@ class ComponentIdentifier:
             self.KEY_PYRIT_VERSION: self.pyrit_version,
         }
 
-        # Include eval_hash if explicitly provided or if preserved from a prior round-trip
-        effective_eval_hash = eval_hash if eval_hash is not None else self.stored_eval_hash
-        if effective_eval_hash is not None:
-            result[self.KEY_EVAL_HASH] = effective_eval_hash
+        if self.eval_hash is not None:
+            result[self.KEY_EVAL_HASH] = self.eval_hash
 
         for key, value in self.params.items():
             result[key] = self._truncate_value(value=value, max_length=max_value_length)
@@ -338,7 +332,7 @@ class ComponentIdentifier:
         class_module = data.pop(cls.KEY_CLASS_MODULE, None) or data.pop(cls.LEGACY_KEY_MODULE, None) or "unknown"
 
         stored_hash = data.pop(cls.KEY_HASH, None)
-        stored_eval_hash = data.pop(cls.KEY_EVAL_HASH, None)
+        restored_eval_hash = data.pop(cls.KEY_EVAL_HASH, None)
         pyrit_version = data.pop(cls.KEY_PYRIT_VERSION, pyrit.__version__)
 
         # Reconstruct children
@@ -361,10 +355,8 @@ class ComponentIdentifier:
         if stored_hash:
             object.__setattr__(identifier, "hash", stored_hash)
 
-        # Preserve stored eval_hash if available — computed before truncation
-        # so that EvaluationIdentifier can use it directly.
-        if stored_eval_hash:
-            object.__setattr__(identifier, "stored_eval_hash", stored_eval_hash)
+        if restored_eval_hash:
+            object.__setattr__(identifier, "eval_hash", restored_eval_hash)
 
         return identifier
 

--- a/pyrit/identifiers/evaluation_identifier.py
+++ b/pyrit/identifiers/evaluation_identifier.py
@@ -170,16 +170,17 @@ class EvaluationIdentifier(ABC):
     CHILD_EVAL_RULES: ClassVar[dict[str, ChildEvalRule]]
 
     def __init__(self, identifier: ComponentIdentifier) -> None:
-        """Wrap a ComponentIdentifier and resolve its eval hash.
+        """
+        Wrap a ComponentIdentifier and resolve its eval hash.
 
-        If the identifier carries a ``stored_eval_hash`` (preserved from a prior
-        DB round-trip), that value is used directly. Otherwise the eval hash is
-        computed from the identifier's params and children using the subclass's
-        ``CHILD_EVAL_RULES``.
+        If the identifier carries an ``eval_hash`` (preserved from a prior
+        DB round-trip or set by the scorer), that value is used directly.
+        Otherwise the eval hash is computed from the identifier's params
+        and children using the subclass's ``CHILD_EVAL_RULES``.
         """
         self._identifier = identifier
-        if identifier.stored_eval_hash is not None:
-            self._eval_hash = identifier.stored_eval_hash
+        if identifier.eval_hash is not None:
+            self._eval_hash = identifier.eval_hash
         else:
             self._eval_hash = compute_eval_hash(
                 identifier,

--- a/pyrit/identifiers/evaluation_identifier.py
+++ b/pyrit/identifiers/evaluation_identifier.py
@@ -170,12 +170,21 @@ class EvaluationIdentifier(ABC):
     CHILD_EVAL_RULES: ClassVar[dict[str, ChildEvalRule]]
 
     def __init__(self, identifier: ComponentIdentifier) -> None:
-        """Wrap a ComponentIdentifier and eagerly compute its eval hash."""
+        """Wrap a ComponentIdentifier and resolve its eval hash.
+
+        If the identifier carries a ``stored_eval_hash`` (preserved from a prior
+        DB round-trip), that value is used directly. Otherwise the eval hash is
+        computed from the identifier's params and children using the subclass's
+        ``CHILD_EVAL_RULES``.
+        """
         self._identifier = identifier
-        self._eval_hash = compute_eval_hash(
-            identifier,
-            child_eval_rules=self.CHILD_EVAL_RULES,
-        )
+        if identifier.stored_eval_hash is not None:
+            self._eval_hash = identifier.stored_eval_hash
+        else:
+            self._eval_hash = compute_eval_hash(
+                identifier,
+                child_eval_rules=self.CHILD_EVAL_RULES,
+            )
 
     @property
     def identifier(self) -> ComponentIdentifier:

--- a/pyrit/memory/memory_models.py
+++ b/pyrit/memory/memory_models.py
@@ -420,6 +420,11 @@ class ScoreEntry(Base):
         try:
             return ScorerEvaluationIdentifier(scorer_identifier).eval_hash
         except Exception:
+            logger.warning(
+                f"Failed to compute eval_hash for scorer {scorer_identifier.class_name}; "
+                "eval_hash will not be stored.",
+                exc_info=True,
+            )
             return None
 
     def get_score(self) -> Score:

--- a/pyrit/memory/memory_models.py
+++ b/pyrit/memory/memory_models.py
@@ -33,6 +33,10 @@ from sqlalchemy.types import Uuid
 import pyrit
 from pyrit.common.utils import to_sha256
 from pyrit.identifiers.component_identifier import ComponentIdentifier
+from pyrit.identifiers.evaluation_identifier import (
+    AtomicAttackEvaluationIdentifier,
+    ScorerEvaluationIdentifier,
+)
 from pyrit.models import (
     AttackOutcome,
     AttackResult,
@@ -50,6 +54,8 @@ from pyrit.models import (
     SeedSimulatedConversation,
     SeedType,
 )
+
+logger = logging.getLogger(__name__)
 
 # Default pyrit_version for database records created before version tracking was added
 LEGACY_PYRIT_VERSION = "<0.10.0"
@@ -398,11 +404,11 @@ class ScoreEntry(Base):
         self.score_metadata = entry.score_metadata
         # Normalize to ComponentIdentifier (handles dict with deprecation warning) then convert to dict for JSON storage
         normalized_scorer = ComponentIdentifier.normalize(entry.scorer_class_identifier)
-        # Compute eval_hash from untruncated identifier before truncation
-        scorer_eval_hash = self._compute_scorer_eval_hash(normalized_scorer)
+        # Ensure eval_hash is set before truncation so it survives the DB round-trip
+        if normalized_scorer.eval_hash is None:
+            self._set_scorer_eval_hash(normalized_scorer)
         self.scorer_class_identifier = normalized_scorer.to_dict(
             max_value_length=MAX_IDENTIFIER_VALUE_LENGTH,
-            eval_hash=scorer_eval_hash,
         )
         self.prompt_request_response_id = entry.message_piece_id if entry.message_piece_id else None
         self.timestamp = entry.timestamp
@@ -413,19 +419,18 @@ class ScoreEntry(Base):
         self.pyrit_version = pyrit.__version__
 
     @staticmethod
-    def _compute_scorer_eval_hash(scorer_identifier: ComponentIdentifier) -> Optional[str]:
-        """Compute scorer eval_hash from an untruncated identifier."""
-        from pyrit.identifiers.evaluation_identifier import ScorerEvaluationIdentifier
-
+    def _set_scorer_eval_hash(scorer_identifier: ComponentIdentifier) -> None:
+        """
+        Set eval_hash on the scorer identifier so it survives truncation.
+        """
         try:
-            return ScorerEvaluationIdentifier(scorer_identifier).eval_hash
+            eval_hash = ScorerEvaluationIdentifier(scorer_identifier).eval_hash
+            object.__setattr__(scorer_identifier, "eval_hash", eval_hash)
         except Exception:
             logger.warning(
-                f"Failed to compute eval_hash for scorer {scorer_identifier.class_name}; "
-                "eval_hash will not be stored.",
+                f"Failed to compute eval_hash for scorer {scorer_identifier.class_name}; eval_hash will not be stored.",
                 exc_info=True,
             )
-            return None
 
     def get_score(self) -> Score:
         """
@@ -790,12 +795,12 @@ class AttackResultEntry(Base):
         self.attack_identifier = (
             _attack_strategy_id.to_dict(max_value_length=MAX_IDENTIFIER_VALUE_LENGTH) if _attack_strategy_id else {}
         )
-        # Compute eval_hash from untruncated identifier before truncation
-        attack_eval_hash = self._compute_attack_eval_hash(entry.atomic_attack_identifier)
+        # Ensure eval_hash is set before truncation so it survives the DB round-trip
+        if entry.atomic_attack_identifier and entry.atomic_attack_identifier.eval_hash is None:
+            self._set_attack_eval_hash(entry.atomic_attack_identifier)
         self.atomic_attack_identifier = (
             entry.atomic_attack_identifier.to_dict(
                 max_value_length=MAX_IDENTIFIER_VALUE_LENGTH,
-                eval_hash=attack_eval_hash,
             )
             if entry.atomic_attack_identifier
             else None
@@ -825,21 +830,18 @@ class AttackResultEntry(Base):
         self.pyrit_version = pyrit.__version__
 
     @staticmethod
-    def _compute_attack_eval_hash(attack_identifier: Optional[ComponentIdentifier]) -> Optional[str]:
-        """Compute attack eval_hash from an untruncated identifier."""
-        if attack_identifier is None:
-            return None
-        from pyrit.identifiers.evaluation_identifier import AtomicAttackEvaluationIdentifier
-
+    def _set_attack_eval_hash(attack_identifier: ComponentIdentifier) -> None:
+        """
+        Set eval_hash on the attack identifier so it survives truncation.
+        """
         try:
-            return AtomicAttackEvaluationIdentifier(attack_identifier).eval_hash
+            eval_hash = AtomicAttackEvaluationIdentifier(attack_identifier).eval_hash
+            object.__setattr__(attack_identifier, "eval_hash", eval_hash)
         except Exception:
             logger.warning(
-                f"Failed to compute eval_hash for attack {attack_identifier.class_name}; "
-                "eval_hash will not be stored.",
+                f"Failed to compute eval_hash for attack {attack_identifier.class_name}; eval_hash will not be stored.",
                 exc_info=True,
             )
-            return None
 
     @staticmethod
     def _get_id_as_uuid(obj: Any) -> Optional[uuid.UUID]:
@@ -1006,8 +1008,6 @@ class ScenarioResultEntry(Base):
         Args:
             entry (ScenarioResult): The scenario result object to convert into a database entry.
         """
-        from pyrit.identifiers.evaluation_identifier import ScorerEvaluationIdentifier
-
         self.id = entry.id
         self.scenario_name = entry.scenario_identifier.name
         self.scenario_description = entry.scenario_identifier.description
@@ -1018,16 +1018,13 @@ class ScenarioResultEntry(Base):
         self.objective_target_identifier = entry.objective_target_identifier.to_dict(
             max_value_length=MAX_IDENTIFIER_VALUE_LENGTH
         )
-        # Compute eval_hash from untruncated identifier BEFORE truncation, then include
-        # it in the serialized dict so it survives the DB round-trip.
-        scorer_eval_hash = None
-        if entry.objective_scorer_identifier:
-            scorer_eval_hash = ScorerEvaluationIdentifier(entry.objective_scorer_identifier).eval_hash
+        # Ensure eval_hash is set before truncation so it survives the DB round-trip.
+        if entry.objective_scorer_identifier and entry.objective_scorer_identifier.eval_hash is None:
+            ScoreEntry._set_scorer_eval_hash(entry.objective_scorer_identifier)
 
         self.objective_scorer_identifier = (
             entry.objective_scorer_identifier.to_dict(
                 max_value_length=MAX_IDENTIFIER_VALUE_LENGTH,
-                eval_hash=scorer_eval_hash,
             )
             if entry.objective_scorer_identifier
             else None

--- a/pyrit/memory/memory_models.py
+++ b/pyrit/memory/memory_models.py
@@ -790,8 +790,13 @@ class AttackResultEntry(Base):
         self.attack_identifier = (
             _attack_strategy_id.to_dict(max_value_length=MAX_IDENTIFIER_VALUE_LENGTH) if _attack_strategy_id else {}
         )
+        # Compute eval_hash from untruncated identifier before truncation
+        attack_eval_hash = self._compute_attack_eval_hash(entry.atomic_attack_identifier)
         self.atomic_attack_identifier = (
-            entry.atomic_attack_identifier.to_dict(max_value_length=MAX_IDENTIFIER_VALUE_LENGTH)
+            entry.atomic_attack_identifier.to_dict(
+                max_value_length=MAX_IDENTIFIER_VALUE_LENGTH,
+                eval_hash=attack_eval_hash,
+            )
             if entry.atomic_attack_identifier
             else None
         )
@@ -818,6 +823,23 @@ class AttackResultEntry(Base):
 
         self.timestamp = datetime.now(tz=timezone.utc)
         self.pyrit_version = pyrit.__version__
+
+    @staticmethod
+    def _compute_attack_eval_hash(attack_identifier: Optional[ComponentIdentifier]) -> Optional[str]:
+        """Compute attack eval_hash from an untruncated identifier."""
+        if attack_identifier is None:
+            return None
+        from pyrit.identifiers.evaluation_identifier import AtomicAttackEvaluationIdentifier
+
+        try:
+            return AtomicAttackEvaluationIdentifier(attack_identifier).eval_hash
+        except Exception:
+            logger.warning(
+                f"Failed to compute eval_hash for attack {attack_identifier.class_name}; "
+                "eval_hash will not be stored.",
+                exc_info=True,
+            )
+            return None
 
     @staticmethod
     def _get_id_as_uuid(obj: Any) -> Optional[uuid.UUID]:

--- a/pyrit/memory/memory_models.py
+++ b/pyrit/memory/memory_models.py
@@ -406,7 +406,16 @@ class ScoreEntry(Base):
         normalized_scorer = ComponentIdentifier.normalize(entry.scorer_class_identifier)
         # Ensure eval_hash is set before truncation so it survives the DB round-trip
         if normalized_scorer.eval_hash is None:
-            self._set_scorer_eval_hash(normalized_scorer)
+            try:
+                normalized_scorer = normalized_scorer.with_eval_hash(
+                    ScorerEvaluationIdentifier(normalized_scorer).eval_hash
+                )
+            except Exception:
+                logger.warning(
+                    f"Failed to compute eval_hash for scorer {normalized_scorer.class_name}; "
+                    "eval_hash will not be stored.",
+                    exc_info=True,
+                )
         self.scorer_class_identifier = normalized_scorer.to_dict(
             max_value_length=MAX_IDENTIFIER_VALUE_LENGTH,
         )
@@ -417,20 +426,6 @@ class ScoreEntry(Base):
         self.task = entry.objective
         self.objective = entry.objective
         self.pyrit_version = pyrit.__version__
-
-    @staticmethod
-    def _set_scorer_eval_hash(scorer_identifier: ComponentIdentifier) -> None:
-        """
-        Set eval_hash on the scorer identifier so it survives truncation.
-        """
-        try:
-            eval_hash = ScorerEvaluationIdentifier(scorer_identifier).eval_hash
-            object.__setattr__(scorer_identifier, "eval_hash", eval_hash)
-        except Exception:
-            logger.warning(
-                f"Failed to compute eval_hash for scorer {scorer_identifier.class_name}; eval_hash will not be stored.",
-                exc_info=True,
-            )
 
     def get_score(self) -> Score:
         """
@@ -797,7 +792,16 @@ class AttackResultEntry(Base):
         )
         # Ensure eval_hash is set before truncation so it survives the DB round-trip
         if entry.atomic_attack_identifier and entry.atomic_attack_identifier.eval_hash is None:
-            self._set_attack_eval_hash(entry.atomic_attack_identifier)
+            try:
+                entry.atomic_attack_identifier = entry.atomic_attack_identifier.with_eval_hash(
+                    AtomicAttackEvaluationIdentifier(entry.atomic_attack_identifier).eval_hash
+                )
+            except Exception:
+                logger.warning(
+                    f"Failed to compute eval_hash for attack {entry.atomic_attack_identifier.class_name}; "
+                    "eval_hash will not be stored.",
+                    exc_info=True,
+                )
         self.atomic_attack_identifier = (
             entry.atomic_attack_identifier.to_dict(
                 max_value_length=MAX_IDENTIFIER_VALUE_LENGTH,
@@ -828,20 +832,6 @@ class AttackResultEntry(Base):
 
         self.timestamp = datetime.now(tz=timezone.utc)
         self.pyrit_version = pyrit.__version__
-
-    @staticmethod
-    def _set_attack_eval_hash(attack_identifier: ComponentIdentifier) -> None:
-        """
-        Set eval_hash on the attack identifier so it survives truncation.
-        """
-        try:
-            eval_hash = AtomicAttackEvaluationIdentifier(attack_identifier).eval_hash
-            object.__setattr__(attack_identifier, "eval_hash", eval_hash)
-        except Exception:
-            logger.warning(
-                f"Failed to compute eval_hash for attack {attack_identifier.class_name}; eval_hash will not be stored.",
-                exc_info=True,
-            )
 
     @staticmethod
     def _get_id_as_uuid(obj: Any) -> Optional[uuid.UUID]:
@@ -1020,7 +1010,16 @@ class ScenarioResultEntry(Base):
         )
         # Ensure eval_hash is set before truncation so it survives the DB round-trip.
         if entry.objective_scorer_identifier and entry.objective_scorer_identifier.eval_hash is None:
-            ScoreEntry._set_scorer_eval_hash(entry.objective_scorer_identifier)
+            try:
+                entry.objective_scorer_identifier = entry.objective_scorer_identifier.with_eval_hash(
+                    ScorerEvaluationIdentifier(entry.objective_scorer_identifier).eval_hash
+                )
+            except Exception:
+                logger.warning(
+                    f"Failed to compute eval_hash for scorer "
+                    f"{entry.objective_scorer_identifier.class_name}; eval_hash will not be stored.",
+                    exc_info=True,
+                )
 
         self.objective_scorer_identifier = (
             entry.objective_scorer_identifier.to_dict(

--- a/pyrit/memory/memory_models.py
+++ b/pyrit/memory/memory_models.py
@@ -398,7 +398,12 @@ class ScoreEntry(Base):
         self.score_metadata = entry.score_metadata
         # Normalize to ComponentIdentifier (handles dict with deprecation warning) then convert to dict for JSON storage
         normalized_scorer = ComponentIdentifier.normalize(entry.scorer_class_identifier)
-        self.scorer_class_identifier = normalized_scorer.to_dict(max_value_length=MAX_IDENTIFIER_VALUE_LENGTH)
+        # Compute eval_hash from untruncated identifier before truncation
+        scorer_eval_hash = self._compute_scorer_eval_hash(normalized_scorer)
+        self.scorer_class_identifier = normalized_scorer.to_dict(
+            max_value_length=MAX_IDENTIFIER_VALUE_LENGTH,
+            eval_hash=scorer_eval_hash,
+        )
         self.prompt_request_response_id = entry.message_piece_id if entry.message_piece_id else None
         self.timestamp = entry.timestamp
         # Store in both columns for backward compatibility
@@ -406,6 +411,16 @@ class ScoreEntry(Base):
         self.task = entry.objective
         self.objective = entry.objective
         self.pyrit_version = pyrit.__version__
+
+    @staticmethod
+    def _compute_scorer_eval_hash(scorer_identifier: ComponentIdentifier) -> Optional[str]:
+        """Compute scorer eval_hash from an untruncated identifier."""
+        from pyrit.identifiers.evaluation_identifier import ScorerEvaluationIdentifier
+
+        try:
+            return ScorerEvaluationIdentifier(scorer_identifier).eval_hash
+        except Exception:
+            return None
 
     def get_score(self) -> Score:
         """
@@ -964,6 +979,8 @@ class ScenarioResultEntry(Base):
         Args:
             entry (ScenarioResult): The scenario result object to convert into a database entry.
         """
+        from pyrit.identifiers.evaluation_identifier import ScorerEvaluationIdentifier
+
         self.id = entry.id
         self.scenario_name = entry.scenario_identifier.name
         self.scenario_description = entry.scenario_identifier.description
@@ -974,9 +991,17 @@ class ScenarioResultEntry(Base):
         self.objective_target_identifier = entry.objective_target_identifier.to_dict(
             max_value_length=MAX_IDENTIFIER_VALUE_LENGTH
         )
-        # Convert ComponentIdentifier to dict for JSON storage
+        # Compute eval_hash from untruncated identifier BEFORE truncation, then include
+        # it in the serialized dict so it survives the DB round-trip.
+        scorer_eval_hash = None
+        if entry.objective_scorer_identifier:
+            scorer_eval_hash = ScorerEvaluationIdentifier(entry.objective_scorer_identifier).eval_hash
+
         self.objective_scorer_identifier = (
-            entry.objective_scorer_identifier.to_dict(max_value_length=MAX_IDENTIFIER_VALUE_LENGTH)
+            entry.objective_scorer_identifier.to_dict(
+                max_value_length=MAX_IDENTIFIER_VALUE_LENGTH,
+                eval_hash=scorer_eval_hash,
+            )
             if entry.objective_scorer_identifier
             else None
         )

--- a/pyrit/memory/memory_models.py
+++ b/pyrit/memory/memory_models.py
@@ -406,16 +406,9 @@ class ScoreEntry(Base):
         normalized_scorer = ComponentIdentifier.normalize(entry.scorer_class_identifier)
         # Ensure eval_hash is set before truncation so it survives the DB round-trip
         if normalized_scorer.eval_hash is None:
-            try:
-                normalized_scorer = normalized_scorer.with_eval_hash(
-                    ScorerEvaluationIdentifier(normalized_scorer).eval_hash
-                )
-            except Exception:
-                logger.warning(
-                    f"Failed to compute eval_hash for scorer {normalized_scorer.class_name}; "
-                    "eval_hash will not be stored.",
-                    exc_info=True,
-                )
+            normalized_scorer = normalized_scorer.with_eval_hash(
+                ScorerEvaluationIdentifier(normalized_scorer).eval_hash
+            )
         self.scorer_class_identifier = normalized_scorer.to_dict(
             max_value_length=MAX_IDENTIFIER_VALUE_LENGTH,
         )
@@ -792,16 +785,9 @@ class AttackResultEntry(Base):
         )
         # Ensure eval_hash is set before truncation so it survives the DB round-trip
         if entry.atomic_attack_identifier and entry.atomic_attack_identifier.eval_hash is None:
-            try:
-                entry.atomic_attack_identifier = entry.atomic_attack_identifier.with_eval_hash(
-                    AtomicAttackEvaluationIdentifier(entry.atomic_attack_identifier).eval_hash
-                )
-            except Exception:
-                logger.warning(
-                    f"Failed to compute eval_hash for attack {entry.atomic_attack_identifier.class_name}; "
-                    "eval_hash will not be stored.",
-                    exc_info=True,
-                )
+            entry.atomic_attack_identifier = entry.atomic_attack_identifier.with_eval_hash(
+                AtomicAttackEvaluationIdentifier(entry.atomic_attack_identifier).eval_hash
+            )
         self.atomic_attack_identifier = (
             entry.atomic_attack_identifier.to_dict(
                 max_value_length=MAX_IDENTIFIER_VALUE_LENGTH,
@@ -1010,16 +996,9 @@ class ScenarioResultEntry(Base):
         )
         # Ensure eval_hash is set before truncation so it survives the DB round-trip.
         if entry.objective_scorer_identifier and entry.objective_scorer_identifier.eval_hash is None:
-            try:
-                entry.objective_scorer_identifier = entry.objective_scorer_identifier.with_eval_hash(
-                    ScorerEvaluationIdentifier(entry.objective_scorer_identifier).eval_hash
-                )
-            except Exception:
-                logger.warning(
-                    f"Failed to compute eval_hash for scorer "
-                    f"{entry.objective_scorer_identifier.class_name}; eval_hash will not be stored.",
-                    exc_info=True,
-                )
+            entry.objective_scorer_identifier = entry.objective_scorer_identifier.with_eval_hash(
+                ScorerEvaluationIdentifier(entry.objective_scorer_identifier).eval_hash
+            )
 
         self.objective_scorer_identifier = (
             entry.objective_scorer_identifier.to_dict(

--- a/pyrit/scenario/core/atomic_attack.py
+++ b/pyrit/scenario/core/atomic_attack.py
@@ -257,8 +257,9 @@ class AtomicAttack:
                 # Set eval_hash before truncation so it survives the DB round-trip.
                 with contextlib.suppress(Exception):
                     if result.atomic_attack_identifier.eval_hash is None:
-                        eval_hash = AtomicAttackEvaluationIdentifier(result.atomic_attack_identifier).eval_hash
-                        object.__setattr__(result.atomic_attack_identifier, "eval_hash", eval_hash)
+                        result.atomic_attack_identifier = result.atomic_attack_identifier.with_eval_hash(
+                            AtomicAttackEvaluationIdentifier(result.atomic_attack_identifier).eval_hash
+                        )
 
                 if result.attack_result_id:
                     memory.update_attack_result_by_id(

--- a/pyrit/scenario/core/atomic_attack.py
+++ b/pyrit/scenario/core/atomic_attack.py
@@ -13,12 +13,14 @@ times when that may not be possible or make sense. So this class exists to
 have a common interface for scenarios.
 """
 
+import contextlib
 import logging
 from typing import TYPE_CHECKING, Any, Optional
 
 from pyrit.executor.attack import AttackExecutor, AttackStrategy
 from pyrit.executor.attack.core.attack_executor import AttackExecutorResult
 from pyrit.identifiers import build_atomic_attack_identifier
+from pyrit.identifiers.evaluation_identifier import AtomicAttackEvaluationIdentifier
 from pyrit.memory import CentralMemory
 from pyrit.memory.memory_models import MAX_IDENTIFIER_VALUE_LENGTH
 from pyrit.models import AttackResult, SeedAttackGroup
@@ -252,16 +254,11 @@ class AtomicAttack:
                 )
 
                 # Persist the enriched identifier back to the database.
-                # Compute eval_hash before truncation so it survives the DB round-trip.
-                from pyrit.identifiers.evaluation_identifier import AtomicAttackEvaluationIdentifier
-
-                attack_eval_hash = None
-                try:
-                    attack_eval_hash = AtomicAttackEvaluationIdentifier(
-                        result.atomic_attack_identifier
-                    ).eval_hash
-                except Exception:
-                    pass
+                # Set eval_hash before truncation so it survives the DB round-trip.
+                with contextlib.suppress(Exception):
+                    if result.atomic_attack_identifier.eval_hash is None:
+                        eval_hash = AtomicAttackEvaluationIdentifier(result.atomic_attack_identifier).eval_hash
+                        object.__setattr__(result.atomic_attack_identifier, "eval_hash", eval_hash)
 
                 if result.attack_result_id:
                     memory.update_attack_result_by_id(
@@ -269,7 +266,6 @@ class AtomicAttack:
                         update_fields={
                             "atomic_attack_identifier": result.atomic_attack_identifier.to_dict(
                                 max_value_length=MAX_IDENTIFIER_VALUE_LENGTH,
-                                eval_hash=attack_eval_hash,
                             ),
                         },
                     )

--- a/pyrit/scenario/core/atomic_attack.py
+++ b/pyrit/scenario/core/atomic_attack.py
@@ -13,7 +13,6 @@ times when that may not be possible or make sense. So this class exists to
 have a common interface for scenarios.
 """
 
-import contextlib
 import logging
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -255,11 +254,10 @@ class AtomicAttack:
 
                 # Persist the enriched identifier back to the database.
                 # Set eval_hash before truncation so it survives the DB round-trip.
-                with contextlib.suppress(Exception):
-                    if result.atomic_attack_identifier.eval_hash is None:
-                        result.atomic_attack_identifier = result.atomic_attack_identifier.with_eval_hash(
-                            AtomicAttackEvaluationIdentifier(result.atomic_attack_identifier).eval_hash
-                        )
+                if result.atomic_attack_identifier.eval_hash is None:
+                    result.atomic_attack_identifier = result.atomic_attack_identifier.with_eval_hash(
+                        AtomicAttackEvaluationIdentifier(result.atomic_attack_identifier).eval_hash
+                    )
 
                 if result.attack_result_id:
                     memory.update_attack_result_by_id(

--- a/pyrit/scenario/core/atomic_attack.py
+++ b/pyrit/scenario/core/atomic_attack.py
@@ -251,13 +251,25 @@ class AtomicAttack:
                     seed_group=self._seed_groups[idx],
                 )
 
-                # Persist the enriched identifier back to the database
+                # Persist the enriched identifier back to the database.
+                # Compute eval_hash before truncation so it survives the DB round-trip.
+                from pyrit.identifiers.evaluation_identifier import AtomicAttackEvaluationIdentifier
+
+                attack_eval_hash = None
+                try:
+                    attack_eval_hash = AtomicAttackEvaluationIdentifier(
+                        result.atomic_attack_identifier
+                    ).eval_hash
+                except Exception:
+                    pass
+
                 if result.attack_result_id:
                     memory.update_attack_result_by_id(
                         attack_result_id=result.attack_result_id,
                         update_fields={
                             "atomic_attack_identifier": result.atomic_attack_identifier.to_dict(
-                                max_value_length=MAX_IDENTIFIER_VALUE_LENGTH
+                                max_value_length=MAX_IDENTIFIER_VALUE_LENGTH,
+                                eval_hash=attack_eval_hash,
                             ),
                         },
                     )

--- a/pyrit/score/float_scale/float_scale_scorer.py
+++ b/pyrit/score/float_scale/float_scale_scorer.py
@@ -59,7 +59,7 @@ class FloatScaleScorer(Scorer):
             return None
 
         return find_harm_metrics_by_eval_hash(
-            eval_hash=self.get_eval_hash(),
+            eval_hash=self.get_identifier().eval_hash,
             harm_category=self.evaluation_file_mapping.harm_category,
         )
 

--- a/pyrit/score/scorer.py
+++ b/pyrit/score/scorer.py
@@ -23,7 +23,7 @@ from pyrit.exceptions import (
     pyrit_json_retry,
     remove_markdown_json,
 )
-from pyrit.identifiers import ComponentIdentifier, Identifiable
+from pyrit.identifiers import ComponentIdentifier, Identifiable, ScorerEvaluationIdentifier
 from pyrit.memory import CentralMemory, MemoryInterface
 from pyrit.models import (
     ChatMessageRole,
@@ -82,8 +82,6 @@ class Scorer(Identifiable, abc.ABC):
         """
         identifier = super().get_identifier()
         if identifier.eval_hash is None:
-            from pyrit.identifiers.evaluation_identifier import ScorerEvaluationIdentifier
-
             identifier = identifier.with_eval_hash(ScorerEvaluationIdentifier(identifier).eval_hash)
             self._identifier = identifier
         return identifier

--- a/pyrit/score/scorer.py
+++ b/pyrit/score/scorer.py
@@ -70,21 +70,22 @@ class Scorer(Identifiable, abc.ABC):
         """
         self._validator = validator
 
-    def get_eval_hash(self) -> str:
+    def get_identifier(self) -> ComponentIdentifier:
         """
-        Compute a behavioral equivalence hash for evaluation grouping.
+        Get the scorer's identifier with eval_hash always attached.
 
-        Delegates to ``ScorerEvaluationIdentifier`` which filters target children
-        (prompt_target, converter_target) to behavioral params only, so the same
-        scorer configuration on different deployments produces the same eval hash.
+        Overrides the base ``Identifiable.get_identifier()`` so that
+        ``to_dict()`` always emits the ``eval_hash`` key.
 
         Returns:
-            str: A hex-encoded SHA256 hash suitable for eval registry keying.
+            ComponentIdentifier: The identity with ``eval_hash`` set.
         """
-        # Deferred import to avoid circular dependency (evaluation_identifier → identifiers → …)
-        from pyrit.identifiers.evaluation_identifier import ScorerEvaluationIdentifier
+        identifier = super().get_identifier()
+        if identifier.eval_hash is None:
+            from pyrit.identifiers.evaluation_identifier import ScorerEvaluationIdentifier
 
-        return ScorerEvaluationIdentifier(self.get_identifier()).eval_hash
+            object.__setattr__(identifier, "eval_hash", ScorerEvaluationIdentifier(identifier).eval_hash)
+        return identifier
 
     @property
     def scorer_type(self) -> ScoreType:

--- a/pyrit/score/scorer.py
+++ b/pyrit/score/scorer.py
@@ -84,7 +84,8 @@ class Scorer(Identifiable, abc.ABC):
         if identifier.eval_hash is None:
             from pyrit.identifiers.evaluation_identifier import ScorerEvaluationIdentifier
 
-            object.__setattr__(identifier, "eval_hash", ScorerEvaluationIdentifier(identifier).eval_hash)
+            identifier = identifier.with_eval_hash(ScorerEvaluationIdentifier(identifier).eval_hash)
+            self._identifier = identifier
         return identifier
 
     @property

--- a/pyrit/score/scorer_evaluation/scorer_evaluator.py
+++ b/pyrit/score/scorer_evaluation/scorer_evaluator.py
@@ -275,7 +275,7 @@ class ScorerEvaluator(abc.ABC):
                 - (False, None) if should run evaluation
         """
         try:
-            scorer_hash = self.scorer.get_eval_hash()
+            scorer_hash = self.scorer.get_identifier().eval_hash
 
             # Determine if this is a harm or objective evaluation
             metrics_type = MetricsType.OBJECTIVE if isinstance(self.scorer, TrueFalseScorer) else MetricsType.HARM
@@ -489,7 +489,7 @@ class ScorerEvaluator(abc.ABC):
             replace_evaluation_results(
                 file_path=result_file_path,
                 scorer_identifier=self.scorer.get_identifier(),
-                eval_hash=self.scorer.get_eval_hash(),
+                eval_hash=self.scorer.get_identifier().eval_hash,
                 metrics=metrics,
             )
         except Exception as e:

--- a/pyrit/score/true_false/true_false_scorer.py
+++ b/pyrit/score/true_false/true_false_scorer.py
@@ -94,7 +94,7 @@ class TrueFalseScorer(Scorer):
         if not result_file.exists():
             return None
 
-        return find_objective_metrics_by_eval_hash(eval_hash=self.get_eval_hash(), file_path=result_file)
+        return find_objective_metrics_by_eval_hash(eval_hash=self.get_identifier().eval_hash, file_path=result_file)
 
     async def _score_async(self, message: Message, *, objective: Optional[str] = None) -> list[Score]:
         """

--- a/tests/unit/identifiers/test_component_identifier.py
+++ b/tests/unit/identifiers/test_component_identifier.py
@@ -546,13 +546,12 @@ class TestComponentIdentifierRoundtrip:
 
     def test_roundtrip_preserves_eval_hash(self):
         """Test that eval_hash is preserved through to_dict -> from_dict round-trip."""
+        expected_eval_hash = "abc123" * 10 + "abcd"  # 64 chars
         original = ComponentIdentifier(
             class_name="Scorer",
             class_module="pyrit.score",
             params={"system_prompt": "Score the response"},
-        )
-        expected_eval_hash = "abc123" * 10 + "abcd"  # 64 chars
-        object.__setattr__(original, "eval_hash", expected_eval_hash)
+        ).with_eval_hash(expected_eval_hash)
         d = original.to_dict()
         assert d["eval_hash"] == expected_eval_hash
 
@@ -567,13 +566,12 @@ class TestComponentIdentifierRoundtrip:
         the dict, it survives truncation.
         """
         long_prompt = "You are a scorer that evaluates responses. " * 20  # >80 chars
+        eval_hash_before_truncation = "correct_eval_hash_" + "0" * 46  # 64 chars
         original = ComponentIdentifier(
             class_name="SelfAskTrueFalseScorer",
             class_module="pyrit.score",
             params={"system_prompt_template": long_prompt},
-        )
-        eval_hash_before_truncation = "correct_eval_hash_" + "0" * 46  # 64 chars
-        object.__setattr__(original, "eval_hash", eval_hash_before_truncation)
+        ).with_eval_hash(eval_hash_before_truncation)
 
         # Serialize with truncation (simulates DB storage)
         truncated_dict = original.to_dict(max_value_length=80)
@@ -608,9 +606,7 @@ class TestComponentIdentifierRoundtrip:
         original = ComponentIdentifier(
             class_name="Test",
             class_module="mod",
-        )
-        # Simulate setting eval_hash then round-tripping
-        object.__setattr__(original, "eval_hash", eval_hash)
+        ).with_eval_hash(eval_hash)
         d1 = original.to_dict()
         reconstructed = ComponentIdentifier.from_dict(d1)
 
@@ -628,7 +624,7 @@ class TestComponentIdentifierRoundtrip:
         )
         original_hash = original.hash
         eval_hash = "eval_" + "a1b2c3d4" * 7 + "a1b2c3"  # 64 chars
-        object.__setattr__(original, "eval_hash", eval_hash)
+        original = original.with_eval_hash(eval_hash)
 
         # First round-trip: store with truncation
         d1 = original.to_dict(max_value_length=80)

--- a/tests/unit/identifiers/test_component_identifier.py
+++ b/tests/unit/identifiers/test_component_identifier.py
@@ -552,11 +552,12 @@ class TestComponentIdentifierRoundtrip:
             params={"system_prompt": "Score the response"},
         )
         expected_eval_hash = "abc123" * 10 + "abcd"  # 64 chars
-        d = original.to_dict(eval_hash=expected_eval_hash)
+        object.__setattr__(original, "eval_hash", expected_eval_hash)
+        d = original.to_dict()
         assert d["eval_hash"] == expected_eval_hash
 
         reconstructed = ComponentIdentifier.from_dict(d)
-        assert reconstructed.stored_eval_hash == expected_eval_hash
+        assert reconstructed.eval_hash == expected_eval_hash
 
     def test_roundtrip_eval_hash_survives_truncation(self):
         """Regression test: eval_hash computed before truncation is preserved after round-trip.
@@ -572,9 +573,10 @@ class TestComponentIdentifierRoundtrip:
             params={"system_prompt_template": long_prompt},
         )
         eval_hash_before_truncation = "correct_eval_hash_" + "0" * 46  # 64 chars
+        object.__setattr__(original, "eval_hash", eval_hash_before_truncation)
 
-        # Serialize with truncation AND eval_hash (simulates DB storage)
-        truncated_dict = original.to_dict(max_value_length=80, eval_hash=eval_hash_before_truncation)
+        # Serialize with truncation (simulates DB storage)
+        truncated_dict = original.to_dict(max_value_length=80)
         # Params are truncated
         assert truncated_dict["system_prompt_template"].endswith("...")
         # But eval_hash is preserved
@@ -583,12 +585,12 @@ class TestComponentIdentifierRoundtrip:
         # Deserialize
         reconstructed = ComponentIdentifier.from_dict(truncated_dict)
         # eval_hash is available on the reconstructed identifier
-        assert reconstructed.stored_eval_hash == eval_hash_before_truncation
+        assert reconstructed.eval_hash == eval_hash_before_truncation
         # And it's NOT in params (from_dict pops it as a reserved key)
         assert "eval_hash" not in reconstructed.params
 
-    def test_roundtrip_no_eval_hash_when_not_provided(self):
-        """Test that stored_eval_hash is None when not included in serialization."""
+    def test_roundtrip_no_eval_hash_when_not_set(self):
+        """Test that eval_hash is None when not set on the identifier."""
         original = ComponentIdentifier(
             class_name="Test",
             class_module="mod",
@@ -598,22 +600,47 @@ class TestComponentIdentifierRoundtrip:
         assert "eval_hash" not in d
 
         reconstructed = ComponentIdentifier.from_dict(d)
-        assert reconstructed.stored_eval_hash is None
+        assert reconstructed.eval_hash is None
 
-    def test_to_dict_includes_stored_eval_hash_from_prior_roundtrip(self):
-        """Test that to_dict re-emits stored_eval_hash from a prior round-trip."""
+    def test_to_dict_includes_eval_hash_from_prior_roundtrip(self):
+        """Test that to_dict re-emits eval_hash from a prior round-trip."""
         eval_hash = "deadbeef" * 8  # 64 chars
         original = ComponentIdentifier(
             class_name="Test",
             class_module="mod",
         )
-        # Simulate a prior round-trip that stored an eval_hash
-        d1 = original.to_dict(eval_hash=eval_hash)
+        # Simulate setting eval_hash then round-tripping
+        object.__setattr__(original, "eval_hash", eval_hash)
+        d1 = original.to_dict()
         reconstructed = ComponentIdentifier.from_dict(d1)
 
-        # Re-serialize without explicitly passing eval_hash — stored one should be emitted
+        # Re-serialize — eval_hash should be emitted
         d2 = reconstructed.to_dict()
         assert d2["eval_hash"] == eval_hash
+
+    def test_double_roundtrip_preserves_eval_hash_and_identity_hash(self):
+        """Test that both eval_hash and identity hash survive retrieve → re-store → retrieve."""
+        long_prompt = "Score the response carefully. " * 20
+        original = ComponentIdentifier(
+            class_name="Scorer",
+            class_module="pyrit.score",
+            params={"system_prompt": long_prompt},
+        )
+        original_hash = original.hash
+        eval_hash = "eval_" + "a1b2c3d4" * 7 + "a1b2c3"  # 64 chars
+        object.__setattr__(original, "eval_hash", eval_hash)
+
+        # First round-trip: store with truncation
+        d1 = original.to_dict(max_value_length=80)
+        r1 = ComponentIdentifier.from_dict(d1)
+        assert r1.hash == original_hash
+        assert r1.eval_hash == eval_hash
+
+        # Second round-trip: re-store (simulating retrieve → use → re-store)
+        d2 = r1.to_dict(max_value_length=80)
+        r2 = ComponentIdentifier.from_dict(d2)
+        assert r2.hash == original_hash
+        assert r2.eval_hash == eval_hash
 
 
 class TestComponentIdentifierNormalize:

--- a/tests/unit/identifiers/test_component_identifier.py
+++ b/tests/unit/identifiers/test_component_identifier.py
@@ -544,6 +544,77 @@ class TestComponentIdentifierRoundtrip:
         assert isinstance(recon_converters, list)
         assert len(recon_converters) == 2
 
+    def test_roundtrip_preserves_eval_hash(self):
+        """Test that eval_hash is preserved through to_dict -> from_dict round-trip."""
+        original = ComponentIdentifier(
+            class_name="Scorer",
+            class_module="pyrit.score",
+            params={"system_prompt": "Score the response"},
+        )
+        expected_eval_hash = "abc123" * 10 + "abcd"  # 64 chars
+        d = original.to_dict(eval_hash=expected_eval_hash)
+        assert d["eval_hash"] == expected_eval_hash
+
+        reconstructed = ComponentIdentifier.from_dict(d)
+        assert reconstructed.stored_eval_hash == expected_eval_hash
+
+    def test_roundtrip_eval_hash_survives_truncation(self):
+        """Regression test: eval_hash computed before truncation is preserved after round-trip.
+
+        This is the core bug fix — long params get truncated in to_dict(), which would
+        cause eval_hash recomputation to produce a wrong hash. By storing eval_hash in
+        the dict, it survives truncation.
+        """
+        long_prompt = "You are a scorer that evaluates responses. " * 20  # >80 chars
+        original = ComponentIdentifier(
+            class_name="SelfAskTrueFalseScorer",
+            class_module="pyrit.score",
+            params={"system_prompt_template": long_prompt},
+        )
+        eval_hash_before_truncation = "correct_eval_hash_" + "0" * 46  # 64 chars
+
+        # Serialize with truncation AND eval_hash (simulates DB storage)
+        truncated_dict = original.to_dict(max_value_length=80, eval_hash=eval_hash_before_truncation)
+        # Params are truncated
+        assert truncated_dict["system_prompt_template"].endswith("...")
+        # But eval_hash is preserved
+        assert truncated_dict["eval_hash"] == eval_hash_before_truncation
+
+        # Deserialize
+        reconstructed = ComponentIdentifier.from_dict(truncated_dict)
+        # eval_hash is available on the reconstructed identifier
+        assert reconstructed.stored_eval_hash == eval_hash_before_truncation
+        # And it's NOT in params (from_dict pops it as a reserved key)
+        assert "eval_hash" not in reconstructed.params
+
+    def test_roundtrip_no_eval_hash_when_not_provided(self):
+        """Test that stored_eval_hash is None when not included in serialization."""
+        original = ComponentIdentifier(
+            class_name="Test",
+            class_module="mod",
+            params={"key": "value"},
+        )
+        d = original.to_dict()
+        assert "eval_hash" not in d
+
+        reconstructed = ComponentIdentifier.from_dict(d)
+        assert reconstructed.stored_eval_hash is None
+
+    def test_to_dict_includes_stored_eval_hash_from_prior_roundtrip(self):
+        """Test that to_dict re-emits stored_eval_hash from a prior round-trip."""
+        eval_hash = "deadbeef" * 8  # 64 chars
+        original = ComponentIdentifier(
+            class_name="Test",
+            class_module="mod",
+        )
+        # Simulate a prior round-trip that stored an eval_hash
+        d1 = original.to_dict(eval_hash=eval_hash)
+        reconstructed = ComponentIdentifier.from_dict(d1)
+
+        # Re-serialize without explicitly passing eval_hash — stored one should be emitted
+        d2 = reconstructed.to_dict()
+        assert d2["eval_hash"] == eval_hash
+
 
 class TestComponentIdentifierNormalize:
     """Tests for normalize class method."""

--- a/tests/unit/identifiers/test_evaluation_identifier.py
+++ b/tests/unit/identifiers/test_evaluation_identifier.py
@@ -230,9 +230,7 @@ class TestEvaluationIdentifier:
             class_name="Scorer",
             class_module="pyrit.score",
             params={"system_prompt": "truncated..."},
-        )
-        # Simulate a DB round-trip where eval_hash was preserved
-        object.__setattr__(cid, "eval_hash", stored_hash)
+        ).with_eval_hash(stored_hash)
 
         identity = _StubEvaluationIdentifier(cid)
         assert identity.eval_hash == stored_hash
@@ -274,7 +272,7 @@ class TestEvaluationIdentifier:
 
         # Compute eval_hash from the untruncated identifier (the correct hash)
         correct_eval_hash = compute_eval_hash(scorer_id, child_eval_rules=_CHILD_EVAL_RULES)
-        object.__setattr__(scorer_id, "eval_hash", correct_eval_hash)
+        scorer_id = scorer_id.with_eval_hash(correct_eval_hash)
 
         # Simulate DB storage: serialize with truncation
         truncated_dict = scorer_id.to_dict(max_value_length=80)
@@ -308,7 +306,7 @@ class TestEvaluationIdentifier:
 
         # First save: compute eval_hash from untruncated identifier
         correct_eval_hash = compute_eval_hash(scorer_id, child_eval_rules=_CHILD_EVAL_RULES)
-        object.__setattr__(scorer_id, "eval_hash", correct_eval_hash)
+        scorer_id = scorer_id.with_eval_hash(correct_eval_hash)
         d1 = scorer_id.to_dict(max_value_length=80)
 
         # First retrieve

--- a/tests/unit/identifiers/test_evaluation_identifier.py
+++ b/tests/unit/identifiers/test_evaluation_identifier.py
@@ -222,3 +222,72 @@ class TestEvaluationIdentifier:
             },
         )
         assert identity.eval_hash == expected
+
+    def test_uses_stored_eval_hash_when_available(self):
+        """Test that EvaluationIdentifier uses stored_eval_hash instead of recomputing."""
+        stored_hash = "stored_eval_hash_value_" + "0" * 42  # 64 chars
+        cid = ComponentIdentifier(
+            class_name="Scorer",
+            class_module="pyrit.score",
+            params={"system_prompt": "truncated..."},
+        )
+        # Simulate a DB round-trip where stored_eval_hash was preserved
+        object.__setattr__(cid, "stored_eval_hash", stored_hash)
+
+        identity = _StubEvaluationIdentifier(cid)
+        assert identity.eval_hash == stored_hash
+
+    def test_computes_eval_hash_when_stored_is_none(self):
+        """Test that eval_hash is computed normally when stored_eval_hash is None."""
+        cid = ComponentIdentifier(
+            class_name="Scorer",
+            class_module="pyrit.score",
+            params={"threshold": 0.5},
+        )
+        assert cid.stored_eval_hash is None
+
+        identity = _StubEvaluationIdentifier(cid)
+        expected = compute_eval_hash(cid, child_eval_rules=_StubEvaluationIdentifier.CHILD_EVAL_RULES)
+        assert identity.eval_hash == expected
+
+    def test_truncation_roundtrip_preserves_eval_hash(self):
+        """Regression test: eval_hash survives DB round-trip with param truncation.
+
+        This is the core scenario for the bug fix. A scorer with a long system_prompt
+        gets stored to the DB with truncation. The eval_hash computed from the untruncated
+        identifier is included in to_dict(). After from_dict() reconstruction, the
+        EvaluationIdentifier should use the stored eval_hash (not recompute from truncated params).
+        """
+        # Build a scorer identifier with a long system_prompt and a target child
+        long_prompt = "Evaluate whether the response achieves the objective. " * 10
+        target_child = ComponentIdentifier(
+            class_name="OpenAIChatTarget",
+            class_module="pyrit.prompt_target",
+            params={"model_name": "gpt-4o", "endpoint": "https://api.openai.com", "temperature": 0.0},
+        )
+        scorer_id = ComponentIdentifier(
+            class_name="SelfAskTrueFalseScorer",
+            class_module="pyrit.score",
+            params={"system_prompt_template": long_prompt},
+            children={"prompt_target": target_child},
+        )
+
+        # Compute eval_hash from the untruncated identifier (the correct hash)
+        correct_eval_hash = compute_eval_hash(scorer_id, child_eval_rules=_CHILD_EVAL_RULES)
+
+        # Simulate DB storage: serialize with truncation + eval_hash
+        truncated_dict = scorer_id.to_dict(max_value_length=80, eval_hash=correct_eval_hash)
+
+        # Verify params are actually truncated
+        assert truncated_dict["system_prompt_template"].endswith("...")
+
+        # Reconstruct from truncated dict (simulates DB read)
+        reconstructed = ComponentIdentifier.from_dict(truncated_dict)
+
+        # The reconstructed identifier has truncated params, so recomputing would give wrong hash
+        recomputed = compute_eval_hash(reconstructed, child_eval_rules=_CHILD_EVAL_RULES)
+        assert recomputed != correct_eval_hash, "Truncated params should produce different eval_hash"
+
+        # But EvaluationIdentifier uses stored_eval_hash, giving the correct result
+        identity = _StubEvaluationIdentifier(reconstructed)
+        assert identity.eval_hash == correct_eval_hash

--- a/tests/unit/identifiers/test_evaluation_identifier.py
+++ b/tests/unit/identifiers/test_evaluation_identifier.py
@@ -223,28 +223,28 @@ class TestEvaluationIdentifier:
         )
         assert identity.eval_hash == expected
 
-    def test_uses_stored_eval_hash_when_available(self):
-        """Test that EvaluationIdentifier uses stored_eval_hash instead of recomputing."""
+    def test_uses_eval_hash_when_available(self):
+        """Test that EvaluationIdentifier uses eval_hash instead of recomputing."""
         stored_hash = "stored_eval_hash_value_" + "0" * 42  # 64 chars
         cid = ComponentIdentifier(
             class_name="Scorer",
             class_module="pyrit.score",
             params={"system_prompt": "truncated..."},
         )
-        # Simulate a DB round-trip where stored_eval_hash was preserved
-        object.__setattr__(cid, "stored_eval_hash", stored_hash)
+        # Simulate a DB round-trip where eval_hash was preserved
+        object.__setattr__(cid, "eval_hash", stored_hash)
 
         identity = _StubEvaluationIdentifier(cid)
         assert identity.eval_hash == stored_hash
 
-    def test_computes_eval_hash_when_stored_is_none(self):
-        """Test that eval_hash is computed normally when stored_eval_hash is None."""
+    def test_computes_eval_hash_when_not_set(self):
+        """Test that eval_hash is computed normally when eval_hash is None."""
         cid = ComponentIdentifier(
             class_name="Scorer",
             class_module="pyrit.score",
             params={"threshold": 0.5},
         )
-        assert cid.stored_eval_hash is None
+        assert cid.eval_hash is None
 
         identity = _StubEvaluationIdentifier(cid)
         expected = compute_eval_hash(cid, child_eval_rules=_StubEvaluationIdentifier.CHILD_EVAL_RULES)
@@ -274,9 +274,10 @@ class TestEvaluationIdentifier:
 
         # Compute eval_hash from the untruncated identifier (the correct hash)
         correct_eval_hash = compute_eval_hash(scorer_id, child_eval_rules=_CHILD_EVAL_RULES)
+        object.__setattr__(scorer_id, "eval_hash", correct_eval_hash)
 
-        # Simulate DB storage: serialize with truncation + eval_hash
-        truncated_dict = scorer_id.to_dict(max_value_length=80, eval_hash=correct_eval_hash)
+        # Simulate DB storage: serialize with truncation
+        truncated_dict = scorer_id.to_dict(max_value_length=80)
 
         # Verify params are actually truncated
         assert truncated_dict["system_prompt_template"].endswith("...")
@@ -288,6 +289,35 @@ class TestEvaluationIdentifier:
         recomputed = compute_eval_hash(reconstructed, child_eval_rules=_CHILD_EVAL_RULES)
         assert recomputed != correct_eval_hash, "Truncated params should produce different eval_hash"
 
-        # But EvaluationIdentifier uses stored_eval_hash, giving the correct result
+        # But EvaluationIdentifier uses the preserved eval_hash, giving the correct result
         identity = _StubEvaluationIdentifier(reconstructed)
         assert identity.eval_hash == correct_eval_hash
+
+    def test_eval_hash_preserved_through_double_roundtrip(self):
+        """Test that eval_hash is preserved when retrieved from DB and re-stored.
+
+        Simulates: fresh save → DB retrieve → re-store → DB retrieve.
+        The eval_hash computed at first save should survive all round-trips.
+        """
+        long_prompt = "Evaluate whether the response achieves the objective. " * 10
+        scorer_id = ComponentIdentifier(
+            class_name="SelfAskTrueFalseScorer",
+            class_module="pyrit.score",
+            params={"system_prompt_template": long_prompt},
+        )
+
+        # First save: compute eval_hash from untruncated identifier
+        correct_eval_hash = compute_eval_hash(scorer_id, child_eval_rules=_CHILD_EVAL_RULES)
+        object.__setattr__(scorer_id, "eval_hash", correct_eval_hash)
+        d1 = scorer_id.to_dict(max_value_length=80)
+
+        # First retrieve
+        r1 = ComponentIdentifier.from_dict(d1)
+        assert _StubEvaluationIdentifier(r1).eval_hash == correct_eval_hash
+
+        # Re-store: EvaluationIdentifier should use stored value, not recompute
+        d2 = r1.to_dict(max_value_length=80)
+
+        # Second retrieve
+        r2 = ComponentIdentifier.from_dict(d2)
+        assert _StubEvaluationIdentifier(r2).eval_hash == correct_eval_hash

--- a/tests/unit/score/test_scorer_evaluation_identifier.py
+++ b/tests/unit/score/test_scorer_evaluation_identifier.py
@@ -4,8 +4,7 @@
 """
 Tests for pyrit.score.scorer_evaluation.scorer_evaluation_identifier.
 
-Covers ``ScorerEvaluationIdentifier`` ClassVar values, eval-hash delegation, and
-the ``Scorer.get_eval_hash()`` convenience method.
+Covers ``ScorerEvaluationIdentifier`` ClassVar values and eval-hash delegation.
 """
 
 import pytest
@@ -85,10 +84,10 @@ class TestScorerEvaluationIdentifierEvalHash:
 
 @pytest.mark.usefixtures("patch_central_database")
 class TestScorerGetEvalHash:
-    """Tests for Scorer.get_eval_hash() convenience method (adapted from old TestGetEvalHash)."""
+    """Tests for ScorerEvaluationIdentifier eval_hash computation."""
 
-    def test_get_eval_hash_uses_scorer_identity(self):
-        """Test that Scorer.get_eval_hash() delegates to ScorerEvaluationIdentifier."""
+    def test_eval_hash_uses_scorer_identity(self):
+        """Test that ScorerEvaluationIdentifier computes eval_hash from identifier."""
 
         class FakeScorer(Identifiable):
             def _build_identifier(self) -> ComponentIdentifier:
@@ -109,8 +108,8 @@ class TestScorerGetEvalHash:
         )
         assert eval_hash == expected
 
-    def test_get_eval_hash_filters_operational_params(self):
-        """Test that Scorer.get_eval_hash() filters operational params from target children."""
+    def test_eval_hash_filters_operational_params(self):
+        """Test that eval_hash filters operational params from target children."""
 
         class ScorerLike(Identifiable):
             def __init__(self, *, endpoint: str):
@@ -135,7 +134,7 @@ class TestScorerGetEvalHash:
         # But different component hashes (endpoint is in full identity)
         assert scorer_a.get_identifier().hash != scorer_b.get_identifier().hash
 
-    def test_get_eval_hash_no_target_children_equals_component_hash(self):
+    def test_eval_hash_no_target_children_equals_component_hash(self):
         """Test that eval hash equals component hash when there are no target children."""
 
         class SimpleScorer(Identifiable):

--- a/tests/unit/score/test_scorer_evaluator.py
+++ b/tests/unit/score/test_scorer_evaluator.py
@@ -31,9 +31,9 @@ def mock_harm_scorer():
     # Create a mock identifier with a controllable hash property
     mock_identifier = MagicMock()
     mock_identifier.hash = "test_hash_456"
+    mock_identifier.eval_hash = "test_hash_456"
     mock_identifier.system_prompt_template = "test_system_prompt"
     scorer.get_identifier = MagicMock(return_value=mock_identifier)
-    scorer.get_eval_hash = MagicMock(return_value="test_hash_456")
     return scorer
 
 
@@ -45,9 +45,9 @@ def mock_objective_scorer():
     # Create a mock identifier with a controllable hash property
     mock_identifier = MagicMock()
     mock_identifier.hash = "test_hash_123"
+    mock_identifier.eval_hash = "test_hash_123"
     mock_identifier.user_prompt_template = "test_user_prompt"
     scorer.get_identifier = MagicMock(return_value=mock_identifier)
-    scorer.get_eval_hash = MagicMock(return_value="test_hash_123")
     return scorer
 
 
@@ -412,8 +412,8 @@ def test_should_skip_evaluation_exception_handling(mock_find, mock_objective_sco
     evaluator = ObjectiveScorerEvaluator(scorer=mock_objective_scorer)
     result_file = tmp_path / "test_results.jsonl"
 
-    # Make get_eval_hash() raise an exception
-    mock_objective_scorer.get_eval_hash = MagicMock(side_effect=Exception("Identifier computation failed"))
+    # Make get_identifier() raise an exception
+    mock_objective_scorer.get_identifier = MagicMock(side_effect=Exception("Identifier computation failed"))
 
     should_skip, result = evaluator._should_skip_evaluation(
         dataset_version="1.0",
@@ -426,8 +426,11 @@ def test_should_skip_evaluation_exception_handling(mock_find, mock_objective_sco
     assert result is None
     mock_find.assert_not_called()
 
-    # Restore get_eval_hash for other tests
-    mock_objective_scorer.get_eval_hash = MagicMock(return_value="test_hash_123")
+    # Restore get_identifier for other tests
+    mock_id = MagicMock()
+    mock_id.hash = "test_hash_123"
+    mock_id.eval_hash = "test_hash_123"
+    mock_objective_scorer.get_identifier = MagicMock(return_value=mock_id)
 
 
 @patch("pyrit.score.scorer_evaluation.scorer_evaluator.find_harm_metrics_by_eval_hash")


### PR DESCRIPTION
**Bug**: Running `await printer.print_summary_async(scenario_result)` in 1_configuring_scenarios.ipynb prints "official evaluation has not been run yet for this specific configuration" — even when evals have been run.

**Root cause**: Long scorer params (e.g., system prompt templates) are truncated to 80 characters when stored in the DB via `ComponentIdentifier.to_dict(max_value_length=80)`. The `identity .hash` is correctly preserved through the round-trip, but `eval_hash` is recomputed from the truncated params by EvaluationIdentifier, producing a different hash than what was stored during the eval run. This causes the metrics lookup to fail silently.

**Fix**: Store eval_hash inside the ComponentIdentifier serialization (to_dict/from_dict) so it survives DB round-trips without recomputation from truncated params.

- ComponentIdentifier: Added stored_eval_hash field and KEY_EVAL_HASH. to_dict(eval_hash=...) includes it in the JSON; from_dict() restores it.
- EvaluationIdentifier: Uses stored_eval_hash when available instead of recomputing from (potentially truncated) params.
- ScenarioResultEntry/ScoreEntry/AttackResultEntry: Compute eval_hash from untruncated identifiers before truncation and pass to to_dict().
- atomic_attack.py: Same fix for the enriched identifier persistence path.

No DB schema migration needed — eval_hash is stored inside the existing JSON columns. Old data without it falls back to recomputation (same as prior behavior).