### PR TITLE
MAINT: Defining pyrit.models boundary

### DIFF
--- a/.github/instructions/models.instructions.md
+++ b/.github/instructions/models.instructions.md
@@ -1,0 +1,24 @@
+---
+applyTo: "pyrit/models/**"
+---
+
+# `pyrit.models` Guidelines
+
+## Import Boundary
+
+`pyrit.models` is the canonical data layer. Files in `pyrit/models/` (excluding
+`seeds/`, which is deferred) may import only from:
+
+- the standard library
+- `pydantic`
+- `pyrit.common.deprecation`
+- other `pyrit.models.*` submodules
+
+If a helper needs another `pyrit.*` package, it does not belong on a model —
+put it in that package as a free function or static helper.
+
+The CI test `tests/unit/models/test_import_boundary.py` enforces this using an
+allowlist of known transitional violations, each tagged with the phase that
+removes it. The list must shrink monotonically: removing an import from source
+without also removing its allowlist entry fails the test, and adding a new
+unlisted import also fails the test.

--- a/.github/instructions/models.instructions.md
+++ b/.github/instructions/models.instructions.md
@@ -6,8 +6,8 @@ applyTo: "pyrit/models/**"
 
 ## Import Boundary
 
-`pyrit.models` is the canonical data layer. Files in `pyrit/models/` (excluding
-`seeds/`, which is deferred) may import only from:
+`pyrit.models` is the canonical data layer. Files in `pyrit/models/` may
+import only from:
 
 - the standard library
 - `pydantic`

--- a/.github/instructions/style-guide.instructions.md
+++ b/.github/instructions/style-guide.instructions.md
@@ -152,6 +152,21 @@ from pyrit.common.net_utility import get_httpx_client
 
 Within the same package, import from the specific file to avoid circular imports.
 
+### `pyrit.models` Import Boundary
+
+`pyrit.models` is the canonical data layer. Files in `pyrit/models/` (excluding
+`seeds/`, which is deferred) may import only from the standard library,
+`pydantic`, `pyrit.common.deprecation`, and other `pyrit.models.*` submodules.
+
+If a helper needs another `pyrit.*` package, it does not belong on a model —
+put it in that package as a free function or static helper.
+
+The CI test `tests/unit/models/test_import_boundary.py` enforces this using an
+allowlist of known transitional violations, each tagged with the phase that
+removes it. The list must shrink monotonically: removing an import from source
+without also removing its allowlist entry fails the test, and adding a new
+unlisted import also fails the test.
+
 ## Documentation Standards
 
 ### Docstring Format

--- a/.github/instructions/style-guide.instructions.md
+++ b/.github/instructions/style-guide.instructions.md
@@ -152,21 +152,6 @@ from pyrit.common.net_utility import get_httpx_client
 
 Within the same package, import from the specific file to avoid circular imports.
 
-### `pyrit.models` Import Boundary
-
-`pyrit.models` is the canonical data layer. Files in `pyrit/models/` (excluding
-`seeds/`, which is deferred) may import only from the standard library,
-`pydantic`, `pyrit.common.deprecation`, and other `pyrit.models.*` submodules.
-
-If a helper needs another `pyrit.*` package, it does not belong on a model —
-put it in that package as a free function or static helper.
-
-The CI test `tests/unit/models/test_import_boundary.py` enforces this using an
-allowlist of known transitional violations, each tagged with the phase that
-removes it. The list must shrink monotonically: removing an import from source
-without also removing its allowlist entry fails the test, and adding a new
-unlisted import also fails the test.
-
 ## Documentation Standards
 
 ### Docstring Format

--- a/pyrit/common/deprecation.py
+++ b/pyrit/common/deprecation.py
@@ -3,11 +3,12 @@
 
 from __future__ import annotations
 
+import importlib
 import warnings
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
 
 
 def print_deprecation_message(
@@ -41,3 +42,89 @@ def print_deprecation_message(
         DeprecationWarning,
         stacklevel=3,
     )
+
+
+def deprecated_kwarg(
+    values: Any,
+    *,
+    old_name: str,
+    new_name: str,
+    removed_in: str,
+    model: str,
+) -> Any:
+    """
+    Promote a deprecated kwarg to its new name and emit a DeprecationWarning.
+
+    Designed for use inside a Pydantic ``@model_validator(mode="before")``. If
+    ``values`` is not a dict (e.g. Pydantic passed a model instance), it is
+    returned unchanged. If ``old_name`` is present, it is popped; its value is
+    assigned to ``new_name`` only when ``new_name`` is not already set.
+
+    Args:
+        values: The pre-validation values dict from a Pydantic validator.
+        old_name: The deprecated kwarg name.
+        new_name: The replacement kwarg name.
+        removed_in: The version in which ``old_name`` will be removed.
+        model: A label for the model receiving the kwarg, used in the warning.
+
+    Returns:
+        The (possibly modified) ``values`` argument.
+    """
+    if not isinstance(values, dict):
+        return values
+    if old_name in values:
+        old_value = values.pop(old_name)
+        if new_name not in values:
+            values[new_name] = old_value
+        warnings.warn(
+            f"The '{old_name}' argument to {model} is deprecated and will be "
+            f"removed in {removed_in}. Use '{new_name}' instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+    return values
+
+
+def module_deprecation_getattr(
+    *,
+    old_module: str,
+    target_module: str,
+    names: Iterable[str],
+    removed_in: str,
+) -> Callable[[str], Any]:
+    """
+    Build a module-level ``__getattr__`` that re-exports names from ``target_module``.
+
+    Each name in ``names`` is resolved from ``target_module`` on first access,
+    with a one-time ``DeprecationWarning`` per name. Attribute access for names
+    outside the configured set raises ``AttributeError``. Intended for use as
+    ``__getattr__ = module_deprecation_getattr(...)`` in a shim module's
+    ``__init__.py`` or top-level file.
+
+    Args:
+        old_module: The fully-qualified name of the deprecated module (the shim).
+        target_module: The fully-qualified name of the module to forward to.
+        names: The names to expose via the shim.
+        removed_in: The version in which the shim will be removed.
+
+    Returns:
+        A ``__getattr__`` function suitable for module-level assignment.
+    """
+    name_set = frozenset(names)
+    warned: set[str] = set()
+
+    def __getattr__(name: str) -> Any:  # noqa: N807 - module __getattr__ hook must use this name
+        if name not in name_set:
+            raise AttributeError(f"module {old_module!r} has no attribute {name!r}")
+        if name not in warned:
+            warned.add(name)
+            warnings.warn(
+                f"{old_module}.{name} is deprecated and will be removed in {removed_in}. "
+                f"Use {target_module}.{name} instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        module = importlib.import_module(target_module)
+        return getattr(module, name)
+
+    return __getattr__

--- a/pyrit/common/deprecation.py
+++ b/pyrit/common/deprecation.py
@@ -118,11 +118,10 @@ def module_deprecation_getattr(
             raise AttributeError(f"module {old_module!r} has no attribute {name!r}")
         if name not in warned:
             warned.add(name)
-            warnings.warn(
-                f"{old_module}.{name} is deprecated and will be removed in {removed_in}. "
-                f"Use {target_module}.{name} instead.",
-                DeprecationWarning,
-                stacklevel=2,
+            print_deprecation_message(
+                old_item=f"{old_module}.{name}",
+                new_item=f"{target_module}.{name}",
+                removed_in=removed_in,
             )
         module = importlib.import_module(target_module)
         return getattr(module, name)

--- a/pyrit/models/__init__.py
+++ b/pyrit/models/__init__.py
@@ -4,11 +4,11 @@
 """
 Public model exports for PyRIT core data structures and helpers.
 
-``pyrit.models`` is the canonical data layer. Files in this package (excluding
-``seeds/``, which is deferred) must import only from the standard library,
-``pydantic``, ``pyrit.common.deprecation``, and other ``pyrit.models.*``
-submodules. The CI test ``tests/unit/models/test_import_boundary.py`` enforces
-this. See ``.github/instructions/models.instructions.md`` for the rule.
+``pyrit.models`` is the canonical data layer. Files in this package must
+import only from the standard library, ``pydantic``,
+``pyrit.common.deprecation``, and other ``pyrit.models.*`` submodules. The
+CI test ``tests/unit/models/test_import_boundary.py`` enforces this. See
+``.github/instructions/models.instructions.md`` for the rule.
 """
 
 from pyrit.models.attack_result import AttackOutcome, AttackResult, AttackResultT

--- a/pyrit/models/__init__.py
+++ b/pyrit/models/__init__.py
@@ -8,7 +8,7 @@ Public model exports for PyRIT core data structures and helpers.
 ``seeds/``, which is deferred) must import only from the standard library,
 ``pydantic``, ``pyrit.common.deprecation``, and other ``pyrit.models.*``
 submodules. The CI test ``tests/unit/models/test_import_boundary.py`` enforces
-this. See ``.github/instructions/style-guide.instructions.md`` for the rule.
+this. See ``.github/instructions/models.instructions.md`` for the rule.
 """
 
 from pyrit.models.attack_result import AttackOutcome, AttackResult, AttackResultT

--- a/pyrit/models/__init__.py
+++ b/pyrit/models/__init__.py
@@ -1,7 +1,15 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-"""Public model exports for PyRIT core data structures and helpers."""
+"""
+Public model exports for PyRIT core data structures and helpers.
+
+``pyrit.models`` is the canonical data layer. Files in this package (excluding
+``seeds/``, which is deferred) must import only from the standard library,
+``pydantic``, ``pyrit.common.deprecation``, and other ``pyrit.models.*``
+submodules. The CI test ``tests/unit/models/test_import_boundary.py`` enforces
+this. See ``.github/instructions/style-guide.instructions.md`` for the rule.
+"""
 
 from pyrit.models.attack_result import AttackOutcome, AttackResult, AttackResultT
 from pyrit.models.chat_message import (

--- a/tests/unit/common/test_deprecation.py
+++ b/tests/unit/common/test_deprecation.py
@@ -1,9 +1,15 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import sys
+import types
 import warnings
 
-from pyrit.common.deprecation import print_deprecation_message
+from pyrit.common.deprecation import (
+    deprecated_kwarg,
+    module_deprecation_getattr,
+    print_deprecation_message,
+)
 
 
 def _old_func():
@@ -59,3 +65,157 @@ def test_deprecation_warning_mixed_types():
     assert len(w) == 1
     assert "_OldClass" in str(w[0].message)
     assert "some.new.path" in str(w[0].message)
+
+
+# --- deprecated_kwarg ----------------------------------------------------
+
+
+def test_deprecated_kwarg_promotes_old_to_new():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = deprecated_kwarg(
+            {"old": 42},
+            old_name="old",
+            new_name="new",
+            removed_in="9.9",
+            model="ExampleModel",
+        )
+    assert result == {"new": 42}
+    assert len(w) == 1
+    assert issubclass(w[0].category, DeprecationWarning)
+    assert "old" in str(w[0].message)
+    assert "new" in str(w[0].message)
+    assert "ExampleModel" in str(w[0].message)
+    assert "9.9" in str(w[0].message)
+
+
+def test_deprecated_kwarg_noop_when_only_new_set():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = deprecated_kwarg(
+            {"new": 42},
+            old_name="old",
+            new_name="new",
+            removed_in="9.9",
+            model="ExampleModel",
+        )
+    assert result == {"new": 42}
+    assert len(w) == 0
+
+
+def test_deprecated_kwarg_does_not_overwrite_new_when_both_set():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = deprecated_kwarg(
+            {"old": 42, "new": 7},
+            old_name="old",
+            new_name="new",
+            removed_in="9.9",
+            model="ExampleModel",
+        )
+    assert result == {"new": 7}
+    assert len(w) == 1
+
+
+def test_deprecated_kwarg_passes_through_non_dict():
+    sentinel = object()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = deprecated_kwarg(
+            sentinel,
+            old_name="old",
+            new_name="new",
+            removed_in="9.9",
+            model="ExampleModel",
+        )
+    assert result is sentinel
+    assert len(w) == 0
+
+
+# --- module_deprecation_getattr ------------------------------------------
+
+
+def _make_target_module(name: str) -> types.ModuleType:
+    module = types.ModuleType(name)
+    module.exposed_value = 123
+    module.another_value = "hello"
+    sys.modules[name] = module
+    return module
+
+
+def test_module_deprecation_getattr_resolves_and_warns_once():
+    target = _make_target_module("pyrit_tests_target_module_for_deprecation")
+    try:
+        getter = module_deprecation_getattr(
+            old_module="legacy.module",
+            target_module=target.__name__,
+            names=["exposed_value", "another_value"],
+            removed_in="9.9",
+        )
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            first = getter("exposed_value")
+            second = getter("exposed_value")  # repeat: no new warning
+            other = getter("another_value")  # different name: warns once
+
+        assert first == 123
+        assert second == 123
+        assert other == "hello"
+        assert len(w) == 2
+        messages = [str(item.message) for item in w]
+        assert any("legacy.module.exposed_value" in m for m in messages)
+        assert any("legacy.module.another_value" in m for m in messages)
+        for item in w:
+            assert issubclass(item.category, DeprecationWarning)
+            assert "9.9" in str(item.message)
+            assert target.__name__ in str(item.message)
+    finally:
+        sys.modules.pop(target.__name__, None)
+
+
+def test_module_deprecation_getattr_raises_for_unknown_name():
+    target = _make_target_module("pyrit_tests_target_module_for_deprecation_unknown")
+    try:
+        getter = module_deprecation_getattr(
+            old_module="legacy.module",
+            target_module=target.__name__,
+            names=["exposed_value"],
+            removed_in="9.9",
+        )
+        try:
+            getter("does_not_exist")
+        except AttributeError as exc:
+            assert "legacy.module" in str(exc)
+            assert "does_not_exist" in str(exc)
+        else:
+            raise AssertionError("Expected AttributeError")
+    finally:
+        sys.modules.pop(target.__name__, None)
+
+
+def test_module_deprecation_getattr_warnings_isolated_per_factory():
+    """Each call to the factory has its own one-time-warning state."""
+    target = _make_target_module("pyrit_tests_target_module_for_deprecation_isolated")
+    try:
+        getter_a = module_deprecation_getattr(
+            old_module="legacy.module.a",
+            target_module=target.__name__,
+            names=["exposed_value"],
+            removed_in="9.9",
+        )
+        getter_b = module_deprecation_getattr(
+            old_module="legacy.module.b",
+            target_module=target.__name__,
+            names=["exposed_value"],
+            removed_in="9.9",
+        )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            getter_a("exposed_value")
+            getter_a("exposed_value")  # no warning
+            getter_b("exposed_value")  # warns once (separate factory)
+            getter_b("exposed_value")  # no warning
+        assert len(w) == 2
+    finally:
+        sys.modules.pop(target.__name__, None)

--- a/tests/unit/models/test_import_boundary.py
+++ b/tests/unit/models/test_import_boundary.py
@@ -250,7 +250,7 @@ def test_no_new_lazy_violations() -> None:
     for source, imports in actual_lazy.items():
         known = set(KNOWN_LAZY_VIOLATIONS.get(source, {}).keys())
         for imp in sorted(imports):
-            if imp in known:
+            if imp in ALLOWED_TOP_LEVEL or imp in known:
                 continue
             new_violations.append(f"{source} -> {imp}")
     if new_violations:

--- a/tests/unit/models/test_import_boundary.py
+++ b/tests/unit/models/test_import_boundary.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable  # noqa: F401
 
 MODELS_PACKAGE = Path(pyrit.models.__file__).parent
-EXCLUDE_FILES = frozenset({"__init__.py"})
+EXCLUDE_FILES: frozenset[str] = frozenset()
 
 # Always allowed at module level (in addition to pyrit.models.* self-imports).
 ALLOWED_TOP_LEVEL: frozenset[str] = frozenset(
@@ -109,7 +109,10 @@ KNOWN_LAZY_VIOLATIONS: dict[str, dict[str, str]] = {
 def _module_name_for(path: Path) -> str:
     """Return the dotted module name for a file inside ``pyrit/models/``."""
     rel = path.relative_to(MODELS_PACKAGE).with_suffix("")
-    return "pyrit.models." + ".".join(rel.parts)
+    parts = [p for p in rel.parts if p != "__init__"]
+    if not parts:
+        return "pyrit.models"
+    return "pyrit.models." + ".".join(parts)
 
 
 def _resolve_from_import(node: ast.ImportFrom, source_module: str) -> str:

--- a/tests/unit/models/test_import_boundary.py
+++ b/tests/unit/models/test_import_boundary.py
@@ -5,8 +5,8 @@
 Enforce the ``pyrit.models`` import boundary.
 
 ``pyrit.models`` is the canonical data layer. Files in ``pyrit/models/``
-(excluding ``seeds/``) may import only from stdlib, ``pydantic``,
-``pyrit.common.deprecation``, and other ``pyrit.models.*`` submodules.
+may import only from stdlib, ``pydantic``, ``pyrit.common.deprecation``,
+and other ``pyrit.models.*`` submodules.
 
 This test uses a ratchet pattern: ``KNOWN_TOP_LEVEL_VIOLATIONS`` and
 ``KNOWN_LAZY_VIOLATIONS`` track imports that exist today and are expected to
@@ -14,7 +14,7 @@ disappear in a specific phase. The lists must shrink monotonically — if a know
 violation is no longer in source, this test fails and the entry must be
 removed.
 
-See plan.md / ``.github/instructions/style-guide.instructions.md`` for context.
+See plan.md / ``.github/instructions/models.instructions.md`` for context.
 """
 
 from __future__ import annotations
@@ -61,6 +61,27 @@ KNOWN_TOP_LEVEL_VIOLATIONS: dict[str, dict[str, str]] = {
     "pyrit.models.data_type_serializer": {
         "pyrit.common.path": "phase-8",
     },
+    "pyrit.models.seeds.seed": {
+        "pyrit.common.utils": "seeds-followup",
+        "pyrit.common.yaml_loadable": "seeds-followup",
+    },
+    "pyrit.models.seeds.seed_dataset": {
+        "pyrit.common": "seeds-followup",
+        "pyrit.common.utils": "seeds-followup",
+        "pyrit.common.yaml_loadable": "seeds-followup",
+    },
+    "pyrit.models.seeds.seed_group": {
+        "pyrit.common.yaml_loadable": "seeds-followup",
+    },
+    "pyrit.models.seeds.seed_objective": {
+        "pyrit.common.path": "seeds-followup",
+    },
+    "pyrit.models.seeds.seed_prompt": {
+        "pyrit.common.path": "seeds-followup",
+    },
+    "pyrit.models.seeds.seed_simulated_conversation": {
+        "pyrit.common.path": "seeds-followup",
+    },
 }
 
 # Lazy / TYPE_CHECKING imports of cross-package modules. Same ratchet, tracked
@@ -87,8 +108,8 @@ KNOWN_LAZY_VIOLATIONS: dict[str, dict[str, str]] = {
 
 def _module_name_for(path: Path) -> str:
     """Return the dotted module name for a file inside ``pyrit/models/``."""
-    # path: .../pyrit/models/<file>.py  →  pyrit.models.<file>
-    return f"pyrit.models.{path.stem}"
+    rel = path.relative_to(MODELS_PACKAGE).with_suffix("")
+    return "pyrit.models." + ".".join(rel.parts)
 
 
 def _resolve_from_import(node: ast.ImportFrom, source_module: str) -> str:
@@ -163,8 +184,8 @@ class _ImportCollector(ast.NodeVisitor):
 
 
 def _scan_files() -> list[Path]:
-    """Return the set of ``pyrit/models/*.py`` files in scope (top-level only)."""
-    return sorted(p for p in MODELS_PACKAGE.glob("*.py") if p.name not in EXCLUDE_FILES)
+    """Return all ``pyrit/models/**/*.py`` files in scope."""
+    return sorted(p for p in MODELS_PACKAGE.rglob("*.py") if p.name not in EXCLUDE_FILES)
 
 
 def _analyze(path: Path) -> tuple[str, set[str], set[str]]:
@@ -253,19 +274,8 @@ def test_known_lazy_violations_still_apply() -> None:
         )
 
 
-def test_seeds_excluded() -> None:
-    """Sanity check: seeds/ is excluded from this test until its own refactor."""
-    scanned = _scan_files()
-    seed_files = [p for p in scanned if "seeds" in p.parts]
-    assert not seed_files, (
-        f"seeds/ should not be in scope yet: {seed_files}. "
-        "When the seeds refactor lands, add seeds-specific allowlists and "
-        "include those files in _scan_files()."
-    )
-
-
 def test_scan_finds_expected_files() -> None:
-    """Sanity check: the scanner picks up the known top-level model files."""
+    """Sanity check: the scanner picks up the known model files."""
     scanned = {p.name for p in _scan_files()}
     # A non-exhaustive sample of files that must exist for this test to be meaningful.
     expected = {
@@ -276,6 +286,8 @@ def test_scan_finds_expected_files() -> None:
         "scenario_result.py",
         "storage_io.py",
         "data_type_serializer.py",
+        "seed.py",
+        "seed_dataset.py",
     }
     missing = expected - scanned
     assert not missing, f"Expected pyrit.models files not found by scanner: {missing}"

--- a/tests/unit/models/test_import_boundary.py
+++ b/tests/unit/models/test_import_boundary.py
@@ -1,0 +1,281 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""
+Enforce the ``pyrit.models`` import boundary.
+
+``pyrit.models`` is the canonical data layer. Files in ``pyrit/models/``
+(excluding ``seeds/``) may import only from stdlib, ``pydantic``,
+``pyrit.common.deprecation``, and other ``pyrit.models.*`` submodules.
+
+This test uses a ratchet pattern: ``KNOWN_TOP_LEVEL_VIOLATIONS`` and
+``KNOWN_LAZY_VIOLATIONS`` track imports that exist today and are expected to
+disappear in a specific phase. The lists must shrink monotonically — if a known
+violation is no longer in source, this test fails and the entry must be
+removed.
+
+See plan.md / ``.github/instructions/style-guide.instructions.md`` for context.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+import pyrit.models
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable  # noqa: F401
+
+MODELS_PACKAGE = Path(pyrit.models.__file__).parent
+EXCLUDE_FILES = frozenset({"__init__.py"})
+
+# Always allowed at module level (in addition to pyrit.models.* self-imports).
+ALLOWED_TOP_LEVEL: frozenset[str] = frozenset(
+    {
+        "pyrit.common.deprecation",
+    }
+)
+
+# Transitional known top-level violations. Each entry names the phase that
+# clears it (documentation only — the test does not parse the tag). New
+# violations not in this list fail the test; entries that no longer match
+# source also fail.
+KNOWN_TOP_LEVEL_VIOLATIONS: dict[str, dict[str, str]] = {
+    "pyrit.models.attack_result": {
+        "pyrit.identifiers.atomic_attack_identifier": "phase-2",
+        "pyrit.identifiers.component_identifier": "phase-2",
+    },
+    "pyrit.models.message_piece": {
+        "pyrit.identifiers.component_identifier": "phase-2",
+    },
+    "pyrit.models.message": {
+        "pyrit.common.utils": "phase-4",
+    },
+    "pyrit.models.harm_definition": {
+        "pyrit.common.path": "phase-1",
+    },
+    "pyrit.models.data_type_serializer": {
+        "pyrit.common.path": "phase-8",
+    },
+}
+
+# Lazy / TYPE_CHECKING imports of cross-package modules. Same ratchet, tracked
+# separately so the phase that removes the lazy workaround is explicit.
+KNOWN_LAZY_VIOLATIONS: dict[str, dict[str, str]] = {
+    "pyrit.models.data_type_serializer": {
+        "pyrit.memory": "phase-8",
+        "pyrit.common.path": "phase-8",
+    },
+    "pyrit.models.scenario_result": {
+        "pyrit.identifiers.component_identifier": "phase-2-and-7",
+        "pyrit.identifiers.evaluation_identifier": "phase-2-and-7",
+        "pyrit.score.scorer_evaluation.scorer_metrics": "phase-7",
+        "pyrit.score.scorer_evaluation.scorer_metrics_io": "phase-7",
+    },
+    "pyrit.models.score": {
+        "pyrit.identifiers.component_identifier": "phase-5-and-2",
+    },
+    "pyrit.models.storage_io": {
+        "pyrit.auth": "phase-8",
+    },
+}
+
+
+def _module_name_for(path: Path) -> str:
+    """Return the dotted module name for a file inside ``pyrit/models/``."""
+    # path: .../pyrit/models/<file>.py  →  pyrit.models.<file>
+    return f"pyrit.models.{path.stem}"
+
+
+def _resolve_from_import(node: ast.ImportFrom, source_module: str) -> str:
+    """Return the absolute module name targeted by a ``from ... import ...`` node."""
+    if not node.level:
+        return node.module or ""
+    parts = source_module.split(".")
+    base = parts[: -node.level]
+    if node.module:
+        return ".".join([*base, node.module])
+    return ".".join(base)
+
+
+def _is_typecheck_test(test: ast.expr) -> bool:
+    """Return True iff the expression is ``TYPE_CHECKING`` or ``typing.TYPE_CHECKING``."""
+    if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
+        return True
+    return (
+        isinstance(test, ast.Attribute)
+        and isinstance(test.value, ast.Name)
+        and test.value.id == "typing"
+        and test.attr == "TYPE_CHECKING"
+    )
+
+
+class _ImportCollector(ast.NodeVisitor):
+    """Walk a module AST and bucket ``pyrit.*`` imports into top-level vs lazy."""
+
+    def __init__(self, source_module: str) -> None:
+        self.source_module = source_module
+        self.top_level: set[str] = set()
+        self.lazy: set[str] = set()
+        self._in_lazy = False
+
+    def _record(self, mod: str) -> None:
+        if not mod.startswith("pyrit."):
+            return
+        # pyrit.models.* self-imports are always allowed (we are inside pyrit.models)
+        if mod == "pyrit.models" or mod.startswith("pyrit.models."):
+            return
+        bucket = self.lazy if self._in_lazy else self.top_level
+        bucket.add(mod)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self._record(alias.name)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        mod = _resolve_from_import(node, self.source_module)
+        self._record(mod)
+
+    def _visit_lazy_block(self, body: Iterable[ast.stmt]) -> None:
+        saved = self._in_lazy
+        self._in_lazy = True
+        for child in body:
+            self.visit(child)
+        self._in_lazy = saved
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_lazy_block(node.body)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_lazy_block(node.body)
+
+    def visit_If(self, node: ast.If) -> None:
+        if _is_typecheck_test(node.test):
+            self._visit_lazy_block(node.body)
+            for child in node.orelse:
+                self.visit(child)
+        else:
+            self.generic_visit(node)
+
+
+def _scan_files() -> list[Path]:
+    """Return the set of ``pyrit/models/*.py`` files in scope (top-level only)."""
+    return sorted(p for p in MODELS_PACKAGE.glob("*.py") if p.name not in EXCLUDE_FILES)
+
+
+def _analyze(path: Path) -> tuple[str, set[str], set[str]]:
+    source_module = _module_name_for(path)
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    collector = _ImportCollector(source_module)
+    collector.visit(tree)
+    return source_module, collector.top_level, collector.lazy
+
+
+def _collect_actual_imports() -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    top: dict[str, set[str]] = {}
+    lazy: dict[str, set[str]] = {}
+    for path in _scan_files():
+        source, top_imports, lazy_imports = _analyze(path)
+        top[source] = top_imports
+        lazy[source] = lazy_imports
+    return top, lazy
+
+
+def test_no_new_top_level_violations() -> None:
+    """Module-level pyrit imports outside the allowlist must be listed in KNOWN_TOP_LEVEL_VIOLATIONS."""
+    actual_top, _ = _collect_actual_imports()
+    new_violations: list[str] = []
+    for source, imports in actual_top.items():
+        known = set(KNOWN_TOP_LEVEL_VIOLATIONS.get(source, {}).keys())
+        for imp in sorted(imports):
+            if imp in ALLOWED_TOP_LEVEL or imp in known:
+                continue
+            new_violations.append(f"{source} -> {imp}")
+    if new_violations:
+        pytest.fail(
+            "New top-level pyrit imports in pyrit.models (not allowed):\n  "
+            + "\n  ".join(new_violations)
+            + "\n\nEither remove the import or, if it is transitional, add it to "
+            "KNOWN_TOP_LEVEL_VIOLATIONS in this file with a phase tag."
+        )
+
+
+def test_known_top_level_violations_still_apply() -> None:
+    """Entries in KNOWN_TOP_LEVEL_VIOLATIONS that no longer exist in source must be removed."""
+    actual_top, _ = _collect_actual_imports()
+    stale: list[str] = []
+    for source, allowed in KNOWN_TOP_LEVEL_VIOLATIONS.items():
+        present = actual_top.get(source, set())
+        stale.extend(f"{source} -> {imp}" for imp in allowed if imp not in present)
+    if stale:
+        pytest.fail(
+            "KNOWN_TOP_LEVEL_VIOLATIONS entries that no longer exist in source:\n  "
+            + "\n  ".join(stale)
+            + "\n\nThe allowlist must shrink monotonically. Remove these entries."
+        )
+
+
+def test_no_new_lazy_violations() -> None:
+    """Lazy/TYPE_CHECKING pyrit imports outside the allowlist must be listed in KNOWN_LAZY_VIOLATIONS."""
+    _, actual_lazy = _collect_actual_imports()
+    new_violations: list[str] = []
+    for source, imports in actual_lazy.items():
+        known = set(KNOWN_LAZY_VIOLATIONS.get(source, {}).keys())
+        for imp in sorted(imports):
+            if imp in known:
+                continue
+            new_violations.append(f"{source} -> {imp}")
+    if new_violations:
+        pytest.fail(
+            "New lazy / TYPE_CHECKING pyrit imports in pyrit.models:\n  "
+            + "\n  ".join(new_violations)
+            + "\n\nLazy imports are tracked separately. Add to KNOWN_LAZY_VIOLATIONS "
+            "with a phase tag or remove."
+        )
+
+
+def test_known_lazy_violations_still_apply() -> None:
+    """Entries in KNOWN_LAZY_VIOLATIONS that no longer exist in source must be removed."""
+    _, actual_lazy = _collect_actual_imports()
+    stale: list[str] = []
+    for source, allowed in KNOWN_LAZY_VIOLATIONS.items():
+        present = actual_lazy.get(source, set())
+        stale.extend(f"{source} -> {imp}" for imp in allowed if imp not in present)
+    if stale:
+        pytest.fail(
+            "KNOWN_LAZY_VIOLATIONS entries that no longer exist in source:\n  "
+            + "\n  ".join(stale)
+            + "\n\nThe allowlist must shrink monotonically. Remove these entries."
+        )
+
+
+def test_seeds_excluded() -> None:
+    """Sanity check: seeds/ is excluded from this test until its own refactor."""
+    scanned = _scan_files()
+    seed_files = [p for p in scanned if "seeds" in p.parts]
+    assert not seed_files, (
+        f"seeds/ should not be in scope yet: {seed_files}. "
+        "When the seeds refactor lands, add seeds-specific allowlists and "
+        "include those files in _scan_files()."
+    )
+
+
+def test_scan_finds_expected_files() -> None:
+    """Sanity check: the scanner picks up the known top-level model files."""
+    scanned = {p.name for p in _scan_files()}
+    # A non-exhaustive sample of files that must exist for this test to be meaningful.
+    expected = {
+        "attack_result.py",
+        "message.py",
+        "message_piece.py",
+        "score.py",
+        "scenario_result.py",
+        "storage_io.py",
+        "data_type_serializer.py",
+    }
+    missing = expected - scanned
+    assert not missing, f"Expected pyrit.models files not found by scanner: {missing}"


### PR DESCRIPTION
Adding guardrails to `pyrit.models` and deprecation helpers to help in migrating pyrit.models to only include very slim models.

Contributors: see `pyrit.shared` design for more context [phase 0]