### PR TITLE
MAINT: Add deprecation warnings when Message Piece is constructed with labels

### DIFF
--- a/pyrit/backend/mappers/attack_mappers.py
+++ b/pyrit/backend/mappers/attack_mappers.py
@@ -33,6 +33,7 @@ from pyrit.backend.models.attacks import (
     Score,
     TargetInfo,
 )
+from pyrit.common.deprecation import print_deprecation_message
 from pyrit.models import AttackResult, ChatMessageRole, PromptDataType
 from pyrit.models import Message as PyritMessage
 from pyrit.models import MessagePiece as PyritMessagePiece
@@ -409,7 +410,7 @@ def request_piece_to_pyrit_message_piece(
     role: ChatMessageRole,
     conversation_id: str,
     sequence: int,
-    labels: Optional[dict[str, str]] = None,
+    labels: Optional[dict[str, str]] = None,  # deprecated
 ) -> PyritMessagePiece:
     """
     Convert a single request piece DTO to a PyRIT MessagePiece domain object.
@@ -420,10 +421,17 @@ def request_piece_to_pyrit_message_piece(
         conversation_id: The conversation/attack ID.
         sequence: The message sequence number.
         labels: Optional labels to attach to the piece.
+            Deprecated: This parameter will be removed in a release 0.16.0.
 
     Returns:
         PyritMessagePiece domain object.
     """
+    if labels is not None:
+        print_deprecation_message(
+            old_item="request_piece_to_pyrit_message_piece(..., labels=...)",
+            new_item="request_piece_to_pyrit_message_piece(...)",
+            removed_in="0.16.0",
+        )
     metadata: Optional[dict[str, str | int]] = None
     if piece.prompt_metadata:
         metadata = dict(piece.prompt_metadata)
@@ -439,7 +447,7 @@ def request_piece_to_pyrit_message_piece(
         conversation_id=conversation_id,
         sequence=sequence,
         prompt_metadata=metadata,
-        labels=labels or {},
+        labels=labels or {},  # deprecated
         original_prompt_id=original_prompt_id,
     )
 
@@ -449,7 +457,7 @@ def request_to_pyrit_message(
     request: AddMessageRequest,
     conversation_id: str,
     sequence: int,
-    labels: Optional[dict[str, str]] = None,
+    labels: Optional[dict[str, str]] = None,  # deprecated
 ) -> PyritMessage:
     """
     Build a PyRIT Message from an AddMessageRequest DTO.
@@ -459,17 +467,24 @@ def request_to_pyrit_message(
         conversation_id: The conversation/attack ID.
         sequence: The message sequence number.
         labels: Optional labels to attach to each piece.
+            Deprecated: This parameter will be removed in a release 0.16.0.
 
     Returns:
         PyritMessage ready to send to the target.
     """
+    if labels is not None:
+        print_deprecation_message(
+            old_item="request_to_pyrit_message(..., labels=...)",
+            new_item="request_to_pyrit_message(...)",
+            removed_in="0.16.0",
+        )
     pieces = [
         request_piece_to_pyrit_message_piece(
             piece=p,
             role=request.role,
             conversation_id=conversation_id,
             sequence=sequence,
-            labels=labels,
+            labels=labels,  # deprecated
         )
         for p in request.pieces
     ]

--- a/pyrit/backend/services/attack_service.py
+++ b/pyrit/backend/services/attack_service.py
@@ -340,7 +340,7 @@ class AttackService:
             await self._store_prepended_messages(
                 conversation_id=conversation_id,
                 prepended=request.prepended_conversation,
-                labels=labels,
+                labels=labels,  # deprecated
             )
 
         return CreateAttackResponse(
@@ -614,14 +614,14 @@ class AttackService:
                 target_registry_name=target_registry_name,
                 request=request,
                 sequence=sequence,
-                labels=attack_labels,
+                labels=attack_labels,  # deprecated
             )
         else:
             await self._store_message_only_async(
                 conversation_id=msg_conversation_id,
                 request=request,
                 sequence=sequence,
-                labels=attack_labels,
+                labels=attack_labels,  # deprecated
             )
 
         await self._update_attack_after_message_async(attack_result_id=attack_result_id, ar=ar, request=request)
@@ -852,7 +852,7 @@ class AttackService:
         # Apply optional overrides to the fresh pieces before persisting
         for piece in all_pieces:
             if labels_override is not None:
-                piece.labels = dict(labels_override)
+                piece.labels = dict(labels_override)  # deprecated
             if remap_assistant_to_simulated and piece.api_role == "assistant":
                 piece._role = "simulated_assistant"
 
@@ -943,7 +943,7 @@ class AttackService:
         self,
         conversation_id: str,
         prepended: list[Any],
-        labels: Optional[dict[str, str]] = None,
+        labels: Optional[dict[str, str]] = None,  # deprecated
     ) -> None:
         """Store prepended conversation messages in memory."""
         for seq, msg in enumerate(prepended):
@@ -953,7 +953,7 @@ class AttackService:
                     role=msg.role,
                     conversation_id=conversation_id,
                     sequence=seq,
-                    labels=labels,
+                    labels=labels,  # deprecated
                 )
                 self._memory.add_message_pieces_to_memory(message_pieces=[piece])
 
@@ -964,7 +964,7 @@ class AttackService:
         target_registry_name: str,
         request: AddMessageRequest,
         sequence: int,
-        labels: Optional[dict[str, str]] = None,
+        labels: Optional[dict[str, str]] = None,  # deprecated
     ) -> None:
         """Send message to target via normalizer and store response."""
         target_obj = get_target_service().get_target_object(target_registry_name=target_registry_name)
@@ -979,7 +979,7 @@ class AttackService:
             request=request,
             conversation_id=conversation_id,
             sequence=sequence,
-            labels=labels,
+            labels=labels,  # deprecated
         )
 
         converter_configs = self._get_converter_configs(request)
@@ -1000,7 +1000,7 @@ class AttackService:
         conversation_id: str,
         request: AddMessageRequest,
         sequence: int,
-        labels: Optional[dict[str, str]] = None,
+        labels: Optional[dict[str, str]] = None,  # deprecated
     ) -> None:
         """Store message without sending (send=False)."""
         await self._persist_base64_pieces_async(request)
@@ -1010,7 +1010,7 @@ class AttackService:
                 role=request.role,
                 conversation_id=conversation_id,
                 sequence=sequence,
-                labels=labels,
+                labels=labels,  # deprecated
             )
             self._memory.add_message_pieces_to_memory(message_pieces=[piece])
 

--- a/pyrit/executor/attack/component/conversation_manager.py
+++ b/pyrit/executor/attack/component/conversation_manager.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Optional
 
+from pyrit.common.deprecation import print_deprecation_message
 from pyrit.common.utils import combine_dict
 from pyrit.executor.attack.component.prepended_conversation_config import (
     PrependedConversationConfig,
@@ -57,7 +58,7 @@ def get_adversarial_chat_messages(
     adversarial_chat_conversation_id: str,
     attack_identifier: ComponentIdentifier,
     adversarial_chat_target_identifier: ComponentIdentifier,
-    labels: Optional[dict[str, str]] = None,
+    labels: Optional[dict[str, str]] = None,  # deprecated
 ) -> list[Message]:
     """
     Transform prepended conversation messages for adversarial chat with swapped roles.
@@ -76,10 +77,17 @@ def get_adversarial_chat_messages(
         attack_identifier (ComponentIdentifier): Attack identifier to associate with messages.
         adversarial_chat_target_identifier (ComponentIdentifier): Target identifier for the adversarial chat.
         labels: Optional labels to associate with the messages.
+            Deprecated: This parameter will be removed in a release 0.16.0.
 
     Returns:
         List of transformed messages with swapped roles and new IDs.
     """
+    if labels is not None:
+        print_deprecation_message(
+            old_item="get_adversarial_chat_messages(..., labels=...)",
+            new_item="get_adversarial_chat_messages(...)",
+            removed_in="0.16.0",
+        )
     if not prepended_conversation:
         return []
 
@@ -110,7 +118,7 @@ def get_adversarial_chat_messages(
                 conversation_id=adversarial_chat_conversation_id,
                 attack_identifier=attack_identifier,
                 prompt_target_identifier=adversarial_chat_target_identifier,
-                labels=labels,
+                labels=labels,  # deprecated
             )
 
             result.append(adversarial_piece.to_message())
@@ -245,7 +253,7 @@ class ConversationManager:
         target: PromptChatTarget,
         conversation_id: str,
         system_prompt: str,
-        labels: Optional[dict[str, str]] = None,
+        labels: Optional[dict[str, str]] = None,  # deprecated
     ) -> None:
         """
         Set or update the system prompt for a conversation.
@@ -255,12 +263,19 @@ class ConversationManager:
             conversation_id: Unique identifier for the conversation.
             system_prompt: The system prompt text.
             labels: Optional labels to associate with the system prompt.
+                Deprecated: This parameter will be removed in a release 0.16.0.
         """
+        if labels is not None:
+            print_deprecation_message(
+                old_item="set_system_prompt(..., labels=...)",
+                new_item="set_system_prompt(...)",
+                removed_in="0.16.0",
+            )
         target.set_system_prompt(
             system_prompt=system_prompt,
             conversation_id=conversation_id,
             attack_identifier=self._attack_identifier,
-            labels=labels,
+            labels=labels,  # deprecated
         )
 
     async def initialize_context_async(

--- a/pyrit/executor/attack/multi_turn/crescendo.py
+++ b/pyrit/executor/attack/multi_turn/crescendo.py
@@ -311,7 +311,7 @@ class CrescendoAttack(MultiTurnAttackStrategy[CrescendoAttackContext, CrescendoA
             system_prompt=system_prompt,
             conversation_id=context.session.adversarial_chat_conversation_id,
             attack_identifier=self.get_identifier(),
-            labels=context.memory_labels,
+            labels=context.memory_labels,  # deprecated
         )
 
         # Initialize backtrack count in context

--- a/pyrit/executor/attack/multi_turn/red_teaming.py
+++ b/pyrit/executor/attack/multi_turn/red_teaming.py
@@ -256,7 +256,7 @@ class RedTeamingAttack(MultiTurnAttackStrategy[MultiTurnAttackContext[Any], Atta
             system_prompt=adversarial_system_prompt,
             conversation_id=context.session.adversarial_chat_conversation_id,
             attack_identifier=self.get_identifier(),
-            labels=context.memory_labels,
+            labels=context.memory_labels,  # deprecated
         )
 
     async def _perform_async(self, *, context: MultiTurnAttackContext[Any]) -> AttackResult:

--- a/pyrit/executor/attack/multi_turn/tree_of_attacks.py
+++ b/pyrit/executor/attack/multi_turn/tree_of_attacks.py
@@ -982,7 +982,7 @@ class _TreeOfAttacksNode:
             system_prompt=system_prompt,
             conversation_id=self.adversarial_chat_conversation_id,
             attack_identifier=self._attack_id,
-            labels=self._memory_labels,
+            labels=self._memory_labels,  # deprecated
         )
 
         logger.debug(f"Node {self.node_id}: Using initial seed prompt for first turn")

--- a/pyrit/executor/promptgen/anecdoctor.py
+++ b/pyrit/executor/promptgen/anecdoctor.py
@@ -213,7 +213,7 @@ class AnecdoctorGenerator(
             system_prompt=system_prompt,
             conversation_id=context.conversation_id,
             attack_identifier=self.get_identifier(),
-            labels=context.memory_labels,
+            labels=context.memory_labels,  # deprecated
         )
 
     async def _perform_async(self, *, context: AnecdoctorContext) -> AnecdoctorResult:
@@ -376,7 +376,7 @@ class AnecdoctorGenerator(
             system_prompt=kg_system_prompt,
             conversation_id=kg_conversation_id,
             attack_identifier=self.get_identifier(),
-            labels=self._memory_labels,
+            labels=self._memory_labels,  # deprecated
         )
 
         # Format examples for knowledge graph extraction using few-shot format

--- a/pyrit/models/message.py
+++ b/pyrit/models/message.py
@@ -555,7 +555,7 @@ def construct_response_from_request(
                 role="assistant",
                 original_value=resp_text,
                 conversation_id=request.conversation_id,
-                labels=request.labels,
+                labels=request.labels,  # deprecated
                 prompt_target_identifier=request.prompt_target_identifier,
                 attack_identifier=request.attack_identifier,
                 original_value_data_type=response_type,

--- a/pyrit/models/message_piece.py
+++ b/pyrit/models/message_piece.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union, get_args
 from uuid import uuid4
 
+from pyrit.common.deprecation import print_deprecation_message
 from pyrit.identifiers.component_identifier import ComponentIdentifier
 from pyrit.models.literals import ChatMessageRole, PromptDataType, PromptResponseError
 
@@ -69,6 +70,7 @@ class MessagePiece:
                 Defaults to None.
             sequence: The order of the conversation within a conversation_id. Defaults to -1.
             labels: The labels associated with the memory entry. Several can be standardized. Defaults to None.
+                Deprecated: This parameter will be removed in a release 0.16.0.
             prompt_metadata: The metadata associated with the prompt. This can be specific to any scenarios.
                 Because memory is how components talk with each other, this can be component specific.
                 e.g. the URI from a file uploaded to a blob store, or a document type you want to upload.
@@ -117,6 +119,12 @@ class MessagePiece:
             self.timestamp = timestamp.replace(tzinfo=timezone.utc)
         else:
             self.timestamp = timestamp
+        if labels is not None:
+            print_deprecation_message(
+                old_item="MessagePiece(..., labels=...)",
+                new_item="MessagePiece(...)",
+                removed_in="0.16.0",
+            )
         self.labels = labels or {}
         self.prompt_metadata = prompt_metadata or {}
 
@@ -212,7 +220,7 @@ class MessagePiece:
             source: The piece whose lineage metadata is authoritative.
         """
         self.conversation_id = source.conversation_id
-        self.labels = dict(source.labels)
+        self.labels = dict(source.labels)  # deprecated
         self.attack_identifier = source.attack_identifier
         self.prompt_target_identifier = source.prompt_target_identifier
         self.prompt_metadata = dict(source.prompt_metadata)
@@ -327,7 +335,7 @@ class MessagePiece:
             "conversation_id": self.conversation_id,
             "sequence": self.sequence,
             "timestamp": self.timestamp.isoformat() if self.timestamp else None,
-            "labels": self.labels,
+            "labels": self.labels,  # deprecated
             "targeted_harm_categories": self.targeted_harm_categories if self.targeted_harm_categories else None,
             "prompt_metadata": self.prompt_metadata,
             "converter_identifiers": [conv.to_dict() for conv in self.converter_identifiers],

--- a/pyrit/prompt_normalizer/prompt_normalizer.py
+++ b/pyrit/prompt_normalizer/prompt_normalizer.py
@@ -8,6 +8,7 @@ import traceback
 from typing import Any, Optional
 from uuid import uuid4
 
+from pyrit.common.deprecation import print_deprecation_message
 from pyrit.exceptions import (
     ComponentRole,
     EmptyResponseException,
@@ -80,6 +81,7 @@ class PromptNormalizer:
             response_converter_configurations (list[PromptConverterConfiguration], optional): Configurations for
                 converting the response. Defaults to an empty list.
             labels (Optional[dict[str, str]], optional): Labels associated with the request. Defaults to None.
+                Deprecated: This parameter will be removed in a release 0.16.0.
             attack_identifier (Optional[ComponentIdentifier], optional): Identifier for the attack. Defaults to
                 None.
 
@@ -90,6 +92,12 @@ class PromptNormalizer:
             Exception: If an error occurs during the request processing.
             ValueError: If the message pieces are not part of the same sequence.
         """
+        if labels is not None:
+            print_deprecation_message(
+                old_item="send_prompt_async(..., labels=...)",
+                new_item="send_prompt_async(...)",
+                removed_in="0.16.0",
+            )
         # Validates that the MessagePieces in the Message are part of the same sequence
         request_converter_configurations = request_converter_configurations or []
         response_converter_configurations = response_converter_configurations or []
@@ -103,7 +111,7 @@ class PromptNormalizer:
         for piece in request.message_pieces:
             piece.conversation_id = conversation_id
             if labels:
-                piece.labels = labels
+                piece.labels = labels  # deprecated
             piece.prompt_target_identifier = target.get_identifier()
             if attack_identifier:
                 piece.attack_identifier = attack_identifier

--- a/pyrit/prompt_target/common/prompt_chat_target.py
+++ b/pyrit/prompt_target/common/prompt_chat_target.py
@@ -3,6 +3,7 @@
 
 from typing import Optional
 
+from pyrit.common.deprecation import print_deprecation_message
 from pyrit.identifiers import ComponentIdentifier
 from pyrit.models import MessagePiece
 from pyrit.models.json_response_config import _JsonResponseConfig
@@ -70,7 +71,7 @@ class PromptChatTarget(PromptTarget):
         system_prompt: str,
         conversation_id: str,
         attack_identifier: Optional[ComponentIdentifier] = None,
-        labels: Optional[dict[str, str]] = None,
+        labels: Optional[dict[str, str]] = None,  # deprecated
     ) -> None:
         """
         Set the system prompt for the prompt target. May be overridden by subclasses.
@@ -78,6 +79,12 @@ class PromptChatTarget(PromptTarget):
         Raises:
             RuntimeError: If the conversation already exists.
         """
+        if labels is not None:
+            print_deprecation_message(
+                old_item="set_system_prompt(..., labels=...)",
+                new_item="set_system_prompt(...)",
+                removed_in="0.16.0",
+            )
         messages = self._memory.get_conversation(conversation_id=conversation_id)
 
         if messages:
@@ -91,7 +98,7 @@ class PromptChatTarget(PromptTarget):
                 converted_value=system_prompt,
                 prompt_target_identifier=self.get_identifier(),
                 attack_identifier=attack_identifier,
-                labels=labels,
+                labels=labels,  # deprecated
             ).to_message()
         )
 

--- a/pyrit/prompt_target/openai/openai_response_target.py
+++ b/pyrit/prompt_target/openai/openai_response_target.py
@@ -678,7 +678,7 @@ class OpenAIResponseTarget(OpenAITarget, PromptChatTarget):
             role="assistant",
             original_value=piece_value,
             conversation_id=message_piece.conversation_id,
-            labels=message_piece.labels,
+            labels=message_piece.labels,  # deprecated
             prompt_target_identifier=message_piece.prompt_target_identifier,
             attack_identifier=message_piece.attack_identifier,
             original_value_data_type=piece_type,
@@ -786,7 +786,7 @@ class OpenAIResponseTarget(OpenAITarget, PromptChatTarget):
             ),
             original_value_data_type="function_call_output",
             conversation_id=reference_piece.conversation_id,
-            labels={"call_id": call_id},
+            labels={"call_id": call_id},  # deprecated
             prompt_target_identifier=reference_piece.prompt_target_identifier,
             attack_identifier=reference_piece.attack_identifier,
         )

--- a/pyrit/prompt_target/playwright_copilot_target.py
+++ b/pyrit/prompt_target/playwright_copilot_target.py
@@ -243,7 +243,7 @@ class PlaywrightCopilotTarget(PromptTarget):
                     role="assistant",
                     original_value=piece_data,
                     conversation_id=request_piece.conversation_id,
-                    labels=request_piece.labels,
+                    labels=request_piece.labels,  # deprecated
                     prompt_target_identifier=request_piece.prompt_target_identifier,
                     attack_identifier=request_piece.attack_identifier,
                     original_value_data_type=piece_type,

--- a/pyrit/prompt_target/text_target.py
+++ b/pyrit/prompt_target/text_target.py
@@ -87,7 +87,7 @@ class TextTarget(PromptTarget):
                     original_value_data_type=row.get("data_type", None),  # type: ignore[arg-type]
                     conversation_id=row.get("conversation_id", None),
                     sequence=int(sequence_str) if sequence_str else 0,
-                    labels=labels,
+                    labels=labels,  # deprecated
                     response_error=row.get("response_error", None),  # type: ignore[arg-type]
                     prompt_target_identifier=self.get_identifier(),
                 )

--- a/pyrit/score/conversation_scorer.py
+++ b/pyrit/score/conversation_scorer.py
@@ -84,7 +84,7 @@ class ConversationScorer(Scorer, ABC):
                     converted_value=conversation_text,
                     id=original_piece.id,
                     conversation_id=original_piece.conversation_id,
-                    labels=original_piece.labels,
+                    labels=original_piece.labels,  # deprecated
                     prompt_target_identifier=original_piece.prompt_target_identifier,
                     attack_identifier=original_piece.attack_identifier,
                     original_value_data_type=original_piece.original_value_data_type,

--- a/tests/unit/backend/test_mappers.py
+++ b/tests/unit/backend/test_mappers.py
@@ -691,6 +691,29 @@ class TestRequestToPyritMessage:
         assert result.message_pieces[0].conversation_id == "conv-1"
         assert result.message_pieces[0].sequence == 0
 
+    def test_labels_emit_deprecation_warning(self) -> None:
+        """Test that passing labels emits deprecation warning through mapper helper."""
+        request = MagicMock()
+        request.role = "user"
+        piece = MagicMock()
+        piece.data_type = "text"
+        piece.original_value = "hello"
+        piece.converted_value = None
+        piece.prompt_metadata = None
+        piece.mime_type = None
+        piece.original_prompt_id = None
+        request.pieces = [piece]
+
+        with patch("pyrit.backend.mappers.attack_mappers.print_deprecation_message") as mock_deprecation:
+            request_to_pyrit_message(
+                request=request,
+                conversation_id="conv-1",
+                sequence=0,
+                labels={"env": "prod"},
+            )
+
+        assert mock_deprecation.call_count == 2
+
 
 class TestRequestPieceToPyritMessagePiece:
     """Tests for request_piece_to_pyrit_message_piece function."""
@@ -810,6 +833,27 @@ class TestRequestPieceToPyritMessagePiece:
         )
 
         assert result.labels == {"env": "prod"}
+
+    def test_labels_emit_deprecation_warning(self) -> None:
+        """Test that passing labels emits deprecation warning."""
+        piece = MagicMock()
+        piece.data_type = "text"
+        piece.original_value = "hello"
+        piece.converted_value = None
+        piece.mime_type = None
+        piece.prompt_metadata = None
+        piece.original_prompt_id = None
+
+        with patch("pyrit.backend.mappers.attack_mappers.print_deprecation_message") as mock_deprecation:
+            request_piece_to_pyrit_message_piece(
+                piece=piece,
+                role="user",
+                conversation_id="conv-1",
+                sequence=0,
+                labels={"env": "prod"},
+            )
+
+        mock_deprecation.assert_called_once()
 
     def test_labels_default_to_empty_dict(self) -> None:
         """Test that labels default to empty dict when not provided."""

--- a/tests/unit/executor/attack/component/test_conversation_manager.py
+++ b/tests/unit/executor/attack/component/test_conversation_manager.py
@@ -19,7 +19,7 @@ Helper functions include:
 
 import uuid
 from typing import Optional
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from unit.mocks import get_mock_scorer_identifier
@@ -370,6 +370,24 @@ class TestGetAdversarialChatMessages:
 
         assert result[0].get_piece().labels == labels
 
+    def test_labels_emit_deprecation_warning(self) -> None:
+        """Test that passing labels emits deprecation warning."""
+        piece = MessagePiece(role="user", original_value="Message", conversation_id="original")
+        messages = [Message(message_pieces=[piece])]
+
+        with patch(
+            "pyrit.executor.attack.component.conversation_manager.print_deprecation_message"
+        ) as mock_deprecation:
+            get_adversarial_chat_messages(
+                messages,
+                adversarial_chat_conversation_id="adversarial_conv",
+                attack_identifier=ComponentIdentifier(class_name="TestAttack", class_module="test_module"),
+                adversarial_chat_target_identifier=_mock_target_id("adversarial_target"),
+                labels={"env": "prod"},
+            )
+
+        mock_deprecation.assert_called_once()
+
 
 class TestBuildConversationContextStringAsync:
     """Tests for the build_conversation_context_string_async helper function."""
@@ -641,6 +659,24 @@ class TestSystemPromptHandling:
         mock_chat_target.set_system_prompt.assert_called_once()
         call_args = mock_chat_target.set_system_prompt.call_args
         assert call_args.kwargs["labels"] is None
+
+    def test_set_system_prompt_labels_emit_deprecation_warning(
+        self, attack_identifier: ComponentIdentifier, mock_chat_target: MagicMock
+    ) -> None:
+        """Test that passing labels emits deprecation warning."""
+        manager = ConversationManager(attack_identifier=attack_identifier)
+
+        with patch(
+            "pyrit.executor.attack.component.conversation_manager.print_deprecation_message"
+        ) as mock_deprecation:
+            manager.set_system_prompt(
+                target=mock_chat_target,
+                conversation_id=str(uuid.uuid4()),
+                system_prompt="You are a helpful assistant",
+                labels={"type": "system"},
+            )
+
+        mock_deprecation.assert_called_once()
 
 
 # =============================================================================

--- a/tests/unit/models/test_message_piece.py
+++ b/tests/unit/models/test_message_piece.py
@@ -1121,6 +1121,13 @@ class TestMessagePieceDeprecationWarnings:
         deprecation_msgs = [x for x in w if issubclass(x.category, DeprecationWarning)]
         assert not any("targeted_harm_categories" in str(m.message) for m in deprecation_msgs)
 
+    def test_labels_emits_deprecation_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            MessagePiece(role="user", original_value="Hello", labels={"env": "prod"})
+        deprecation_msgs = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert any("labels" in str(m.message) for m in deprecation_msgs)
+
 
 class TestCopyLineageFrom:
     """Tests for MessagePiece.copy_lineage_from."""

--- a/tests/unit/prompt_normalizer/test_prompt_normalizer.py
+++ b/tests/unit/prompt_normalizer/test_prompt_normalizer.py
@@ -137,6 +137,23 @@ async def test_send_prompt_async_no_response_adds_memory(mock_memory_instance, s
 
 
 @pytest.mark.asyncio
+async def test_send_prompt_async_labels_emit_deprecation_warning(mock_memory_instance, seed_group):
+    prompt_target = MagicMock()
+    prompt_target.send_prompt_async = AsyncMock(
+        return_value=[MessagePiece(role="assistant", original_value="ok", conversation_id="conv-1").to_message()]
+    )
+    prompt_target.get_identifier.return_value = get_mock_target_identifier("MockTarget")
+
+    normalizer = PromptNormalizer()
+    message = Message.from_prompt(prompt=seed_group.prompts[0].value, role="user")
+
+    with patch("pyrit.prompt_normalizer.prompt_normalizer.print_deprecation_message") as mock_deprecation:
+        await normalizer.send_prompt_async(message=message, target=prompt_target, labels={"env": "prod"})
+
+    mock_deprecation.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_send_prompt_async_empty_response_exception_handled(mock_memory_instance, seed_group):
     # Use MagicMock with send_prompt_async as AsyncMock to avoid coroutine warnings on other methods
     prompt_target = MagicMock()

--- a/tests/unit/prompt_target/test_prompt_chat_target.py
+++ b/tests/unit/prompt_target/test_prompt_chat_target.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 import warnings
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from unit.mocks import MockPromptTarget, get_mock_attack_identifier
@@ -50,6 +50,21 @@ def test_set_system_prompt_raises_if_conversation_exists():
     # but MockPromptTarget overrides it. Test the base class directly via a concrete subclass.
     # We test using the real PromptChatTarget.set_system_prompt by calling it on a
     # target that uses the real implementation.
+
+
+@pytest.mark.usefixtures("patch_central_database")
+def test_base_set_system_prompt_labels_emit_deprecation_warning():
+    target = MockPromptTarget()
+
+    with patch("pyrit.prompt_target.common.prompt_chat_target.print_deprecation_message") as mock_deprecation:
+        PromptChatTarget.set_system_prompt(
+            target,
+            system_prompt="You are a helpful assistant.",
+            conversation_id="conv-base-1",
+            labels={"key": "value"},
+        )
+
+    mock_deprecation.assert_called_once()
 
 
 @pytest.mark.usefixtures("patch_central_database")


### PR DESCRIPTION
Follow up on #1624 

As part of deprecating message_piece labels in favor of attack_result ones, this PR makes changes to emit deprecation warnings when message_piece is constructed with labels, along with all the upstream APIs that accept labels and use it to construct a message_piece with it

A follow-up to this will be made to completely remove references to message_piece labels (for release 0.16.0)