### PR TITLE
DOC: Re-execute 1_class_registry notebook to populate cell outputs

### DIFF
--- a/doc/code/registry/1_class_registry.ipynb
+++ b/doc/code/registry/1_class_registry.ipynb
@@ -15,7 +15,39 @@
    "execution_count": null,
    "id": "1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "./git/PyRIT-wt-class-registry-output/.venv/Lib/site-packages/confusables/__init__.py:46: SyntaxWarning: \"\\*\" is an invalid escape sequence. Such sequences will not work in the future. Did you mean \"\\\\*\"? A raw string is also an option.\n",
+      "  space_regex = \"[\\*_~|`\\-\\.]*\" if include_character_padding else ''\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "./git/PyRIT-wt-class-registry-output/.venv/Lib/site-packages/multiprocess/connection.py:335: SyntaxWarning: 'return' in a 'finally' block\n",
+      "  return f\n",
+      "./git/PyRIT-wt-class-registry-output/.venv/Lib/site-packages/multiprocess/connection.py:337: SyntaxWarning: 'return' in a 'finally' block\n",
+      "  return self._get_more_data(ov, maxsize)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Available scenarios: ['airt.cyber', 'airt.jailbreak', 'airt.leakage', 'airt.psychosocial', 'airt.rapid_response']...\n",
+      "\n",
+      "Cyber:\n",
+      "  Description: Cyber scenario implementation for PyRIT. This scenario tests how willing models ...\n",
+      "\n",
+      "Jailbreak:\n",
+      "  Description: Jailbreak scenario implementation for PyRIT. This scenario tests how vulnerable ...\n"
+     ]
+    }
+   ],
    "source": [
     "from pyrit.registry import ScenarioRegistry\n",
     "\n",
@@ -47,7 +79,16 @@
    "execution_count": null,
    "id": "3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Got class: <class 'pyrit.scenario.scenarios.garak.encoding.Encoding'>\n",
+      "Class name: Encoding\n"
+     ]
+    }
+   ],
    "source": [
     "scenario_class = registry.get_class(\"garak.encoding\")\n",
     "\n",
@@ -70,7 +111,38 @@
    "execution_count": null,
    "id": "5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found default environment files: ['./.pyrit/.env', './.pyrit/.env.local']\n",
+      "Loaded environment file: ./.pyrit/.env\n",
+      "Loaded environment file: ./.pyrit/.env.local\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No new upgrade operations detected.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Scenarios can be instantiated with your target and parameters\n"
+     ]
+    }
+   ],
    "source": [
     "from pyrit.prompt_target import OpenAIChatTarget\n",
     "from pyrit.setup import IN_MEMORY, initialize_pyrit_async\n",
@@ -107,7 +179,20 @@
    "execution_count": null,
    "id": "7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'garak.encoding' registered: True\n",
+      "'nonexistent' registered: False\n",
+      "Total scenarios: 9\n",
+      "  - airt.cyber\n",
+      "  - airt.jailbreak\n",
+      "  - airt.leakage\n"
+     ]
+    }
+   ],
    "source": [
     "# Check if a name is registered\n",
     "print(f\"'garak.encoding' registered: {'garak.encoding' in registry}\")\n",
@@ -136,7 +221,23 @@
    "execution_count": null,
    "id": "9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Available initializers: ['airt', 'load_default_datasets', 'scenario_objective_list', 'scenario_technique', 'scorer']...\n",
+      "\n",
+      "airt:\n",
+      "  Class: AIRTInitializer\n",
+      "  Description: AIRT (AI Red Team) configuration initializer. This initializer provides a unifie...\n",
+      "\n",
+      "load_default_datasets:\n",
+      "  Class: LoadDefaultDatasets\n",
+      "  Description: Load default datasets for all registered scenarios....\n"
+     ]
+    }
+   ],
    "source": [
     "from pyrit.registry import InitializerRegistry\n",
     "\n",
@@ -155,8 +256,17 @@
   }
  ],
  "metadata": {
-  "jupytext": {
-   "main_language": "python"
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## What

`doc/code/registry/1_class_registry.ipynb` was committed with `execution_count: null` on every code cell. As a result, the published docs page at https://microsoft.github.io/PyRIT/code/registry/class_registry/ renders all 5 code cells with no output. Re-executing populates them:

- Cell 1: the list of available scenario names and their metadata (Cyber, Jailbreak, …)
- Cell 3: the resolved class for `garak.encoding`
- Cell 5: pyrit init logs and confirmation that the scenario was instantiated
- Cell 7: registry container operations (`in` / `len` / `iter`)
- Cell 9: the same flow on `InitializerRegistry`

## Notes

- The .py file is untouched; jupytext sync preserved.
- Cell 1 output contains a `SyntaxWarning` from upstream `confusables 1.2.0` (unfixed; see [woodgern/confusables](https://github.com/woodgern/confusables/blob/master/confusables/__init__.py#L46)). I'll audit our use of `confusables` in a follow-up — we may be able to swap it for `confusable_homoglyphs` (already in our deps) or remove it entirely.
- Cell 1 output also contains the `multiprocess` SyntaxWarning addressed by #1709. Once #1709 merges and these notebooks are next re-executed (manually or via `pct_to_ipynb.py` in CI), it will disappear from outputs.
