### PR TITLE
MAINT: Add merge_group trigger to CI workflows for merge queue support

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,6 +13,7 @@ on:
     branches:
       - "main"
       - "release/**"
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/diff_cover.yml
+++ b/.github/workflows/diff_cover.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - "main"
       - "release/**"
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - "main"
       - "release/**"
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/frontend_tests.yml
+++ b/.github/workflows/frontend_tests.yml
@@ -17,6 +17,7 @@ on:
     paths:
       - "frontend/**"
       - ".github/workflows/frontend_tests.yml"
+  merge_group:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Enable GitHub merge queue by adding the `merge_group` event trigger to:
- `build_and_test.yml`
- `diff_cover.yml`
- `docker_build.yml`
- `frontend_tests.yml`

**Note:** `merge_group` does not support `paths` filtering, so the frontend_tests workflow will run on all merge queue entries.

`docs.yml` was intentionally left unchanged since it is not a required CI check.