### PR TITLE
FIX: Small fixes to CLI docs and openai_objective_target initializer

### DIFF
--- a/.pyrit_conf_example
+++ b/.pyrit_conf_example
@@ -45,8 +45,8 @@ memory_db_type: sqlite
 #         - scorer
 initializers:
   - name: simple
-  - name: scorer
-  - name: target
+  - name: scorers
+  - name: targets
     args:
       tags:
         - default

--- a/doc/setup/pyrit_conf.md
+++ b/doc/setup/pyrit_conf.md
@@ -132,7 +132,7 @@ Because initializers run last, they can modify anything set up in earlier steps 
 The CLI and shell automatically load `~/.pyrit/.pyrit_conf`. You can also point to a different config file:
 
 ```bash
-pyrit scan run --config-file ./my_project_config.yaml --database InMemory
+pyrit_scan run --config-file ./my_project_config.yaml --database InMemory
 ```
 
 Individual CLI arguments (like `--database`) override values from the config file.

--- a/pyrit/cli/pyrit_scan.py
+++ b/pyrit/cli/pyrit_scan.py
@@ -43,7 +43,7 @@ Examples:
   pyrit_scan garak.encoding --initialization-scripts ./my_config.py
 
   # Run specific strategies or options
-  pyrit scan foundry --strategies base64 rot13 --initializers openai_objective_target
+  pyrit_scan foundry --strategies base64 rot13 --initializers openai_objective_target
   pyrit_scan foundry --initializers openai_objective_target --max-concurrency 10 --max-retries 3
   pyrit_scan garak.encoding --initializers openai_objective_target --memory-labels '{"run_id":"test123"}'
 """,

--- a/pyrit/setup/initializers/scenarios/openai_objective_target.py
+++ b/pyrit/setup/initializers/scenarios/openai_objective_target.py
@@ -45,7 +45,6 @@ class ScenarioObjectiveTargetInitializer(PyRITInitializer):
         """Get list of required environment variables."""
         return [
             "DEFAULT_OPENAI_FRONTEND_ENDPOINT",
-            "DEFAULT_OPENAI_FRONTEND_KEY",
         ]
 
     async def initialize_async(self) -> None:


### PR DESCRIPTION
## Description
This PR makes small fixes to CLI documentation and the `openai_objective_target` initializer which required an api_key environment variable (entra should be supported instead of just key-based access). 


## Tests and Documentation

N/A