### PR TITLE
MAINT Breaking: Standardizing Attack Args

### DIFF
--- a/doc/code/executor/attack/role_play_attack.ipynb
+++ b/doc/code/executor/attack/role_play_attack.ipynb
@@ -7,8 +7,8 @@
    "source": [
     "# Role Play Attack (Single-Turn) - optional\n",
     "\n",
-    "This attack prepends some prompts defined in `role_play_definition`, along with an `adversarial_chat` target LLM to generate the first turns to send. Typically these prompts describe a fictional scenario to attempt and elicit harmful responses.\n",
-    "Any converters that you provide will be applied to the prompt that has already been converted by the role play definition (using the provided `adversarial_chat` target). You may see better success if you provide a LLM that has no content moderation or other safety mechanisms. Otherwise, it may refuse to convert the prompt as expected.\n",
+    "This attack prepends some prompts defined in `role_play_definition`, along with an `attack_adversarial_config` target LLM to generate the first turns to send. Typically these prompts describe a fictional scenario to attempt and elicit harmful responses.\n",
+    "Any converters that you provide will be applied to the prompt that has already been converted by the role play definition (using the provided `attack_adversarial_config` target). You may see better success if you provide a LLM that has no content moderation or other safety mechanisms. Otherwise, it may refuse to convert the prompt as expected.\n",
     "\n",
     "\n",
     "The results and intermediate interactions will be saved to memory according to the environment settings. For details, see the [Memory Configuration Guide](../../memory/0_memory.md)."
@@ -343,6 +343,7 @@
     "\n",
     "from pyrit.auth import get_azure_openai_auth\n",
     "from pyrit.executor.attack import (\n",
+    "    AttackAdversarialConfig,\n",
     "    AttackConverterConfig,\n",
     "    AttackExecutor,\n",
     "    AttackScoringConfig,\n",
@@ -375,7 +376,7 @@
     "\n",
     "attack = RolePlayAttack(\n",
     "    objective_target=objective_target,\n",
-    "    adversarial_chat=adversarial_chat,\n",
+    "    attack_adversarial_config=AttackAdversarialConfig(target=adversarial_chat),\n",
     "    role_play_definition_path=RolePlayPaths.MOVIE_SCRIPT.value,\n",
     "    attack_scoring_config=scoring_config,\n",
     "    attack_converter_config=converter_config,\n",

--- a/doc/code/executor/attack/role_play_attack.py
+++ b/doc/code/executor/attack/role_play_attack.py
@@ -15,8 +15,8 @@
 # %% [markdown]
 # # Role Play Attack (Single-Turn) - optional
 #
-# This attack prepends some prompts defined in `role_play_definition`, along with an `adversarial_chat` target LLM to generate the first turns to send. Typically these prompts describe a fictional scenario to attempt and elicit harmful responses.
-# Any converters that you provide will be applied to the prompt that has already been converted by the role play definition (using the provided `adversarial_chat` target). You may see better success if you provide a LLM that has no content moderation or other safety mechanisms. Otherwise, it may refuse to convert the prompt as expected.
+# This attack prepends some prompts defined in `role_play_definition`, along with an `attack_adversarial_config` target LLM to generate the first turns to send. Typically these prompts describe a fictional scenario to attempt and elicit harmful responses.
+# Any converters that you provide will be applied to the prompt that has already been converted by the role play definition (using the provided `attack_adversarial_config` target). You may see better success if you provide a LLM that has no content moderation or other safety mechanisms. Otherwise, it may refuse to convert the prompt as expected.
 #
 #
 # The results and intermediate interactions will be saved to memory according to the environment settings. For details, see the [Memory Configuration Guide](../../memory/0_memory.md).
@@ -26,6 +26,7 @@ import os
 
 from pyrit.auth import get_azure_openai_auth
 from pyrit.executor.attack import (
+    AttackAdversarialConfig,
     AttackConverterConfig,
     AttackExecutor,
     AttackScoringConfig,
@@ -58,7 +59,7 @@ scoring_config = AttackScoringConfig(
 
 attack = RolePlayAttack(
     objective_target=objective_target,
-    adversarial_chat=adversarial_chat,
+    attack_adversarial_config=AttackAdversarialConfig(target=adversarial_chat),
     role_play_definition_path=RolePlayPaths.MOVIE_SCRIPT.value,
     attack_scoring_config=scoring_config,
     attack_converter_config=converter_config,

--- a/pyrit/executor/attack/single_turn/flip_attack.py
+++ b/pyrit/executor/attack/single_turn/flip_attack.py
@@ -39,6 +39,7 @@ class FlipAttack(PromptSendingAttack):
     @apply_defaults
     def __init__(
         self,
+        *,
         objective_target: PromptChatTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         attack_converter_config: Optional[AttackConverterConfig] = None,
         attack_scoring_config: Optional[AttackScoringConfig] = None,

--- a/pyrit/executor/attack/single_turn/many_shot_jailbreak.py
+++ b/pyrit/executor/attack/single_turn/many_shot_jailbreak.py
@@ -64,6 +64,7 @@ class ManyShotJailbreakAttack(PromptSendingAttack):
     @apply_defaults
     def __init__(
         self,
+        *,
         objective_target: PromptTarget = REQUIRED_VALUE,  # type: ignore[assignment]
         attack_converter_config: Optional[AttackConverterConfig] = None,
         attack_scoring_config: Optional[AttackScoringConfig] = None,

--- a/pyrit/executor/attack/single_turn/role_play.py
+++ b/pyrit/executor/attack/single_turn/role_play.py
@@ -8,7 +8,7 @@ from typing import Any, Optional
 
 from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import EXECUTOR_SEED_PROMPT_PATH
-from pyrit.executor.attack.core.attack_config import AttackConverterConfig, AttackScoringConfig
+from pyrit.executor.attack.core.attack_config import AttackAdversarialConfig, AttackConverterConfig, AttackScoringConfig
 from pyrit.executor.attack.core.attack_parameters import AttackParameters
 from pyrit.executor.attack.single_turn.prompt_sending import PromptSendingAttack
 from pyrit.executor.attack.single_turn.single_turn_attack_strategy import (
@@ -20,7 +20,7 @@ from pyrit.models import (
 )
 from pyrit.prompt_converter import LLMGenericTextConverter
 from pyrit.prompt_normalizer import PromptConverterConfiguration, PromptNormalizer
-from pyrit.prompt_target import PromptChatTarget, PromptTarget
+from pyrit.prompt_target import PromptTarget
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ class RolePlayAttack(PromptSendingAttack):
         self,
         *,
         objective_target: PromptTarget = REQUIRED_VALUE,  # type: ignore[assignment]
-        adversarial_chat: PromptChatTarget,
+        attack_adversarial_config: AttackAdversarialConfig,
         role_play_definition_path: pathlib.Path,
         attack_converter_config: Optional[AttackConverterConfig] = None,
         attack_scoring_config: Optional[AttackScoringConfig] = None,
@@ -78,8 +78,8 @@ class RolePlayAttack(PromptSendingAttack):
 
         Args:
             objective_target (PromptTarget): The target system to attack.
-            adversarial_chat (PromptChatTarget): The adversarial chat target used to rephrase
-                objectives into role-play scenarios.
+            attack_adversarial_config (AttackAdversarialConfig): Configuration for the adversarial component,
+                including the adversarial chat target used to rephrase objectives into role-play scenarios.
             role_play_definition_path (pathlib.Path): Path to the YAML file containing role-play
                 definitions (rephrase instructions, user start turn, assistant start turn).
             attack_converter_config (Optional[AttackConverterConfig]): Configuration for prompt converters.
@@ -102,7 +102,7 @@ class RolePlayAttack(PromptSendingAttack):
         )
 
         # Store the adversarial chat for role-play rephrasing
-        self._adversarial_chat = adversarial_chat
+        self._adversarial_chat = attack_adversarial_config.target
 
         # Load role-play definitions
         role_play_definition = SeedDataset.from_yaml_file(role_play_definition_path)

--- a/pyrit/scenario/scenarios/airt/content_harms.py
+++ b/pyrit/scenario/scenarios/airt/content_harms.py
@@ -303,7 +303,7 @@ class ContentHarms(Scenario):
 
         role_play_attack = RolePlayAttack(
             objective_target=self._objective_target,
-            adversarial_chat=self._adversarial_chat,
+            attack_adversarial_config=AttackAdversarialConfig(target=self._adversarial_chat),
             role_play_definition_path=RolePlayPaths.MOVIE_SCRIPT.value,
         )
 

--- a/pyrit/scenario/scenarios/airt/jailbreak.py
+++ b/pyrit/scenario/scenarios/airt/jailbreak.py
@@ -9,6 +9,7 @@ from pyrit.auth import get_azure_openai_auth
 from pyrit.common import apply_defaults
 from pyrit.datasets import TextJailBreak
 from pyrit.executor.attack.core.attack_config import (
+    AttackAdversarialConfig,
     AttackConverterConfig,
     AttackScoringConfig,
 )
@@ -279,7 +280,9 @@ class Jailbreak(Scenario):
             case "skeleton":
                 attack = SkeletonKeyAttack(**args)
             case "role_play":
-                args["adversarial_chat"] = self._get_or_create_adversarial_target()
+                args["attack_adversarial_config"] = AttackAdversarialConfig(
+                    target=self._get_or_create_adversarial_target()
+                )
                 args["role_play_definition_path"] = RolePlayPaths.PERSUASION_SCRIPT.value
                 attack = RolePlayAttack(**args)
             case _:

--- a/pyrit/scenario/scenarios/airt/leakage.py
+++ b/pyrit/scenario/scenarios/airt/leakage.py
@@ -361,9 +361,9 @@ class Leakage(Scenario):
         """
         return RolePlayAttack(
             objective_target=self._objective_target,
-            adversarial_chat=self._adversarial_chat,
             role_play_definition_path=RolePlayPaths.PERSUASION_SCRIPT.value,
             attack_scoring_config=self._scorer_config,
+            attack_adversarial_config=self._adversarial_config,
         )
 
     def _resolve_seed_groups(self) -> list[SeedAttackGroup]:

--- a/pyrit/scenario/scenarios/airt/psychosocial.py
+++ b/pyrit/scenario/scenarios/airt/psychosocial.py
@@ -480,9 +480,9 @@ class Psychosocial(Scenario):
         )
         role_play = RolePlayAttack(
             objective_target=self._objective_target,
-            adversarial_chat=self._adversarial_chat,
             role_play_definition_path=RolePlayPaths.MOVIE_SCRIPT.value,
             attack_scoring_config=scoring_config,
+            attack_adversarial_config=AttackAdversarialConfig(target=self._adversarial_chat),
         )
         attacks.append(
             AtomicAttack(

--- a/pyrit/scenario/scenarios/airt/scam.py
+++ b/pyrit/scenario/scenarios/airt/scam.py
@@ -294,9 +294,9 @@ class Scam(Scenario):
         elif strategy == "role_play":
             attack_strategy = RolePlayAttack(
                 objective_target=self._objective_target,
-                adversarial_chat=self._adversarial_chat,
                 role_play_definition_path=RolePlayPaths.PERSUASION_SCRIPT_WRITTEN.value,
                 attack_scoring_config=self._scorer_config,
+                attack_adversarial_config=self._adversarial_config,
             )
         elif strategy == "context_compliance":
             # Set system prompt to default

--- a/tests/unit/executor/attack/single_turn/test_role_play.py
+++ b/tests/unit/executor/attack/single_turn/test_role_play.py
@@ -11,6 +11,7 @@ import yaml
 from unit.mocks import get_mock_scorer_identifier, get_mock_target_identifier
 
 from pyrit.executor.attack import (
+    AttackAdversarialConfig,
     AttackConverterConfig,
     AttackParameters,
     AttackScoringConfig,
@@ -96,7 +97,7 @@ def role_play_attack(mock_objective_target, mock_adversarial_chat_target, role_p
     """Create a RolePlayAttack instance with default configuration"""
     return RolePlayAttack(
         objective_target=mock_objective_target,
-        adversarial_chat=mock_adversarial_chat_target,
+        attack_adversarial_config=AttackAdversarialConfig(target=mock_adversarial_chat_target),
         role_play_definition_path=role_play_definition_file,
     )
 
@@ -118,7 +119,7 @@ class TestRolePlayAttackInitialization:
         """Test RolePlayAttack initialization with default parameters"""
         attack = RolePlayAttack(
             objective_target=mock_objective_target,
-            adversarial_chat=mock_adversarial_chat_target,
+            attack_adversarial_config=AttackAdversarialConfig(target=mock_adversarial_chat_target),
             role_play_definition_path=role_play_definition_file,
         )
 
@@ -133,7 +134,7 @@ class TestRolePlayAttackInitialization:
         """Test RolePlayAttack initialization with a valid true/false scorer"""
         attack = RolePlayAttack(
             objective_target=mock_objective_target,
-            adversarial_chat=mock_adversarial_chat_target,
+            attack_adversarial_config=AttackAdversarialConfig(target=mock_adversarial_chat_target),
             role_play_definition_path=role_play_definition_file,
             attack_scoring_config=AttackScoringConfig(objective_scorer=mock_scorer),
         )
@@ -148,7 +149,7 @@ class TestRolePlayAttackInitialization:
         with pytest.raises(ValueError, match="Objective scorer must be a TrueFalseScorer"):
             RolePlayAttack(
                 objective_target=mock_objective_target,
-                adversarial_chat=mock_adversarial_chat_target,
+                attack_adversarial_config=AttackAdversarialConfig(target=mock_adversarial_chat_target),
                 role_play_definition_path=role_play_definition_file,
                 attack_scoring_config=AttackScoringConfig(objective_scorer=scorer),
             )
@@ -159,7 +160,7 @@ class TestRolePlayAttackInitialization:
         with pytest.raises(FileNotFoundError):
             RolePlayAttack(
                 objective_target=mock_objective_target,
-                adversarial_chat=mock_adversarial_chat_target,
+                attack_adversarial_config=AttackAdversarialConfig(target=mock_adversarial_chat_target),
                 role_play_definition_path=invalid_path,
             )
 
@@ -172,7 +173,7 @@ class TestRolePlayAttackInitialization:
 
         attack = RolePlayAttack(
             objective_target=mock_objective_target,
-            adversarial_chat=mock_adversarial_chat_target,
+            attack_adversarial_config=AttackAdversarialConfig(target=mock_adversarial_chat_target),
             role_play_definition_path=role_play_definition_file,
             attack_converter_config=AttackConverterConfig(
                 request_converters=request_converters, response_converters=response_converters
@@ -194,7 +195,7 @@ class TestRolePlayAttackInitialization:
         with pytest.raises(ValueError, match="max_attempts_on_failure must be a non-negative integer"):
             RolePlayAttack(
                 objective_target=mock_objective_target,
-                adversarial_chat=mock_adversarial_chat_target,
+                attack_adversarial_config=AttackAdversarialConfig(target=mock_adversarial_chat_target),
                 role_play_definition_path=role_play_definition_file,
                 max_attempts_on_failure=-1,
             )
@@ -205,7 +206,7 @@ class TestRolePlayAttackInitialization:
         """Test that role play definitions are loaded correctly from YAML"""
         attack = RolePlayAttack(
             objective_target=mock_objective_target,
-            adversarial_chat=mock_adversarial_chat_target,
+            attack_adversarial_config=AttackAdversarialConfig(target=mock_adversarial_chat_target),
             role_play_definition_path=role_play_definition_file,
         )
 
@@ -220,7 +221,7 @@ class TestRolePlayAttackInitialization:
         """Test that the rephrase converter is properly created"""
         attack = RolePlayAttack(
             objective_target=mock_objective_target,
-            adversarial_chat=mock_adversarial_chat_target,
+            attack_adversarial_config=AttackAdversarialConfig(target=mock_adversarial_chat_target),
             role_play_definition_path=role_play_definition_file,
         )
 


### PR DESCRIPTION
   1. role_play.py — adversarial_chat: PromptChatTarget → attack_adversarial_config: AttackAdversarialConfig
   2. flip_attack.py — Added *, keyword-only separator
   3. many_shot_jailbreak.py — Added *, keyword-only separator