### PR TITLE
MAINT: Tag AtomicAttack(attack=...) deprecation for v0.16.0 removal

### DIFF
--- a/pyrit/scenario/core/atomic_attack.py
+++ b/pyrit/scenario/core/atomic_attack.py
@@ -14,9 +14,9 @@ have a common interface for scenarios.
 """
 
 import logging
-import warnings
 from typing import TYPE_CHECKING, Any, Optional
 
+from pyrit.common.deprecation import print_deprecation_message
 from pyrit.executor.attack import AttackExecutor, AttackStrategy
 from pyrit.executor.attack.core.attack_executor import AttackExecutorResult
 from pyrit.identifiers import build_atomic_attack_identifier
@@ -74,8 +74,8 @@ class AtomicAttack:
                 to ``atomic_attack_name``.
             attack_technique: An AttackTechnique bundling the attack strategy and optional
                 technique seeds. Preferred over the deprecated ``attack`` parameter.
-            attack: Deprecated. The configured attack strategy to execute. Use
-                ``attack_technique`` instead.
+            attack: **Deprecated.** Will be removed in v0.16.0. The configured attack
+                strategy to execute. Use ``attack_technique`` instead.
             seed_groups: List of seed attack groups. Each seed group must
                 have an objective set.
             adversarial_chat: Optional chat target for generating
@@ -99,10 +99,10 @@ class AtomicAttack:
         if attack_technique is not None:
             self._attack_technique = attack_technique
         elif attack is not None:
-            warnings.warn(
-                "The 'attack' parameter is deprecated. Use 'attack_technique=AttackTechnique(attack=...)' instead.",
-                DeprecationWarning,
-                stacklevel=2,
+            print_deprecation_message(
+                old_item="AtomicAttack(attack=...)",
+                new_item="AtomicAttack(attack_technique=AttackTechnique(attack=...))",
+                removed_in="0.16.0",
             )
             self._attack_technique = AttackTechnique(attack=attack)
         else:


### PR DESCRIPTION
## Description

The legacy AtomicAttack(attack=...) constructor kwarg was emitting a `DeprecationWarning` without a removal version, leaving callers (and reviewers) no signal for when the parameter will actually disappear. This change pins it to v0.16.0 so it lines up with the rest of the in-flight scenario churn (`Jailbreak`, `Scam`, `Cyber`, `Psychosocial`, `include_default_baseline`, etc.), all of which already target the same release.

The implementation now routes through the shared `pyrit.common.deprecation.print_deprecation_message` helper instead of a bare `warnings.warn`, which is the established pattern across the codebase for ""kwarg -> replacement kwarg"" deprecations. The docstring for `attack` is also updated to mention the v0.16.0 removal so users see it at API-doc time, not only at runtime. The unused `import warnings` was dropped.

No behavior changes beyond the warning text and call site.

## Tests and Documentation

No new tests; the existing scenario suite covers the deprecated path. Ran `uv run pytest tests/unit/scenario/` locally -- 578 passed. No doc updates needed; the only user-facing doc lives in the constructor docstring, which was updated.