### PR TITLE
MAINT: standardize converter docstrings

### DIFF
--- a/pyrit/prompt_converter/ask_to_decode_converter.py
+++ b/pyrit/prompt_converter/ask_to_decode_converter.py
@@ -53,7 +53,7 @@ class AskToDecodeConverter(PromptConverter):
                 If None, a random template is selected. Defaults to None.
             encoding_name (str, optional): Name of the encoding scheme (e.g., "Base64",
                 "ROT13", "Morse"). Used in encoding_name_templates to provide context
-                about the encoding type. Defaults to empty string.
+                about the encoding type. Defaults to "cipher".
         """
         self._encoding_name = encoding_name
         self._template = template

--- a/pyrit/prompt_converter/image_compression_converter.py
+++ b/pyrit/prompt_converter/image_compression_converter.py
@@ -65,7 +65,8 @@ class ImageCompressionConverter(PromptConverter):
         Initialize the converter with specified compression settings.
 
         Args:
-            output_format (str, optional): Output image format. If None, keeps original format (if supported).
+            output_format (str, optional): Output image format. Must be one of 'JPEG', 'PNG', or 'WEBP'. 
+            If None, keeps original format (if supported).
             quality (int, optional): General quality setting for JPEG and WEBP formats (0-100).
                 For JPEG format, it represents the image quality, on a scale from 0 (worst) to 95 (best).
                 For WEBP format, the value ranges from 0 to 100; for lossy compression: 0-smallest file size and

--- a/pyrit/prompt_converter/image_compression_converter.py
+++ b/pyrit/prompt_converter/image_compression_converter.py
@@ -65,7 +65,7 @@ class ImageCompressionConverter(PromptConverter):
         Initialize the converter with specified compression settings.
 
         Args:
-            output_format (str, optional): Output image format. Must be one of 'JPEG', 'PNG', or 'WEBP'. 
+            output_format (str, optional): Output image format. Must be one of 'JPEG', 'PNG', or 'WEBP'.
             If None, keeps original format (if supported).
             quality (int, optional): General quality setting for JPEG and WEBP formats (0-100).
                 For JPEG format, it represents the image quality, on a scale from 0 (worst) to 95 (best).

--- a/pyrit/prompt_converter/image_compression_converter.py
+++ b/pyrit/prompt_converter/image_compression_converter.py
@@ -66,12 +66,12 @@ class ImageCompressionConverter(PromptConverter):
 
         Args:
             output_format (str, optional): Output image format. If None, keeps original format (if supported).
-            quality (int, optional): General quality setting for JPEG and WEBP formats (0-100).\n
-                For JPEG format, it represents the image quality, on a scale from 0 (worst) to 95 (best).\n
+            quality (int, optional): General quality setting for JPEG and WEBP formats (0-100).
+                For JPEG format, it represents the image quality, on a scale from 0 (worst) to 95 (best).
                 For WEBP format, the value ranges from 0 to 100; for lossy compression: 0-smallest file size and
                 100-largest; for ``lossless``: 0-fastest/less efficient, and 100 gives the best compression.
-            optimize (bool, optional): Whether to optimize the image during compression. \n
-                For JPEG: makes the encoder perform an extra pass over the image to select optimal settings.\n
+            optimize (bool, optional): Whether to optimize the image during compression.
+                For JPEG: makes the encoder perform an extra pass over the image to select optimal settings.
                 For PNG: instructs the PNG writer to make the output file as small as possible.
             progressive (bool, optional): Whether to save JPEG images as progressive.
             compress_level (int, optional): ZLIB compression level (0-9): 1=fastest, 9=best, 0=none.

--- a/pyrit/prompt_converter/negation_trap_converter.py
+++ b/pyrit/prompt_converter/negation_trap_converter.py
@@ -41,9 +41,9 @@ class NegationTrapConverter(PromptConverter):
         Initialize the Negation Trap Converter.
 
         Args:
-            wrong_value: (str) A deliberately wrong value to use in the trap. The target
+            wrong_value (str): A deliberately wrong value to use in the trap. The target
                         may reveal the correct value when correcting this. Defaults to "incorrect_guess".
-            trap_template: (str) A custom template string. Must include {prompt} and {wrong_value}
+            trap_template (str): A custom template string. Must include {prompt} and {wrong_value}
                           placeholders. If None, uses the default denial template.
 
         Raises:

--- a/pyrit/prompt_converter/negation_trap_converter.py
+++ b/pyrit/prompt_converter/negation_trap_converter.py
@@ -41,9 +41,9 @@ class NegationTrapConverter(PromptConverter):
         Initialize the Negation Trap Converter.
 
         Args:
-            wrong_value: A deliberately wrong value to use in the trap. The target
-                        may reveal the correct value when correcting this.
-            trap_template: A custom template string. Must include {prompt} and {wrong_value}
+            wrong_value: (str) A deliberately wrong value to use in the trap. The target
+                        may reveal the correct value when correcting this. Defaults to "incorrect_guess".
+            trap_template: (str) A custom template string. Must include {prompt} and {wrong_value}
                           placeholders. If None, uses the default denial template.
 
         Raises:


### PR DESCRIPTION
## Description
Fixing docstrings for converters since these are pulled into the GUI! Some of our docstrings were missing var type or hadn't been updated.

## Tests and Documentation
Pre-commit passes, no other tests needed (just changing docstrings not code)
