### PR TITLE
FIX Replace deprecated piece.role with piece.api_role in doc notebooks

### DIFF
--- a/doc/code/memory/5_advanced_memory.ipynb
+++ b/doc/code/memory/5_advanced_memory.ipynb
@@ -131,8 +131,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "./AppData/Local/Temp/ipykernel_16856/1441526989.py:17: DeprecationWarning: MessagePiece.role getter is deprecated. Use api_role for comparisons. This property will be removed in 0.13.0.\n",
-      "  original_user_prompts = [prompt.original_value for prompt in prompts if prompt.role == \"user\"]\n",
+      "  original_user_prompts = [prompt.original_value for prompt in prompts if prompt.api_role == \"user\"]\n",
       "[PromptSendingAttack (ID: 1cb5c9f1)] No response received on attempt 1 (likely filtered)\n"
      ]
     },
@@ -196,7 +195,7 @@
     "print(\"-----------------\")\n",
     "\n",
     "# These are all original prompts sent previously\n",
-    "original_user_prompts = [prompt.original_value for prompt in prompts if prompt.role == \"user\"]\n",
+    "original_user_prompts = [prompt.original_value for prompt in prompts if prompt.api_role == \"user\"]\n",
     "\n",
     "# we can now send them to a new target, using different converters\n",
     "\n",
@@ -277,8 +276,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "./AppData/Local/Temp/ipykernel_16856/4148307427.py:19: DeprecationWarning: MessagePiece.role getter is deprecated. Use api_role for comparisons. This property will be removed in 0.13.0.\n",
-      "  print(f\"  [{piece.role}] {piece.converted_value[:80]}\")\n"
+      "  print(f\"  [{piece.api_role}] {piece.converted_value[:80]}\")\n"
      ]
     }
    ],
@@ -301,7 +299,7 @@
     "\n",
     "    print(f\"Message pieces to/from {filter_target_class}: {len(target_class_pieces)}\")\n",
     "    for piece in target_class_pieces:\n",
-    "        print(f\"  [{piece.role}] {piece.converted_value[:80]}\")"
+    "        print(f\"  [{piece.api_role}] {piece.converted_value[:80]}\")"
    ]
   },
   {
@@ -336,8 +334,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "./AppData/Local/Temp/ipykernel_13356/2793915745.py:15: DeprecationWarning: MessagePiece.role getter is deprecated. Use api_role for comparisons. This property will be removed in 0.13.0.\n",
-      "  print(f\"  [{piece.role}] {piece.original_value[:80]}\")\n"
+      "  print(f\"  [{piece.api_role}] {piece.original_value[:80]}\")\n"
      ]
     }
    ],
@@ -356,7 +353,7 @@
     "\n",
     "print(f\"Message pieces to/from *OpenAI* targets: {len(openai_pieces)}\")\n",
     "for piece in openai_pieces:\n",
-    "    print(f\"  [{piece.role}] {piece.original_value[:80]}\")"
+    "    print(f\"  [{piece.api_role}] {piece.original_value[:80]}\")"
    ]
   },
   {
@@ -389,8 +386,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "./AppData/Local/Temp/ipykernel_13356/3979432580.py:15: DeprecationWarning: MessagePiece.role getter is deprecated. Use api_role for comparisons. This property will be removed in 0.13.0.\n",
-      "  print(f\"  [{piece.role}] original: {piece.original_value[:60]} → converted: {piece.converted_value[:60]}\")\n"
+      "  print(f\"  [{piece.api_role}] original: {piece.original_value[:60]} → converted: {piece.converted_value[:60]}\")\n"
      ]
     }
    ],
@@ -409,7 +405,7 @@
     "\n",
     "print(f\"Message pieces that used Base64Converter: {len(base64_pieces)}\")\n",
     "for piece in base64_pieces:\n",
-    "    print(f\"  [{piece.role}] original: {piece.original_value[:60]} → converted: {piece.converted_value[:60]}\")"
+    "    print(f\"  [{piece.api_role}] original: {piece.original_value[:60]} → converted: {piece.converted_value[:60]}\")"
    ]
   },
   {
@@ -442,8 +438,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "./AppData/Local/Temp/ipykernel_13356/814594877.py:13: DeprecationWarning: MessagePiece.role getter is deprecated. Use api_role for comparisons. This property will be removed in 0.13.0.\n",
-      "  print(f\"  [{piece.role}] {piece.original_value[:80]}\")\n"
+      "  print(f\"  [{piece.api_role}] {piece.original_value[:80]}\")\n"
      ]
     }
    ],
@@ -460,7 +455,7 @@
     "\n",
     "print(f\"Pieces to/from TextTarget AND using Base64Converter: {len(combined_pieces)}\")\n",
     "for piece in combined_pieces:\n",
-    "    print(f\"  [{piece.role}] {piece.original_value[:80]}\")"
+    "    print(f\"  [{piece.api_role}] {piece.original_value[:80]}\")"
    ]
   },
   {
@@ -494,8 +489,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "./AppData/Local/Temp/ipykernel_13356/2461341104.py:9: DeprecationWarning: MessagePiece.role getter is deprecated. Use api_role for comparisons. This property will be removed in 0.13.0.\n",
-      "  print(f\"  [{piece.role}] {piece.original_value[:80]}\")\n"
+      "  print(f\"  [{piece.api_role}] {piece.original_value[:80]}\")\n"
      ]
     }
    ],
@@ -508,7 +502,7 @@
     "\n",
     "print(f\"Labeled + filtered pieces: {len(labeled_and_filtered)}\")\n",
     "for piece in labeled_and_filtered:\n",
-    "    print(f\"  [{piece.role}] {piece.original_value[:80]}\")"
+    "    print(f\"  [{piece.api_role}] {piece.original_value[:80]}\")"
    ]
   },
   {

--- a/doc/code/memory/5_advanced_memory.py
+++ b/doc/code/memory/5_advanced_memory.py
@@ -84,7 +84,7 @@ for piece in prompts:
 print("-----------------")
 
 # These are all original prompts sent previously
-original_user_prompts = [prompt.original_value for prompt in prompts if prompt.role == "user"]
+original_user_prompts = [prompt.original_value for prompt in prompts if prompt.api_role == "user"]
 
 # we can now send them to a new target, using different converters
 
@@ -149,7 +149,7 @@ for filter_target_class in filter_target_classes:
 
     print(f"Message pieces to/from {filter_target_class}: {len(target_class_pieces)}")
     for piece in target_class_pieces:
-        print(f"  [{piece.role}] {piece.converted_value[:80]}")
+        print(f"  [{piece.api_role}] {piece.converted_value[:80]}")
 
 # %% [markdown]
 # ### Filter by target with partial match
@@ -172,7 +172,7 @@ openai_pieces = memory.get_message_pieces(
 
 print(f"Message pieces to/from *OpenAI* targets: {len(openai_pieces)}")
 for piece in openai_pieces:
-    print(f"  [{piece.role}] {piece.original_value[:80]}")
+    print(f"  [{piece.api_role}] {piece.original_value[:80]}")
 
 # %% [markdown]
 # ### Filter by converter (array column)
@@ -195,7 +195,7 @@ base64_pieces = memory.get_message_pieces(
 
 print(f"Message pieces that used Base64Converter: {len(base64_pieces)}")
 for piece in base64_pieces:
-    print(f"  [{piece.role}] original: {piece.original_value[:60]} → converted: {piece.converted_value[:60]}")
+    print(f"  [{piece.api_role}] original: {piece.original_value[:60]} → converted: {piece.converted_value[:60]}")
 
 # %% [markdown]
 # ### Combining multiple filters
@@ -216,7 +216,7 @@ combined_pieces = memory.get_message_pieces(
 
 print(f"Pieces to/from TextTarget AND using Base64Converter: {len(combined_pieces)}")
 for piece in combined_pieces:
-    print(f"  [{piece.role}] {piece.original_value[:80]}")
+    print(f"  [{piece.api_role}] {piece.original_value[:80]}")
 
 # %% [markdown]
 # ### Mixing labels and identifier filters
@@ -234,7 +234,7 @@ labeled_and_filtered = memory.get_message_pieces(
 
 print(f"Labeled + filtered pieces: {len(labeled_and_filtered)}")
 for piece in labeled_and_filtered:
-    print(f"  [{piece.role}] {piece.original_value[:80]}")
+    print(f"  [{piece.api_role}] {piece.original_value[:80]}")
 
 # %% [markdown]
 # ## Part 3 — Filtering Scores by Scorer Identity

--- a/doc/code/targets/11_message_normalizer.ipynb
+++ b/doc/code/targets/11_message_normalizer.ipynb
@@ -56,7 +56,7 @@
     "\n",
     "print(\"Sample messages created:\")\n",
     "for msg in messages:\n",
-    "    print(f\"  {msg.role}: {msg.get_piece().converted_value[:50]}...\")"
+    "    print(f\"  {msg.api_role}: {msg.get_piece().converted_value[:50]}...\")"
    ]
   },
   {

--- a/doc/code/targets/11_message_normalizer.ipynb
+++ b/doc/code/targets/11_message_normalizer.ipynb
@@ -502,7 +502,7 @@
     "        lines = []\n",
     "        for msg in messages:\n",
     "            piece = msg.get_piece()\n",
-    "            role = piece.role.capitalize()\n",
+    "            role = piece.api_role.capitalize()\n",
     "            content = piece.converted_value\n",
     "            lines.append(f\"**{role}**: {content}\")\n",
     "        return \"\\n\\n\".join(lines)\n",

--- a/doc/code/targets/11_message_normalizer.py
+++ b/doc/code/targets/11_message_normalizer.py
@@ -41,7 +41,7 @@ messages = [system_message, user_message, assistant_message, followup_message]
 
 print("Sample messages created:")
 for msg in messages:
-    print(f"  {msg.role}: {msg.get_piece().converted_value[:50]}...")
+    print(f"  {msg.api_role}: {msg.get_piece().converted_value[:50]}...")
 
 # %% [markdown]
 # ## ChatMessageNormalizer

--- a/doc/code/targets/11_message_normalizer.py
+++ b/doc/code/targets/11_message_normalizer.py
@@ -215,7 +215,7 @@ class SimpleMarkdownNormalizer(MessageStringNormalizer):
         lines = []
         for msg in messages:
             piece = msg.get_piece()
-            role = piece.role.capitalize()
+            role = piece.api_role.capitalize()
             content = piece.converted_value
             lines.append(f"**{role}**: {content}")
         return "\n\n".join(lines)


### PR DESCRIPTION
## Summary

The \.role\ property was removed from \MessagePiece\ in #1618. Two doc notebooks still referenced it, causing runtime errors when executed.

## Changes
- \doc/code/memory/5_advanced_memory.py\ + \.ipynb\ — \prompt.role\ / \piece.role\ → \prompt.api_role\ / \piece.api_role\
- \doc/code/targets/11_message_normalizer.py\ + \.ipynb\ — \piece.role\ → \piece.api_role\
- Removed stale deprecation warning outputs from ipynb cells

## Testing
- Integration test \	est_notebooks_memory[5_advanced_memory.ipynb]\ was failing; this fixes it.