### PR TITLE
FIX: bump transitive idna 3.11 -> 3.16 (Dependabot #169, CVE-2026-45409)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2161,11 +2161,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps the transitive dependency `idna` from **3.11 → 3.16** to address Dependabot alert [#169](https://github.com/microsoft/PyRIT/security/dependabot/169).

## Details

- **Advisory:** [GHSA-65pc-fj4g-8rjx](https://github.com/advisories/GHSA-65pc-fj4g-8rjx) / CVE-2026-45409
- **Severity:** Medium (CVSS v4 6.9)
- **Issue:** Incomplete fix for CVE-2024-3651. Specially crafted inputs to `idna.encode()` (e.g. `"\u0660" * N` or `"\u30fb" * N + "\u6f22"`) reach the `valid_contexto` function prior to length rejection and consume significant CPU for large `N`, leading to denial-of-service.
- **First patched version:** 3.15. This PR ships 3.16, the latest release.

## Scope

- Lockfile-only change. Only `uv.lock` is modified (3 lines).
- `idna` is a transitive dependency (no direct usage in PyRIT).
- Verified with `uv sync --frozen` and a runtime `import idna; idna.__version__` check (reports `3.16`).

Closes Dependabot alert #169.
