### PR TITLE
FIX Docker PyPI build: add missing alembic dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,6 +51,8 @@ COPY --chown=vscode:vscode doc/ /app/doc/
 RUN if [ "$PYRIT_SOURCE" = "pypi" ]; then \
         echo "Installing PyRIT from PyPI version: $PYRIT_VERSION"; \
         uv pip install --python /opt/venv/bin/python pyrit[speech,opencv,fairness_bias,fastapi,playwright]==$PYRIT_VERSION; \
+        echo "Installing alembic (required for DB migrations, may be missing from older PyPI releases)"; \
+        uv pip install --python /opt/venv/bin/python "alembic>=1.16.0"; \
     elif [ "$PYRIT_SOURCE" = "local" ]; then \
         echo "Installing PyRIT from local source"; \
         uv pip install --python /opt/venv/bin/python -e .[speech,opencv,fairness_bias,fastapi,playwright]; \


### PR DESCRIPTION
 ## Problem

  The Test GUI (PyPI) job in the docker_build CI workflow is failing with:

   Error: No module named 'alembic'

  [Failed run](https://github.com/microsoft/PyRIT/actions/runs/25711747893/job/75494156909)

  The PyPI-published version of PyRIT (0.14.0.dev0) was released before alembic>=1.16.0 was added as a dependency in 
  pyproject.toml. When the Docker build installs from PyPI, alembic is not included, but the runtime now requires it
  for database migrations — causing the container to crash on startup.

  The local source build is unaffected because it reads dependencies directly from the current pyproject.toml.

  ## Fix

  Adds an explicit uv pip install "alembic>=1.16.0" step in the Dockerfile's PyPI install path. This ensures the
  Docker image has alembic regardless of whether the published PyPI package declares it.

  Once a new PyRIT version is published to PyPI with alembic in its dependency list, this line becomes a no-op and can
  optionally be removed.

  ## Changes

   - docker/Dockerfile — added alembic install after PyPI package install
