### PR TITLE
MAINT: Release v0.12.0 version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="./doc/roakey.png" width="150"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/Azure/PyRIT/releases/v0.12.0/doc/roakey.png" width="150"></p>
 
 # Python Risk Identification Tool for generative AI (PyRIT)
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyrit-frontend",
-  "version": "0.11.1-dev.0",
+  "version": "0.12.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyrit"
-version = "0.11.1.dev0"
+version = "0.12.0"
 description = "The Python Risk Identification Tool for LLMs (PyRIT) is a library used to assess the robustness of LLMs"
 authors = [
     { name = "Microsoft AI Red Team", email = "airedteam@microsoft.com" },

--- a/pyrit/__init__.py
+++ b/pyrit/__init__.py
@@ -6,7 +6,7 @@ __name__ = "pyrit"
 # NOTE: __version__ must be set before imports below to avoid circular import issues.
 # Submodules (e.g., component_identifier, memory_models) reference pyrit.__version__
 # and get imported transitively during the .common import chain.
-__version__ = "0.11.1.dev0"
+__version__ = "0.12.0"
 
 from .common import turn_off_transformers_warning  # noqa: F401
 from .show_versions import show_versions  # noqa: F401


### PR DESCRIPTION
## Description
Version bump and README link update for v0.12.0 release.

- Set version to `0.12.0` in `pyrit/__init__.py`, `pyproject.toml`, and `frontend/package.json`
- Updated README image link from relative `./doc/roakey.png` to absolute `raw.githubusercontent.com` URL for PyPI compatibility



## Tests and Documentation
No test or doc changes - version-only updates. Verified README image link resolves (HTTP 200).