### PR TITLE
FIX: Windows support for npm lookup

### DIFF
--- a/build_scripts/prepare_package.py
+++ b/build_scripts/prepare_package.py
@@ -26,9 +26,12 @@ def build_frontend(frontend_dir: Path) -> bool:
     print("Building TypeScript/React frontend...")
     print("=" * 60)
 
-    # Check if npm is available
+    # Check if npm is available (with cross-platform compatibility)
+    npm = shutil.which("npm")
     try:
-        result = subprocess.run(["npm", "--version"], capture_output=True, text=True, check=True)
+        if npm is None:
+            raise FileNotFoundError("npm not found")
+        result = subprocess.run([npm, "--version"], capture_output=True, text=True, check=True)
         print(f"Found npm version: {result.stdout.strip()}")
     except (subprocess.CalledProcessError, FileNotFoundError):
         print("ERROR: npm is not installed or not in PATH")
@@ -45,7 +48,7 @@ def build_frontend(frontend_dir: Path) -> bool:
     print("\nInstalling frontend dependencies...")
     try:
         subprocess.run(
-            ["npm", "install"],
+            [npm, "install"],
             cwd=frontend_dir,
             check=True,
             stdout=subprocess.PIPE,
@@ -61,7 +64,7 @@ def build_frontend(frontend_dir: Path) -> bool:
     print("\nBuilding frontend for production...")
     try:
         subprocess.run(
-            ["npm", "run", "build"],
+            [npm, "run", "build"],
             cwd=frontend_dir,
             check=True,
             stdout=subprocess.PIPE,


### PR DESCRIPTION
## Description

Currently, the `prepare_package.py` script fails on Windows because it cannot find `npm` even though it is installed and accessible from the command line. This is apparently due to how `subprocess` handles aliases.

To fix the issue, we look up the actual location of `npm` and pass it to the subsequent script steps instead of passing directly `npm`. This is confirmed to work on Windows and Copilot says this should be also compatible with Linux but a maintainer should confirm.