### PR TITLE
TEST Add AWS Bedrock integration tests for OpenAI-compatible Mantle endpoint

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -85,6 +85,11 @@ AZURE_FOUNDRY_MISTRAL_LARGE_ENDPOINT="https://xxxxx.services.ai.azure.com/openai
 AZURE_FOUNDRY_MISTRAL_LARGE_KEY="xxxxx"
 AZURE_FOUNDRY_MISTRAL_LARGE_MODEL="Mistral-Large-3"
 
+AWS_ENDPOINT="https://bedrock-mantle.us-east-1.api.aws/v1"
+AWS_KEY="xxxxx"
+AWS_CHAT_MODEL="nvidia.nemotron-super-3-120b"
+AWS_RESPONSES_MODEL="openai.gpt-oss-120b"
+
 GROQ_ENDPOINT="https://api.groq.com/openai/v1"
 GROQ_KEY="gsk_xxxxxxxx"
 GROQ_LLAMA_MODEL="llama3-8b-8192"

--- a/tests/integration/targets/test_targets_and_secrets.py
+++ b/tests/integration/targets/test_targets_and_secrets.py
@@ -135,6 +135,7 @@ async def _assert_can_send_video_prompt(target):
         ("AZURE_FOUNDRY_PHI4_ENDPOINT", "AZURE_CHAT_PHI4_KEY", "AZURE_CHAT_PHI4_MODEL", True),
         ("GOOGLE_GEMINI_ENDPOINT", "GOOGLE_GEMINI_API_KEY", "GOOGLE_GEMINI_MODEL", False),
         ("ANTHROPIC_CHAT_ENDPOINT", "ANTHROPIC_CHAT_KEY", "ANTHROPIC_CHAT_MODEL", False),
+        ("AWS_ENDPOINT", "AWS_KEY", "AWS_CHAT_MODEL", False),
     ],
 )
 async def test_connect_required_openai_text_targets(sqlite_instance, endpoint, api_key, model_name, supports_seed):
@@ -178,6 +179,7 @@ async def test_connect_required_openai_text_targets(sqlite_instance, endpoint, a
             "AZURE_OPENAI_GPT5_KEY",
             "AZURE_OPENAI_GPT5_MODEL",
         ),
+        ("AWS_ENDPOINT", "AWS_KEY", "AWS_RESPONSES_MODEL"),
     ],
 )
 async def test_connect_required_openai_response_targets(sqlite_instance, endpoint, api_key, model_name):


### PR DESCRIPTION
Adds AWS Bedrock's OpenAI-compatible Mantle endpoint as parametrize entries in test_targets_and_secrets.py for both OpenAIChatTarget and OpenAIResponseTarget.

Changes

 - Added ("AWS_ENDPOINT", "AWS_KEY", "AWS_CHAT_MODEL", False) to test_connect_required_openai_text_targets
 - Added ("AWS_ENDPOINT", "AWS_KEY", "AWS_RESPONSES_MODEL") to test_connect_required_openai_response_targets

Environment variables

Requires these in ~/.pyrit/.env:

 - AWS_ENDPOINT — Mantle endpoint (e.g. https://bedrock-mantle.us-east-1.api.aws/v1)
 - AWS_KEY — Bedrock API key
 - AWS_CHAT_MODEL — model for Chat Completions (e.g. nvidia.nemotron-super-3-120b)
 - AWS_RESPONSES_MODEL — model for Responses API (e.g. openai.gpt-oss-120b)

Notes

 - Bedrock Mantle only serves open-weight models (Claude/Nova are not available through this endpoint)
 - Only openai.gpt-oss-* models support the Responses API; all models support Chat Completions
 - supports_seed is False for Bedrock