### PR TITLE
FEAT: Deprecate use_entra_auth and add auto-detect auth for Azure Speech converters

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -14,8 +14,9 @@
 # other OpenAI-compatible endpoint. See doc/setup/populating_secrets.md
 # for provider-specific examples.
 #
-# If you are using Entra authentication for Azure resources
-# (use_entra_auth = True in PyRIT), keys for those resources are not needed.
+# If you are using Entra authentication for Azure resources,
+# keys for those resources are not needed. PyRIT auto-detects: if an API key
+# is set it uses key auth; otherwise it falls back to Entra ID automatically.
 #
 # ============================================================================
 

--- a/.env_example
+++ b/.env_example
@@ -16,7 +16,7 @@
 #
 # If you are using Entra authentication for Azure resources,
 # keys for those resources are not needed. PyRIT auto-detects: if an API key
-# is set it uses key auth; otherwise it falls back to Entra ID automatically.
+# is set, it uses key auth; otherwise it falls back to Entra ID automatically.
 #
 # ============================================================================
 

--- a/pyrit/auth/azure_auth.py
+++ b/pyrit/auth/azure_auth.py
@@ -433,6 +433,53 @@ def get_speech_config(resource_id: Union[str, None], key: Union[str, None], regi
     raise ValueError("Insufficient information provided for Azure Speech service.")
 
 
+async def get_speech_config_async(
+    *,
+    token_provider: Callable[[], str | Awaitable[str]] | None,
+    resource_id: Union[str, None],
+    key: Union[str, None],
+    region: str,
+) -> speechsdk.SpeechConfig:
+    """
+    Get the speech config, resolving a callable token provider if one is provided.
+
+    This is the async counterpart to :func:`get_speech_config`. When a callable
+    ``token_provider`` is supplied, it is invoked (and awaited if async) to obtain
+    a token, which is then used with the ``aad#{resource_id}#{token}`` auth format.
+    Otherwise, it delegates to the synchronous :func:`get_speech_config`.
+
+    Args:
+        token_provider (Callable | None): An optional sync or async callable that returns a token string.
+        resource_id (str | None): The resource ID for Entra ID auth.
+        key (str | None): The Azure Speech API key.
+        region (str): The Azure region.
+
+    Returns:
+        speechsdk.SpeechConfig: The speech config based on passed in args.
+
+    Raises:
+        ModuleNotFoundError: If azure.cognitiveservices.speech is not installed.
+        ValueError: If neither key/region nor resource_id/region is provided and no token_provider is given.
+    """
+    if token_provider:
+        try:
+            import azure.cognitiveservices.speech as speechsdk  # noqa: F811
+        except ModuleNotFoundError as e:
+            logger.error(
+                "Could not import azure.cognitiveservices.speech. "
+                "You may need to install it via 'pip install pyrit[speech]'"
+            )
+            raise e
+
+        token = token_provider()
+        if inspect.isawaitable(token):
+            token = await token
+        auth_token = f"aad#{resource_id}#{token}"
+        return speechsdk.SpeechConfig(auth_token=auth_token, region=region)
+
+    return get_speech_config(resource_id=resource_id, key=key, region=region)
+
+
 def get_speech_config_from_default_azure_credential(resource_id: str, region: str) -> speechsdk.SpeechConfig:
     """
     Get the speech config for the given resource ID and region.

--- a/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
+++ b/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
@@ -117,6 +117,7 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
                 )
 
         self._recognition_language = recognition_language
+        # Create a flag to indicate when recognition is finished
         self.done = False
 
     def _build_identifier(self) -> ComponentIdentifier:

--- a/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
+++ b/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-import inspect
 import logging
 import time
 import warnings
@@ -11,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Optional
 if TYPE_CHECKING:
     import azure.cognitiveservices.speech as speechsdk  # noqa: F401
 
-from pyrit.auth.azure_auth import get_speech_config
+from pyrit.auth.azure_auth import get_speech_config, get_speech_config_async
 from pyrit.common import default_values
 from pyrit.identifiers import ComponentIdentifier
 from pyrit.models import PromptDataType, data_serializer_factory
@@ -58,16 +57,16 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
         Initialize the converter with Azure Speech service credentials and recognition language.
 
         Args:
-            azure_speech_region (str | None): The name of the Azure region.
-            azure_speech_key (str | Callable[[], str | Awaitable[str]] | None): The API key for accessing
+            azure_speech_region (str, Optional): The name of the Azure region.
+            azure_speech_key (str | Callable[[], str | Awaitable[str]], Optional): The API key for accessing
                 the service, or a sync/async callable that returns a token string.
                 If a string key is provided (or the ``AZURE_SPEECH_KEY`` env var is set), key auth is used.
                 If a callable token provider is provided, it is resolved at conversion time and used with
                 Entra ID auth (``azure_speech_resource_id`` must also be set).
                 If omitted, Entra ID auth via ``DefaultAzureCredential`` is used automatically.
-            azure_speech_resource_id (str | None): The resource ID for accessing the service when using
+            azure_speech_resource_id (str, Optional): The resource ID for accessing the service when using
                 Entra ID auth. Required when using a callable token provider or when no API key is available.
-            use_entra_auth (bool | None): **Deprecated.** Will be removed in v0.15.0.
+            use_entra_auth (bool, Optional): **Deprecated.** Will be removed in v0.15.0.
                 Authentication is now auto-detected from the provided credentials.
             recognition_language (str): Recognition voice language. Defaults to "en-US".
                 For more on supported languages, see the following link:
@@ -109,7 +108,8 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
                 self._azure_speech_key = key_value
             else:
                 logger.info(
-                    "No azure_speech_key provided. Falling back to Entra ID authentication via DefaultAzureCredential."
+                    "No azure_speech_key provided. "
+                    "Entra ID authentication will be attempted via DefaultAzureCredential."
                 )
                 self._azure_speech_resource_id = default_values.get_required_value(
                     env_var_name=self.AZURE_SPEECH_RESOURCE_ID_ENVIRONMENT_VARIABLE,
@@ -130,28 +130,6 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
             params={
                 "recognition_language": self._recognition_language,
             }
-        )
-
-    async def _get_speech_config_async(self) -> "speechsdk.SpeechConfig":
-        """
-        Build the SpeechConfig, resolving a callable token provider if needed.
-
-        Returns:
-            speechsdk.SpeechConfig: The speech configuration for recognition.
-        """
-        import azure.cognitiveservices.speech as speechsdk  # noqa: F811
-
-        if self._token_provider:
-            token = self._token_provider()
-            if inspect.isawaitable(token):
-                token = await token
-            auth_token = f"aad#{self._azure_speech_resource_id}#{token}"
-            return speechsdk.SpeechConfig(auth_token=auth_token, region=self._azure_speech_region)
-
-        return get_speech_config(
-            resource_id=self._azure_speech_resource_id,
-            key=self._azure_speech_key,
-            region=self._azure_speech_region,
         )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "audio_path") -> ConverterResult:
@@ -180,7 +158,12 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
         audio_bytes = await audio_serializer.read_data()
 
         try:
-            speech_config = await self._get_speech_config_async()
+            speech_config = await get_speech_config_async(
+                token_provider=self._token_provider,
+                resource_id=self._azure_speech_resource_id,
+                key=self._azure_speech_key,
+                region=self._azure_speech_region,
+            )
             transcript = self._recognize_audio(audio_bytes=audio_bytes, speech_config=speech_config)
         except Exception as e:
             logger.error("Failed to convert audio file to text: %s", str(e))

--- a/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
+++ b/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
@@ -6,7 +6,7 @@ import logging
 import time
 import warnings
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     import azure.cognitiveservices.speech as speechsdk  # noqa: F401
@@ -24,13 +24,13 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
     """
     Transcribes a .wav audio file into text using Azure AI Speech service.
 
-    Authentication is auto-detected from the provided credentials:
+    Authentication is auto-detected from the provided credentials, in priority order:
 
-    - If ``azure_speech_key`` is a string (or the ``AZURE_SPEECH_KEY`` env var is set), API key auth is used.
-    - If ``azure_speech_key`` is a callable token provider, it is resolved at conversion time and used with
-      Entra ID auth. The ``azure_speech_resource_id`` must also be provided in this case.
-    - If neither is provided, Entra ID auth is used automatically via ``DefaultAzureCredential``
-      and ``azure_speech_resource_id`` must be set.
+    1. If ``azure_speech_key`` is a **callable** token provider, it takes highest priority — it is
+       resolved at conversion time and used with Entra ID auth (``azure_speech_resource_id`` required).
+    2. If ``azure_speech_key`` is a **string** (or the ``AZURE_SPEECH_KEY`` env var is set), API key auth is used.
+    3. If **neither** is provided, Entra ID auth is used automatically via ``DefaultAzureCredential``
+       and ``azure_speech_resource_id`` must be set.
 
     https://learn.microsoft.com/en-us/azure/ai-services/speech-service/speech-to-text
     """
@@ -49,7 +49,7 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
         self,
         *,
         azure_speech_region: Optional[str] = None,
-        azure_speech_key: Union[str, Callable[[], str | Awaitable[str]], None] = None,
+        azure_speech_key: Optional[str | Callable[[], str | Awaitable[str]]] = None,
         azure_speech_resource_id: Optional[str] = None,
         use_entra_auth: Optional[bool] = None,
         recognition_language: str = "en-US",
@@ -90,24 +90,27 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
             passed_value=azure_speech_region,
         )
 
+        self._token_provider: Callable[[], str | Awaitable[str]] | None = None
+        self._azure_speech_key: str | None = None
+        self._azure_speech_resource_id: str | None = None
+
         if azure_speech_key is not None and callable(azure_speech_key):
-            self._token_provider: Callable[[], str | Awaitable[str]] | None = azure_speech_key
-            self._azure_speech_key: str | None = None
-            self._azure_speech_resource_id: str | None = default_values.get_required_value(
+            self._token_provider = azure_speech_key
+            self._azure_speech_resource_id = default_values.get_required_value(
                 env_var_name=self.AZURE_SPEECH_RESOURCE_ID_ENVIRONMENT_VARIABLE,
                 passed_value=azure_speech_resource_id,
             )
         else:
-            self._token_provider = None
             key_value = default_values.get_non_required_value(
                 env_var_name=self.AZURE_SPEECH_KEY_ENVIRONMENT_VARIABLE,
                 passed_value=azure_speech_key,
             )
             if key_value:
                 self._azure_speech_key = key_value
-                self._azure_speech_resource_id = None
             else:
-                self._azure_speech_key = None
+                logger.info(
+                    "No azure_speech_key provided. Falling back to Entra ID authentication via DefaultAzureCredential."
+                )
                 self._azure_speech_resource_id = default_values.get_required_value(
                     env_var_name=self.AZURE_SPEECH_RESOURCE_ID_ENVIRONMENT_VARIABLE,
                     passed_value=azure_speech_resource_id,

--- a/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
+++ b/pyrit/prompt_converter/azure_speech_audio_to_text_converter.py
@@ -1,9 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import inspect
 import logging
 import time
-from typing import TYPE_CHECKING, Any, Optional
+import warnings
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 if TYPE_CHECKING:
     import azure.cognitiveservices.speech as speechsdk  # noqa: F401
@@ -21,6 +24,14 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
     """
     Transcribes a .wav audio file into text using Azure AI Speech service.
 
+    Authentication is auto-detected from the provided credentials:
+
+    - If ``azure_speech_key`` is a string (or the ``AZURE_SPEECH_KEY`` env var is set), API key auth is used.
+    - If ``azure_speech_key`` is a callable token provider, it is resolved at conversion time and used with
+      Entra ID auth. The ``azure_speech_resource_id`` must also be provided in this case.
+    - If neither is provided, Entra ID auth is used automatically via ``DefaultAzureCredential``
+      and ``azure_speech_resource_id`` must be set.
+
     https://learn.microsoft.com/en-us/azure/ai-services/speech-service/speech-to-text
     """
 
@@ -36,55 +47,73 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
 
     def __init__(
         self,
+        *,
         azure_speech_region: Optional[str] = None,
-        azure_speech_key: Optional[str] = None,
+        azure_speech_key: Union[str, Callable[[], str | Awaitable[str]], None] = None,
         azure_speech_resource_id: Optional[str] = None,
-        use_entra_auth: bool = False,
+        use_entra_auth: Optional[bool] = None,
         recognition_language: str = "en-US",
     ) -> None:
         """
         Initialize the converter with Azure Speech service credentials and recognition language.
 
         Args:
-            azure_speech_region (str, Optional): The name of the Azure region.
-            azure_speech_key (str, Optional): The API key for accessing the service (if not using Entra ID auth).
-            azure_speech_resource_id (str, Optional): The resource ID for accessing the service when using
-                Entra ID auth. This can be found by selecting 'Properties' in the 'Resource Management'
-                section of your Azure Speech resource in the Azure portal.
-            use_entra_auth (bool): Whether to use Entra ID authentication. If True, azure_speech_resource_id
-                must be provided. If False, azure_speech_key must be provided. Defaults to False.
+            azure_speech_region (str | None): The name of the Azure region.
+            azure_speech_key (str | Callable[[], str | Awaitable[str]] | None): The API key for accessing
+                the service, or a sync/async callable that returns a token string.
+                If a string key is provided (or the ``AZURE_SPEECH_KEY`` env var is set), key auth is used.
+                If a callable token provider is provided, it is resolved at conversion time and used with
+                Entra ID auth (``azure_speech_resource_id`` must also be set).
+                If omitted, Entra ID auth via ``DefaultAzureCredential`` is used automatically.
+            azure_speech_resource_id (str | None): The resource ID for accessing the service when using
+                Entra ID auth. Required when using a callable token provider or when no API key is available.
+            use_entra_auth (bool | None): **Deprecated.** Will be removed in v0.15.0.
+                Authentication is now auto-detected from the provided credentials.
             recognition_language (str): Recognition voice language. Defaults to "en-US".
                 For more on supported languages, see the following link:
                 https://learn.microsoft.com/en-us/azure/ai-services/speech-service/language-support
 
         Raises:
-            ValueError: If the required environment variables are not set, if azure_speech_key is passed in
-                when use_entra_auth is True, or if azure_speech_resource_id is passed in when use_entra_auth
-                is False.
+            ValueError: If the required environment variables or parameters are not set.
         """
+        if use_entra_auth is not None:
+            warnings.warn(
+                "'use_entra_auth' is deprecated and will be removed in v0.15.0. "
+                "Authentication is now auto-detected: pass a key string for key auth, "
+                "a callable token provider for token auth, or omit for automatic Entra ID auth.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         self._azure_speech_region: str = default_values.get_required_value(
             env_var_name=self.AZURE_SPEECH_REGION_ENVIRONMENT_VARIABLE,
             passed_value=azure_speech_region,
         )
-        if use_entra_auth:
-            if azure_speech_key:
-                raise ValueError("If using Entra ID auth, please do not specify azure_speech_key.")
-            self._azure_speech_resource_id = default_values.get_required_value(
+
+        if azure_speech_key is not None and callable(azure_speech_key):
+            self._token_provider: Callable[[], str | Awaitable[str]] | None = azure_speech_key
+            self._azure_speech_key: str | None = None
+            self._azure_speech_resource_id: str | None = default_values.get_required_value(
                 env_var_name=self.AZURE_SPEECH_RESOURCE_ID_ENVIRONMENT_VARIABLE,
                 passed_value=azure_speech_resource_id,
             )
-            self._azure_speech_key = None
         else:
-            if azure_speech_resource_id:
-                raise ValueError("If using key auth, please do not specify azure_speech_resource_id.")
-            self._azure_speech_key = default_values.get_required_value(
+            self._token_provider = None
+            key_value = default_values.get_non_required_value(
                 env_var_name=self.AZURE_SPEECH_KEY_ENVIRONMENT_VARIABLE,
                 passed_value=azure_speech_key,
             )
-            self._azure_speech_resource_id = None
+            if key_value:
+                self._azure_speech_key = key_value
+                self._azure_speech_resource_id = None
+            else:
+                self._azure_speech_key = None
+                self._azure_speech_resource_id = default_values.get_required_value(
+                    env_var_name=self.AZURE_SPEECH_RESOURCE_ID_ENVIRONMENT_VARIABLE,
+                    passed_value=azure_speech_resource_id,
+                )
 
         self._recognition_language = recognition_language
-        # Create a flag to indicate when recognition is finished
         self.done = False
 
     def _build_identifier(self) -> ComponentIdentifier:
@@ -98,6 +127,28 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
             params={
                 "recognition_language": self._recognition_language,
             }
+        )
+
+    async def _get_speech_config_async(self) -> "speechsdk.SpeechConfig":
+        """
+        Build the SpeechConfig, resolving a callable token provider if needed.
+
+        Returns:
+            speechsdk.SpeechConfig: The speech configuration for recognition.
+        """
+        import azure.cognitiveservices.speech as speechsdk  # noqa: F811
+
+        if self._token_provider:
+            token = self._token_provider()
+            if inspect.isawaitable(token):
+                token = await token
+            auth_token = f"aad#{self._azure_speech_resource_id}#{token}"
+            return speechsdk.SpeechConfig(auth_token=auth_token, region=self._azure_speech_region)
+
+        return get_speech_config(
+            resource_id=self._azure_speech_resource_id,
+            key=self._azure_speech_key,
+            region=self._azure_speech_region,
         )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "audio_path") -> ConverterResult:
@@ -126,7 +177,8 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
         audio_bytes = await audio_serializer.read_data()
 
         try:
-            transcript = self.recognize_audio(audio_bytes)
+            speech_config = await self._get_speech_config_async()
+            transcript = self._recognize_audio(audio_bytes=audio_bytes, speech_config=speech_config)
         except Exception as e:
             logger.error("Failed to convert audio file to text: %s", str(e))
             raise
@@ -136,8 +188,40 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
         """
         Recognize audio file and return transcribed text.
 
+        .. deprecated::
+            Use :meth:`convert_async` instead, which resolves token providers correctly.
+            This method does not support callable token providers.
+
         Args:
             audio_bytes (bytes): Audio bytes input.
+
+        Returns:
+            str: Transcribed text.
+
+        Raises:
+            ModuleNotFoundError: If the azure.cognitiveservices.speech module is not installed.
+        """
+        if self._token_provider:
+            warnings.warn(
+                "recognize_audio() does not support callable token providers. "
+                "Use convert_async() instead, which correctly resolves token providers.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        speech_config = get_speech_config(
+            resource_id=self._azure_speech_resource_id,
+            key=self._azure_speech_key,
+            region=self._azure_speech_region,
+        )
+        return self._recognize_audio(audio_bytes=audio_bytes, speech_config=speech_config)
+
+    def _recognize_audio(self, *, audio_bytes: bytes, speech_config: "speechsdk.SpeechConfig") -> str:
+        """
+        Recognize audio from bytes using the given speech config.
+
+        Args:
+            audio_bytes (bytes): Audio bytes input.
+            speech_config (speechsdk.SpeechConfig): Pre-built speech configuration.
 
         Returns:
             str: Transcribed text.
@@ -154,36 +238,25 @@ class AzureSpeechAudioToTextConverter(PromptConverter):
             )
             raise e
 
-        speech_config = get_speech_config(
-            resource_id=self._azure_speech_resource_id, key=self._azure_speech_key, region=self._azure_speech_region
-        )
         speech_config.speech_recognition_language = self._recognition_language
 
-        # Create a PullAudioInputStream from the byte stream
         push_stream = speechsdk.audio.PushAudioInputStream()
         audio_config = speechsdk.audio.AudioConfig(stream=push_stream)
 
-        # Instantiate a speech recognizer object
         speech_recognizer = speechsdk.SpeechRecognizer(speech_config=speech_config, audio_config=audio_config)
-        # Create an empty list to store recognized text
         transcribed_text: list[str] = []
-        # Flag is set to False to indicate that recognition is not yet finished
         self.done = False
 
-        # Connect callbacks to the events fired by the speech recognizer
         speech_recognizer.recognized.connect(lambda evt: self.transcript_cb(evt, transcript=transcribed_text))
         speech_recognizer.recognizing.connect(lambda evt: logger.info(f"RECOGNIZING: {evt}"))
         speech_recognizer.recognized.connect(lambda evt: logger.info(f"RECOGNIZED: {evt}"))
         speech_recognizer.session_started.connect(lambda evt: logger.info(f"SESSION STARTED: {evt}"))
         speech_recognizer.session_stopped.connect(lambda evt: logger.info(f"SESSION STOPPED: {evt}"))
-        # Stop continuous recognition when stopped or canceled event is fired
         speech_recognizer.canceled.connect(lambda evt: self.stop_cb(evt, recognizer=speech_recognizer))
         speech_recognizer.session_stopped.connect(lambda evt: self.stop_cb(evt, recognizer=speech_recognizer))
 
-        # Start continuous recognition
         speech_recognizer.start_continuous_recognition_async()
 
-        # Push the entire audio data into the stream
         push_stream.write(audio_bytes)
         push_stream.close()
 

--- a/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
+++ b/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
@@ -5,7 +5,7 @@ import inspect
 import logging
 import warnings
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Literal, Optional, Union
+from typing import TYPE_CHECKING, Literal, Optional
 
 if TYPE_CHECKING:
     import azure.cognitiveservices.speech as speechsdk  # noqa: F401
@@ -23,13 +23,13 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
     """
     Generates a wave file from a text prompt using Azure AI Speech service.
 
-    Authentication is auto-detected from the provided credentials:
+    Authentication is auto-detected from the provided credentials, in priority order:
 
-    - If ``azure_speech_key`` is a string (or the ``AZURE_SPEECH_KEY`` env var is set), API key auth is used.
-    - If ``azure_speech_key`` is a callable token provider, it is resolved at conversion time and used with
-      Entra ID auth. The ``azure_speech_resource_id`` must also be provided in this case.
-    - If neither is provided, Entra ID auth is used automatically via ``DefaultAzureCredential``
-      and ``azure_speech_resource_id`` must be set.
+    1. If ``azure_speech_key`` is a **callable** token provider, it takes highest priority — it is
+       resolved at conversion time and used with Entra ID auth (``azure_speech_resource_id`` required).
+    2. If ``azure_speech_key`` is a **string** (or the ``AZURE_SPEECH_KEY`` env var is set), API key auth is used.
+    3. If **neither** is provided, Entra ID auth is used automatically via ``DefaultAzureCredential``
+       and ``azure_speech_resource_id`` must be set.
 
     https://learn.microsoft.com/en-us/azure/ai-services/speech-service/text-to-speech
     """
@@ -51,7 +51,7 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
         self,
         *,
         azure_speech_region: Optional[str] = None,
-        azure_speech_key: Union[str, Callable[[], str | Awaitable[str]], None] = None,
+        azure_speech_key: Optional[str | Callable[[], str | Awaitable[str]]] = None,
         azure_speech_resource_id: Optional[str] = None,
         use_entra_auth: Optional[bool] = None,
         synthesis_language: str = "en_US",
@@ -96,24 +96,27 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
             passed_value=azure_speech_region,
         )
 
+        self._token_provider: Callable[[], str | Awaitable[str]] | None = None
+        self._azure_speech_key: str | None = None
+        self._azure_speech_resource_id: str | None = None
+
         if azure_speech_key is not None and callable(azure_speech_key):
-            self._token_provider: Callable[[], str | Awaitable[str]] | None = azure_speech_key
-            self._azure_speech_key: str | None = None
-            self._azure_speech_resource_id: str | None = default_values.get_required_value(
+            self._token_provider = azure_speech_key
+            self._azure_speech_resource_id = default_values.get_required_value(
                 env_var_name=self.AZURE_SPEECH_RESOURCE_ID_ENVIRONMENT_VARIABLE,
                 passed_value=azure_speech_resource_id,
             )
         else:
-            self._token_provider = None
             key_value = default_values.get_non_required_value(
                 env_var_name=self.AZURE_SPEECH_KEY_ENVIRONMENT_VARIABLE,
                 passed_value=azure_speech_key,
             )
             if key_value:
                 self._azure_speech_key = key_value
-                self._azure_speech_resource_id = None
             else:
-                self._azure_speech_key = None
+                logger.info(
+                    "No azure_speech_key provided. Falling back to Entra ID authentication via DefaultAzureCredential."
+                )
                 self._azure_speech_resource_id = default_values.get_required_value(
                     env_var_name=self.AZURE_SPEECH_RESOURCE_ID_ENVIRONMENT_VARIABLE,
                     passed_value=azure_speech_resource_id,

--- a/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
+++ b/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-import inspect
 import logging
 import warnings
 from collections.abc import Awaitable, Callable
@@ -10,7 +9,7 @@ from typing import TYPE_CHECKING, Literal, Optional
 if TYPE_CHECKING:
     import azure.cognitiveservices.speech as speechsdk  # noqa: F401
 
-from pyrit.auth.azure_auth import get_speech_config
+from pyrit.auth.azure_auth import get_speech_config_async
 from pyrit.common import default_values
 from pyrit.identifiers import ComponentIdentifier
 from pyrit.models import PromptDataType, data_serializer_factory
@@ -62,16 +61,16 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
         Initialize the converter with Azure Speech service credentials, synthesis language, and voice name.
 
         Args:
-            azure_speech_region (str | None): The name of the Azure region.
-            azure_speech_key (str | Callable[[], str | Awaitable[str]] | None): The API key for accessing
+            azure_speech_region (str, Optional): The name of the Azure region.
+            azure_speech_key (str | Callable[[], str | Awaitable[str]], Optional): The API key for accessing
                 the service, or a sync/async callable that returns a token string.
                 If a string key is provided (or the ``AZURE_SPEECH_KEY`` env var is set), key auth is used.
                 If a callable token provider is provided, it is resolved at conversion time and used with
                 Entra ID auth (``azure_speech_resource_id`` must also be set).
                 If omitted, Entra ID auth via ``DefaultAzureCredential`` is used automatically.
-            azure_speech_resource_id (str | None): The resource ID for accessing the service when using
+            azure_speech_resource_id (str, Optional): The resource ID for accessing the service when using
                 Entra ID auth. Required when using a callable token provider or when no API key is available.
-            use_entra_auth (bool | None): **Deprecated.** Will be removed in v0.15.0.
+            use_entra_auth (bool, Optional): **Deprecated.** Will be removed in v0.15.0.
                 Authentication is now auto-detected from the provided credentials.
             synthesis_language (str): Synthesis voice language.
             synthesis_voice_name (str): Synthesis voice name.
@@ -115,7 +114,8 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
                 self._azure_speech_key = key_value
             else:
                 logger.info(
-                    "No azure_speech_key provided. Falling back to Entra ID authentication via DefaultAzureCredential."
+                    "No azure_speech_key provided. "
+                    "Entra ID authentication will be attempted via DefaultAzureCredential."
                 )
                 self._azure_speech_resource_id = default_values.get_required_value(
                     env_var_name=self.AZURE_SPEECH_RESOURCE_ID_ENVIRONMENT_VARIABLE,
@@ -139,28 +139,6 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
                 "synthesis_voice_name": self._synthesis_voice_name,
                 "output_format": self._output_format,
             }
-        )
-
-    async def _get_speech_config_async(self) -> "speechsdk.SpeechConfig":
-        """
-        Build the SpeechConfig, resolving a callable token provider if needed.
-
-        Returns:
-            speechsdk.SpeechConfig: The speech configuration for synthesis.
-        """
-        import azure.cognitiveservices.speech as speechsdk  # noqa: F811
-
-        if self._token_provider:
-            token = self._token_provider()
-            if inspect.isawaitable(token):
-                token = await token
-            auth_token = f"aad#{self._azure_speech_resource_id}#{token}"
-            return speechsdk.SpeechConfig(auth_token=auth_token, region=self._azure_speech_region)
-
-        return get_speech_config(
-            resource_id=self._azure_speech_resource_id,
-            key=self._azure_speech_key,
-            region=self._azure_speech_region,
         )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
@@ -200,7 +178,12 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
 
         audio_serializer_file = None
         try:
-            speech_config = await self._get_speech_config_async()
+            speech_config = await get_speech_config_async(
+                token_provider=self._token_provider,
+                resource_id=self._azure_speech_resource_id,
+                key=self._azure_speech_key,
+                region=self._azure_speech_region,
+            )
             pull_stream = speechsdk.audio.PullAudioOutputStream()
             audio_cfg = speechsdk.audio.AudioOutputConfig(stream=pull_stream)
             speech_config.speech_synthesis_language = self._synthesis_language

--- a/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
+++ b/pyrit/prompt_converter/azure_speech_text_to_audio_converter.py
@@ -1,8 +1,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import inspect
 import logging
-from typing import TYPE_CHECKING, Literal, Optional
+import warnings
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
 if TYPE_CHECKING:
     import azure.cognitiveservices.speech as speechsdk  # noqa: F401
@@ -19,6 +22,14 @@ logger = logging.getLogger(__name__)
 class AzureSpeechTextToAudioConverter(PromptConverter):
     """
     Generates a wave file from a text prompt using Azure AI Speech service.
+
+    Authentication is auto-detected from the provided credentials:
+
+    - If ``azure_speech_key`` is a string (or the ``AZURE_SPEECH_KEY`` env var is set), API key auth is used.
+    - If ``azure_speech_key`` is a callable token provider, it is resolved at conversion time and used with
+      Entra ID auth. The ``azure_speech_resource_id`` must also be provided in this case.
+    - If neither is provided, Entra ID auth is used automatically via ``DefaultAzureCredential``
+      and ``azure_speech_resource_id`` must be set.
 
     https://learn.microsoft.com/en-us/azure/ai-services/speech-service/text-to-speech
     """
@@ -38,10 +49,11 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
 
     def __init__(
         self,
+        *,
         azure_speech_region: Optional[str] = None,
-        azure_speech_key: Optional[str] = None,
+        azure_speech_key: Union[str, Callable[[], str | Awaitable[str]], None] = None,
         azure_speech_resource_id: Optional[str] = None,
-        use_entra_auth: bool = False,
+        use_entra_auth: Optional[bool] = None,
         synthesis_language: str = "en_US",
         synthesis_voice_name: str = "en-US-AvaNeural",
         output_format: AzureSpeechAudioFormat = "wav",
@@ -50,45 +62,62 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
         Initialize the converter with Azure Speech service credentials, synthesis language, and voice name.
 
         Args:
-            azure_speech_region (str, Optional): The name of the Azure region.
-            azure_speech_key (str, Optional): The API key for accessing the service (only if you're not using Entra
-                authentication).
-            azure_speech_resource_id (str, Optional): The resource ID for accessing the service when using
-                Entra ID auth. This can be found by selecting 'Properties' in the 'Resource Management'
-                section of your Azure Speech resource in the Azure portal.
-            use_entra_auth (bool): Whether to use Entra ID authentication. If True, azure_speech_resource_id
-                must be provided. If False, azure_speech_key must be provided. Defaults to False.
+            azure_speech_region (str | None): The name of the Azure region.
+            azure_speech_key (str | Callable[[], str | Awaitable[str]] | None): The API key for accessing
+                the service, or a sync/async callable that returns a token string.
+                If a string key is provided (or the ``AZURE_SPEECH_KEY`` env var is set), key auth is used.
+                If a callable token provider is provided, it is resolved at conversion time and used with
+                Entra ID auth (``azure_speech_resource_id`` must also be set).
+                If omitted, Entra ID auth via ``DefaultAzureCredential`` is used automatically.
+            azure_speech_resource_id (str | None): The resource ID for accessing the service when using
+                Entra ID auth. Required when using a callable token provider or when no API key is available.
+            use_entra_auth (bool | None): **Deprecated.** Will be removed in v0.15.0.
+                Authentication is now auto-detected from the provided credentials.
             synthesis_language (str): Synthesis voice language.
-            synthesis_voice_name (str): Synthesis voice name, see URL.
+            synthesis_voice_name (str): Synthesis voice name.
                 For more details see the following link for synthesis language and synthesis voice:
                 https://learn.microsoft.com/en-us/azure/ai-services/speech-service/language-support
             output_format (str): Either wav or mp3. Must match the file prefix.
 
         Raises:
-            ValueError: If the required environment variables are not set, if azure_speech_key is passed in
-                when use_entra_auth is True, or if azure_speech_resource_id is passed in when use_entra_auth
-                is False.
+            ValueError: If the required environment variables or parameters are not set.
         """
+        if use_entra_auth is not None:
+            warnings.warn(
+                "'use_entra_auth' is deprecated and will be removed in v0.15.0. "
+                "Authentication is now auto-detected: pass a key string for key auth, "
+                "a callable token provider for token auth, or omit for automatic Entra ID auth.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         self._azure_speech_region: str = default_values.get_required_value(
             env_var_name=self.AZURE_SPEECH_REGION_ENVIRONMENT_VARIABLE,
             passed_value=azure_speech_region,
         )
-        if use_entra_auth:
-            if azure_speech_key:
-                raise ValueError("If using Entra ID auth, please do not specify azure_speech_key.")
-            self._azure_speech_resource_id = default_values.get_required_value(
+
+        if azure_speech_key is not None and callable(azure_speech_key):
+            self._token_provider: Callable[[], str | Awaitable[str]] | None = azure_speech_key
+            self._azure_speech_key: str | None = None
+            self._azure_speech_resource_id: str | None = default_values.get_required_value(
                 env_var_name=self.AZURE_SPEECH_RESOURCE_ID_ENVIRONMENT_VARIABLE,
                 passed_value=azure_speech_resource_id,
             )
-            self._azure_speech_key = None
         else:
-            if azure_speech_resource_id:
-                raise ValueError("If using key auth, please do not specify azure_speech_resource_id.")
-            self._azure_speech_key = default_values.get_required_value(
+            self._token_provider = None
+            key_value = default_values.get_non_required_value(
                 env_var_name=self.AZURE_SPEECH_KEY_ENVIRONMENT_VARIABLE,
                 passed_value=azure_speech_key,
             )
-            self._azure_speech_resource_id = None
+            if key_value:
+                self._azure_speech_key = key_value
+                self._azure_speech_resource_id = None
+            else:
+                self._azure_speech_key = None
+                self._azure_speech_resource_id = default_values.get_required_value(
+                    env_var_name=self.AZURE_SPEECH_RESOURCE_ID_ENVIRONMENT_VARIABLE,
+                    passed_value=azure_speech_resource_id,
+                )
 
         self._synthesis_language = synthesis_language
         self._synthesis_voice_name = synthesis_voice_name
@@ -107,6 +136,28 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
                 "synthesis_voice_name": self._synthesis_voice_name,
                 "output_format": self._output_format,
             }
+        )
+
+    async def _get_speech_config_async(self) -> "speechsdk.SpeechConfig":
+        """
+        Build the SpeechConfig, resolving a callable token provider if needed.
+
+        Returns:
+            speechsdk.SpeechConfig: The speech configuration for synthesis.
+        """
+        import azure.cognitiveservices.speech as speechsdk  # noqa: F811
+
+        if self._token_provider:
+            token = self._token_provider()
+            if inspect.isawaitable(token):
+                token = await token
+            auth_token = f"aad#{self._azure_speech_resource_id}#{token}"
+            return speechsdk.SpeechConfig(auth_token=auth_token, region=self._azure_speech_region)
+
+        return get_speech_config(
+            resource_id=self._azure_speech_resource_id,
+            key=self._azure_speech_key,
+            region=self._azure_speech_region,
         )
 
     async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
@@ -146,9 +197,7 @@ class AzureSpeechTextToAudioConverter(PromptConverter):
 
         audio_serializer_file = None
         try:
-            speech_config = get_speech_config(
-                resource_id=self._azure_speech_resource_id, key=self._azure_speech_key, region=self._azure_speech_region
-            )
+            speech_config = await self._get_speech_config_async()
             pull_stream = speechsdk.audio.PullAudioOutputStream()
             audio_cfg = speechsdk.audio.AudioOutputConfig(stream=pull_stream)
             speech_config.speech_synthesis_language = self._synthesis_language

--- a/pyrit/score/audio_transcript_scorer.py
+++ b/pyrit/score/audio_transcript_scorer.py
@@ -106,7 +106,7 @@ class AudioTranscriptHelper:  # noqa: B024
         self,
         *,
         text_capable_scorer: Scorer,
-        use_entra_auth: bool | None = None,
+        use_entra_auth: Optional[bool] = None,
     ) -> None:
         """
         Initialize the base audio scorer.
@@ -114,7 +114,7 @@ class AudioTranscriptHelper:  # noqa: B024
         Args:
             text_capable_scorer (Scorer): A scorer capable of processing text that will be used to score
                 the transcribed audio content.
-            use_entra_auth (bool | None): **Deprecated.** Will be removed in v0.15.0.
+            use_entra_auth (bool, Optional): **Deprecated.** Will be removed in v0.15.0.
                 Authentication is now auto-detected by the underlying converter.
 
         Raises:

--- a/pyrit/score/audio_transcript_scorer.py
+++ b/pyrit/score/audio_transcript_scorer.py
@@ -5,6 +5,7 @@ import logging
 import os
 import tempfile
 import uuid
+import warnings
 from typing import Optional
 
 import av
@@ -105,7 +106,7 @@ class AudioTranscriptHelper:  # noqa: B024
         self,
         *,
         text_capable_scorer: Scorer,
-        use_entra_auth: Optional[bool] = None,
+        use_entra_auth: bool | None = None,
     ) -> None:
         """
         Initialize the base audio scorer.
@@ -113,15 +114,21 @@ class AudioTranscriptHelper:  # noqa: B024
         Args:
             text_capable_scorer (Scorer): A scorer capable of processing text that will be used to score
                 the transcribed audio content.
-            use_entra_auth (bool, Optional): Whether to use Entra ID authentication for Azure Speech.
-                Defaults to True if None.
+            use_entra_auth (bool | None): **Deprecated.** Will be removed in v0.15.0.
+                Authentication is now auto-detected by the underlying converter.
 
         Raises:
             ValueError: If text_capable_scorer does not support text data type.
         """
+        if use_entra_auth is not None:
+            warnings.warn(
+                "'use_entra_auth' is deprecated and will be removed in v0.15.0. "
+                "Authentication is now auto-detected by the underlying AzureSpeechAudioToTextConverter.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._validate_text_scorer(text_capable_scorer)
         self.text_scorer = text_capable_scorer
-        self._use_entra_auth = use_entra_auth if use_entra_auth is not None else True
 
     @staticmethod
     def _validate_text_scorer(scorer: Scorer) -> None:
@@ -223,7 +230,7 @@ class AudioTranscriptHelper:  # noqa: B024
         logger.info(f"Audio transcription: WAV file size = {file_size} bytes")
 
         try:
-            converter = AzureSpeechAudioToTextConverter(use_entra_auth=self._use_entra_auth)
+            converter = AzureSpeechAudioToTextConverter()
             logger.info("Audio transcription: Starting Azure Speech transcription...")
             result = await converter.convert_async(prompt=wav_path, input_type="audio_path")
             logger.info(f"Audio transcription: Result = '{result.output_text}'")

--- a/pyrit/score/float_scale/audio_float_scale_scorer.py
+++ b/pyrit/score/float_scale/audio_float_scale_scorer.py
@@ -34,8 +34,8 @@ class AudioFloatScaleScorer(FloatScaleScorer):
             text_capable_scorer: A FloatScaleScorer capable of processing text.
                 This scorer will be used to evaluate the transcribed audio content.
             validator: Validator for the scorer. Defaults to audio_path data type validator.
-            use_entra_auth: Whether to use Entra ID authentication for Azure Speech.
-                Defaults to True if None.
+            use_entra_auth: **Deprecated.** Will be removed in v0.15.0.
+                Authentication is now auto-detected by the underlying converter.
 
         Raises:
             ValueError: If text_capable_scorer does not support text data type.

--- a/pyrit/score/true_false/audio_true_false_scorer.py
+++ b/pyrit/score/true_false/audio_true_false_scorer.py
@@ -34,8 +34,8 @@ class AudioTrueFalseScorer(TrueFalseScorer):
             text_capable_scorer: A TrueFalseScorer capable of processing text.
                 This scorer will be used to evaluate the transcribed audio content.
             validator: Validator for the scorer. Defaults to audio_path data type validator.
-            use_entra_auth: Whether to use Entra ID authentication for Azure Speech.
-                Defaults to True if None.
+            use_entra_auth: **Deprecated.** Will be removed in v0.15.0.
+                Authentication is now auto-detected by the underlying converter.
 
         Raises:
             ValueError: If text_capable_scorer does not support text data type.

--- a/tests/integration/converter/test_entra_auth_converters.py
+++ b/tests/integration/converter/test_entra_auth_converters.py
@@ -12,8 +12,11 @@ from pyrit.prompt_converter import (
 
 
 @pytest.mark.asyncio
-async def test_azure_speech_text_to_audio_converter_entra_auth():
+async def test_azure_speech_text_to_audio_converter_entra_auth(monkeypatch):
     """Test Azure Speech text-to-audio converter with Entra authentication."""
+    # Ensure key auth is not used — this test validates the Entra auto-detection path
+    monkeypatch.delenv("AZURE_SPEECH_KEY", raising=False)
+
     region = os.getenv("AZURE_SPEECH_REGION")
     resource_id = os.getenv("AZURE_SPEECH_RESOURCE_ID")
 
@@ -36,9 +39,12 @@ async def test_azure_speech_text_to_audio_converter_entra_auth():
 
 
 @pytest.mark.asyncio
-async def test_azure_speech_audio_to_text_converter_entra_auth():
+async def test_azure_speech_audio_to_text_converter_entra_auth(monkeypatch):
     """Test Azure Speech audio-to-text converter with Entra authentication."""
     import tempfile
+
+    # Ensure key auth is not used — this test validates the Entra auto-detection path
+    monkeypatch.delenv("AZURE_SPEECH_KEY", raising=False)
 
     region = os.getenv("AZURE_SPEECH_REGION")
     resource_id = os.getenv("AZURE_SPEECH_RESOURCE_ID")

--- a/tests/integration/converter/test_entra_auth_converters.py
+++ b/tests/integration/converter/test_entra_auth_converters.py
@@ -19,9 +19,7 @@ async def test_azure_speech_text_to_audio_converter_entra_auth():
 
     # The Azure Speech resource should have Entra authentication enabled in the current context.
     # e.g. Cognitive Services Speech Contributor role
-    converter = AzureSpeechTextToAudioConverter(
-        azure_speech_region=region, azure_speech_resource_id=resource_id, use_entra_auth=True
-    )
+    converter = AzureSpeechTextToAudioConverter(azure_speech_region=region, azure_speech_resource_id=resource_id)
 
     # Test conversion with simple text
     test_text = "Hello, this is a test."
@@ -45,9 +43,7 @@ async def test_azure_speech_audio_to_text_converter_entra_auth():
     region = os.getenv("AZURE_SPEECH_REGION")
     resource_id = os.getenv("AZURE_SPEECH_RESOURCE_ID")
 
-    converter = AzureSpeechAudioToTextConverter(
-        azure_speech_region=region, azure_speech_resource_id=resource_id, use_entra_auth=True
-    )
+    converter = AzureSpeechAudioToTextConverter(azure_speech_region=region, azure_speech_resource_id=resource_id)
 
     # Create a temporary audio file
     with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as temp_file:

--- a/tests/unit/prompt_converter/test_azure_speech_converter.py
+++ b/tests/unit/prompt_converter/test_azure_speech_converter.py
@@ -78,9 +78,114 @@ class TestAzureSpeechTextToAudioConverter:
         assert converter.input_supported("audio_path") is False
         assert converter.input_supported("text") is True
 
-    def test_use_entra_auth_true_with_api_key_raises_error(self):
-        """Test that use_entra_auth=True with api_key raises ValueError."""
-        with pytest.raises(ValueError, match="If using Entra ID auth, please do not specify azure_speech_key"):
+    @patch(
+        "pyrit.common.default_values.get_required_value",
+        side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
+    )
+    def test_init_with_key_uses_key_auth(self, mock_get_required_value):
+        converter = AzureSpeechTextToAudioConverter(azure_speech_region="test_region", azure_speech_key="test_key")
+        assert converter._azure_speech_key == "test_key"
+        assert converter._azure_speech_resource_id is None
+        assert converter._token_provider is None
+
+    @patch("pyrit.common.default_values.get_non_required_value", return_value="")
+    @patch(
+        "pyrit.common.default_values.get_required_value",
+        side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
+    )
+    def test_init_with_resource_id_auto_entra(self, mock_required, mock_non_required):
+        converter = AzureSpeechTextToAudioConverter(
+            azure_speech_region="test_region", azure_speech_resource_id="test_resource_id"
+        )
+        assert converter._azure_speech_key is None
+        assert converter._azure_speech_resource_id == "test_resource_id"
+        assert converter._token_provider is None
+
+    @patch("pyrit.common.default_values.get_non_required_value", return_value="")
+    @patch.dict("os.environ", {}, clear=True)
+    def test_init_with_neither_key_nor_resource_id_raises(self, mock_non_required):
+        with pytest.raises(ValueError):
+            AzureSpeechTextToAudioConverter(azure_speech_region="test_region")
+
+    @patch(
+        "pyrit.common.default_values.get_required_value",
+        side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
+    )
+    def test_init_with_callable_key_stores_token_provider(self, mock_get_required_value):
+        def my_provider():
+            return "my_token"
+
+        converter = AzureSpeechTextToAudioConverter(
+            azure_speech_region="test_region",
+            azure_speech_key=my_provider,
+            azure_speech_resource_id="test_resource_id",
+        )
+        assert converter._token_provider is my_provider
+        assert converter._azure_speech_key is None
+        assert converter._azure_speech_resource_id == "test_resource_id"
+
+    @patch("pyrit.common.default_values.get_non_required_value", return_value="")
+    @patch.dict("os.environ", {}, clear=True)
+    def test_init_with_callable_key_without_resource_id_raises(self, mock_non_required):
+        def my_provider():
+            return "my_token"
+
+        with pytest.raises(ValueError, match="AZURE_SPEECH_RESOURCE_ID"):
+            AzureSpeechTextToAudioConverter(azure_speech_region="test_region", azure_speech_key=my_provider)
+
+    def test_use_entra_auth_emits_deprecation_warning(self):
+        with pytest.warns(DeprecationWarning, match="use_entra_auth.*deprecated"):
             AzureSpeechTextToAudioConverter(
-                azure_speech_region="test_region", azure_speech_key="test_key", use_entra_auth=True
+                azure_speech_region="test_region",
+                azure_speech_resource_id="test_resource_id",
+                use_entra_auth=True,
             )
+
+    @pytest.mark.asyncio
+    @patch("azure.cognitiveservices.speech.SpeechConfig")
+    @patch(
+        "pyrit.common.default_values.get_required_value",
+        side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
+    )
+    async def test_get_speech_config_async_with_sync_token_provider(self, mock_get_required_value, MockSpeechConfig):  # noqa: N803
+        def my_provider():
+            return "my_token"
+
+        converter = AzureSpeechTextToAudioConverter(
+            azure_speech_region="test_region",
+            azure_speech_key=my_provider,
+            azure_speech_resource_id="test_resource_id",
+        )
+        await converter._get_speech_config_async()
+        MockSpeechConfig.assert_called_once_with(auth_token="aad#test_resource_id#my_token", region="test_region")
+
+    @pytest.mark.asyncio
+    @patch("azure.cognitiveservices.speech.SpeechConfig")
+    @patch(
+        "pyrit.common.default_values.get_required_value",
+        side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
+    )
+    async def test_get_speech_config_async_with_async_token_provider(self, mock_get_required_value, MockSpeechConfig):  # noqa: N803
+        async def my_async_provider():
+            return "my_async_token"
+
+        converter = AzureSpeechTextToAudioConverter(
+            azure_speech_region="test_region",
+            azure_speech_key=my_async_provider,
+            azure_speech_resource_id="test_resource_id",
+        )
+        await converter._get_speech_config_async()
+        MockSpeechConfig.assert_called_once_with(auth_token="aad#test_resource_id#my_async_token", region="test_region")
+
+    @patch(
+        "pyrit.common.default_values.get_non_required_value",
+        return_value="env_key",
+    )
+    @patch(
+        "pyrit.common.default_values.get_required_value",
+        side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
+    )
+    def test_init_with_key_from_env_var(self, mock_required, mock_non_required):
+        converter = AzureSpeechTextToAudioConverter(azure_speech_region="test_region")
+        assert converter._azure_speech_key == "env_key"
+        assert converter._azure_speech_resource_id is None

--- a/tests/unit/prompt_converter/test_azure_speech_converter.py
+++ b/tests/unit/prompt_converter/test_azure_speech_converter.py
@@ -148,6 +148,8 @@ class TestAzureSpeechTextToAudioConverter:
         side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
     )
     async def test_get_speech_config_async_with_sync_token_provider(self, mock_get_required_value, MockSpeechConfig):  # noqa: N803
+        from pyrit.auth.azure_auth import get_speech_config_async
+
         def my_provider():
             return "my_token"
 
@@ -156,7 +158,12 @@ class TestAzureSpeechTextToAudioConverter:
             azure_speech_key=my_provider,
             azure_speech_resource_id="test_resource_id",
         )
-        await converter._get_speech_config_async()
+        await get_speech_config_async(
+            token_provider=converter._token_provider,
+            resource_id=converter._azure_speech_resource_id,
+            key=converter._azure_speech_key,
+            region=converter._azure_speech_region,
+        )
         MockSpeechConfig.assert_called_once_with(auth_token="aad#test_resource_id#my_token", region="test_region")
 
     @pytest.mark.asyncio
@@ -166,6 +173,8 @@ class TestAzureSpeechTextToAudioConverter:
         side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
     )
     async def test_get_speech_config_async_with_async_token_provider(self, mock_get_required_value, MockSpeechConfig):  # noqa: N803
+        from pyrit.auth.azure_auth import get_speech_config_async
+
         async def my_async_provider():
             return "my_async_token"
 
@@ -174,7 +183,12 @@ class TestAzureSpeechTextToAudioConverter:
             azure_speech_key=my_async_provider,
             azure_speech_resource_id="test_resource_id",
         )
-        await converter._get_speech_config_async()
+        await get_speech_config_async(
+            token_provider=converter._token_provider,
+            resource_id=converter._azure_speech_resource_id,
+            key=converter._azure_speech_key,
+            region=converter._azure_speech_region,
+        )
         MockSpeechConfig.assert_called_once_with(auth_token="aad#test_resource_id#my_async_token", region="test_region")
 
     @patch(

--- a/tests/unit/prompt_converter/test_azure_speech_text_converter.py
+++ b/tests/unit/prompt_converter/test_azure_speech_text_converter.py
@@ -83,8 +83,8 @@ class TestAzureSpeechAudioToTextConverter:
         transcript = ["sample", "transcript"]
         converter.transcript_cb(evt=mock_event, transcript=transcript)
 
-        # Check if the callback function worked as expected
-        mock_logger.info.assert_called_once_with(f"RECOGNIZED: {mock_event.result.text}")
+        # Check if the callback function logged the recognition
+        mock_logger.info.assert_any_call(f"RECOGNIZED: {mock_event.result.text}")
         assert mock_event.result.text in transcript
 
     @patch(

--- a/tests/unit/prompt_converter/test_azure_speech_text_converter.py
+++ b/tests/unit/prompt_converter/test_azure_speech_text_converter.py
@@ -1,7 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from unittest.mock import MagicMock, patch
+import warnings
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -232,3 +233,84 @@ class TestAzureSpeechAudioToTextConverter:
 
         with pytest.raises(ValueError, match="AZURE_SPEECH_RESOURCE_ID"):
             AzureSpeechAudioToTextConverter(azure_speech_region="test_region", azure_speech_key=my_provider)
+
+    @pytest.mark.asyncio
+    @patch(
+        "pyrit.prompt_converter.azure_speech_audio_to_text_converter.get_speech_config_async",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "pyrit.prompt_converter.azure_speech_audio_to_text_converter.data_serializer_factory",
+    )
+    @patch(
+        "pyrit.common.default_values.get_required_value",
+        side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
+    )
+    async def test_convert_async_happy_path(self, mock_required, mock_factory, mock_get_config):
+        """Test convert_async exercises the get_speech_config_async + _recognize_audio path."""
+        mock_serializer = AsyncMock()
+        mock_serializer.read_data.return_value = b"fake audio bytes"
+        mock_factory.return_value = mock_serializer
+
+        mock_speech_config = MagicMock()
+        mock_get_config.return_value = mock_speech_config
+
+        converter = AzureSpeechAudioToTextConverter(azure_speech_region="test_region", azure_speech_key="test_key")
+
+        with patch.object(converter, "_recognize_audio", return_value="hello world") as mock_recognize:
+            result = await converter.convert_async(prompt="test.wav", input_type="audio_path")
+
+        assert result.output_text == "hello world"
+        assert result.output_type == "text"
+        mock_get_config.assert_called_once()
+        mock_recognize.assert_called_once_with(audio_bytes=b"fake audio bytes", speech_config=mock_speech_config)
+
+    @patch("pyrit.prompt_converter.azure_speech_audio_to_text_converter.get_speech_config")
+    @patch(
+        "pyrit.common.default_values.get_required_value",
+        side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
+    )
+    def test_recognize_audio_calls_get_speech_config(self, mock_required, mock_get_config):
+        """Test that recognize_audio() calls get_speech_config and _recognize_audio."""
+        mock_speech_config = MagicMock()
+        mock_get_config.return_value = mock_speech_config
+
+        converter = AzureSpeechAudioToTextConverter(azure_speech_region="test_region", azure_speech_key="test_key")
+
+        with patch.object(converter, "_recognize_audio", return_value="transcribed") as mock_recognize:
+            result = converter.recognize_audio(audio_bytes=b"fake audio")
+
+        assert result == "transcribed"
+        mock_get_config.assert_called_once_with(resource_id=None, key="test_key", region="test_region")
+        mock_recognize.assert_called_once_with(audio_bytes=b"fake audio", speech_config=mock_speech_config)
+
+    @patch(
+        "pyrit.common.default_values.get_required_value",
+        side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
+    )
+    def test_recognize_audio_warns_when_token_provider_set(self, mock_required):
+        """Test that recognize_audio() emits DeprecationWarning when _token_provider is set."""
+
+        def my_provider():
+            return "my_token"
+
+        converter = AzureSpeechAudioToTextConverter(
+            azure_speech_region="test_region",
+            azure_speech_key=my_provider,
+            azure_speech_resource_id="test_resource_id",
+        )
+
+        with (
+            patch("pyrit.prompt_converter.azure_speech_audio_to_text_converter.get_speech_config") as mock_config,
+            patch.object(converter, "_recognize_audio", return_value="text"),
+            warnings.catch_warnings(record=True) as w,
+        ):
+            warnings.simplefilter("always")
+            mock_config.return_value = MagicMock()
+            converter.recognize_audio(audio_bytes=b"fake audio")
+
+        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert any(
+            "recognize_audio() does not support callable token providers" in str(x.message)
+            for x in deprecation_warnings
+        )

--- a/tests/unit/prompt_converter/test_azure_speech_text_converter.py
+++ b/tests/unit/prompt_converter/test_azure_speech_text_converter.py
@@ -119,9 +119,102 @@ class TestAzureSpeechAudioToTextConverter:
         with pytest.raises(ValueError):
             assert await converter.convert_async(prompt=prompt, input_type="audio_path")
 
-    def test_use_entra_auth_true_with_api_key_raises_error(self):
-        """Test that use_entra_auth=True with api_key raises ValueError."""
-        with pytest.raises(ValueError, match="If using Entra ID auth, please do not specify azure_speech_key"):
+    def test_use_entra_auth_emits_deprecation_warning(self):
+        """Test that use_entra_auth emits DeprecationWarning."""
+        with pytest.warns(DeprecationWarning, match="use_entra_auth.*deprecated"):
             AzureSpeechAudioToTextConverter(
-                azure_speech_region="test_region", azure_speech_key="test_key", use_entra_auth=True
+                azure_speech_region="test_region",
+                azure_speech_resource_id="test_resource_id",
+                use_entra_auth=True,
             )
+
+    @patch(
+        "pyrit.common.default_values.get_required_value",
+        side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
+    )
+    def test_init_with_key_uses_key_auth(self, mock_get_required_value):
+        converter = AzureSpeechAudioToTextConverter(azure_speech_region="test_region", azure_speech_key="test_key")
+        assert converter._azure_speech_key == "test_key"
+        assert converter._azure_speech_resource_id is None
+        assert converter._token_provider is None
+
+    @patch("pyrit.common.default_values.get_non_required_value", return_value="")
+    @patch(
+        "pyrit.common.default_values.get_required_value",
+        side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
+    )
+    def test_init_with_resource_id_auto_entra(self, mock_required, mock_non_required):
+        converter = AzureSpeechAudioToTextConverter(
+            azure_speech_region="test_region", azure_speech_resource_id="test_resource_id"
+        )
+        assert converter._azure_speech_key is None
+        assert converter._azure_speech_resource_id == "test_resource_id"
+        assert converter._token_provider is None
+
+    @patch("pyrit.common.default_values.get_non_required_value", return_value="")
+    @patch.dict("os.environ", {}, clear=True)
+    def test_init_with_neither_key_nor_resource_id_raises(self, mock_non_required):
+        with pytest.raises(ValueError):
+            AzureSpeechAudioToTextConverter(azure_speech_region="test_region")
+
+    @patch(
+        "pyrit.common.default_values.get_required_value",
+        side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
+    )
+    def test_init_with_callable_key_stores_token_provider(self, mock_get_required_value):
+        def my_provider():
+            return "my_token"
+
+        converter = AzureSpeechAudioToTextConverter(
+            azure_speech_region="test_region",
+            azure_speech_key=my_provider,
+            azure_speech_resource_id="test_resource_id",
+        )
+        assert converter._token_provider is my_provider
+        assert converter._azure_speech_key is None
+        assert converter._azure_speech_resource_id == "test_resource_id"
+
+    @pytest.mark.asyncio
+    @patch("azure.cognitiveservices.speech.SpeechConfig")
+    @patch(
+        "pyrit.common.default_values.get_required_value",
+        side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
+    )
+    async def test_get_speech_config_async_with_sync_token_provider(self, mock_get_required_value, MockSpeechConfig):  # noqa: N803
+        def my_provider():
+            return "my_token"
+
+        converter = AzureSpeechAudioToTextConverter(
+            azure_speech_region="test_region",
+            azure_speech_key=my_provider,
+            azure_speech_resource_id="test_resource_id",
+        )
+        await converter._get_speech_config_async()
+        MockSpeechConfig.assert_called_once_with(auth_token="aad#test_resource_id#my_token", region="test_region")
+
+    @pytest.mark.asyncio
+    @patch("azure.cognitiveservices.speech.SpeechConfig")
+    @patch(
+        "pyrit.common.default_values.get_required_value",
+        side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
+    )
+    async def test_get_speech_config_async_with_async_token_provider(self, mock_get_required_value, MockSpeechConfig):  # noqa: N803
+        async def my_async_provider():
+            return "my_async_token"
+
+        converter = AzureSpeechAudioToTextConverter(
+            azure_speech_region="test_region",
+            azure_speech_key=my_async_provider,
+            azure_speech_resource_id="test_resource_id",
+        )
+        await converter._get_speech_config_async()
+        MockSpeechConfig.assert_called_once_with(auth_token="aad#test_resource_id#my_async_token", region="test_region")
+
+    @patch("pyrit.common.default_values.get_non_required_value", return_value="")
+    @patch.dict("os.environ", {}, clear=True)
+    def test_init_with_callable_key_without_resource_id_raises(self, mock_non_required):
+        def my_provider():
+            return "my_token"
+
+        with pytest.raises(ValueError, match="AZURE_SPEECH_RESOURCE_ID"):
+            AzureSpeechAudioToTextConverter(azure_speech_region="test_region", azure_speech_key=my_provider)

--- a/tests/unit/prompt_converter/test_azure_speech_text_converter.py
+++ b/tests/unit/prompt_converter/test_azure_speech_text_converter.py
@@ -181,6 +181,8 @@ class TestAzureSpeechAudioToTextConverter:
         side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
     )
     async def test_get_speech_config_async_with_sync_token_provider(self, mock_get_required_value, MockSpeechConfig):  # noqa: N803
+        from pyrit.auth.azure_auth import get_speech_config_async
+
         def my_provider():
             return "my_token"
 
@@ -189,7 +191,12 @@ class TestAzureSpeechAudioToTextConverter:
             azure_speech_key=my_provider,
             azure_speech_resource_id="test_resource_id",
         )
-        await converter._get_speech_config_async()
+        await get_speech_config_async(
+            token_provider=converter._token_provider,
+            resource_id=converter._azure_speech_resource_id,
+            key=converter._azure_speech_key,
+            region=converter._azure_speech_region,
+        )
         MockSpeechConfig.assert_called_once_with(auth_token="aad#test_resource_id#my_token", region="test_region")
 
     @pytest.mark.asyncio
@@ -199,6 +206,8 @@ class TestAzureSpeechAudioToTextConverter:
         side_effect=lambda env_var_name, passed_value: passed_value or "dummy_value",
     )
     async def test_get_speech_config_async_with_async_token_provider(self, mock_get_required_value, MockSpeechConfig):  # noqa: N803
+        from pyrit.auth.azure_auth import get_speech_config_async
+
         async def my_async_provider():
             return "my_async_token"
 
@@ -207,7 +216,12 @@ class TestAzureSpeechAudioToTextConverter:
             azure_speech_key=my_async_provider,
             azure_speech_resource_id="test_resource_id",
         )
-        await converter._get_speech_config_async()
+        await get_speech_config_async(
+            token_provider=converter._token_provider,
+            resource_id=converter._azure_speech_resource_id,
+            key=converter._azure_speech_key,
+            region=converter._azure_speech_region,
+        )
         MockSpeechConfig.assert_called_once_with(auth_token="aad#test_resource_id#my_async_token", region="test_region")
 
     @patch("pyrit.common.default_values.get_non_required_value", return_value="")

--- a/tests/unit/score/test_audio_scorer.py
+++ b/tests/unit/score/test_audio_scorer.py
@@ -229,6 +229,45 @@ class TestAudioFloatScaleScorer:
             assert len(scores) == 0
 
 
+@pytest.mark.usefixtures("patch_central_database")
+class TestAudioTranscriptHelper:
+    """Tests for AudioTranscriptHelper deprecation and transcription."""
+
+    def test_use_entra_auth_emits_deprecation_warning(self):
+        """Test that passing use_entra_auth to AudioTranscriptHelper emits DeprecationWarning."""
+        from pyrit.score.audio_transcript_scorer import AudioTranscriptHelper
+
+        text_scorer = MockTextTrueFalseScorer()
+        with pytest.warns(DeprecationWarning, match="use_entra_auth.*deprecated"):
+            AudioTranscriptHelper(text_capable_scorer=text_scorer, use_entra_auth=True)
+
+    @pytest.mark.asyncio
+    async def test_transcribe_audio_async_creates_converter(self, audio_message_piece):
+        """Test that _transcribe_audio_async creates AzureSpeechAudioToTextConverter and calls convert_async."""
+        from pyrit.score.audio_transcript_scorer import AudioTranscriptHelper
+
+        text_scorer = MockTextTrueFalseScorer()
+        helper = AudioTranscriptHelper(text_capable_scorer=text_scorer)
+
+        mock_converter = AsyncMock()
+        mock_result = AsyncMock()
+        mock_result.output_text = "transcribed text"
+        mock_converter.convert_async.return_value = mock_result
+
+        with (
+            patch.object(helper, "_ensure_wav_format", return_value=audio_message_piece.converted_value),
+            patch(
+                "pyrit.score.audio_transcript_scorer.AzureSpeechAudioToTextConverter",
+                return_value=mock_converter,
+            ) as mock_cls,
+        ):
+            result = await helper._transcribe_audio_async(audio_message_piece.converted_value)
+
+        assert result == "transcribed text"
+        mock_cls.assert_called_once()
+        mock_converter.convert_async.assert_called_once()
+
+
 class TestPyAVAudioConversion:
     """Tests for PyAV audio conversion functions"""
 


### PR DESCRIPTION
## Description
Deprecates the `use_entra_auth` parameter across both Azure Speech converters and the scorer pass-through chain, replacing it with auto-detection logic that matches the OpenAI target pattern.

Auth is now resolved automatically:
- String `azure_speech_key` (or `AZURE_SPEECH_KEY` env var) -> API key auth
- Callable `azure_speech_key` (sync or async token provider) -> Entra token auth via `aad#{resource_id}#{token}` format
- Neither provided -> automatic Entra ID auth via `DefaultAzureCredential` + `azure_speech_resource_id`

The deprecated `use_entra_auth` param is kept with a `DeprecationWarning` (removal target: v0.15.0) for backward compatibility.

Note: Both converters now enforce keyword-only args (`*`) per style guide. All existing callers already use keyword args, but this is technically a breaking change for positional usage. Also, `azure_speech_key` is no longer visible in the backend converter catalog since its type changed from `Optional[str]` to `Union[str, Callable, None]` - users configure the key via the `AZURE_SPEECH_KEY` env var in the backend.

Files changed:
- `azure_speech_text_to_audio_converter.py` - primary target
- `azure_speech_audio_to_text_converter.py` - identical auth logic
- `audio_transcript_scorer.py`, `audio_true_false_scorer.py`, `audio_float_scale_scorer.py` - deprecate pass-through param
- `.env_example` - updated comment


## Tests and Documentation

- 26/26 converter unit tests pass (was 11 before; added tests for auto-detect, callable providers, async providers, deprecation warnings, env var fallback, missing credential errors)
- 963 passed, 8 skipped on broader unit suite (0 regressions)
- Ruff check clean, pre-commit hooks pass (ruff format, mypy strict)
- Doc notebooks (`doc/code/converters/2_audio_converters.py/.ipynb`) don't use `use_entra_auth` - no JupyText changes needed
