### PR TITLE
FIX VLGuard review fixes: document subcategory mapping, move import to top

### DIFF
--- a/pyrit/datasets/seed_datasets/remote/vlguard_dataset.py
+++ b/pyrit/datasets/seed_datasets/remote/vlguard_dataset.py
@@ -9,6 +9,8 @@ import zipfile
 from enum import Enum
 from pathlib import Path
 
+from huggingface_hub import hf_hub_download
+
 from pyrit.common.path import DB_DATA_PATH
 from pyrit.datasets.seed_datasets.remote.remote_dataset_loader import (
     _RemoteDatasetLoader,
@@ -37,7 +39,14 @@ class VLGuardCategory(Enum):
 
 
 class VLGuardSubcategory(Enum):
-    """Subcategories in the VLGuard dataset, nested under the main categories."""
+    """
+    Subcategories in the VLGuard dataset. Each subcategory belongs to a specific category.
+
+    privacy: personal data
+    risky behavior: professional advice, political, sexually explicit, violence
+    deception: disinformation
+    discrimination: sex, race, other
+    """
 
     PERSONAL_DATA = "personal data"
     PROFESSIONAL_ADVICE = "professional advice"
@@ -263,8 +272,6 @@ class _VLGuardDataset(_RemoteDatasetLoader):
         Returns:
             tuple[list[dict], Path]: Tuple of (metadata list, image directory path).
         """
-        from huggingface_hub import hf_hub_download
-
         cache_dir = DB_DATA_PATH / "seed-prompt-entries" / "vlguard"
         cache_dir.mkdir(parents=True, exist_ok=True)
 

--- a/tests/unit/datasets/test_vlguard_dataset.py
+++ b/tests/unit/datasets/test_vlguard_dataset.py
@@ -409,7 +409,7 @@ class TestVLGuardDataset:
 
         with (
             patch("pyrit.datasets.seed_datasets.remote.vlguard_dataset.DB_DATA_PATH", tmp_path),
-            patch("huggingface_hub.hf_hub_download", side_effect=mock_hf_download),
+            patch("pyrit.datasets.seed_datasets.remote.vlguard_dataset.hf_hub_download", side_effect=mock_hf_download),
         ):
             metadata, result_dir = await loader._download_dataset_files_async(cache=False)
 


### PR DESCRIPTION
Follow-up to #1447 — these review-comment fixes were pushed after the PR was merged.

### Changes
- **Document subcategory-category mapping** in \VLGuardSubcategory\ docstring (addresses review comment)
- **Move \huggingface_hub\ import to top of file** — it's a transitive dependency of \datasets\ (a required dep), so always available. Inline import was flagged in review.
- Update test mock path accordingly