### PR TITLE
FIX: flaky target capabilities tests causing intermittent failures

### DIFF
--- a/tests/unit/target/test_realtime_target.py
+++ b/tests/unit/target/test_realtime_target.py
@@ -10,7 +10,6 @@ from pyrit.models import Message, MessagePiece
 from pyrit.prompt_target import RealtimeTarget
 from pyrit.prompt_target.openai.openai_realtime_target import RealtimeTargetResult
 
-
 # Env vars that may leak from .env files loaded by other tests in parallel workers.
 _CLEAN_UNDERLYING_MODEL_ENV = {
     "OPENAI_REALTIME_UNDERLYING_MODEL": "",

--- a/tests/unit/target/test_realtime_target.py
+++ b/tests/unit/target/test_realtime_target.py
@@ -11,7 +11,14 @@ from pyrit.prompt_target import RealtimeTarget
 from pyrit.prompt_target.openai.openai_realtime_target import RealtimeTargetResult
 
 
+# Env vars that may leak from .env files loaded by other tests in parallel workers.
+_CLEAN_UNDERLYING_MODEL_ENV = {
+    "OPENAI_REALTIME_UNDERLYING_MODEL": "",
+}
+
+
 @pytest.fixture
+@patch.dict("os.environ", _CLEAN_UNDERLYING_MODEL_ENV)
 def target(sqlite_instance):
     return RealtimeTarget(api_key="test_key", endpoint="wss://test_url", model_name="test")
 

--- a/tests/unit/target/test_supports_multi_turn.py
+++ b/tests/unit/target/test_supports_multi_turn.py
@@ -10,6 +10,8 @@ from tests.unit.mocks import MockPromptTarget
 # Env vars that may leak from .env files loaded by other tests in parallel workers.
 _CLEAN_UNDERLYING_MODEL_ENV = {
     "OPENAI_VIDEO_UNDERLYING_MODEL": "",
+    "OPENAI_TTS_UNDERLYING_MODEL": "",
+    "OPENAI_COMPLETION_UNDERLYING_MODEL": "",
 }
 
 
@@ -59,6 +61,7 @@ class TestSupportsMultiTurn:
         )
         assert target.capabilities.supports_multi_turn is False
 
+    @patch.dict("os.environ", _CLEAN_UNDERLYING_MODEL_ENV)
     def test_openai_tts_target_returns_false(self):
         from pyrit.prompt_target import OpenAITTSTarget
 
@@ -69,6 +72,7 @@ class TestSupportsMultiTurn:
         )
         assert target.capabilities.supports_multi_turn is False
 
+    @patch.dict("os.environ", _CLEAN_UNDERLYING_MODEL_ENV)
     def test_openai_completion_target_returns_false(self):
         from pyrit.prompt_target import OpenAICompletionTarget
 

--- a/tests/unit/target/test_supports_multi_turn.py
+++ b/tests/unit/target/test_supports_multi_turn.py
@@ -1,9 +1,17 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+from unittest.mock import patch
+
 import pytest
 
 from tests.unit.mocks import MockPromptTarget
+
+
+# Env vars that may leak from .env files loaded by other tests in parallel workers.
+_CLEAN_UNDERLYING_MODEL_ENV = {
+    "OPENAI_VIDEO_UNDERLYING_MODEL": "",
+}
 
 
 @pytest.mark.usefixtures("patch_central_database")
@@ -41,6 +49,7 @@ class TestSupportsMultiTurn:
         )
         assert target.capabilities.supports_multi_turn is False
 
+    @patch.dict("os.environ", _CLEAN_UNDERLYING_MODEL_ENV)
     def test_openai_video_target_returns_false(self):
         from pyrit.prompt_target import OpenAIVideoTarget
 

--- a/tests/unit/target/test_supports_multi_turn.py
+++ b/tests/unit/target/test_supports_multi_turn.py
@@ -7,7 +7,6 @@ import pytest
 
 from tests.unit.mocks import MockPromptTarget
 
-
 # Env vars that may leak from .env files loaded by other tests in parallel workers.
 _CLEAN_UNDERLYING_MODEL_ENV = {
     "OPENAI_VIDEO_UNDERLYING_MODEL": "",

--- a/tests/unit/target/test_target_capabilities.py
+++ b/tests/unit/target/test_target_capabilities.py
@@ -7,7 +7,6 @@ import pytest
 
 from pyrit.prompt_target.common.target_capabilities import TargetCapabilities
 
-
 # Env vars that may leak from .env files loaded by other tests in parallel workers.
 # Clear them so that targets use _DEFAULT_CAPABILITIES instead of _KNOWN_CAPABILITIES.
 _CLEAN_UNDERLYING_MODEL_ENV = {

--- a/tests/unit/target/test_target_capabilities.py
+++ b/tests/unit/target/test_target_capabilities.py
@@ -15,6 +15,8 @@ _CLEAN_UNDERLYING_MODEL_ENV = {
     "OPENAI_CHAT_UNDERLYING_MODEL": "",
     "OPENAI_IMAGE_UNDERLYING_MODEL": "",
     "OPENAI_TTS_UNDERLYING_MODEL": "",
+    "OPENAI_COMPLETION_UNDERLYING_MODEL": "",
+    "OPENAI_RESPONSES_UNDERLYING_MODEL": "",
 }
 
 
@@ -89,6 +91,7 @@ class TestTargetCapabilitiesModalities:
         assert caps.input_modalities == frozenset({frozenset(["text"])})
         assert caps.output_modalities == frozenset({frozenset(["text"])})
 
+    @patch.dict("os.environ", _CLEAN_UNDERLYING_MODEL_ENV)
     def test_openai_chat_target_modalities(self):
         from pyrit.prompt_target import OpenAIChatTarget
 
@@ -102,6 +105,7 @@ class TestTargetCapabilitiesModalities:
         assert target.capabilities.supports_json_output is True
         assert target.capabilities.supports_multi_message_pieces is True
 
+    @patch.dict("os.environ", _CLEAN_UNDERLYING_MODEL_ENV)
     def test_openai_image_target_modalities(self):
         from pyrit.prompt_target import OpenAIImageTarget
 
@@ -114,6 +118,7 @@ class TestTargetCapabilitiesModalities:
         assert target.capabilities.output_modalities == frozenset({frozenset(["image_path"])})
         assert target.capabilities.supports_multi_message_pieces is True
 
+    @patch.dict("os.environ", _CLEAN_UNDERLYING_MODEL_ENV)
     def test_openai_tts_target_modalities(self):
         from pyrit.prompt_target import OpenAITTSTarget
 
@@ -139,6 +144,7 @@ class TestTargetCapabilitiesModalities:
         assert target.capabilities.output_modalities == frozenset({frozenset(["video_path"])})
         assert target.capabilities.supports_multi_message_pieces is True
 
+    @patch.dict("os.environ", _CLEAN_UNDERLYING_MODEL_ENV)
     def test_openai_realtime_target_modalities(self):
         from pyrit.prompt_target import RealtimeTarget
 
@@ -152,6 +158,7 @@ class TestTargetCapabilitiesModalities:
         assert any("text" in combo for combo in target.capabilities.output_modalities)
         assert any("audio_path" in combo for combo in target.capabilities.output_modalities)
 
+    @patch.dict("os.environ", _CLEAN_UNDERLYING_MODEL_ENV)
     def test_openai_response_target_modalities(self):
         from pyrit.prompt_target import OpenAIResponseTarget
 
@@ -166,6 +173,7 @@ class TestTargetCapabilitiesModalities:
         assert target.capabilities.supports_json_output is True
         assert target.capabilities.supports_multi_message_pieces is True
 
+    @patch.dict("os.environ", _CLEAN_UNDERLYING_MODEL_ENV)
     def test_openai_completion_target_modalities(self):
         from pyrit.prompt_target import OpenAICompletionTarget
 

--- a/tests/unit/target/test_target_capabilities.py
+++ b/tests/unit/target/test_target_capabilities.py
@@ -8,6 +8,17 @@ import pytest
 from pyrit.prompt_target.common.target_capabilities import TargetCapabilities
 
 
+# Env vars that may leak from .env files loaded by other tests in parallel workers.
+# Clear them so that targets use _DEFAULT_CAPABILITIES instead of _KNOWN_CAPABILITIES.
+_CLEAN_UNDERLYING_MODEL_ENV = {
+    "OPENAI_VIDEO_UNDERLYING_MODEL": "",
+    "OPENAI_REALTIME_UNDERLYING_MODEL": "",
+    "OPENAI_CHAT_UNDERLYING_MODEL": "",
+    "OPENAI_IMAGE_UNDERLYING_MODEL": "",
+    "OPENAI_TTS_UNDERLYING_MODEL": "",
+}
+
+
 class TestDefaultCapabilitiesDefined:
     """Verify that every concrete PromptTarget subclass defines _DEFAULT_CAPABILITIES."""
 
@@ -115,6 +126,7 @@ class TestTargetCapabilitiesModalities:
         assert target.capabilities.input_modalities == frozenset({frozenset(["text"])})
         assert target.capabilities.output_modalities == frozenset({frozenset(["audio_path"])})
 
+    @patch.dict("os.environ", _CLEAN_UNDERLYING_MODEL_ENV)
     def test_openai_video_target_modalities(self):
         from pyrit.prompt_target import OpenAIVideoTarget
 


### PR DESCRIPTION
The env vars would get polluted when running in parallel, causing test failures