### PR TITLE
MAINT: Emit deprecation warnings for ContentHarms and Originator aliases

### DIFF
--- a/doc/scanner/0_scanner.md
+++ b/doc/scanner/0_scanner.md
@@ -32,7 +32,7 @@ PyRIT ships with scenarios organized into the following families:
 
 | Family | Scenarios | Documentation |
 |--------|-----------|---------------|
-| **AIRT** | ContentHarms, Psychosocial, Cyber, Jailbreak, Leakage, Scam | [AIRT Scenarios](airt.ipynb) |
+| **AIRT** | RapidResponse, Psychosocial, Cyber, Jailbreak, Leakage, Scam | [AIRT Scenarios](airt.ipynb) |
 | **Benchmark** | AdversarialBenchmark | [Benchmark Scenarios](benchmark.ipynb) |
 | **Foundry** | RedTeamAgent | [Foundry Scenarios](foundry.ipynb) |
 | **Garak** | Encoding | [Garak Scenarios](garak.ipynb) |

--- a/pyrit/models/message_piece.py
+++ b/pyrit/models/message_piece.py
@@ -17,8 +17,31 @@ from pyrit.models.score import Score
 if TYPE_CHECKING:
     from pyrit.models.message import Message
 
-Originator = Literal["attack", "converter", "undefined", "scorer"]
-"""Deprecated: The Originator type alias will be removed in a future release."""
+    Originator = Literal["attack", "converter", "undefined", "scorer"]
+
+
+def __getattr__(name: str) -> Any:
+    """
+    Lazily resolve deprecated module-level aliases.
+
+    Returns:
+        Any: The resolved deprecated alias.
+
+    Raises:
+        AttributeError: If the attribute name is not recognized.
+    """
+    if name == "Originator":
+        print_deprecation_message(
+            old_item="pyrit.models.message_piece.Originator",
+            new_item=(
+                "inline Literal['attack', 'converter', 'undefined', 'scorer'] "
+                "(the type alias is being removed; the originator field itself is "
+                "deprecated and will be removed in 0.15.0)"
+            ),
+            removed_in="0.15.0",
+        )
+        return Literal["attack", "converter", "undefined", "scorer"]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 class MessagePiece:
@@ -50,7 +73,7 @@ class MessagePiece:
         original_value_data_type: PromptDataType = "text",
         converted_value_data_type: Optional[PromptDataType] = None,
         response_error: PromptResponseError = "none",
-        originator: Originator = "undefined",
+        originator: Literal["attack", "converter", "undefined", "scorer"] = "undefined",
         original_prompt_id: Optional[uuid.UUID] = None,
         timestamp: Optional[datetime] = None,
         scores: Optional[list[Score]] = None,

--- a/pyrit/scenario/scenarios/airt/__init__.py
+++ b/pyrit/scenario/scenarios/airt/__init__.py
@@ -3,9 +3,9 @@
 
 """AIRT scenario classes."""
 
-from typing import Any
+import importlib
+from typing import TYPE_CHECKING, Any
 
-from pyrit.scenario.scenarios.airt.content_harms import ContentHarms
 from pyrit.scenario.scenarios.airt.cyber import Cyber
 from pyrit.scenario.scenarios.airt.jailbreak import Jailbreak, JailbreakStrategy
 from pyrit.scenario.scenarios.airt.leakage import Leakage
@@ -13,13 +13,18 @@ from pyrit.scenario.scenarios.airt.psychosocial import Psychosocial, Psychosocia
 from pyrit.scenario.scenarios.airt.rapid_response import RapidResponse
 from pyrit.scenario.scenarios.airt.scam import Scam, ScamStrategy
 
+if TYPE_CHECKING:
+    from pyrit.scenario.scenarios.airt.rapid_response import RapidResponse as ContentHarms  # noqa: F401
+
+    ContentHarmsStrategy = Any
+
 
 def __getattr__(name: str) -> Any:
     """
-    Lazily resolve dynamic strategy classes.
+    Lazily resolve dynamic strategy classes and deprecated aliases.
 
     Returns:
-        Any: The resolved strategy class.
+        Any: The resolved strategy class or deprecated alias.
 
     Raises:
         AttributeError: If the attribute name is not recognized.
@@ -28,8 +33,12 @@ def __getattr__(name: str) -> Any:
         return RapidResponse.get_strategy_class()
     if name == "LeakageStrategy":
         return Leakage.get_strategy_class()
-    if name == "ContentHarmsStrategy":
-        return ContentHarms.get_strategy_class()
+    if name in ("ContentHarms", "ContentHarmsStrategy"):
+        # Delegate to the content_harms module so it can emit the deprecation
+        # warning. We import lazily here to avoid triggering the warning on
+        # every `import pyrit.scenario.scenarios.airt`.
+        content_harms = importlib.import_module("pyrit.scenario.scenarios.airt.content_harms")
+        return getattr(content_harms, name)
     if name == "CyberStrategy":
         return Cyber.get_strategy_class()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/pyrit/scenario/scenarios/airt/content_harms.py
+++ b/pyrit/scenario/scenarios/airt/content_harms.py
@@ -5,28 +5,47 @@
 Deprecated — use ``rapid_response`` instead.
 
 ``ContentHarms`` and ``ContentHarmsStrategy`` are thin aliases kept for
-backward compatibility.  They will be removed in v0.15.0.
+backward compatibility. They will be removed in v0.15.0.
 """
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from pyrit.scenario.scenarios.airt.rapid_response import (
-    RapidResponse as ContentHarms,
-)
+from pyrit.common.deprecation import print_deprecation_message
+
+if TYPE_CHECKING:
+    from pyrit.scenario.scenarios.airt.rapid_response import RapidResponse as ContentHarms  # noqa: F401
+
+    ContentHarmsStrategy = Any
 
 
 def __getattr__(name: str) -> Any:
     """
-    Lazily resolve deprecated strategy class.
+    Lazily resolve deprecated aliases and emit a deprecation warning.
 
     Returns:
-        Any: The resolved strategy class.
+        Any: The resolved alias (``RapidResponse`` or its strategy class).
 
     Raises:
         AttributeError: If the attribute name is not recognized.
     """
+    if name == "ContentHarms":
+        print_deprecation_message(
+            old_item="pyrit.scenario.scenarios.airt.content_harms.ContentHarms",
+            new_item="pyrit.scenario.scenarios.airt.rapid_response.RapidResponse",
+            removed_in="0.15.0",
+        )
+        from pyrit.scenario.scenarios.airt.rapid_response import RapidResponse
+
+        return RapidResponse
     if name == "ContentHarmsStrategy":
-        return ContentHarms.get_strategy_class()
+        print_deprecation_message(
+            old_item="pyrit.scenario.scenarios.airt.content_harms.ContentHarmsStrategy",
+            new_item="pyrit.scenario.scenarios.airt.rapid_response.RapidResponse.get_strategy_class()",
+            removed_in="0.15.0",
+        )
+        from pyrit.scenario.scenarios.airt.rapid_response import RapidResponse
+
+        return RapidResponse.get_strategy_class()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/tests/unit/models/test_message_piece.py
+++ b/tests/unit/models/test_message_piece.py
@@ -1104,6 +1104,19 @@ class TestMessagePieceDeprecationWarnings:
         assert any("labels" in str(m.message) for m in deprecation_msgs)
 
 
+class TestOriginatorTypeAliasDeprecation:
+    """Tests for the deprecated ``Originator`` module-level type alias."""
+
+    def test_originator_alias_emits_deprecation_warning(self):
+        from typing import Literal, get_args
+
+        with pytest.warns(DeprecationWarning, match="Originator"):
+            from pyrit.models.message_piece import Originator
+
+        assert get_args(Originator) == ("attack", "converter", "undefined", "scorer")
+        assert Originator is Literal["attack", "converter", "undefined", "scorer"]
+
+
 class TestCopyLineageFrom:
     """Tests for MessagePiece.copy_lineage_from."""
 

--- a/tests/unit/scenario/test_rapid_response.py
+++ b/tests/unit/scenario/test_rapid_response.py
@@ -501,6 +501,20 @@ class TestDeprecatedAliases:
         assert scenario.name == "RapidResponse"
         assert isinstance(scenario, RapidResponse)
 
+    def test_content_harms_via_airt_package_emits_deprecation_warning(self):
+        """Importing ``ContentHarms`` from the parent ``airt`` package emits the warning."""
+        with pytest.warns(DeprecationWarning, match="ContentHarms"):
+            from pyrit.scenario.scenarios.airt import ContentHarms
+
+        assert ContentHarms is RapidResponse
+
+    def test_content_harms_strategy_via_airt_package_emits_deprecation_warning(self):
+        """Importing ``ContentHarmsStrategy`` from the parent ``airt`` package emits the warning."""
+        with pytest.warns(DeprecationWarning, match="ContentHarmsStrategy"):
+            from pyrit.scenario.scenarios.airt import ContentHarmsStrategy
+
+        assert ContentHarmsStrategy is _strategy_class()
+
 
 # ===========================================================================
 # Registry integration tests

--- a/tests/unit/scenario/test_rapid_response.py
+++ b/tests/unit/scenario/test_rapid_response.py
@@ -479,18 +479,21 @@ class TestDeprecatedAliases:
     """Tests for backward-compatible ContentHarms aliases."""
 
     def test_content_harms_is_rapid_response(self):
-        from pyrit.scenario.scenarios.airt.content_harms import ContentHarms
+        with pytest.warns(DeprecationWarning, match="ContentHarms"):
+            from pyrit.scenario.scenarios.airt.content_harms import ContentHarms
 
         assert ContentHarms is RapidResponse
 
     def test_content_harms_strategy_is_rapid_response_strategy(self):
-        from pyrit.scenario.scenarios.airt.content_harms import ContentHarmsStrategy
+        with pytest.warns(DeprecationWarning, match="ContentHarmsStrategy"):
+            from pyrit.scenario.scenarios.airt.content_harms import ContentHarmsStrategy
 
         assert ContentHarmsStrategy is _strategy_class()
 
     def test_content_harms_instance_name_is_rapid_response(self, mock_objective_scorer):
         """ContentHarms() creates a RapidResponse with name 'RapidResponse'."""
-        from pyrit.scenario.scenarios.airt.content_harms import ContentHarms
+        with pytest.warns(DeprecationWarning, match="ContentHarms"):
+            from pyrit.scenario.scenarios.airt.content_harms import ContentHarms
 
         scenario = ContentHarms(
             objective_scorer=mock_objective_scorer,


### PR DESCRIPTION
Fixes two silent deprecations flagged in the recent code audit. Both target the **0.15.0** removal cycle (matching the existing `originator` parameter deprecation and the `ContentHarms` docstring).

## Case 1 — `pyrit/scenario/scenarios/airt/content_harms.py`

`ContentHarms` and `ContentHarmsStrategy` were silent aliases for `RapidResponse`. Users importing them would get **zero warning** today and a hard break at 0.15.0.

- Rewrote `content_harms.py` so both symbols are resolved lazily via a module-level `__getattr__`, each emitting `print_deprecation_message(removed_in="0.15.0")`.
- Updated `pyrit/scenario/scenarios/airt/__init__.py` to remove the eager `from ... import ContentHarms` (which would have triggered the warning on every `import pyrit.scenario.scenarios.airt`) and instead lazily delegate to `content_harms.__getattr__`.
- Added `TYPE_CHECKING` blocks so IDEs/static type checkers still resolve the symbols.
- Wrapped the affected tests in `tests/unit/scenario/test_rapid_response.py` with `pytest.warns(DeprecationWarning, match="ContentHarms"|"ContentHarmsStrategy")` so they also verify the warning fires.
- Updated `doc/scanner/0_scanner.md` to use `RapidResponse` instead of `ContentHarms`.

## Case 2 — `pyrit/models/message_piece.py`

`Originator = Literal[...]` was marked "deprecated" in a docstring but emitted no warning and had no `removed_in`. It dies with the `originator` parameter at **0.15.0**.

- Inlined the Literal at the only internal use site (`MessagePiece.__init__`) so internal code doesn't trigger the new warning.
- Removed the module-level `Originator = Literal[...]` assignment.
- Added a module-level `__getattr__` that emits the warning and returns the Literal type when the name is imported externally.
- Added `Originator` to the existing `if TYPE_CHECKING:` block for static-analysis support.

## Verification

- `uv run python -W error::DeprecationWarning -c "import pyrit.scenario.scenarios.airt"` — succeeds (package import alone does not trigger the warning).
- `from pyrit.scenario.scenarios.airt.content_harms import ContentHarms` — raises `DeprecationWarning`.
- `from pyrit.scenario.scenarios.airt.content_harms import ContentHarmsStrategy` — raises `DeprecationWarning`.
- `from pyrit.models.message_piece import Originator` — raises `DeprecationWarning`.
- `uv run pytest tests/unit -x -q` — 8049 passed, 118 skipped.
- `uv run pre-commit run --all-files` — clean.