### PR TITLE
MAINT: Formalize JSON-condition helper contract on MemoryInterface

### DIFF
--- a/pyrit/memory/azure_sql_memory.py
+++ b/pyrit/memory/azure_sql_memory.py
@@ -354,7 +354,7 @@ class AzureSQLMemory(MemoryInterface, metaclass=Singleton):
             json_column (InstrumentedAttribute[Any]): The JSON-backed model field to query.
             property_path (str): The JSON path for the property to match.
             value (str): The string value that must match the extracted JSON property value.
-            partial_match (bool): Whether to perform a substring match.
+            partial_match (bool): Whether to perform a substring match. Defaults to False.
             case_sensitive (bool): Whether the match should be case-sensitive. Defaults to False.
 
         Returns:

--- a/pyrit/memory/azure_sql_memory.py
+++ b/pyrit/memory/azure_sql_memory.py
@@ -348,14 +348,7 @@ class AzureSQLMemory(MemoryInterface, metaclass=Singleton):
         case_sensitive: bool = False,
     ) -> Any:
         """
-        Return an Azure SQL DB condition for matching a value at a given path within a JSON object.
-
-        Args:
-            json_column (InstrumentedAttribute[Any]): The JSON-backed model field to query.
-            property_path (str): The JSON path for the property to match.
-            value (str): The string value that must match the extracted JSON property value.
-            partial_match (bool): Whether to perform a substring match.
-            case_sensitive (bool): Whether the match should be case-sensitive. Defaults to False.
+        Azure SQL implementation. See base class for contract.
 
         Returns:
             Any: A SQLAlchemy condition for the backend-specific JSON query.
@@ -396,19 +389,7 @@ class AzureSQLMemory(MemoryInterface, metaclass=Singleton):
         match_mode: Literal["all", "any"] = "all",
     ) -> Any:
         """
-        Return an Azure SQL DB condition for matching an array at a given path within a JSON object.
-
-        Args:
-            json_column (InstrumentedAttribute[Any]): The JSON-backed SQLAlchemy field to query.
-            property_path (str): The JSON path for the target array.
-            array_element_path (Optional[str]): An optional JSON path applied to each array item before matching.
-            array_to_match (Sequence[str]): The array that must match the extracted JSON array values.
-                Combination semantics for multiple entries are controlled by ``match_mode``.
-                If ``array_to_match`` is empty, the condition matches only if the target is also an
-                empty array or None (overloaded "absence" semantics, regardless of ``match_mode``).
-            match_mode (Literal["all", "any"]): How to combine multiple entries in ``array_to_match``.
-                ``"all"`` (default) requires every listed value to be present in the JSON array.
-                ``"any"`` requires at least one listed value to be present.
+        Azure SQL implementation. See base class for contract.
 
         Returns:
             Any: A database-specific SQLAlchemy condition.

--- a/pyrit/memory/azure_sql_memory.py
+++ b/pyrit/memory/azure_sql_memory.py
@@ -348,7 +348,14 @@ class AzureSQLMemory(MemoryInterface, metaclass=Singleton):
         case_sensitive: bool = False,
     ) -> Any:
         """
-        Azure SQL implementation. See base class for contract.
+        Return an Azure SQL DB condition for matching a value at a given path within a JSON object.
+
+        Args:
+            json_column (InstrumentedAttribute[Any]): The JSON-backed model field to query.
+            property_path (str): The JSON path for the property to match.
+            value (str): The string value that must match the extracted JSON property value.
+            partial_match (bool): Whether to perform a substring match.
+            case_sensitive (bool): Whether the match should be case-sensitive. Defaults to False.
 
         Returns:
             Any: A SQLAlchemy condition for the backend-specific JSON query.
@@ -389,7 +396,19 @@ class AzureSQLMemory(MemoryInterface, metaclass=Singleton):
         match_mode: Literal["all", "any"] = "all",
     ) -> Any:
         """
-        Azure SQL implementation. See base class for contract.
+        Return an Azure SQL DB condition for matching an array at a given path within a JSON object.
+
+        Args:
+            json_column (InstrumentedAttribute[Any]): The JSON-backed SQLAlchemy field to query.
+            property_path (str): The JSON path for the target array.
+            array_element_path (Optional[str]): An optional JSON path applied to each array item before matching.
+            array_to_match (Sequence[str]): The array that must match the extracted JSON array values.
+                Combination semantics for multiple entries are controlled by ``match_mode``.
+                If ``array_to_match`` is empty, the condition matches only if the target is also an
+                empty array or None (overloaded "absence" semantics, regardless of ``match_mode``).
+            match_mode (Literal["all", "any"]): How to combine multiple entries in ``array_to_match``.
+                ``"all"`` (default) requires every listed value to be present in the JSON array.
+                ``"any"`` requires at least one listed value to be present.
 
         Returns:
             Any: A database-specific SQLAlchemy condition.

--- a/pyrit/memory/memory_interface.py
+++ b/pyrit/memory/memory_interface.py
@@ -238,6 +238,11 @@ class MemoryInterface(abc.ABC):
         """
         Return a database-specific condition for matching a value at a given path within a JSON object.
 
+        Concrete subclasses translate this contract into their SQL dialect (e.g. SQLite's
+        ``json_extract``, Azure SQL's ``JSON_VALUE`` + ``ISJSON``). Implementations must honor
+        ``partial_match`` and ``case_sensitive`` identically so callers can rely on consistent
+        matching semantics across backends.
+
         Args:
             json_column (InstrumentedAttribute[Any]): The JSON-backed model field to query.
             property_path (str): The JSON path for the property to match.
@@ -261,6 +266,11 @@ class MemoryInterface(abc.ABC):
     ) -> Any:
         """
         Return a database-specific condition for matching an array at a given path within a JSON object.
+
+        Concrete subclasses translate this contract into their SQL dialect (e.g. SQLite's
+        ``json_each`` + ``json_extract``, Azure SQL's ``OPENJSON`` + ``JSON_QUERY``).
+        Implementations must honor ``match_mode`` and the empty-``array_to_match`` "absence"
+        semantics identically so callers can rely on consistent matching across backends.
 
         Args:
             json_column (InstrumentedAttribute[Any]): The JSON-backed SQLAlchemy field to query.

--- a/pyrit/memory/memory_interface.py
+++ b/pyrit/memory/memory_interface.py
@@ -197,7 +197,7 @@ class MemoryInterface(abc.ABC):
                 and the condition should resolve if any element in that array matches the value.
                 Cannot be used with partial_match.
             value (str): The string value that must match the extracted JSON property value.
-            partial_match (bool): Whether to perform a substring match.
+            partial_match (bool): Whether to perform a substring match. Defaults to False.
             case_sensitive (bool): Whether the match should be case-sensitive. Defaults to False.
 
         Returns:
@@ -247,7 +247,7 @@ class MemoryInterface(abc.ABC):
             json_column (InstrumentedAttribute[Any]): The JSON-backed model field to query.
             property_path (str): The JSON path for the property to match.
             value (str): The string value that must match the extracted JSON property value.
-            partial_match (bool): Whether to perform a substring match.
+            partial_match (bool): Whether to perform a substring match. Defaults to False.
             case_sensitive (bool): Whether the match should be case-sensitive. Defaults to False.
 
         Returns:

--- a/pyrit/memory/sqlite_memory.py
+++ b/pyrit/memory/sqlite_memory.py
@@ -220,7 +220,7 @@ class SQLiteMemory(MemoryInterface, metaclass=Singleton):
             json_column (InstrumentedAttribute[Any]): The JSON-backed model field to query.
             property_path (str): The JSON path for the property to match.
             value (str): The string value that must match the extracted JSON property value.
-            partial_match (bool): Whether to perform a substring match.
+            partial_match (bool): Whether to perform a substring match. Defaults to False.
             case_sensitive (bool): Whether the match should be case-sensitive. Defaults to False.
 
         Returns:

--- a/pyrit/memory/sqlite_memory.py
+++ b/pyrit/memory/sqlite_memory.py
@@ -214,7 +214,14 @@ class SQLiteMemory(MemoryInterface, metaclass=Singleton):
         case_sensitive: bool = False,
     ) -> Any:
         """
-        SQLite implementation. See base class for contract.
+        Return a SQLite DB condition for matching a value at a given path within a JSON object.
+
+        Args:
+            json_column (InstrumentedAttribute[Any]): The JSON-backed model field to query.
+            property_path (str): The JSON path for the property to match.
+            value (str): The string value that must match the extracted JSON property value.
+            partial_match (bool): Whether to perform a substring match.
+            case_sensitive (bool): Whether the match should be case-sensitive. Defaults to False.
 
         Returns:
             Any: A SQLAlchemy condition for the backend-specific JSON query.
@@ -240,7 +247,19 @@ class SQLiteMemory(MemoryInterface, metaclass=Singleton):
         match_mode: Literal["all", "any"] = "all",
     ) -> Any:
         """
-        SQLite implementation. See base class for contract.
+        Return a SQLite DB condition for matching an array at a given path within a JSON object.
+
+        Args:
+            json_column (InstrumentedAttribute[Any]): The JSON-backed SQLAlchemy field to query.
+            property_path (str): The JSON path for the target array.
+            array_element_path (Optional[str]): An optional JSON path applied to each array item before matching.
+            array_to_match (Sequence[str]): The array that must match the extracted JSON array values.
+                Combination semantics for multiple entries are controlled by ``match_mode``.
+                If ``array_to_match`` is empty, the condition matches only if the target is also an
+                empty array or None (overloaded "absence" semantics, regardless of ``match_mode``).
+            match_mode (Literal["all", "any"]): How to combine multiple entries in ``array_to_match``.
+                ``"all"`` (default) requires every listed value to be present in the JSON array.
+                ``"any"`` requires at least one listed value to be present.
 
         Returns:
             Any: A database-specific SQLAlchemy condition.

--- a/pyrit/memory/sqlite_memory.py
+++ b/pyrit/memory/sqlite_memory.py
@@ -214,14 +214,7 @@ class SQLiteMemory(MemoryInterface, metaclass=Singleton):
         case_sensitive: bool = False,
     ) -> Any:
         """
-        Return a SQLite DB condition for matching a value at a given path within a JSON object.
-
-        Args:
-            json_column (InstrumentedAttribute[Any]): The JSON-backed model field to query.
-            property_path (str): The JSON path for the property to match.
-            value (str): The string value that must match the extracted JSON property value.
-            partial_match (bool): Whether to perform a substring match.
-            case_sensitive (bool): Whether the match should be case-sensitive. Defaults to False.
+        SQLite implementation. See base class for contract.
 
         Returns:
             Any: A SQLAlchemy condition for the backend-specific JSON query.
@@ -247,19 +240,7 @@ class SQLiteMemory(MemoryInterface, metaclass=Singleton):
         match_mode: Literal["all", "any"] = "all",
     ) -> Any:
         """
-        Return a SQLite DB condition for matching an array at a given path within a JSON object.
-
-        Args:
-            json_column (InstrumentedAttribute[Any]): The JSON-backed SQLAlchemy field to query.
-            property_path (str): The JSON path for the target array.
-            array_element_path (Optional[str]): An optional JSON path applied to each array item before matching.
-            array_to_match (Sequence[str]): The array that must match the extracted JSON array values.
-                Combination semantics for multiple entries are controlled by ``match_mode``.
-                If ``array_to_match`` is empty, the condition matches only if the target is also an
-                empty array or None (overloaded "absence" semantics, regardless of ``match_mode``).
-            match_mode (Literal["all", "any"]): How to combine multiple entries in ``array_to_match``.
-                ``"all"`` (default) requires every listed value to be present in the JSON array.
-                ``"any"`` requires at least one listed value to be present.
+        SQLite implementation. See base class for contract.
 
         Returns:
             Any: A database-specific SQLAlchemy condition.


### PR DESCRIPTION
## What

Tightens the polymorphic contract for `_get_condition_json_property_match` and `_get_condition_json_array_match` on `MemoryInterface`. The abstract decls already existed; this PR adds an explicit "Concrete subclasses translate this contract into their SQL dialect…" sentence to both abstract docstrings so the dialect-divergence reason for the polymorphism is captured in one place.

## Why `@abstractmethod` and not "extract to a shared function"

The two implementations have **identical signatures but completely different SQL** — SQLite uses `json_extract` / `json_each`, Azure SQL uses `JSON_VALUE` / `ISJSON` / `OPENJSON` / `JSON_QUERY`. There is no shared logic to extract; every line is dialect-specific. The right way to formalize the polymorphism is an abstract method on the base, not a shared function or mixin. Callers in `memory_interface.py` (e.g. `get_attack_results`, `_get_condition_json_match`) already dispatch through `self._get_condition_json_*` — this PR just makes the contract those callers depend on explicit and well-documented in one place.

Subclass docstrings are intentionally kept full (not collapsed to "see base class") because the doc builder and IDE hover don't auto-inherit docstrings — whatever is in the file is what renders.

## Verified

- `uv run pytest tests/unit -x -q` — 8049 passed, 118 skipped
- `uv run pre-commit run --all-files` — clean (ruff, ty, etc.)