### PR TITLE
DOC: Fix trailing-space typo in 4_dataset_coding sample code

### DIFF
--- a/doc/code/datasets/4_dataset_coding.ipynb
+++ b/doc/code/datasets/4_dataset_coding.ipynb
@@ -71,7 +71,7 @@
     "        # Fetch from HuggingFace\n",
     "        data = await self._fetch_from_huggingface(\n",
     "            dataset_name=\"apart/darkbench\",\n",
-    "            config=\"default \",\n",
+    "            config=\"default\",\n",
     "            split=\"train\",\n",
     "            cache=cache,\n",
     "            data_files=\"darkbench.tsv\",\n",
@@ -103,7 +103,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.14.4"
   }
  },
  "nbformat": 4,

--- a/doc/code/datasets/4_dataset_coding.py
+++ b/doc/code/datasets/4_dataset_coding.py
@@ -68,7 +68,7 @@ class SimpleDarkBench(_RemoteDatasetLoader):
         # Fetch from HuggingFace
         data = await self._fetch_from_huggingface(
             dataset_name="apart/darkbench",
-            config="default ",
+            config="default",
             split="train",
             cache=cache,
             data_files="darkbench.tsv",


### PR DESCRIPTION
## What

The `SimpleDarkBench` example in `doc/code/datasets/4_dataset_coding.ipynb` passes `config=\"default \"` (trailing space) to `_fetch_from_huggingface`. The real [`DarkBenchDataset`](https://github.com/microsoft/PyRIT/blob/main/pyrit/datasets/seed_datasets/remote/darkbench_dataset.py) loader uses `config=\"default\"`. The trailing space would cause the HuggingFace API to fail to find the config if anyone copy-pasted the example.

## Why now

Noticed while auditing notebooks that have `execution_count: null` (no cell outputs) on the published docs site (follow-up to #1707). This notebook's only cell defines a class without instantiating it, so the missing output is expected — but the typo is real. Re-executed the notebook for hygiene; the .py and .ipynb stay in sync.