### PR TITLE
MAINT: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -80,3 +80,8 @@ updates:
       prefix: "MAINT"
     reviewers:
       - "microsoft/ai-red-team-dev"
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,82 @@
+version: 2
+updates:
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "MAINT"
+    reviewers:
+      - "microsoft/ai-red-team-dev"
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "MAINT"
+    reviewers:
+      - "microsoft/ai-red-team-dev"
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "MAINT"
+    reviewers:
+      - "microsoft/ai-red-team-dev"
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: pre-commit
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "MAINT"
+    reviewers:
+      - "microsoft/ai-red-team-dev"
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: docker
+    directories:
+      - /docker
+      - /.devcontainer
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "MAINT"
+    reviewers:
+      - "microsoft/ai-red-team-dev"
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: devcontainers
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "MAINT"
+    reviewers:
+      - "microsoft/ai-red-team-dev"


### PR DESCRIPTION
## Description

Adds `.github/dependabot.yml` to enable automated dependency update PRs, modeled on the configuration in [microsoft/RAMPART](https://github.com/microsoft/RAMPART/blob/main/.github/dependabot.yml) and adapted to PyRIT's stack.

Ecosystems covered:
- `uv` at `/` — updates `pyproject.toml` + `uv.lock` together
- `npm` at `/frontend`
- `github-actions` at `/`
- `pre-commit` at `/`
- `docker` at `/docker` and `/.devcontainer`
- `devcontainers` at `/`

Conventions:
- Weekly schedule
- Commit/PR prefix `MAINT` (per `PULL_REQUEST_TEMPLATE.md`)
- Minor + patch updates grouped per ecosystem to reduce PR noise; majors still come as individual PRs
- Reviews auto-requested from @microsoft/ai-red-team-dev

No `ignore` rules and no `target-branch` override (defaults to `main`).

## Tests and Documentation

No code changes; configuration-only. YAML validated locally. Behavior will be observable once merged via PRs opened by the Dependabot bot. No JupyText runs applicable.