### PR TITLE
FIX: RTD build - use --group dev for PEP 735 dependency groups

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
     nodejs: "20"
   jobs:
     install:
-      - pip install .[dev]
+      - pip install . --group dev
     pre_build:
       - python build_scripts/pydoc2json.py pyrit --submodules -o doc/_api/pyrit_all.json
       - python build_scripts/gen_api_md.py


### PR DESCRIPTION
## Problem

ReadTheDocs build fails with `ModuleNotFoundError: No module named 'griffe'`.

PR #1674 moved dev dependencies from `[project.optional-dependencies]` to `[dependency-groups]` (PEP 735). The `.readthedocs.yaml` still used `pip install .[dev]`, which only reads `[project.optional-dependencies]`, so griffe/jupyter-book were never installed.

## Fix

Change `pip install .[dev]` to `pip install . --group dev`, which is the correct pip 25+ syntax for PEP 735 dependency groups. RTD uses pip 25.2, so this is supported.
