### PR TITLE
FIX Default backend to localhost instead of 0.0.0.0

### DIFF
--- a/docker/run_pyrit_docker.py
+++ b/docker/run_pyrit_docker.py
@@ -79,7 +79,7 @@ def run_container(mode, tag="latest"):
         "--name",
         container_name,
         "-p",
-        f"{port}:{port}",
+        f"127.0.0.1:{port}:{port}",
         "-e",
         f"PYRIT_MODE={mode}",
         "-v",

--- a/frontend/dev.py
+++ b/frontend/dev.py
@@ -180,7 +180,7 @@ def start_backend(*, config_file: str | None = None, initializers: list[str] | N
         "-m",
         "pyrit.cli.pyrit_backend",
         "--host",
-        "0.0.0.0",
+        "localhost",
         "--port",
         "8000",
         "--log-level",

--- a/pyrit/backend/README.md
+++ b/pyrit/backend/README.md
@@ -35,6 +35,6 @@ The API will be available at `http://localhost:8000`
 ## Configuration
 
 Environment variables:
-- `PYRIT_API_HOST` - Host to bind to (default: 0.0.0.0)
+- `PYRIT_API_HOST` - Host to bind to (default: localhost)
 - `PYRIT_API_PORT` - Port to listen on (default: 8000)
 - `PYRIT_API_RELOAD` - Enable auto-reload (default: false)

--- a/pyrit/cli/pyrit_backend.py
+++ b/pyrit/cli/pyrit_backend.py
@@ -40,6 +40,9 @@ Examples:
   # Start with custom port and host
   pyrit_backend --host 0.0.0.0 --port 8080
 
+  # Expose to network (listen on all interfaces)
+  pyrit_backend --host 0.0.0.0
+
   # List available initializers
   pyrit_backend --list-initializers
 """,
@@ -49,8 +52,8 @@ Examples:
     parser.add_argument(
         "--host",
         type=str,
-        default="0.0.0.0",
-        help="Host to bind the server to (default: 0.0.0.0)",
+        default="localhost",
+        help="Host to bind the server to (default: localhost)",
     )
 
     parser.add_argument(
@@ -196,8 +199,11 @@ async def initialize_and_run_async(*, parsed_args: Namespace) -> int:
         default_labels["operation"] = context._operation
     app.state.default_labels = default_labels
 
-    print(f"🚀 Starting PyRIT backend on http://{parsed_args.host}:{parsed_args.port}")
-    print(f"   API Docs: http://{parsed_args.host}:{parsed_args.port}/docs")
+    display_host = parsed_args.host
+    print(f"🚀 Starting PyRIT backend on http://{display_host}:{parsed_args.port}")
+    print(f"   API Docs: http://{display_host}:{parsed_args.port}/docs")
+    if parsed_args.host == "0.0.0.0":
+        print(f"   Open in browser: http://localhost:{parsed_args.port}")
 
     uvicorn_config = uvicorn.Config(
         "pyrit.backend.main:app",

--- a/tests/unit/cli/test_pyrit_backend.py
+++ b/tests/unit/cli/test_pyrit_backend.py
@@ -16,7 +16,7 @@ class TestParseArgs:
         """Should parse backend defaults correctly."""
         args = pyrit_backend.parse_args(args=[])
 
-        assert args.host == "0.0.0.0"
+        assert args.host == "localhost"
         assert args.port == 8000
         assert args.config_file is None
 


### PR DESCRIPTION
## Description
 
 The backend defaults to `host="0.0.0.0"`. This changes the default to `localhost` so the server is only reachable from the local machine by default.
 
 - Default `--host` changed to `localhost` in `pyrit_backend` CLI and `frontend/dev.py`
 - Docker port mapping bound to `127.0.0.1` in `run_pyrit_docker.py`
 - Users can still opt in to network exposure with `--host 0.0.0.0` (non-Docker) or `docker run -p 0.0.0.0:8000:8000` (Docker)
 
 ## Tests and Documentation
 
 - Updated unit test assertion in `test_pyrit_backend.py` to match new default
 - Updated `pyrit/backend/README.md` default
 - No JupyText changes needed (no notebook changes)