### PR TITLE
MAINT FIX: Fix ReadTheDocs config validation error

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,7 +17,6 @@ build:
     build:
       html:
         - cd doc && jupyter-book build --all
-      commands:
         - mkdir -p $READTHEDOCS_OUTPUT/html
         - cp -r doc/_build/site/* $READTHEDOCS_OUTPUT/html/
 


### PR DESCRIPTION
The `commands` key under `build.jobs.build` is not valid — only format keys (`html`, `pdf`, `epub`, `htmlzip`) are allowed. This moves the `mkdir`/`cp` commands into the `html` build step to fix the config validation error.
