### PR TITLE
TEST Fix flaky XPIA unit tests by stubbing `workflow._memory`

### DIFF
--- a/tests/unit/executor/workflow/test_xpia.py
+++ b/tests/unit/executor/workflow/test_xpia.py
@@ -91,9 +91,11 @@ def workflow(
     mock_attack_setup_target: MagicMock, mock_scorer: MagicMock, mock_prompt_normalizer: MagicMock
 ) -> XPIAWorkflow:
     """Create an XPIA workflow instance for testing."""
-    return XPIAWorkflow(
+    workflow = XPIAWorkflow(
         attack_setup_target=mock_attack_setup_target, scorer=mock_scorer, prompt_normalizer=mock_prompt_normalizer
     )
+    workflow._memory = MagicMock()
+    return workflow
 
 
 @pytest.mark.usefixtures("patch_central_database")
@@ -237,6 +239,7 @@ class TestXPIAWorkflowPerform:
         workflow = XPIAWorkflow(
             attack_setup_target=mock_attack_setup_target, scorer=None, prompt_normalizer=mock_prompt_normalizer
         )
+        workflow._memory = MagicMock()
 
         # Setup mock responses
         mock_response = MagicMock()


### PR DESCRIPTION

### Problem
Four tests in test_xpia.py were failing in CI with `RuntimeError: memory offline`:

- `test_perform_async_complete_workflow_with_scorer`
- `test_perform_async_workflow_without_scorer`
- `test_perform_async_scorer_returns_empty_list`
- `test_perform_async_scorer_raises_exception`

### Root cause
These tests exercise `XPIAWorkflow._perform_async`, which calls `_execute_processing_async`, which in turn writes the processing response to memory via `self._memory.add_message_to_memory(...)`. Unlike `test_execute_processing_async_adds_to_memory`, the failing tests did not replace `workflow._memory` with a mock, so they depended on a live central memory backend that isn't reliably available in CI.

### Fix
Update the shared `workflow` pytest fixture (and the inline workflow construction in `test_perform_async_workflow_without_scorer`) to stub `workflow._memory` with a `MagicMock`. This keeps the tests properly unit-scoped and isolates them from the real memory backend without changing production behavior.

## Tests and Documentation
Ran updated tests