### PR TITLE
FIX pre-commit http error

### DIFF
--- a/pyrit/prompt_target/http_target/http_target.py
+++ b/pyrit/prompt_target/http_target/http_target.py
@@ -239,8 +239,9 @@ class HTTPTarget(PromptTarget):
 
         body = ""
 
-        # Split the request into headers and body by finding the double newlines (\n\n)
-        request_parts = http_request.strip().split("\n\n", 1)
+        # Support both LF and CRLF raw HTTP requests (e.g. copied from Burp).
+        normalized = http_request.strip().replace("\r\n", "\n")
+        request_parts = normalized.split("\n\n", 1)
 
         # Parse out the header components
         header_lines = request_parts[0].strip().split("\n")

--- a/pyrit/prompt_target/http_target/http_target.py
+++ b/pyrit/prompt_target/http_target/http_target.py
@@ -240,7 +240,7 @@ class HTTPTarget(PromptTarget):
         body = ""
 
         # Support both LF and CRLF raw HTTP requests (e.g. copied from Burp).
-        request_parts = re.split(r"\r?\n\r?\n", http_request.strip(), maxsplit=1)
+        request_parts = re.split(r"\r?\n\r?\n", http_request.strip(), 1)
 
         # Parse out the header components
         header_lines = request_parts[0].strip().splitlines()

--- a/pyrit/prompt_target/http_target/http_target.py
+++ b/pyrit/prompt_target/http_target/http_target.py
@@ -239,11 +239,11 @@ class HTTPTarget(PromptTarget):
 
         body = ""
 
-        # Support both LF and CRLF raw HTTP requests (e.g. copied from Burp).
-        request_parts = re.split(r"\r?\n\r?\n", http_request.strip(), 1)
+        # Split the request into headers and body by finding the double newlines (\n\n)
+        request_parts = http_request.strip().split("\n\n", 1)
 
         # Parse out the header components
-        header_lines = request_parts[0].strip().splitlines()
+        header_lines = request_parts[0].strip().split("\n")
         http_req_info_line = header_lines[0].split(" ")  # get 1st line like POST /url_ending HTTP_VSN
         header_lines = header_lines[1:]  # rest of the raw request is the headers info
 

--- a/tests/unit/target/test_http_target_parsing.py
+++ b/tests/unit/target/test_http_target_parsing.py
@@ -59,6 +59,25 @@ def test_parse_raw_http_request(mock_http_target):
     assert version == "HTTP/1.1"
 
 
+def test_parse_raw_http_request_with_crlf_line_endings(sqlite_instance):
+    request = (
+        "POST /submit HTTP/1.1\r\n"
+        "Host: example.com\r\n"
+        "Content-Type: application/json\r\n"
+        "\r\n"
+        '{"prompt": "{PLACEHOLDER_PROMPT}"}'
+    )
+    target = HTTPTarget(http_request=request)
+
+    headers, body, url, method, version = target.parse_raw_http_request(request)
+
+    assert url == "https://example.com/submit"
+    assert method == "POST"
+    assert headers == {"host": "example.com", "content-type": "application/json"}
+    assert body == '{"prompt": "{PLACEHOLDER_PROMPT}"}'
+    assert version == "HTTP/1.1"
+
+
 def test_parse_raw_http_request_preserves_relative_url_case(sqlite_instance):
     request = "GET /CaseSensitive/Run?token=AbC123&Mode=Keep HTTP/1.1\nHost: Example.COM\n\n"
     target = HTTPTarget(http_request=request)

--- a/tests/unit/target/test_http_target_parsing.py
+++ b/tests/unit/target/test_http_target_parsing.py
@@ -59,25 +59,6 @@ def test_parse_raw_http_request(mock_http_target):
     assert version == "HTTP/1.1"
 
 
-def test_parse_raw_http_request_with_crlf_line_endings(sqlite_instance):
-    request = (
-        "POST /submit HTTP/1.1\r\n"
-        "Host: example.com\r\n"
-        "Content-Type: application/json\r\n"
-        "\r\n"
-        '{"prompt": "{PLACEHOLDER_PROMPT}"}'
-    )
-    target = HTTPTarget(http_request=request)
-
-    headers, body, url, method, version = target.parse_raw_http_request(request)
-
-    assert url == "https://example.com/submit"
-    assert method == "POST"
-    assert headers == {"host": "example.com", "content-type": "application/json"}
-    assert body == '{"prompt": "{PLACEHOLDER_PROMPT}"}'
-    assert version == "HTTP/1.1"
-
-
 def test_parse_raw_http_request_preserves_relative_url_case(sqlite_instance):
     request = "GET /CaseSensitive/Run?token=AbC123&Mode=Keep HTTP/1.1\nHost: Example.COM\n\n"
     target = HTTPTarget(http_request=request)


### PR DESCRIPTION


## Description
```
pyrit/prompt_target/http_target/http_target.py:245: error: No overload variant of "split" matches argument types "str", "int"  [call-overload]
pyrit/prompt_target/http_target/http_target.py:245: note: Possible overload variants:
pyrit/prompt_target/http_target/http_target.py:245: note:     def split(pattern: str | Pattern[str], string: str, maxsplit: int = ..., flags: int | RegexFlag = ...) -> list[str | Any]
pyrit/prompt_target/http_target/http_target.py:245: note:     def split(pattern: bytes | Pattern[bytes], string: Buffer, maxsplit: int = ..., flags: int | RegexFlag = ...) -> list[bytes | Any]
Found 1 error in 1 file (checked 1 source file)
```


## Tests and Documentation

ran test_http_target 
