### PR TITLE
FIX default to editable history for OAI response target

### DIFF
--- a/pyrit/prompt_target/openai/openai_response_target.py
+++ b/pyrit/prompt_target/openai/openai_response_target.py
@@ -75,6 +75,7 @@ class OpenAIResponseTarget(OpenAITarget, PromptChatTarget):
             supports_json_output=True,
             supports_multi_message_pieces=True,
             supports_system_prompt=True,
+            supports_editable_history=True,
             input_modalities=frozenset(
                 {
                     frozenset(["text"]),


### PR DESCRIPTION


## Description
default to supports_editable_history = true for OpenAI Response Target since we don't currently support stateful conversation history

## Tests and Documentation
n/a
