### PR TITLE
FEAT add supports_system_prompt flag

### DIFF
--- a/pyrit/prompt_target/azure_ml_chat_target.py
+++ b/pyrit/prompt_target/azure_ml_chat_target.py
@@ -42,7 +42,10 @@ class AzureMLChatTarget(PromptChatTarget):
     api_key_environment_variable: str = "AZURE_ML_KEY"
 
     _DEFAULT_CAPABILITIES: TargetCapabilities = TargetCapabilities(
-        supports_multi_message_pieces=True, supports_editable_history=True, supports_multi_turn=True
+        supports_multi_message_pieces=True,
+        supports_editable_history=True,
+        supports_multi_turn=True,
+        supports_system_prompt=True,
     )
 
     def __init__(

--- a/pyrit/prompt_target/common/prompt_chat_target.py
+++ b/pyrit/prompt_target/common/prompt_chat_target.py
@@ -22,7 +22,9 @@ class PromptChatTarget(PromptTarget):
     """
 
     _DEFAULT_CAPABILITIES: TargetCapabilities = TargetCapabilities(
-        supports_multi_turn=True, supports_multi_message_pieces=True
+        supports_multi_turn=True,
+        supports_multi_message_pieces=True,
+        supports_system_prompt=True,
     )
 
     def __init__(

--- a/pyrit/prompt_target/common/target_capabilities.py
+++ b/pyrit/prompt_target/common/target_capabilities.py
@@ -38,6 +38,9 @@ class TargetCapabilities:
     # multi-turn interactions and that the attack history is not immutable once set.
     supports_editable_history: bool = False
 
+    # Whether the target natively supports system prompts.
+    supports_system_prompt: bool = False
+
     # The input modalities supported by the target (e.g., "text", "image").
     input_modalities: frozenset[frozenset[PromptDataType]] = frozenset({frozenset(["text"])})
 
@@ -76,6 +79,7 @@ _TEXT_OUTPUT: frozenset[frozenset[PromptDataType]] = cast(
 _GPT_4O = TargetCapabilities(
     supports_multi_turn=True,
     supports_multi_message_pieces=True,
+    supports_system_prompt=True,
     supports_json_output=True,
     input_modalities=_TEXT_IMAGE_INPUT,
     output_modalities=_TEXT_OUTPUT,
@@ -84,6 +88,7 @@ _GPT_4O = TargetCapabilities(
 _GPT_5 = TargetCapabilities(
     supports_multi_turn=True,
     supports_multi_message_pieces=True,
+    supports_system_prompt=True,
     supports_json_schema=True,
     supports_json_output=True,
     input_modalities=_TEXT_IMAGE_INPUT,

--- a/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
+++ b/pyrit/prompt_target/hugging_face/hugging_face_chat_target.py
@@ -33,7 +33,9 @@ class HuggingFaceChatTarget(PromptChatTarget):
     """
 
     _DEFAULT_CAPABILITIES: TargetCapabilities = TargetCapabilities(
-        supports_multi_turn=True, supports_editable_history=True
+        supports_multi_turn=True,
+        supports_editable_history=True,
+        supports_system_prompt=True,
     )
 
     # Class-level cache for model and tokenizer

--- a/pyrit/prompt_target/openai/openai_chat_target.py
+++ b/pyrit/prompt_target/openai/openai_chat_target.py
@@ -69,6 +69,7 @@ class OpenAIChatTarget(OpenAITarget, PromptChatTarget):
         supports_multi_turn=True,
         supports_json_output=True,
         supports_multi_message_pieces=True,
+        supports_system_prompt=True,
     )
 
     def __init__(

--- a/pyrit/prompt_target/openai/openai_realtime_target.py
+++ b/pyrit/prompt_target/openai/openai_realtime_target.py
@@ -71,6 +71,7 @@ class RealtimeTarget(OpenAITarget, PromptChatTarget):
     _DEFAULT_CAPABILITIES: TargetCapabilities = TargetCapabilities(
         supports_multi_turn=True,
         supports_multi_message_pieces=True,
+        supports_system_prompt=True,
         input_modalities=frozenset(
             {
                 frozenset(["text"]),

--- a/pyrit/prompt_target/openai/openai_response_target.py
+++ b/pyrit/prompt_target/openai/openai_response_target.py
@@ -72,6 +72,7 @@ class OpenAIResponseTarget(OpenAITarget, PromptChatTarget):
         supports_multi_turn=True,
         supports_json_output=True,
         supports_multi_message_pieces=True,
+        supports_system_prompt=True,
         input_modalities=frozenset(
             {
                 frozenset(["text"]),

--- a/tests/unit/target/test_target_capabilities.py
+++ b/tests/unit/target/test_target_capabilities.py
@@ -243,6 +243,7 @@ class TestTargetCapabilitiesModalities:
         caps = HuggingFaceChatTarget._DEFAULT_CAPABILITIES
         assert caps.supports_editable_history is True
         assert caps.supports_multi_turn is True
+        assert caps.supports_system_prompt is True
 
     def test_azure_ml_chat_target_capabilities(self):
         from pyrit.prompt_target import AzureMLChatTarget
@@ -253,6 +254,31 @@ class TestTargetCapabilitiesModalities:
         )
         assert target.capabilities.supports_editable_history is True
         assert target.capabilities.supports_multi_message_pieces is True
+        assert target.capabilities.supports_system_prompt is True
+
+    @patch.dict("os.environ", _CLEAN_UNDERLYING_MODEL_ENV)
+    def test_prompt_chat_targets_support_system_prompt(self):
+        from pyrit.prompt_target import OpenAIChatTarget, OpenAIResponseTarget, RealtimeTarget
+
+        openai_chat_target = OpenAIChatTarget(
+            model_name="test-model",
+            endpoint="https://mock.azure.com/",
+            api_key="mock-api-key",
+        )
+        openai_response_target = OpenAIResponseTarget(
+            model_name="o1",
+            endpoint="https://mock.azure.com/",
+            api_key="mock-api-key",
+        )
+        realtime_target = RealtimeTarget(
+            model_name="gpt-4o-realtime",
+            endpoint="https://mock.azure.com/",
+            api_key="mock-api-key",
+        )
+
+        assert openai_chat_target.capabilities.supports_system_prompt is True
+        assert openai_response_target.capabilities.supports_system_prompt is True
+        assert realtime_target.capabilities.supports_system_prompt is True
 
     def test_custom_capabilities_override_modalities(self):
         from pyrit.prompt_target import OpenAIChatTarget, TargetCapabilities
@@ -415,3 +441,12 @@ class TestGetDefaultCapabilities:
         cls = self._make_target_class(default_caps=minimal_caps)
         result = cls.get_default_capabilities("tts")
         assert result.output_modalities == frozenset({frozenset(["audio_path"])})
+
+    def test_prompt_chat_target_preserves_system_prompt_for_recognized_model(self):
+        from pyrit.prompt_target.common.prompt_chat_target import PromptChatTarget
+
+        result = PromptChatTarget.get_default_capabilities("gpt-4o")
+
+        assert result.supports_multi_turn is True
+        assert result.supports_multi_message_pieces is True
+        assert result.supports_system_prompt is True


### PR DESCRIPTION
## Description
Add supports_system_prompt to the TargetCapabilities. This allows us to specify when a target can support system prompts (ie it can accept a privileged instruction (separate from user input) that is persisted and replayed as part of the conversation across turns). As with other TargetCapabilities, by default we set it to false and that default is overridden in the chat targets (note: PromptChatTarget will soon be deprecated and supports_system_prompt as well as other chat target capabilities will need to be overridden explicitly by the child classes)

## Tests and Documentation

updated tests, currently running notebooks
