### PR TITLE
MAINT post-0.12.0 release update to 0.12.1.dev0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyrit-frontend",
-  "version": "0.11.1-dev.0",
+  "version": "0.12.1-dev.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyrit"
-version = "0.11.1.dev0"
+version = "0.12.1.dev0"
 description = "The Python Risk Identification Tool for LLMs (PyRIT) is a library used to assess the robustness of LLMs"
 authors = [
     { name = "Microsoft AI Red Team", email = "airedteam@microsoft.com" },

--- a/pyrit/__init__.py
+++ b/pyrit/__init__.py
@@ -6,7 +6,7 @@ __name__ = "pyrit"
 # NOTE: __version__ must be set before imports below to avoid circular import issues.
 # Submodules (e.g., component_identifier, memory_models) reference pyrit.__version__
 # and get imported transitively during the .common import chain.
-__version__ = "0.11.1.dev0"
+__version__ = "0.12.1.dev0"
 
 from .common import turn_off_transformers_warning  # noqa: F401
 from .show_versions import show_versions  # noqa: F401


### PR DESCRIPTION
Post-release version bump after v0.12.0 was published to PyPI.

Changes:

pyrit/init.py: 0.11.1.dev0 → 0.12.1.dev0
pyproject.toml: 0.11.1.dev0 → 0.12.1.dev0
frontend/package.json: 0.11.1-dev.0 → 0.12.1-dev.0

No references to 0.11.0 were found in installation docs or user-facing pages that required updates.