### PR TITLE
FIX: RTD build - add --html flag so static index.html is generated

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,6 +18,9 @@ build:
       - python build_scripts/gen_api_md.py
     build:
       html:
-        - cd doc && jupyter-book build --all
+        # --all builds frontmatter exports (PDF, per doc/myst.yml); --html is
+        # required to produce the static HTML site (_build/html/index.html)
+        # that RTD serves. Mirrors the Makefile's docs-build-all target.
+        - cd doc && jupyter-book build --all --html
         - mkdir -p $READTHEDOCS_OUTPUT/html
-        - cp -r doc/_build/site/* $READTHEDOCS_OUTPUT/html/
+        - cp -r doc/_build/html/* $READTHEDOCS_OUTPUT/html/


### PR DESCRIPTION
## Description

Read the Docs has been silently failing every build with the post-build notification "Your documentation did not generate an `index.html` at its root directory", even though every command in the build returned exit-code 0. None of the recent docs fixes (#1740, #1745, #1793) addressed this because they all targeted *content* issues (TOC entries, image paths, broken cross-references) while the actual failure was a *build-command* issue.

In jupyter-book v2 (myst-cli), `--all` means "build all frontmatter exports" -- for PyRIT that's only the PDF declared in `doc/myst.yml`. It does **not** produce the static HTML site. Generating `_build/html/index.html` requires the explicit `--html` flag. The `Makefile`'s `docs-build-all` target already uses `--all --html --pdf --strict` for exactly this reason; `.readthedocs.yaml` was just never brought into alignment, so the build kept producing only PDF + dynamic site JSON in `_build/site/` (no `index.html`), and the subsequent `cp -r doc/_build/site/* $READTHEDOCS_OUTPUT/html/` copied an HTML-less tree.

This PR adds `--html` to the build command and updates the cp source to `doc/_build/html/`, matching the Makefile.

Verified locally that `doc/_build/html/index.html` is now produced (194 KB, valid `<title>PyRIT Documentation</title>`) along with 1897 site files.

## Tests and Documentation

N/A -- config-only change. Verified locally by running the exact RTD command sequence (`jupyter-book build --all --html` followed by inspecting `doc/_build/html/`) and confirming `index.html` is present. The next RTD build on `main` after this lands will be the real test.