### PR TITLE
FIX: use tmp_path for hardcoded test files to fix xdist races

### DIFF
--- a/tests/unit/models/test_seed.py
+++ b/tests/unit/models/test_seed.py
@@ -582,18 +582,18 @@ async def test_hashes_generated_files():
     os.remove(filename)
 
 
-async def test_memory_encoding_metadata_image(sqlite_instance):
+async def test_memory_encoding_metadata_image(tmp_path, sqlite_instance):
     mock_image = Image.new("RGB", (400, 300), (255, 255, 255))
-    mock_image.save("test.png")
+    image_path = str(tmp_path / "test.png")
+    mock_image.save(image_path)
     sp = SeedPrompt(
-        value="test.png",
+        value=image_path,
         data_type="image_path",
     )
     await sqlite_instance.add_seeds_to_memory_async(seeds=[sp], added_by="test")
     entry = sqlite_instance.get_seeds()[0]
     assert len(entry.metadata) == 1
     assert entry.metadata["format"] == "png"
-    os.remove("test.png")
 
 
 @patch("pyrit.models.seeds.seed_prompt.TinyTag")

--- a/tests/unit/prompt_converter/test_add_text_image_converter.py
+++ b/tests/unit/prompt_converter/test_add_text_image_converter.py
@@ -85,18 +85,18 @@ async def test_add_text_image_converter_invalid_input_image() -> None:
         assert await converter.convert_async(prompt="mock_image.png", input_type="image_path")  # type: ignore[arg-type]
 
 
-async def test_add_text_image_converter_convert_async(sqlite_instance) -> None:
+async def test_add_text_image_converter_convert_async(tmp_path, sqlite_instance) -> None:
     converter = AddTextImageConverter(text_to_add="test")
     mock_image = Image.new("RGB", (400, 300), (255, 255, 255))
-    mock_image.save("test.png")
+    image_path = str(tmp_path / "test.png")
+    mock_image.save(image_path)
 
-    converted_image = await converter.convert_async(prompt="test.png", input_type="image_path")
+    converted_image = await converter.convert_async(prompt=image_path, input_type="image_path")
     assert converted_image
     assert converted_image.output_text
     assert converted_image.output_type == "image_path"
     assert os.path.exists(converted_image.output_text)
     os.remove(converted_image.output_text)
-    os.remove("test.png")
 
 
 def test_text_image_converter_input_supported():

--- a/tests/unit/prompt_converter/test_qr_code_converter.py
+++ b/tests/unit/prompt_converter/test_qr_code_converter.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT license.
 
 import os
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -50,17 +49,16 @@ async def test_qr_code_converter_invalid_prompt() -> None:
         await converter.convert_async(prompt="", input_type="text")
 
 
-async def test_qr_code_converter_convert_async() -> None:
+async def test_qr_code_converter_convert_async(tmp_path) -> None:
     converter = QRCodeConverter()
     with patch.object(converter._img_serializer, "get_data_filename") as mock_get_data_filename:
-        expected_filename = Path("sample_file.png").resolve()
+        expected_filename = tmp_path / "sample_file.png"
         mock_get_data_filename.return_value = expected_filename
         qr = await converter.convert_async(prompt="Sample prompt", input_type="text")
         assert qr
         assert str(qr.output_text) == str(expected_filename)
         assert qr.output_type == "image_path"
         assert os.path.exists(qr.output_text)
-        os.remove(qr.output_text)
 
 
 def test_text_image_converter_input_supported():


### PR DESCRIPTION
Fixes the same xdist race as #1795, in three more places.

Three unit tests write to CWD-relative hardcoded paths (`test.png`, `sample_file.png`) and clean them up manually:

- `tests/unit/prompt_converter/test_add_text_image_converter.py`
- `tests/unit/models/test_seed.py`
- `tests/unit/prompt_converter/test_qr_code_converter.py`

Under `pytest -n auto` (default `--dist=load`) workers share CWD and race on these names. Worse, the first two use the same filename `test.png`, so they race across files even under CI's `--dist=loadfile`.

### Fix

Inject `tmp_path` into each test and write under it. Per-test temp dirs are unique per worker; pytest cleans them up, so manual `os.remove` calls go away too. Same surgical pattern as #1795.

### Verification

- `pytest <files>` sequentially: 124 passed in ~25s
- `pytest <files> -n auto` x5 runs: 124 passed every run

### Notes

Investigation and patch were drafted with Copilot CLI assistance during review of #1795; I verified the bug pattern and validated the fix.