### PR TITLE
Fix code scanning path injection alerts in media endpoint

### DIFF
--- a/pyrit/backend/routes/media.py
+++ b/pyrit/backend/routes/media.py
@@ -12,6 +12,7 @@ Azure Blob Storage via signed URLs and this endpoint is not used.
 
 import logging
 import mimetypes
+import os
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Query
@@ -60,6 +61,44 @@ _ALLOWED_EXTENSIONS = {
 }
 
 
+def _validate_media_path(*, path: str, allowed_root: str) -> str:
+    """
+    Validate and sanitize a user-provided file path against an allowed root directory.
+
+    Uses ``os.path.realpath`` to resolve symlinks and ``..`` components, then
+    verifies the canonical path starts with the allowed root prefix. This is
+    the standard sanitization pattern recognized by static analysis tools
+    (e.g. CodeQL ``py/path-injection``).
+
+    Args:
+        path: The user-provided file path to validate.
+        allowed_root: The canonical (``realpath``-resolved) allowed root directory.
+
+    Returns:
+        The canonical, validated file path.
+
+    Raises:
+        HTTPException 403: If the path fails any validation check.
+    """
+    real_path = os.path.realpath(path)
+    allowed_prefix = allowed_root + os.sep
+
+    if not real_path.startswith(allowed_prefix):
+        raise HTTPException(status_code=403, detail="Access denied: path is outside the allowed results directory.")
+
+    # Restrict to known media subdirectories (e.g. prompt-memory-entries/)
+    relative_parts = Path(os.path.relpath(real_path, allowed_root)).parts
+    if not relative_parts or relative_parts[0] not in _ALLOWED_SUBDIRECTORIES:
+        raise HTTPException(status_code=403, detail="Access denied: path is not in a media subdirectory.")
+
+    # Only allow known media file extensions
+    _, ext = os.path.splitext(real_path)
+    if ext.lower() not in _ALLOWED_EXTENSIONS:
+        raise HTTPException(status_code=403, detail="Access denied: file type is not allowed.")
+
+    return real_path
+
+
 @router.get("/media")
 async def serve_media_async(
     path: str = Query(..., description="Absolute path to the local media file to serve."),
@@ -82,33 +121,19 @@ async def serve_media_async(
         HTTPException 404: If the file does not exist.
         HTTPException 500: If memory is not initialized.
     """
-    requested = Path(path).resolve()
-
-    # Determine allowed directory from memory results_path
     try:
         memory = CentralMemory.get_memory_instance()
-        allowed_root = Path(memory.results_path).resolve()
+        allowed_root = os.path.realpath(memory.results_path)
     except Exception as exc:
         raise HTTPException(status_code=500, detail="Memory not initialized; cannot determine results path.") from exc
 
-    # Path traversal guard
-    if not requested.is_relative_to(allowed_root):
-        raise HTTPException(status_code=403, detail="Access denied: path is outside the allowed results directory.")
+    validated_path = _validate_media_path(path=path, allowed_root=allowed_root)
 
-    # Restrict to known media subdirectories (e.g. prompt-memory-entries/)
-    relative = requested.relative_to(allowed_root)
-    if not relative.parts or relative.parts[0] not in _ALLOWED_SUBDIRECTORIES:
-        raise HTTPException(status_code=403, detail="Access denied: path is not in a media subdirectory.")
-
-    # Only allow known media file extensions
-    if requested.suffix.lower() not in _ALLOWED_EXTENSIONS:
-        raise HTTPException(status_code=403, detail="Access denied: file type is not allowed.")
-
-    if not requested.is_file():
+    if not os.path.isfile(validated_path):
         raise HTTPException(status_code=404, detail="File not found.")
 
-    mime_type, _ = mimetypes.guess_type(str(requested))
+    mime_type, _ = mimetypes.guess_type(validated_path)
     return FileResponse(
-        path=str(requested),
+        path=validated_path,
         media_type=mime_type or "application/octet-stream",
     )


### PR DESCRIPTION
## Summary

Refactor the \/api/media\ endpoint to resolve 3 CodeQL \py/path-injection\ alerts (#19, #20, #21).

### Changes
- Extract path validation into a dedicated \_validate_media_path\ helper
- Use \os.path.realpath\ + \str.startswith\ sanitization pattern (the standard pattern recognized by CodeQL's path injection analysis) instead of \pathlib.resolve\ + \is_relative_to\
- Use \os.path\ operations for file checks and \FileResponse\ construction so the validated path flows through consistently

### Security model (unchanged)
All existing guards are preserved:
1. Path must resolve under the configured \esults_path\
2. Must be in an allowed subdirectory (\prompt-memory-entries\ or \seed-prompt-entries\)
3. Must have an allowed file extension (media types only)

All 12 existing tests pass without modification.
