### PR TITLE
DOC: Re-execute pyrit_initializer notebook to populate cell outputs

### DIFF
--- a/doc/code/setup/pyrit_initializer.ipynb
+++ b/doc/code/setup/pyrit_initializer.ipynb
@@ -34,7 +34,36 @@
    "execution_count": null,
    "id": "2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "./git/PyRIT-wt-pyrit-initializer-output/.venv/Lib/site-packages/confusables/__init__.py:46: SyntaxWarning: \"\\*\" is an invalid escape sequence. Such sequences will not work in the future. Did you mean \"\\\\*\"? A raw string is also an option.\n",
+      "  space_regex = \"[\\*_~|`\\-\\.]*\" if include_character_padding else ''\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "./git/PyRIT-wt-pyrit-initializer-output/.venv/Lib/site-packages/multiprocess/connection.py:335: SyntaxWarning: 'return' in a 'finally' block\n",
+      "  return f\n",
+      "./git/PyRIT-wt-pyrit-initializer-output/.venv/Lib/site-packages/multiprocess/connection.py:337: SyntaxWarning: 'return' in a 'finally' block\n",
+      "  return self._get_more_data(ov, maxsize)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<__main__.CustomInitializer at 0x1d7bda7ae40>"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from pyrit.common.apply_defaults import set_default_value\n",
     "from pyrit.prompt_target import OpenAIChatTarget\n",
@@ -71,7 +100,24 @@
    "execution_count": null,
    "id": "4",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found default environment files: ['./.pyrit/.env', './.pyrit/.env.local']\n",
+      "Loaded environment file: ./.pyrit/.env\n",
+      "Loaded environment file: ./.pyrit/.env.local\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No new upgrade operations detected.\n"
+     ]
+    }
+   ],
    "source": [
     "from pyrit.setup import initialize_pyrit_async\n",
     "from pyrit.setup.initializers import SimpleInitializer\n",
@@ -104,7 +150,18 @@
    "execution_count": null,
    "id": "6",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created: ./AppData/Local/Temp/tmp39v2h43v/custom_init.py\n",
+      "Found default environment files: ['./.pyrit/.env', './.pyrit/.env.local']\n",
+      "Loaded environment file: ./.pyrit/.env\n",
+      "Loaded environment file: ./.pyrit/.env.local\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "import shutil\n",
@@ -162,8 +219,17 @@
   }
  ],
  "metadata": {
-  "jupytext": {
-   "main_language": "python"
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## What

`doc/code/setup/pyrit_initializer.ipynb` was committed with `execution_count: null` on every code cell. As a result, the published docs page at https://microsoft.github.io/PyRIT/code/setup/pyrit_initializer/ renders all 3 code cells with no output. Re-executing populates them:

- Cell 2: the `CustomInitializer` instance repr
- Cell 4: env-file loading + memory init via `SimpleInitializer`
- Cell 6: temp-script creation and initialization via `initialization_scripts`

## Notes

- The .py file is untouched; jupytext sync preserved.
- Cell 2 output contains a `SyntaxWarning` from upstream `confusables 1.2.0` (unfixed; see [woodgern/confusables](https://github.com/woodgern/confusables/blob/master/confusables/__init__.py#L46)). I'll audit our use of `confusables` in a follow-up.
- Cell 2 output also contains the `multiprocess` SyntaxWarning addressed by #1709. Once #1709 merges and these notebooks are next re-executed, it will disappear from outputs.
