### PR TITLE
FIX test_video_scorer: use tmp_path for sample video so tests are xdist-safe

### DIFF
--- a/tests/unit/score/test_video_scorer.py
+++ b/tests/unit/score/test_video_scorer.py
@@ -30,9 +30,9 @@ def is_opencv_installed():
 
 
 @pytest.fixture(autouse=True)
-def video_converter_sample_video(patch_central_database):
+def video_converter_sample_video(tmp_path, patch_central_database):
     # Create a sample video file
-    video_path = "test_video.mp4"
+    video_path = str(tmp_path / "test_video.mp4")
     width, height = 512, 512
     if is_opencv_installed():
         import cv2  # noqa: F401
@@ -57,9 +57,6 @@ def video_converter_sample_video(patch_central_database):
     )
     message_piece.id = uuid.uuid4()
     yield message_piece
-    # Cleanup the sample video file
-    if os.path.exists(video_path):
-        os.remove(video_path)
 
 
 class MockTrueFalseScorer(TrueFalseScorer):


### PR DESCRIPTION
Fixes #1794.

The `video_converter_sample_video` fixture in `tests/unit/score/test_video_scorer.py` wrote its sample MP4 to a CWD-relative path (`"test_video.mp4"`). Under `pytest-xdist -n auto` (default `--dist=load`), the 17 tests in this file shard across workers that share the same CWD, racing on a single file and producing flaky `FileNotFoundError`s.

CI runs `pytest -n 4 --dist=loadfile` (Makefile) which pins each file to one worker and masks the race, so this only bites devs running the xdist default locally.

### Fix

Inject `tmp_path` into the fixture and place the sample video there. Per-test temp dirs are unique across workers, so the race vanishes. The same pattern is already used by `tests/unit/prompt_converter/test_add_image_video_converter.py`; this brings `test_video_scorer.py` in line.

The explicit `os.path.exists` / `os.remove` teardown is removed -- `tmp_path` cleans itself up.

### Verification

```
# Pre-fix:
pytest tests/unit/score/test_video_scorer.py -n auto   -> 2 failed, 3 passed
pytest tests/unit -n auto                              -> 2 failed in 99s

# Post-fix:
pytest tests/unit/score/test_video_scorer.py -n auto   -> 17 passed in 4.12s
pytest tests/unit -n auto                              -> 8215 passed in 37s
```
