### PR TITLE
FIX: resolve npm path in prepare_package.py on Windows

### DIFF
--- a/build_scripts/prepare_package.py
+++ b/build_scripts/prepare_package.py
@@ -48,7 +48,7 @@ def build_frontend(frontend_dir: Path) -> bool:
     print("\nInstalling frontend dependencies...")
     try:
         subprocess.run(
-            ["npm", "install", "--legacy-peer-deps"],
+            [npm, "install", "--legacy-peer-deps"],
             cwd=frontend_dir,
             check=True,
             stdout=subprocess.PIPE,


### PR DESCRIPTION
## Description
 
Discovered bug in build script while running step 6 (`python build_scripts/prepare_package.py`) of the v0.13.0 release process on Windows.
 
 ## Tests and Documentation
 
Re-ran `python build_scripts/prepare_package.py` on Windows end-to-end after the fix — frontend dependencies install and the frontend bundle builds successfully. 