### PR TITLE
FIX: AIRTInitializer container crash and parameters.example.json typo

### DIFF
--- a/infra/parameters.example.json
+++ b/infra/parameters.example.json
@@ -27,7 +27,7 @@
       "value": "YOUR_DATABASE_NAME"
     },
     "pyritInitializer": {
-      "value": "targets airt"
+      "value": "target airt"
     },
     "envSecretName": {
       "value": "env-global"

--- a/pyrit/setup/initializers/airt.py
+++ b/pyrit/setup/initializers/airt.py
@@ -9,6 +9,7 @@ AIRT configuration including converters, scorers, and targets using Azure OpenAI
 """
 
 import json
+import logging
 import os
 from collections.abc import Callable
 
@@ -37,6 +38,8 @@ from pyrit.score import (
 )
 from pyrit.score.float_scale.self_ask_scale_scorer import SelfAskScaleScorer
 from pyrit.setup.initializers.pyrit_initializer import PyRITInitializer
+
+logger = logging.getLogger(__name__)
 
 
 class AIRTInitializer(PyRITInitializer):
@@ -275,32 +278,43 @@ class AIRTInitializer(PyRITInitializer):
 
     def _validate_operation_fields(self) -> None:
         """
-        Check that mandatory global memory labels (operation, operator)
-        are populated.
+        Ensure operator and operation are populated in GLOBAL_MEMORY_LABELS.
+
+        Reads operator/operation from .pyrit_conf if it exists, then merges
+        them into GLOBAL_MEMORY_LABELS. In container/GUI deployments where
+        .pyrit_conf is not present, the labels are set per-user by the GUI
+        at runtime, so this method is a no-op.
 
         Raises:
-            ValueError: If mandatory global memory labels are missing.
+            ValueError: If .pyrit_conf exists but is missing operator or operation.
         """
-        with open(DEFAULT_CONFIG_PATH) as f:
-            data = yaml.load(f, Loader=yaml.SafeLoader)
-
-        if "operator" not in data:
-            raise ValueError(
-                "Error: `operator` was not set in .pyrit_conf. This is a required value for the AIRTInitializer."
-            )
-
-        if "operation" not in data:
-            raise ValueError(
-                "Error: `operation` was not set in .pyrit_conf. This is a required value for the AIRTInitializer."
-            )
-
         raw_labels = os.environ.get("GLOBAL_MEMORY_LABELS")
         labels = dict(json.loads(raw_labels)) if raw_labels else {}
 
-        if "operator" not in labels:
-            labels["operator"] = data["operator"]
+        if DEFAULT_CONFIG_PATH.exists():
+            with open(DEFAULT_CONFIG_PATH) as f:
+                data = yaml.load(f, Loader=yaml.SafeLoader) or {}
 
-        if "operation" not in labels:
-            labels["operation"] = data["operation"]
+            if "operator" not in data:
+                raise ValueError(
+                    "Error: `operator` was not set in .pyrit_conf. This is a required value for the AIRTInitializer."
+                )
 
-        os.environ["GLOBAL_MEMORY_LABELS"] = json.dumps(labels)
+            if "operation" not in data:
+                raise ValueError(
+                    "Error: `operation` was not set in .pyrit_conf. This is a required value for the AIRTInitializer."
+                )
+
+            if "operator" not in labels:
+                labels["operator"] = data["operator"]
+
+            if "operation" not in labels:
+                labels["operation"] = data["operation"]
+
+            os.environ["GLOBAL_MEMORY_LABELS"] = json.dumps(labels)
+        else:
+            logger.info(
+                "No .pyrit_conf found at %s — skipping operator/operation validation. "
+                "In GUI mode, these labels are set per-user at runtime.",
+                DEFAULT_CONFIG_PATH,
+            )

--- a/tests/unit/setup/test_airt_initializer.py
+++ b/tests/unit/setup/test_airt_initializer.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import json
 import os
 import sys
 from unittest.mock import patch
@@ -213,6 +214,65 @@ class TestAIRTInitializerInitialize:
             pytest.raises(ValueError, match="operation"),
         ):
             init._validate_operation_fields()
+
+    def test_validate_operation_fields_skips_when_pyrit_conf_missing(self, tmp_path):
+        """Test that _validate_operation_fields does not crash when .pyrit_conf is missing.
+
+        In container/GUI deployments, .pyrit_conf does not exist. The method should
+        skip validation gracefully instead of raising FileNotFoundError.
+        """
+        nonexistent_path = tmp_path / "nonexistent" / ".pyrit_conf"
+        init = AIRTInitializer()
+        with patch("pyrit.setup.initializers.airt.DEFAULT_CONFIG_PATH", nonexistent_path):
+            # Should not raise
+            init._validate_operation_fields()
+
+    def test_validate_operation_fields_preserves_existing_labels_when_pyrit_conf_missing(self, tmp_path):
+        """Test that existing GLOBAL_MEMORY_LABELS are preserved when .pyrit_conf is missing."""
+        nonexistent_path = tmp_path / "nonexistent" / ".pyrit_conf"
+        init = AIRTInitializer()
+        with (
+            patch("pyrit.setup.initializers.airt.DEFAULT_CONFIG_PATH", nonexistent_path),
+            patch.dict("os.environ", {"GLOBAL_MEMORY_LABELS": '{"operator": "gui_user", "operation": "gui_op"}'}),
+        ):
+            init._validate_operation_fields()
+            # Existing labels should remain untouched
+            labels = json.loads(os.environ["GLOBAL_MEMORY_LABELS"])
+            assert labels["operator"] == "gui_user"
+            assert labels["operation"] == "gui_op"
+
+    def test_validate_operation_fields_merges_conf_into_labels(self, tmp_path):
+        """Test that .pyrit_conf values are merged into GLOBAL_MEMORY_LABELS when labels are missing."""
+        conf_file = tmp_path / ".pyrit_conf"
+        conf_file.write_text(yaml.dump({"operator": "conf_user", "operation": "conf_op"}))
+        init = AIRTInitializer()
+        with (
+            patch("pyrit.setup.initializers.airt.DEFAULT_CONFIG_PATH", conf_file),
+            patch.dict("os.environ", {}, clear=False),
+        ):
+            # Remove GLOBAL_MEMORY_LABELS if present
+            os.environ.pop("GLOBAL_MEMORY_LABELS", None)
+            init._validate_operation_fields()
+            labels = json.loads(os.environ["GLOBAL_MEMORY_LABELS"])
+            assert labels["operator"] == "conf_user"
+            assert labels["operation"] == "conf_op"
+
+    def test_validate_operation_fields_does_not_overwrite_existing_labels(self, tmp_path):
+        """Test that .pyrit_conf values do not overwrite existing GLOBAL_MEMORY_LABELS entries."""
+        conf_file = tmp_path / ".pyrit_conf"
+        conf_file.write_text(yaml.dump({"operator": "conf_user", "operation": "conf_op"}))
+        init = AIRTInitializer()
+        with (
+            patch("pyrit.setup.initializers.airt.DEFAULT_CONFIG_PATH", conf_file),
+            patch.dict(
+                "os.environ",
+                {"GLOBAL_MEMORY_LABELS": '{"operator": "existing_user", "operation": "existing_op"}'},
+            ),
+        ):
+            init._validate_operation_fields()
+            labels = json.loads(os.environ["GLOBAL_MEMORY_LABELS"])
+            assert labels["operator"] == "existing_user"
+            assert labels["operation"] == "existing_op"
 
     def test_validate_db_connection_raises_error(self):
         """Test that validate raises error when AZURE_SQL_DB_CONNECTION_STRING is missing."""


### PR DESCRIPTION
## Description
Fixes two pre-existing bugs blocking Azure Container App deployments on current main.

AIRTInitializer crashes with FileNotFoundError when .pyrit_conf is missing. PR #1578 added _validate_operation_fields() which unconditionally opens ~/.pyrit/.pyrit_conf. This file does not exist in container deployments. The fix checks if the file exists before reading it, and skips gracefully in container/GUI mode where operator/operation are set per-user at runtime (PR #1636). This unblocks the test environment where new revisions have been ActivationFailed since Apr 10.

infra/parameters.example.json has "targets airt" but the valid initializer name is "target" (no s). Fixed the typo. Does not affect the pipeline (uses Bicep default) but would break manual deployments following the example.

Related to User Story #8520


## Tests and Documentation
Added 4 unit tests for _validate_operation_fields():

test_validate_operation_fields_skips_when_pyrit_conf_missing
test_validate_operation_fields_preserves_existing_labels_when_pyrit_conf_missing
test_validate_operation_fields_merges_conf_into_labels
test_validate_operation_fields_does_not_overwrite_existing_labels
All 18 airt initializer tests pass. All 180 setup module tests pass. Ruff lint and format clean. E2E validated: backend starts with --initializers target airt and no .pyrit_conf, health check passes.

No documentation changes needed. No JupyText changes.
