### PR TITLE
FEAT: Add DecodingTrust Machine Ethics dataset loader

### DIFF
--- a/pyrit/datasets/seed_datasets/remote/__init__.py
+++ b/pyrit/datasets/seed_datasets/remote/__init__.py
@@ -51,6 +51,9 @@ from pyrit.datasets.seed_datasets.remote.dangerous_qa_dataset import (
 from pyrit.datasets.seed_datasets.remote.darkbench_dataset import (
     _DarkBenchDataset,
 )  # noqa: F401
+from pyrit.datasets.seed_datasets.remote.decoding_trust_machine_ethics_dataset import (
+    _DecodingTrustMachineEthicsDataset,
+)  # noqa: F401
 from pyrit.datasets.seed_datasets.remote.equitymedqa_dataset import (
     _EquityMedQADataset,
 )  # noqa: F401
@@ -186,6 +189,7 @@ __all__ = [
     "ComicJailbreakTemplateConfig",
     "_DangerousQADataset",
     "_DarkBenchDataset",
+    "_DecodingTrustMachineEthicsDataset",
     "_EquityMedQADataset",
     "_ForbiddenQuestionsDataset",
     "_HarmBenchDataset",

--- a/pyrit/datasets/seed_datasets/remote/decoding_trust_machine_ethics_dataset.py
+++ b/pyrit/datasets/seed_datasets/remote/decoding_trust_machine_ethics_dataset.py
@@ -1,0 +1,308 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import logging
+import re
+from typing import Literal
+
+from pyrit.datasets.seed_datasets.remote.remote_dataset_loader import (
+    _RemoteDatasetLoader,
+)
+from pyrit.models import SeedDataset, SeedPrompt
+
+logger = logging.getLogger(__name__)
+
+
+# Pinned commit SHA of AI-secure/DecodingTrust `main` (2024-09-16). Defined locally
+# rather than shared with the Toxicity loader so each perspective can be re-pinned
+# independently if upstream regenerates one subset but not the others.
+_DECODING_TRUST_COMMIT = "161ae8321ced62f45fcd9ceb412e05b47c603cd4"
+_BASE_URL = f"https://raw.githubusercontent.com/AI-secure/DecodingTrust/{_DECODING_TRUST_COMMIT}/data/machine_ethics/"
+_CSV_URL = f"{_BASE_URL}jiminy_subset.csv"
+
+# Source Morality field uses the pattern "{good|bad}, {self|others}, {1|2|3}".
+# Multiple labels in one row are joined with "\n" (e.g. "bad, others, 2\nbad, self, 2").
+_MORALITY_LABEL_RE = re.compile(r"^(bad|good)\s*,\s*(self|others)\s*,\s*([123])\s*$")
+
+# Required CSV columns. The source file ships extra trailing junk columns
+# ("Unnamed: 8/9/10", "Annotation completed by Dan and Mantas") that we ignore.
+_REQUIRED_COLUMNS = ("Description", "Morality")
+
+
+class _DecodingTrustMachineEthicsDataset(_RemoteDatasetLoader):
+    """
+    Loader for the Machine Ethics perspective of the DecodingTrust benchmark.
+
+    DecodingTrust [1] evaluates LLM trustworthiness across eight perspectives.
+    For Machine Ethics it bundles the human-annotated Jiminy Cricket [2] subset:
+    2091 actions extracted from interactive-fiction games, each labelled by
+    humans with a structured ``Morality`` field of the form
+    ``"{good|bad}, {self|others}, {1|2|3}"`` (with multi-label rows joining
+    multiple labels via ``\\n``). Some rows carry no morality label and
+    represent a neutral baseline.
+
+    The two JSON splits shipped alongside the CSV (``jiminy_train.json``,
+    ``jiminy_test.json``) encode a label vector whose schema is not documented
+    in the DecodingTrust repository and so are intentionally **not** loaded
+    here; they can be added in a follow-up loader once the schema is
+    confirmed against the paper.
+
+    The loader fetches the CSV at runtime from ``raw.githubusercontent.com``
+    (no redistribution) at a pinned commit SHA.
+
+    Per-prompt ``harm_categories`` are derived from each row's ``Morality``
+    label(s) using the source's terminology: ``bad_to_self``, ``bad_to_others``,
+    ``good_to_self``, ``good_to_others``. The intensity (1-3) is not folded
+    into the category name but is preserved per-seed in ``metadata`` so callers
+    can filter or rank by severity.
+
+    References:
+        - Wang et al., 2023. *DecodingTrust: A Comprehensive Assessment of
+          Trustworthiness in GPT Models.* https://arxiv.org/abs/2306.11698
+        - Hendrycks et al., 2021. *What Would Jiminy Cricket Do? Towards
+          Agents That Behave Morally.* https://arxiv.org/abs/2110.13136
+        - https://github.com/AI-secure/DecodingTrust
+
+    License:
+        DecodingTrust is distributed under CC BY-SA 4.0. PyRIT fetches the
+        annotations at runtime and does not redistribute them. Full attribution
+        to both the DecodingTrust authors and the Jiminy Cricket authors is
+        recorded on every ``SeedPrompt`` produced.
+
+    Warning:
+        The dataset describes harmful actions (self-harm, violence, theft,
+        deception) extracted from text-adventure games. Use only for
+        authorised safety and ethics evaluation.
+    """
+
+    # Class-level metadata picked up by _RemoteDatasetLoader._parse_metadata.
+    modalities: list[str] = ["text"]
+    size: str = "large"  # 2091 raw rows; ~1.5k after default morality="bad" filter
+    tags: set[str] = {"default", "safety", "machine_ethics"}
+
+    _AUTHORS: tuple[str, ...] = (
+        # DecodingTrust authors
+        "Boxin Wang",
+        "Weixin Chen",
+        "Hengzhi Pei",
+        "Chulin Xie",
+        "Mintong Kang",
+        "Chenhui Zhang",
+        "Chejian Xu",
+        "Zidi Xiong",
+        "Ritik Dutta",
+        "Rylan Schaeffer",
+        "Sang T. Truong",
+        "Simran Arora",
+        "Mantas Mazeika",
+        "Dan Hendrycks",
+        "Zinan Lin",
+        "Yu Cheng",
+        "Sanmi Koyejo",
+        "Dawn Song",
+        "Bo Li",
+        # Jiminy Cricket authors (whose annotations DecodingTrust uses)
+        "Andy Zou",
+        "Tristan Xiao",
+        "Ryan Jia",
+        "John Kwon",
+        "Jacob Steinhardt",
+    )
+
+    _GROUPS: tuple[str, ...] = (
+        "University of Illinois Urbana-Champaign",
+        "Stanford University",
+        "University of California, Berkeley",
+        "Center for AI Safety",
+        "Microsoft Research",
+        "Allen Institute for Artificial Intelligence",
+        "University of Washington",
+    )
+
+    _DESCRIPTION = (
+        "Machine Ethics perspective of the DecodingTrust benchmark (Wang et al., 2023). "
+        "Loads the human-annotated Jiminy Cricket subset (Hendrycks et al., 2021): "
+        "2091 actions extracted from text-adventure games, each labelled with a "
+        "structured `Morality` field of the form `{good|bad}, {self|others}, {1|2|3}`. "
+        "Per-prompt `harm_categories` are derived from these labels at load time; "
+        "the intensity (1-3) is preserved in `metadata['max_intensity']`."
+    )
+
+    def __init__(
+        self,
+        *,
+        morality: Literal["bad", "good", "neutral", "all"] = "bad",
+        min_intensity: int = 1,
+    ) -> None:
+        """
+        Initialize the DecodingTrust Machine Ethics dataset loader.
+
+        Args:
+            morality: Which rows to retain. ``"bad"`` (default) keeps only rows
+                whose ``Morality`` field contains at least one ``bad, *, *``
+                label — matches the red-teaming use case. ``"good"`` keeps only
+                rows with a ``good, *, *`` label. ``"neutral"`` keeps only
+                unlabelled rows. ``"all"`` retains every row, including
+                unlabelled ones.
+            min_intensity: Minimum max-intensity (1, 2 or 3) to retain a row.
+                Defaults to 1 (no severity filtering). Unlabelled rows have
+                effective intensity 0 and are dropped when ``min_intensity >= 1``
+                under ``morality="all"``.
+        """
+        self.morality: Literal["bad", "good", "neutral", "all"] = morality
+        self.min_intensity = min_intensity
+
+    @property
+    def dataset_name(self) -> str:
+        """Return the dataset name."""
+        return "decoding_trust_machine_ethics"
+
+    async def fetch_dataset_async(self, *, cache: bool = True) -> SeedDataset:
+        """
+        Fetch the DecodingTrust Machine Ethics prompts and return them as a SeedDataset.
+
+        Args:
+            cache: Whether to cache the fetched CSV locally. Defaults to True.
+
+        Returns:
+            SeedDataset: A SeedDataset whose seeds are the selected Jiminy actions.
+
+        Raises:
+            ValueError: If the source CSV is missing the required columns.
+        """
+        logger.info(
+            f"Loading DecodingTrust Machine Ethics (Jiminy subset) "
+            f"morality={self.morality!r} min_intensity={self.min_intensity} from {_CSV_URL}"
+        )
+
+        rows = self._fetch_from_url(source=_CSV_URL, source_type="public_url", cache=cache)
+        seed_prompts = self._rows_to_seed_prompts(rows=rows)
+        logger.info(f"Loaded {len(seed_prompts)} prompts from DecodingTrust Machine Ethics")
+        return SeedDataset(seeds=seed_prompts, dataset_name=self.dataset_name)
+
+    def _rows_to_seed_prompts(self, *, rows: list[dict[str, str]]) -> list[SeedPrompt]:
+        """
+        Convert raw CSV rows into SeedPrompt instances, applying morality and intensity filters.
+
+        Args:
+            rows: List of CSV rows as dicts (``csv.DictReader`` output from
+                ``_fetch_from_url``).
+
+        Returns:
+            List of SeedPrompt objects, one per row that passes filters and has
+            a non-empty ``Description``.
+
+        Raises:
+            ValueError: If the first row is missing any required column. We
+                only check the first row because the CSV has fixed columns.
+        """
+        if rows:
+            missing = [c for c in _REQUIRED_COLUMNS if c not in rows[0]]
+            if missing:
+                raise ValueError(f"DecodingTrust Machine Ethics CSV is missing required columns: {', '.join(missing)}")
+
+        seed_prompts: list[SeedPrompt] = []
+        for row in rows:
+            description = (row.get("Description") or "").strip()
+            if not description:
+                logger.warning("Skipping row with empty 'Description'")
+                continue
+
+            categories, max_intensity = self._parse_morality(raw=row.get("Morality") or "")
+
+            if not self._passes_morality_filter(categories=categories):
+                continue
+            if max_intensity < self.min_intensity:
+                continue
+
+            seed_prompts.append(
+                SeedPrompt(
+                    value=description,
+                    data_type="text",
+                    dataset_name=self.dataset_name,
+                    harm_categories=categories,
+                    description=self._DESCRIPTION,
+                    source=_CSV_URL,
+                    authors=list(self._AUTHORS),
+                    groups=list(self._GROUPS),
+                    metadata={
+                        "source_file": row.get("File", ""),
+                        "source_line": self._coerce_int(row.get("Line", "")),
+                        "morality_raw": row.get("Morality", ""),
+                        "max_intensity": max_intensity,
+                        "neighboring_text": row.get("Neighboring text", ""),
+                    },
+                )
+            )
+        return seed_prompts
+
+    def _parse_morality(self, *, raw: str) -> tuple[list[str], int]:
+        """
+        Parse a Morality cell into a list of harm categories and the max intensity.
+
+        Args:
+            raw: Raw Morality cell value. May be empty (neutral), a single
+                label, or multiple labels joined by ``\\n``.
+
+        Returns:
+            A tuple ``(categories, max_intensity)``. ``categories`` is the
+            de-duplicated list of harm category strings (e.g. ``["bad_to_self",
+            "bad_to_others"]``) in stable insertion order, with intensity
+            stripped. ``max_intensity`` is 0 for empty input, otherwise the
+            maximum intensity across recognised labels (1-3). Malformed labels
+            are logged and skipped — a row with at least one valid label still
+            yields a SeedPrompt.
+        """
+        categories: list[str] = []
+        seen: set[str] = set()
+        max_intensity = 0
+        for line in raw.split("\n"):
+            label = line.strip()
+            if not label:
+                continue
+            match = _MORALITY_LABEL_RE.match(label)
+            if not match:
+                logger.warning(f"Skipping malformed Morality label: {label!r}")
+                continue
+            polarity, target, intensity_str = match.groups()
+            category = f"{polarity}_to_{target}"
+            if category not in seen:
+                seen.add(category)
+                categories.append(category)
+            max_intensity = max(max_intensity, int(intensity_str))
+        return categories, max_intensity
+
+    def _passes_morality_filter(self, *, categories: list[str]) -> bool:
+        """
+        Return True if a row's parsed categories satisfy ``self.morality``.
+
+        Args:
+            categories: Parsed harm category list for the row (possibly empty).
+
+        Returns:
+            True if the row should be included given the current ``morality``
+            filter setting.
+        """
+        if self.morality == "all":
+            return True
+        if self.morality == "neutral":
+            return not categories
+        prefix = f"{self.morality}_to_"  # "bad_to_" or "good_to_"
+        return any(c.startswith(prefix) for c in categories)
+
+    @staticmethod
+    def _coerce_int(value: str) -> int:
+        """
+        Best-effort int coercion for the CSV ``Line`` column.
+
+        Args:
+            value: Raw cell value.
+
+        Returns:
+            Parsed integer, or 0 if the cell is empty or non-numeric. We don't
+            fail the row on a missing line number — it's metadata, not data.
+        """
+        try:
+            return int(value.strip())
+        except (ValueError, AttributeError):
+            return 0

--- a/tests/unit/datasets/test_decoding_trust_machine_ethics_dataset.py
+++ b/tests/unit/datasets/test_decoding_trust_machine_ethics_dataset.py
@@ -1,0 +1,222 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from unittest.mock import patch
+
+import pytest
+
+from pyrit.datasets.seed_datasets.remote.decoding_trust_machine_ethics_dataset import (
+    _CSV_URL,
+    _DecodingTrustMachineEthicsDataset,
+)
+from pyrit.models import SeedDataset, SeedPrompt
+
+
+def _row(
+    *,
+    description: str,
+    morality: str,
+    file: str = "actions.zil",
+    line: str = "42",
+    neighboring_text: str = "<TELL .STROPN>",
+) -> dict[str, str]:
+    """Build a CSV-shaped row mirroring jiminy_subset.csv."""
+    return {
+        "File": file,
+        "Line": line,
+        "Neighboring text": neighboring_text,
+        "Description": description,
+        "Review": "",
+        "Conditioning": "",
+        "Morality": morality,
+        "Python Filters": "",
+    }
+
+
+@pytest.fixture
+def mixed_rows():
+    """Mix of bad / good / neutral rows with assorted intensities."""
+    return [
+        _row(description="brush teeth with glue", morality="bad, self, 3"),
+        _row(description="break a window", morality="bad, others, 1"),
+        _row(description="help an old lady", morality="good, others, 1"),
+        _row(description="walk to the door", morality=""),  # neutral
+        _row(description="steal AND hurt", morality="bad, others, 2\nbad, self, 2"),
+        _row(description="rescue and self-care", morality="good, others, 1\ngood, self, 1"),
+    ]
+
+
+class TestDecodingTrustMachineEthicsDataset:
+    """Test the DecodingTrust Machine Ethics dataset loader."""
+
+    async def test_default_morality_is_bad_only(self, mixed_rows):
+        """Default constructor (morality='bad') drops good-only and neutral rows."""
+        loader = _DecodingTrustMachineEthicsDataset()
+
+        with patch.object(loader, "_fetch_from_url", return_value=mixed_rows) as mock_fetch:
+            dataset = await loader.fetch_dataset_async()
+
+        mock_fetch.assert_called_once_with(source=_CSV_URL, source_type="public_url", cache=True)
+        assert isinstance(dataset, SeedDataset)
+        values = [seed.value for seed in dataset.seeds]
+        assert values == ["brush teeth with glue", "break a window", "steal AND hurt"]
+
+    async def test_morality_good_returns_only_good_labels(self, mixed_rows):
+        loader = _DecodingTrustMachineEthicsDataset(morality="good")
+
+        with patch.object(loader, "_fetch_from_url", return_value=mixed_rows):
+            dataset = await loader.fetch_dataset_async()
+
+        values = [seed.value for seed in dataset.seeds]
+        assert values == ["help an old lady", "rescue and self-care"]
+
+    async def test_morality_neutral_returns_only_unlabeled_rows(self, mixed_rows):
+        # min_intensity=0 to allow the neutral row through (its max intensity is 0).
+        loader = _DecodingTrustMachineEthicsDataset(morality="neutral", min_intensity=0)
+
+        with patch.object(loader, "_fetch_from_url", return_value=mixed_rows):
+            dataset = await loader.fetch_dataset_async()
+
+        assert [seed.value for seed in dataset.seeds] == ["walk to the door"]
+
+    async def test_morality_all_returns_everything_including_neutrals(self, mixed_rows):
+        loader = _DecodingTrustMachineEthicsDataset(morality="all", min_intensity=0)
+
+        with patch.object(loader, "_fetch_from_url", return_value=mixed_rows):
+            dataset = await loader.fetch_dataset_async()
+
+        assert len(dataset.seeds) == len(mixed_rows)
+
+    async def test_morality_all_with_default_min_intensity_drops_neutrals(self, mixed_rows):
+        """morality='all' with default min_intensity=1 still drops the neutral row (intensity 0)."""
+        loader = _DecodingTrustMachineEthicsDataset(morality="all")
+
+        with patch.object(loader, "_fetch_from_url", return_value=mixed_rows):
+            dataset = await loader.fetch_dataset_async()
+
+        assert "walk to the door" not in [seed.value for seed in dataset.seeds]
+
+    async def test_multi_label_row_emits_multiple_categories(self):
+        rows = [_row(description="steal AND hurt", morality="bad, others, 2\nbad, self, 2")]
+        loader = _DecodingTrustMachineEthicsDataset()
+
+        with patch.object(loader, "_fetch_from_url", return_value=rows):
+            dataset = await loader.fetch_dataset_async()
+
+        seed = dataset.seeds[0]
+        assert seed.harm_categories is not None
+        assert sorted(seed.harm_categories) == ["bad_to_others", "bad_to_self"]
+        assert seed.metadata is not None
+        assert seed.metadata["max_intensity"] == 2
+
+    async def test_min_intensity_filter(self, mixed_rows):
+        """min_intensity=3 keeps only rows whose max intensity reaches 3."""
+        loader = _DecodingTrustMachineEthicsDataset(min_intensity=3)
+
+        with patch.object(loader, "_fetch_from_url", return_value=mixed_rows):
+            dataset = await loader.fetch_dataset_async()
+
+        assert [seed.value for seed in dataset.seeds] == ["brush teeth with glue"]
+
+    async def test_harm_category_vocabulary(self):
+        """Intensity is not folded into the category name."""
+        rows = [_row(description="x", morality="bad, self, 3")]
+        loader = _DecodingTrustMachineEthicsDataset()
+
+        with patch.object(loader, "_fetch_from_url", return_value=rows):
+            dataset = await loader.fetch_dataset_async()
+
+        assert dataset.seeds[0].harm_categories == ["bad_to_self"]
+
+    async def test_metadata_preserves_source_traceability(self):
+        rows = [
+            _row(
+                description="x",
+                morality="bad, self, 2",
+                file="actions.zil",
+                line="34",
+                neighboring_text="<TELL .STROPN>",
+            )
+        ]
+        loader = _DecodingTrustMachineEthicsDataset()
+
+        with patch.object(loader, "_fetch_from_url", return_value=rows):
+            dataset = await loader.fetch_dataset_async()
+
+        meta = dataset.seeds[0].metadata
+        assert meta is not None
+        assert meta["source_file"] == "actions.zil"
+        assert meta["source_line"] == 34
+        assert isinstance(meta["source_line"], int)
+        assert meta["morality_raw"] == "bad, self, 2"
+        assert meta["max_intensity"] == 2
+        assert meta["neighboring_text"] == "<TELL .STROPN>"
+
+    async def test_skips_rows_missing_description(self):
+        """Rows with empty or whitespace-only Description are skipped, not failed."""
+        rows = [
+            _row(description="keep me", morality="bad, self, 1"),
+            _row(description="", morality="bad, self, 1"),
+            _row(description="   ", morality="bad, self, 1"),
+        ]
+        loader = _DecodingTrustMachineEthicsDataset()
+
+        with patch.object(loader, "_fetch_from_url", return_value=rows):
+            dataset = await loader.fetch_dataset_async()
+
+        assert [seed.value for seed in dataset.seeds] == ["keep me"]
+
+    async def test_raises_on_missing_required_columns(self):
+        """Missing Morality column on the first row raises ValueError."""
+        rows = [{"File": "x", "Line": "1", "Description": "x"}]  # no Morality
+        loader = _DecodingTrustMachineEthicsDataset()
+
+        with patch.object(loader, "_fetch_from_url", return_value=rows):
+            with pytest.raises(ValueError, match="Morality"):
+                await loader.fetch_dataset_async()
+
+    async def test_malformed_morality_label_does_not_fail_row(self):
+        """A row with one valid label and one garbage label still yields a SeedPrompt."""
+        rows = [_row(description="x", morality="bad, self, 1\nweird-thing")]
+        loader = _DecodingTrustMachineEthicsDataset()
+
+        with patch.object(loader, "_fetch_from_url", return_value=rows):
+            dataset = await loader.fetch_dataset_async()
+
+        assert dataset.seeds[0].harm_categories == ["bad_to_self"]
+
+    async def test_per_seed_metadata(self):
+        rows = [_row(description="x", morality="bad, self, 1")]
+        loader = _DecodingTrustMachineEthicsDataset()
+
+        with patch.object(loader, "_fetch_from_url", return_value=rows):
+            dataset = await loader.fetch_dataset_async()
+
+        seed = dataset.seeds[0]
+        assert isinstance(seed, SeedPrompt)
+        assert seed.dataset_name == "decoding_trust_machine_ethics"
+        assert seed.source == _CSV_URL
+        assert seed.data_type == "text"
+        assert seed.description is not None
+        assert "DecodingTrust" in seed.description
+        assert "Jiminy" in seed.description
+        assert seed.authors is not None
+        assert "Boxin Wang" in seed.authors  # DecodingTrust lead
+        assert "Andy Zou" in seed.authors  # Jiminy Cricket author
+        assert seed.groups is not None
+        assert "University of Illinois Urbana-Champaign" in seed.groups
+
+    def test_dataset_name(self):
+        assert _DecodingTrustMachineEthicsDataset().dataset_name == "decoding_trust_machine_ethics"
+
+    def test_default_source_is_pinned_commit(self):
+        from pyrit.datasets.seed_datasets.remote import decoding_trust_machine_ethics_dataset as mod
+
+        assert mod._DECODING_TRUST_COMMIT == "161ae8321ced62f45fcd9ceb412e05b47c603cd4"
+        assert mod._DECODING_TRUST_COMMIT in _CSV_URL
+        assert _CSV_URL.endswith("/data/machine_ethics/jiminy_subset.csv")
+
+    def test_class_level_metadata(self):
+        assert _DecodingTrustMachineEthicsDataset.modalities == ["text"]
+        assert _DecodingTrustMachineEthicsDataset.size == "large"
+        assert _DecodingTrustMachineEthicsDataset.tags == {"default", "safety", "machine_ethics"}


### PR DESCRIPTION
## Description

Adds `_DecodingTrustMachineEthicsDataset` — a remote dataset loader for the **Machine Ethics** perspective of the DecodingTrust benchmark, fetching the human-annotated Jiminy Cricket subset at runtime from a pinned commit of [`AI-secure/DecodingTrust`](https://github.com/AI-secure/DecodingTrust/blob/main/data/machine_ethics/jiminy_subset.csv).

Closes #1828 (subtask of #291). Follows the same pattern established by #1821 (Toxicity).

### Design decisions

- **Scope: `jiminy_subset.csv` only** — 2091 human-labelled rows with a structured `Morality` field (`{good|bad}, {self|others}, {1|2|3}`). The two JSON splits in the same folder (`jiminy_train.json`, `jiminy_test.json`) encode a label vector whose schema is not documented in the DecodingTrust repository; they're left for a follow-up sub-issue.
- **`morality: Literal["bad", "good", "neutral", "all"]`, default `"bad"`** — matches the red-teaming convention agreed for Toxicity on #1798. `"neutral"` selects the 245 unlabelled rows (DecodingTrust's neutral baseline).
- **`min_intensity: int = 1`** — keeps rows whose max label intensity is at or above the threshold. Set to 2 or 3 to focus on more severe cases.
- **Per-row `harm_categories`** are derived from `Morality` using the source's terminology: `bad_to_self`, `bad_to_others`, `good_to_self`, `good_to_others`. Multi-label rows (50+ in the source, e.g. `"bad, others, 2\nbad, self, 2"`) emit one category per label. Intensity is not folded into the category name but is preserved in `metadata["max_intensity"]`.
- **`value = Description`** (clear English summary) rather than `Neighboring text` (decompiled Zork ZIL source code). The ZIL snippet is preserved in `metadata["neighboring_text"]` for reproducibility.
- **Pinned commit SHA** — same `161ae8321ced62f45fcd9ceb412e05b47c603cd4` as the Toxicity loader, defined locally so each perspective can be re-pinned independently.
- **License & attribution** — CC BY-SA 4.0 source consumed via runtime fetch + attribution (no redistribution); matches the policy confirmed by @romanlutz on #1798. Every `SeedPrompt` carries full author and institution lists for both DecodingTrust and Jiminy Cricket.
- **`metadata` per SeedPrompt** preserves `source_file`, `source_line` (int), `morality_raw`, `max_intensity`, `neighboring_text` for downstream filtering and traceability.
- **Resilient parsing** — malformed Morality labels are logged and skipped (row still emitted if at least one valid label remains). Empty `Description` rows are logged and skipped. Missing required CSV columns raise `ValueError` up front.

### Files

- New: `pyrit/datasets/seed_datasets/remote/decoding_trust_machine_ethics_dataset.py`
- New: `tests/unit/datasets/test_decoding_trust_machine_ethics_dataset.py`
- Modified: `pyrit/datasets/seed_datasets/remote/__init__.py` (auto-discovery import + `__all__` entry)

## Tests and Documentation

- `uv run pre-commit run --files <three changed files>` — clean (ruff format/check, ty type check, copyright header `CPY001`).
- `uv run pytest tests/unit/datasets/test_decoding_trust_machine_ethics_dataset.py -v` — **16 / 16 passed**. Tests cover: default `morality="bad"` behaviour, each `morality` selector (`good`/`neutral`/`all`), default `min_intensity=1` excluding neutrals under `morality="all"`, multi-label rows, `min_intensity` filtering, harm-category vocabulary, metadata traceability (`source_file` / `source_line` int / `morality_raw` / `max_intensity` / `neighboring_text`), skipping rows with empty Description, hard error on missing required columns, resilience against malformed labels, per-`SeedPrompt` metadata (Wang & Zou both present in `authors`), pinned commit SHA, class-level metadata.
- `uv run pytest tests/unit/datasets/` — **561 / 561 passed**, no regressions.
- No notebook / JupyText changes — dataset loaders are auto-discovered by `SeedDatasetProvider`, same as every other entry in `pyrit/datasets/seed_datasets/remote/`.
