### PR TITLE
MAINT: Add pre-commit hook to strip kernelspec from jupytext .py files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,11 @@ repos:
         entry: python ./build_scripts/strip_notebook_progress_bars.py
         language: python
         files: ^doc.*\.(ipynb)$
+      - id: strip-py-kernelspec
+        name: Strip kernelspec from jupytext .py files
+        entry: python ./build_scripts/strip_py_kernelspec.py
+        language: python
+        files: ^doc/.*\.py$
       - id: validate-docs
         name: Validate Documentation Structure
         entry: python ./build_scripts/validate_docs.py

--- a/build_scripts/strip_py_kernelspec.py
+++ b/build_scripts/strip_py_kernelspec.py
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import re
+import sys
+
+# Matches the kernelspec block inside a jupytext YAML header comment.
+# The block starts with "#   kernelspec:" and includes all following
+# lines that are indented deeper (i.e. start with "#     ").
+_KERNELSPEC_PATTERN = re.compile(
+    r"^#   kernelspec:\n(?:#     .+\n)+",
+    re.MULTILINE,
+)
+
+
+def strip_kernelspec(file_path: str) -> bool:
+    """
+    Remove the kernelspec block from a jupytext .py file's YAML header.
+
+    Args:
+        file_path (str): Path to the .py file.
+
+    Returns:
+        bool: True if the file was modified.
+    """
+    with open(file_path, encoding="utf-8") as f:
+        content = f.read()
+
+    new_content = _KERNELSPEC_PATTERN.sub("", content)
+
+    if new_content == content:
+        return False
+
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write(new_content)
+
+    return True
+
+
+if __name__ == "__main__":
+    modified_files = [fp for fp in sys.argv[1:] if strip_kernelspec(fp)]
+    if modified_files:
+        print("Stripped kernelspec from:", modified_files)
+        sys.exit(1)

--- a/doc/code/converters/6_selectively_converting.py
+++ b/doc/code/converters/6_selectively_converting.py
@@ -6,10 +6,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.17.3
-#   kernelspec:
-#     display_name: pyrit-dev
-#     language: python
-#     name: python3
 # ---
 
 # %% [markdown]

--- a/doc/code/datasets/5_simulated_conversation.py
+++ b/doc/code/datasets/5_simulated_conversation.py
@@ -6,10 +6,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.19.1
-#   kernelspec:
-#     display_name: pyrit-dev
-#     language: python
-#     name: pyrit-dev
 # ---
 
 # %% [markdown]

--- a/doc/code/executor/attack/context_compliance_attack.py
+++ b/doc/code/executor/attack/context_compliance_attack.py
@@ -6,10 +6,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.18.1
-#   kernelspec:
-#     display_name: pyrit-dev
-#     language: python
-#     name: python3
 # ---
 
 # %% [markdown]

--- a/doc/code/executor/attack/role_play_attack.py
+++ b/doc/code/executor/attack/role_play_attack.py
@@ -6,10 +6,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.18.1
-#   kernelspec:
-#     display_name: pyrit-dev
-#     language: python
-#     name: python3
 # ---
 
 # %% [markdown]

--- a/doc/code/executor/benchmark/1_qa_benchmark.py
+++ b/doc/code/executor/benchmark/1_qa_benchmark.py
@@ -6,10 +6,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.17.3
-#   kernelspec:
-#     display_name: pyrit-312
-#     language: python
-#     name: python3
 # ---
 
 # %% [markdown]

--- a/doc/code/executor/benchmark/2_bias_benchmark.py
+++ b/doc/code/executor/benchmark/2_bias_benchmark.py
@@ -6,10 +6,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.19.1
-#   kernelspec:
-#     display_name: pyrit-dev
-#     language: python
-#     name: pyrit-dev
 # ---
 
 # %% [markdown]

--- a/doc/code/executor/promptgen/1_anecdoctor_generator.py
+++ b/doc/code/executor/promptgen/1_anecdoctor_generator.py
@@ -6,10 +6,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.17.2
-#   kernelspec:
-#     display_name: pyrit-dev
-#     language: python
-#     name: python3
 # ---
 
 # %% [markdown]

--- a/doc/code/executor/workflow/2_xpia_ai_recruiter.py
+++ b/doc/code/executor/workflow/2_xpia_ai_recruiter.py
@@ -7,10 +7,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.17.3
-#   kernelspec:
-#     display_name: pyrit-dev
-#     language: python
-#     name: python3
 # ---
 
 # %% [markdown]

--- a/doc/code/memory/8_seed_database.py
+++ b/doc/code/memory/8_seed_database.py
@@ -7,10 +7,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.17.3
-#   kernelspec:
-#     display_name: pyrit-dev
-#     language: python
-#     name: python3
 # ---
 
 # %% [markdown]

--- a/doc/code/registry/2_instance_registry.py
+++ b/doc/code/registry/2_instance_registry.py
@@ -6,10 +6,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.17.2
-#   kernelspec:
-#     display_name: pyrit-dev
-#     language: python
-#     name: python3
 # ---
 
 # %% [markdown]

--- a/doc/code/scenarios/0_scenarios.py
+++ b/doc/code/scenarios/0_scenarios.py
@@ -6,10 +6,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.18.1
-#   kernelspec:
-#     display_name: pyrit (3.13.5)
-#     language: python
-#     name: python3
 # ---
 
 # %% [markdown]

--- a/doc/code/scoring/2_true_false_scorers.py
+++ b/doc/code/scoring/2_true_false_scorers.py
@@ -7,10 +7,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.19.0
-#   kernelspec:
-#     display_name: pyrit-dev
-#     language: python
-#     name: python3
 # ---
 
 # %% [markdown]

--- a/doc/code/scoring/4_likert_scorers.py
+++ b/doc/code/scoring/4_likert_scorers.py
@@ -7,10 +7,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.19.1
-#   kernelspec:
-#     display_name: pyrit-dev
-#     language: python
-#     name: python3
 # ---
 
 # %% [markdown]

--- a/doc/code/scoring/7_scorer_metrics.py
+++ b/doc/code/scoring/7_scorer_metrics.py
@@ -6,10 +6,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.18.1
-#   kernelspec:
-#     display_name: pyrit (3.13.5)
-#     language: python
-#     name: python3
 # ---
 
 # %% [markdown]

--- a/doc/code/scoring/generic_scorers.py
+++ b/doc/code/scoring/generic_scorers.py
@@ -6,10 +6,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.17.3
-#   kernelspec:
-#     display_name: pyrit-312
-#     language: python
-#     name: python3
 # ---
 
 # %% [markdown]

--- a/doc/code/scoring/persuasion_full_conversation_scorer.py
+++ b/doc/code/scoring/persuasion_full_conversation_scorer.py
@@ -6,10 +6,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.17.3
-#   kernelspec:
-#     display_name: pyrit-dev
-#     language: python
-#     name: python3
 # ---
 
 # %% [markdown]

--- a/doc/code/scoring/prompt_shield_scorer.py
+++ b/doc/code/scoring/prompt_shield_scorer.py
@@ -6,10 +6,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.17.3
-#   kernelspec:
-#     display_name: pyrit-dev
-#     language: python
-#     name: python3
 # ---
 
 # %% [markdown]

--- a/doc/code/setup/2_resiliency.py
+++ b/doc/code/setup/2_resiliency.py
@@ -6,10 +6,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.17.3
-#   kernelspec:
-#     display_name: pyrit-dev
-#     language: python
-#     name: python3
 # ---
 
 # %% [markdown]

--- a/doc/code/targets/10_3_websocket_copilot_target.py
+++ b/doc/code/targets/10_3_websocket_copilot_target.py
@@ -6,10 +6,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.18.1
-#   kernelspec:
-#     display_name: pyrit (3.13.5)
-#     language: python
-#     name: python3
 # ---
 
 # %% [markdown]

--- a/doc/code/targets/1_openai_chat_target.py
+++ b/doc/code/targets/1_openai_chat_target.py
@@ -6,10 +6,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.18.1
-#   kernelspec:
-#     display_name: Python 3 (ipykernel)
-#     language: python
-#     name: python3
 # ---
 
 # %% [markdown]

--- a/doc/code/targets/2_openai_responses_target.py
+++ b/doc/code/targets/2_openai_responses_target.py
@@ -6,10 +6,6 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.18.1
-#   kernelspec:
-#     display_name: Python (pyrit-copilot)
-#     language: python
-#     name: pyrit-copilot
 # ---
 
 # %% [markdown]


### PR DESCRIPTION
## Summary

\
bstripout\ already strips \metadata.kernelspec\ from \.ipynb\ files, but jupytext \.py\ files can accumulate kernelspec blocks (\display_name\, \language\, \
ame\) that leak local environment details into the repo.

This adds a new pre-commit hook (\strip-py-kernelspec\) that automatically removes these blocks from \doc/**/*.py\ files.

## Changes

- **New**: \uild_scripts/strip_py_kernelspec.py\ — script that strips \#   kernelspec:\ blocks from jupytext YAML headers
- **Updated**: \.pre-commit-config.yaml\ — added hook entry for \doc/**/*.py\ files
- **Cleaned up**: Stripped existing kernelspec blocks from 21 doc \.py\ files

## Motivation

Discovered during PR #1633 review — a contributor's local kernelspec (\pyrit-dev\) was committed via a jupytext \.py\ file. This hook prevents it from happening again.