### PR TITLE
FIX Updates to address Integration Test failures (Likert notebook + dict identifier)

### DIFF
--- a/doc/code/scoring/4_likert_scorers.ipynb
+++ b/doc/code/scoring/4_likert_scorers.ipynb
@@ -31,13 +31,13 @@
     }
    ],
    "source": [
-    "from pyrit.prompt_target import OpenAIResponseTarget\n",
+    "from pyrit.prompt_target import OpenAIChatTarget\n",
     "from pyrit.score import LikertScalePaths, SelfAskLikertScorer\n",
     "from pyrit.setup import IN_MEMORY, initialize_pyrit_async\n",
     "\n",
     "await initialize_pyrit_async(memory_db_type=IN_MEMORY)  # type: ignore\n",
     "\n",
-    "self_ask_target = OpenAIResponseTarget()\n",
+    "self_ask_target = OpenAIChatTarget()\n",
     "\n",
     "political_misinfo_scorer = SelfAskLikertScorer(\n",
     "    likert_scale=LikertScalePaths.MISINFORMATION_SCALE, chat_target=self_ask_target\n",
@@ -76,7 +76,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,

--- a/doc/code/scoring/4_likert_scorers.py
+++ b/doc/code/scoring/4_likert_scorers.py
@@ -19,13 +19,13 @@
 #
 
 # %%
-from pyrit.prompt_target import OpenAIResponseTarget
+from pyrit.prompt_target import OpenAIChatTarget
 from pyrit.score import LikertScalePaths, SelfAskLikertScorer
 from pyrit.setup import IN_MEMORY, initialize_pyrit_async
 
 await initialize_pyrit_async(memory_db_type=IN_MEMORY)  # type: ignore
 
-self_ask_target = OpenAIResponseTarget()
+self_ask_target = OpenAIChatTarget()
 
 political_misinfo_scorer = SelfAskLikertScorer(
     likert_scale=LikertScalePaths.MISINFORMATION_SCALE, chat_target=self_ask_target

--- a/tests/integration/datasets/test_seed_dataset_provider_integration.py
+++ b/tests/integration/datasets/test_seed_dataset_provider_integration.py
@@ -14,6 +14,7 @@ from pyrit.datasets.seed_datasets.remote import _SimpleSafetyTestsDataset, _XSTe
 from pyrit.datasets.seed_datasets.seed_metadata import (
     SeedDatasetFilter,
 )
+from pyrit.identifiers.component_identifier import ComponentIdentifier
 from pyrit.models import SeedDataset, SeedPrompt
 
 logger = logging.getLogger(__name__)
@@ -676,7 +677,7 @@ class TestHarmbenchMetadataInScenario:
 
         # Mock scorer to avoid Azure dependency
         mock_scorer = MagicMock(spec=TrueFalseScorer)
-        mock_scorer.get_identifier.return_value = {"__type__": "MockScorer"}
+        mock_scorer.get_identifier.return_value = ComponentIdentifier.from_dict({"__type__": "MockScorer"})
 
         target = TextTarget()
         rta = RedTeamAgent(

--- a/tests/integration/memory/test_azure_sql_memory_integration.py
+++ b/tests/integration/memory/test_azure_sql_memory_integration.py
@@ -465,7 +465,9 @@ async def test_scenario_result_scorer_identifier_roundtrip(azuresql_instance: Az
                 name=f"Scorer Test Scenario {test_id}",
                 scenario_version=1,
             ),
-            objective_target_identifier={"endpoint": f"https://test-{test_id}.example.com"},
+            objective_target_identifier=ComponentIdentifier.from_dict(
+                {"endpoint": f"https://test-{test_id}.example.com"}
+            ),
             attack_results={},
             objective_scorer_identifier=scorer_identifier,
             labels={"test_id": test_id},
@@ -504,21 +506,21 @@ async def test_get_scenario_results_by_labels(azuresql_instance: AzureSQLMemory)
         scorer_id = get_test_scorer_identifier()
         scenario1 = ScenarioResult(
             scenario_identifier=ScenarioIdentifier(name=f"Test Scenario 1 {test_id}", scenario_version=1),
-            objective_target_identifier={"endpoint": "https://api.openai.com"},
+            objective_target_identifier=ComponentIdentifier.from_dict({"endpoint": "https://api.openai.com"}),
             attack_results={},
             objective_scorer_identifier=scorer_id,
             labels={"environment": "test", "priority": "high", "team": "red", "test_id": test_id},
         )
         scenario2 = ScenarioResult(
             scenario_identifier=ScenarioIdentifier(name=f"Test Scenario 2 {test_id}", scenario_version=1),
-            objective_target_identifier={"endpoint": "https://api.azure.com"},
+            objective_target_identifier=ComponentIdentifier.from_dict({"endpoint": "https://api.azure.com"}),
             attack_results={},
             objective_scorer_identifier=scorer_id,
             labels={"environment": "test", "priority": "high", "test_id": test_id},
         )
         scenario3 = ScenarioResult(
             scenario_identifier=ScenarioIdentifier(name=f"Test Scenario 3 {test_id}", scenario_version=1),
-            objective_target_identifier={"endpoint": "https://api.anthropic.com"},
+            objective_target_identifier=ComponentIdentifier.from_dict({"endpoint": "https://api.anthropic.com"}),
             attack_results={},
             objective_scorer_identifier=scorer_id,
             labels={"environment": "prod", "test_id": test_id},
@@ -565,25 +567,33 @@ async def test_get_scenario_results_by_target_endpoint(azuresql_instance: AzureS
         scorer_id = get_test_scorer_identifier()
         scenario1 = ScenarioResult(
             scenario_identifier=ScenarioIdentifier(name=f"OpenAI Test {test_id}", scenario_version=1),
-            objective_target_identifier={"endpoint": f"https://api-{test_id}.openai.com/v1/chat"},
+            objective_target_identifier=ComponentIdentifier.from_dict(
+                {"endpoint": f"https://api-{test_id}.openai.com/v1/chat"}
+            ),
             attack_results={},
             objective_scorer_identifier=scorer_id,
         )
         scenario2 = ScenarioResult(
             scenario_identifier=ScenarioIdentifier(name=f"Azure OpenAI Test {test_id}", scenario_version=1),
-            objective_target_identifier={"endpoint": f"https://myresource-{test_id}.openai.azure.com/openai"},
+            objective_target_identifier=ComponentIdentifier.from_dict(
+                {"endpoint": f"https://myresource-{test_id}.openai.azure.com/openai"}
+            ),
             attack_results={},
             objective_scorer_identifier=scorer_id,
         )
         scenario3 = ScenarioResult(
             scenario_identifier=ScenarioIdentifier(name=f"Anthropic Test {test_id}", scenario_version=1),
-            objective_target_identifier={"endpoint": f"https://api-{test_id}.anthropic.com/v1/messages"},
+            objective_target_identifier=ComponentIdentifier.from_dict(
+                {"endpoint": f"https://api-{test_id}.anthropic.com/v1/messages"}
+            ),
             attack_results={},
             objective_scorer_identifier=scorer_id,
         )
         scenario4 = ScenarioResult(
             scenario_identifier=ScenarioIdentifier(name=f"Azure Other {test_id}", scenario_version=1),
-            objective_target_identifier={"endpoint": f"https://myresource-{test_id}.cognitiveservices.azure.com"},
+            objective_target_identifier=ComponentIdentifier.from_dict(
+                {"endpoint": f"https://myresource-{test_id}.cognitiveservices.azure.com"}
+            ),
             attack_results={},
             objective_scorer_identifier=scorer_id,
         )
@@ -634,25 +644,25 @@ async def test_get_scenario_results_by_target_model_name(azuresql_instance: Azur
         scorer_id = get_test_scorer_identifier()
         scenario1 = ScenarioResult(
             scenario_identifier=ScenarioIdentifier(name=f"GPT-4 Test {test_id}", scenario_version=1),
-            objective_target_identifier={"model_name": f"gpt-4-turbo-{test_id}"},
+            objective_target_identifier=ComponentIdentifier.from_dict({"model_name": f"gpt-4-turbo-{test_id}"}),
             attack_results={},
             objective_scorer_identifier=scorer_id,
         )
         scenario2 = ScenarioResult(
             scenario_identifier=ScenarioIdentifier(name=f"GPT-4 Omni Test {test_id}", scenario_version=1),
-            objective_target_identifier={"model_name": f"gpt-4o-{test_id}"},
+            objective_target_identifier=ComponentIdentifier.from_dict({"model_name": f"gpt-4o-{test_id}"}),
             attack_results={},
             objective_scorer_identifier=scorer_id,
         )
         scenario3 = ScenarioResult(
             scenario_identifier=ScenarioIdentifier(name=f"GPT-3.5 Test {test_id}", scenario_version=1),
-            objective_target_identifier={"model_name": f"gpt-3.5-turbo-{test_id}"},
+            objective_target_identifier=ComponentIdentifier.from_dict({"model_name": f"gpt-3.5-turbo-{test_id}"}),
             attack_results={},
             objective_scorer_identifier=scorer_id,
         )
         scenario4 = ScenarioResult(
             scenario_identifier=ScenarioIdentifier(name=f"Claude Test {test_id}", scenario_version=1),
-            objective_target_identifier={"model_name": f"claude-3-opus-{test_id}"},
+            objective_target_identifier=ComponentIdentifier.from_dict({"model_name": f"claude-3-opus-{test_id}"}),
             attack_results={},
             objective_scorer_identifier=scorer_id,
         )
@@ -710,10 +720,12 @@ async def test_get_scenario_results_combined_filters(azuresql_instance: AzureSQL
             scenario_identifier=ScenarioIdentifier(
                 name=f"Production Test {test_id}", scenario_version=1, pyrit_version="0.4.0"
             ),
-            objective_target_identifier={
-                "endpoint": f"https://api-{test_id}.openai.com",
-                "model_name": f"gpt-4-turbo-{test_id}",
-            },
+            objective_target_identifier=ComponentIdentifier.from_dict(
+                {
+                    "endpoint": f"https://api-{test_id}.openai.com",
+                    "model_name": f"gpt-4-turbo-{test_id}",
+                }
+            ),
             attack_results={},
             objective_scorer_identifier=scorer_id,
             labels={"environment": "prod", "priority": "high", "test_id": test_id},
@@ -723,10 +735,12 @@ async def test_get_scenario_results_combined_filters(azuresql_instance: AzureSQL
             scenario_identifier=ScenarioIdentifier(
                 name=f"Test Environment {test_id}", scenario_version=1, pyrit_version="0.4.0"
             ),
-            objective_target_identifier={
-                "endpoint": f"https://test-{test_id}.openai.com",
-                "model_name": f"gpt-4-turbo-{test_id}",
-            },
+            objective_target_identifier=ComponentIdentifier.from_dict(
+                {
+                    "endpoint": f"https://test-{test_id}.openai.com",
+                    "model_name": f"gpt-4-turbo-{test_id}",
+                }
+            ),
             attack_results={},
             objective_scorer_identifier=scorer_id,
             labels={"environment": "test", "priority": "low", "test_id": test_id},
@@ -736,10 +750,12 @@ async def test_get_scenario_results_combined_filters(azuresql_instance: AzureSQL
             scenario_identifier=ScenarioIdentifier(
                 name=f"Old Version Test {test_id}", scenario_version=1, pyrit_version="0.3.0"
             ),
-            objective_target_identifier={
-                "endpoint": f"https://api-{test_id}.openai.com",
-                "model_name": f"gpt-3.5-turbo-{test_id}",
-            },
+            objective_target_identifier=ComponentIdentifier.from_dict(
+                {
+                    "endpoint": f"https://api-{test_id}.openai.com",
+                    "model_name": f"gpt-3.5-turbo-{test_id}",
+                }
+            ),
             attack_results={},
             objective_scorer_identifier=scorer_id,
             labels={"environment": "prod", "test_id": test_id},

--- a/tests/integration/targets/test_openai_responses_gpt5.py
+++ b/tests/integration/targets/test_openai_responses_gpt5.py
@@ -9,6 +9,7 @@ import uuid
 import jsonschema
 import pytest
 
+from pyrit.identifiers.component_identifier import ComponentIdentifier
 from pyrit.models import MessagePiece
 from pyrit.prompt_target import OpenAIResponseTarget
 
@@ -33,7 +34,7 @@ async def test_openai_responses_gpt5(sqlite_instance, gpt5_args):
         original_value="You are a helpful assistant.",
         original_value_data_type="text",
         conversation_id=conv_id,
-        attack_identifier={"id": str(uuid.uuid4())},
+        attack_identifier=ComponentIdentifier.from_dict({"id": str(uuid.uuid4())}),
     )
     sqlite_instance.add_message_to_memory(request=developer_piece.to_message())
 
@@ -64,7 +65,7 @@ async def test_openai_responses_gpt5_json_schema(sqlite_instance, gpt5_args):
         original_value="You are an expert in the lore of cats.",
         original_value_data_type="text",
         conversation_id=conv_id,
-        attack_identifier={"id": str(uuid.uuid4())},
+        attack_identifier=ComponentIdentifier.from_dict({"id": str(uuid.uuid4())}),
     )
     sqlite_instance.add_message_to_memory(request=developer_piece.to_message())
 
@@ -115,7 +116,7 @@ async def test_openai_responses_gpt5_json_object(sqlite_instance, gpt5_args):
         original_value="You are an expert in the lore of cats.",
         original_value_data_type="text",
         conversation_id=conv_id,
-        attack_identifier={"id": str(uuid.uuid4())},
+        attack_identifier=ComponentIdentifier.from_dict({"id": str(uuid.uuid4())}),
     )
 
     sqlite_instance.add_message_to_memory(request=developer_piece.to_message())


### PR DESCRIPTION
some changes to address failures in integration tests:

1- In this notebook, OpenAIResponseTarget is used right now, which does not have the supports_editable_history capability, so this notebook fails with an error saying:

 ValueError: Target does not satisfy 1 required capability(ies):
E             - Target does not support 'supports_editable_history' and no handling policy exists for it.


this PR fixes that by using a different target in the Likert scorer demo notebook

2- some integration test updates missed in #1685 