### PR TITLE
MAINT: reorder pyrit_conf example initializers, use default font in AddImageTextConverter

### DIFF
--- a/.pyrit_conf_example
+++ b/.pyrit_conf_example
@@ -47,12 +47,12 @@ memory_db_type: sqlite
 initializers:
   - name: simple
   - name: load_default_datasets
-  - name: scorer
   - name: target
     args:
       tags:
         - default
         - scorer
+  - name: scorer
 
 # Operator and Operation Labels
 # ------------------------------

--- a/pyrit/prompt_converter/add_image_text_converter.py
+++ b/pyrit/prompt_converter/add_image_text_converter.py
@@ -41,7 +41,7 @@ class AddImageTextConverter(_BaseImageTextConverter):
         self,
         *args: str,
         img_to_add: str = "",
-        font_name: str = "helvetica.ttf",
+        font_name: str | None = None,
         color: tuple[int, int, int] = (0, 0, 0),
         font_size: int | tuple[int, int] = 15,
         x_pos: int = _UNSET,  # type: ignore[ty:invalid-parameter-default]
@@ -57,7 +57,8 @@ class AddImageTextConverter(_BaseImageTextConverter):
             *args: Deprecated positional argument for img_to_add. Use img_to_add=... instead.
                 Will be removed in version 0.15.0.
             img_to_add (str): File path of image to add text to.
-            font_name (str): Path of font to use. Must be a TrueType font (.ttf). Defaults to "helvetica.ttf".
+            font_name (str | None): Path of font to use. Must be a TrueType font (.ttf).
+                Defaults to None which uses Pillow's built-in default font.
             color (tuple[int, int, int]): Color to print text in, using RGB values. Defaults to (0, 0, 0).
             font_size (int | tuple[int, int]): Font size as a fixed int, or a (min, max) tuple for automatic
                 sizing that shrinks from max down to min to fit text in the bounding box. Defaults to 15.
@@ -108,7 +109,7 @@ class AddImageTextConverter(_BaseImageTextConverter):
             y_pos = 10
         if not img_to_add:
             raise ValueError("Please provide valid image path")
-        if not font_name.endswith(".ttf"):
+        if font_name is not None and not font_name.endswith(".ttf"):
             raise ValueError("The specified font must be a TrueType font with a .ttf extension")
         self._extract_font_size(font_size)
         if bounding_box is not None:
@@ -118,7 +119,7 @@ class AddImageTextConverter(_BaseImageTextConverter):
         self._img_to_add = img_to_add
         self._font_name = font_name
         self._font_size = self._font_size_max
-        self._font_load_failed = False
+        self._font_load_failed = font_name is None
         self._font = self._load_font()
         self._color = color
         self._x_pos = x_pos

--- a/tests/unit/prompt_converter/test_add_image_text_converter.py
+++ b/tests/unit/prompt_converter/test_add_image_text_converter.py
@@ -28,12 +28,11 @@ def large_sample_image(tmp_path):
 def test_add_image_text_converter_initialization(image_text_converter_sample_image):
     converter = AddImageTextConverter(
         img_to_add=image_text_converter_sample_image,
-        font_name="helvetica.ttf",
         color=(255, 255, 255),
         font_size=20,
     )
     assert converter._img_to_add == image_text_converter_sample_image
-    assert converter._font_name == "helvetica.ttf"
+    assert converter._font_name is None
     assert converter._color == (255, 255, 255)
     assert converter._font_size_max == 20
     assert converter._font_size_min == 20
@@ -88,7 +87,7 @@ def test_add_image_text_converter_invalid_font(image_text_converter_sample_image
 
 def test_add_image_text_converter_null_img_to_add():
     with pytest.raises(ValueError):
-        AddImageTextConverter(img_to_add="", font_name="helvetica.ttf")
+        AddImageTextConverter(img_to_add="")
 
 
 def test_add_image_text_converter_fallback_to_default_font(image_text_converter_sample_image, caplog):
@@ -125,7 +124,7 @@ def test_add_image_text_converter_font_size_tuple_zero_min(image_text_converter_
 
 def test_image_text_converter_add_text_to_image(image_text_converter_sample_image):
     converter = AddImageTextConverter(
-        img_to_add=image_text_converter_sample_image, font_name="helvetica.ttf", color=(255, 255, 255)
+        img_to_add=image_text_converter_sample_image, color=(255, 255, 255)
     )
     with Image.open(image_text_converter_sample_image) as image:
         pixels_before = list(image.get_flattened_data())
@@ -143,7 +142,7 @@ async def test_add_image_text_converter_invalid_input_text(image_text_converter_
 
 
 async def test_add_image_text_converter_invalid_file_path():
-    converter = AddImageTextConverter(img_to_add="nonexistent_image.png", font_name="helvetica.ttf")
+    converter = AddImageTextConverter(img_to_add="nonexistent_image.png")
     with pytest.raises(FileNotFoundError):
         assert await converter.convert_async(prompt="Sample Text!", input_type="text")  # type: ignore[arg-type]
 

--- a/tests/unit/prompt_converter/test_add_image_text_converter.py
+++ b/tests/unit/prompt_converter/test_add_image_text_converter.py
@@ -123,9 +123,7 @@ def test_add_image_text_converter_font_size_tuple_zero_min(image_text_converter_
 
 
 def test_image_text_converter_add_text_to_image(image_text_converter_sample_image):
-    converter = AddImageTextConverter(
-        img_to_add=image_text_converter_sample_image, color=(255, 255, 255)
-    )
+    converter = AddImageTextConverter(img_to_add=image_text_converter_sample_image, color=(255, 255, 255))
     with Image.open(image_text_converter_sample_image) as image:
         pixels_before = list(image.get_flattened_data())
     updated_image = converter._add_text_to_image("Sample Text!")


### PR DESCRIPTION
- Changing converter to use default font (which was causing a warning before if the font wasn't installed)
- Fixing the pyrit_conf example to use an order (targets need to be initialized before scorers)