### PR TITLE
DOCS: Fix dead URL for Robust Intelligence (Cisco) bibliography entry

### DIFF
--- a/doc/references.bib
+++ b/doc/references.bib
@@ -366,10 +366,10 @@
 
 @misc{robustintelligence2024bypass,
   title     = {Bypassing Meta's {LLaMA} Classifier: A Simple Jailbreak},
-  author    = {{Robust Intelligence}},
+  author    = {Aman Priyanshu},
   year      = {2024},
-  url       = {https://www.robustintelligence.com/blog-posts/bypassing-metas-llama-classifier-a-simple-jailbreak},
-  note      = {Robust Intelligence Blog},
+  url       = {https://blogs.cisco.com/security/bypassing-metas-llama-classifier-a-simple-jailbreak},
+  note      = {Robust Intelligence (now part of Cisco) Blog},
 }
 
 @misc{adversaai2023universal,


### PR DESCRIPTION
The original URL for the `robustintelligence2024bypass` reference in `doc/references.bib` is dead. Robust Intelligence was acquired by Cisco in August 2024, and the blog content was migrated to the Cisco blogs domain.

This PR:

- Updates the `url` from `https://www.robustintelligence.com/blog-posts/bypassing-metas-llama-classifier-a-simple-jailbreak` (404) to `https://blogs.cisco.com/security/bypassing-metas-llama-classifier-a-simple-jailbreak` (the same article at its new home).
- Updates the `author` from the corporate `{{Robust Intelligence}}` to the actual byline on the migrated post, `Aman Priyanshu`.
- Updates the `note` to reflect that Robust Intelligence is now part of Cisco.

No other entries are modified.
