### PR TITLE
MAINT: Set PYRIT_CORS_ORIGINS env var in Bicep instead of imperatively

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -388,12 +388,6 @@ az deployment group create \
 4. **Manage access** — Add or remove users via Entra security groups
    (`allowedGroupObjectIds`). Each group must also be assigned to the enterprise app.
 
-5. **Set CORS origins** for production (the Bicep template does not set this):
-   ```bash
-   az containerapp update -n <appName> -g <rg> \
-     --set-env-vars "PYRIT_CORS_ORIGINS=https://$FQDN"
-   ```
-
 ## Access the GUI
 
 ```bash

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -477,10 +477,7 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
             }
             // CORS origin for the SPA. The ACA-generated FQDN is deterministic
             // (<appName>.<envDefaultDomain>), so we compute it from upstream
-            // resources rather than self-referencing containerApp (which would
-            // create a deploy-time cycle). Set as an env var here so it stays
-            // in sync with the ingress on every deploy — no out-of-band
-            // `az containerapp update` needed.
+            // resources rather than self-referencing containerApp.
             {
               name: 'PYRIT_CORS_ORIGINS'
               value: 'https://${appName}.${acaEnvironment.properties.defaultDomain}'

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -475,6 +475,16 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'AZURE_CLIENT_ID'
               value: managedIdentity.properties.clientId
             }
+            // CORS origin for the SPA. The ACA-generated FQDN is deterministic
+            // (<appName>.<envDefaultDomain>), so we compute it from upstream
+            // resources rather than self-referencing containerApp (which would
+            // create a deploy-time cycle). Set as an env var here so it stays
+            // in sync with the ingress on every deploy — no out-of-band
+            // `az containerapp update` needed.
+            {
+              name: 'PYRIT_CORS_ORIGINS'
+              value: 'https://${appName}.${acaEnvironment.properties.defaultDomain}'
+            }
           ]
         }
       ]


### PR DESCRIPTION
## Description

Folds the manual `az containerapp update --set-env-vars PYRIT_CORS_ORIGINS=...` step (currently step 5 in `infra/README.md`) into `infra/main.bicep` so deploys are self-correcting and the GUI no longer silently breaks on CORS when someone forgets to re-run the command.

The value is computed from `acaEnvironment.properties.defaultDomain` rather than the container app's own FQDN to avoid a self-reference cycle; ACA's FQDN is deterministically `<appName>.<defaultDomain>`, so the result matches what the manual command was setting.

## Tests and Documentation

- `az bicep build --file infra/main.bicep --stdout` - clean.
- `az deployment group what-if -g copyrit-gui-rg-prod` - clean `Create` of `containers[0].env[11]` resolving to the SPA's existing FQDN.
- Backend parsing (`pyrit/backend/main.py:73`) splits on `,`; single value parses to a 1-element list as expected.
- Removed the now-redundant CORS step from `infra/README.md`.
- JupyText: N/A (Bicep + Markdown only).