### PR TITLE
MAINT: fix ruff 0.15.15 D420 errors and revert ty-pre-commit to v0.0.32

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
       args: [--fix]
 
   - repo: https://github.com/allganize/ty-pre-commit
-    rev: v0.0.40
+    rev: v0.0.32
     hooks:
       - id: ty-check
         name: ty (type check)

--- a/pyrit/common/data_url_converter.py
+++ b/pyrit/common/data_url_converter.py
@@ -16,12 +16,12 @@ async def convert_local_image_to_data_url_async(image_path: str) -> str:
     Args:
         image_path (str): The file system path to the image file.
 
+    Returns:
+        str: A string containing the MIME type and the base64-encoded data of the image, formatted as a data URL.
+
     Raises:
         FileNotFoundError: If no file is found at the specified `image_path`.
         ValueError: If the image file's extension is not in the supported formats list.
-
-    Returns:
-        str: A string containing the MIME type and the base64-encoded data of the image, formatted as a data URL.
     """
     ext = DataTypeSerializer.get_extension(image_path)
     if ext is None or ext.lower() not in AZURE_OPENAI_GPT4O_SUPPORTED_IMAGE_FORMATS:

--- a/pyrit/common/utils.py
+++ b/pyrit/common/utils.py
@@ -184,16 +184,6 @@ def get_kwarg_param(
     Returns:
         Optional[_T]: The validated parameter value if present and valid, otherwise None.
 
-    Args:
-        kwargs (Dict[str, Any]): The dictionary containing parameters.
-        param_name (str): The name of the parameter to validate.
-        expected_type (Type[_T]): The expected type of the parameter.
-        required (bool): Whether the parameter is required. If True, raises ValueError if missing.
-        default_value (Optional[_T]): Default value to return if the parameter is not required and not present.
-
-    Returns:
-        Optional[_T]: The validated parameter value if present and valid, otherwise None.
-
     Raises:
         ValueError: If the parameter is missing or None.
         TypeError: If the parameter is not of the expected type.

--- a/pyrit/models/score.py
+++ b/pyrit/models/score.py
@@ -120,12 +120,11 @@ class Score:
 
         If the score type is "float_scale", it returns the score value as a float.
 
-        Raises:
-            ValueError: If the score type is unknown.
-
         Returns:
             bool | float: Parsed score value.
 
+        Raises:
+            ValueError: If the score type is unknown.
         """
         if self.score_type == "true_false":
             return self.score_value.lower() == "true"

--- a/pyrit/prompt_target/azure_ml_chat_target.py
+++ b/pyrit/prompt_target/azure_ml_chat_target.py
@@ -284,12 +284,12 @@ class AzureMLChatTarget(PromptTarget):
         Args:
             messages (list[Message]): The message objects containing the role and content.
 
+        Returns:
+            str: The generated response message.
+
         Raises:
             EmptyResponseException: If the response from the chat is empty.
             Exception: For any other errors during the process.
-
-        Returns:
-            str: The generated response message.
         """
         headers = await self._get_headers_async()
         payload = await self._construct_http_body_async(messages)

--- a/tests/unit/common/test_pyrit_default_value.py
+++ b/tests/unit/common/test_pyrit_default_value.py
@@ -614,7 +614,7 @@ class TestSetGlobalVariable:
 
         # Ensure the variable doesn't exist initially
         if hasattr(sys.modules["__main__"], "test_global_var"):
-            delattr(sys.modules["__main__"], "test_global_var")
+            del sys.modules["__main__"].test_global_var
 
         try:
             # Set a global variable
@@ -627,7 +627,7 @@ class TestSetGlobalVariable:
         finally:
             # Cleanup
             if hasattr(sys.modules["__main__"], "test_global_var"):
-                delattr(sys.modules["__main__"], "test_global_var")
+                del sys.modules["__main__"].test_global_var
 
     def test_set_global_variable_overwrites_existing(self) -> None:
         """Test that set_global_variable overwrites existing variables."""
@@ -645,7 +645,7 @@ class TestSetGlobalVariable:
         finally:
             # Cleanup
             if hasattr(sys.modules["__main__"], "test_overwrite_var"):
-                delattr(sys.modules["__main__"], "test_overwrite_var")
+                del sys.modules["__main__"].test_overwrite_var
 
     def test_set_global_variable_with_complex_objects(self) -> None:
         """Test that set_global_variable works with complex objects."""
@@ -674,9 +674,9 @@ class TestSetGlobalVariable:
         finally:
             # Cleanup
             if hasattr(sys.modules["__main__"], "test_dict_var"):
-                delattr(sys.modules["__main__"], "test_dict_var")
+                del sys.modules["__main__"].test_dict_var
             if hasattr(sys.modules["__main__"], "test_obj_var"):
-                delattr(sys.modules["__main__"], "test_obj_var")
+                del sys.modules["__main__"].test_obj_var
 
     def test_set_global_variable_with_none_value(self) -> None:
         """Test that set_global_variable can set None as a value."""
@@ -691,7 +691,7 @@ class TestSetGlobalVariable:
         finally:
             # Cleanup
             if hasattr(sys.modules["__main__"], "test_none_var"):
-                delattr(sys.modules["__main__"], "test_none_var")
+                del sys.modules["__main__"].test_none_var
 
 
 class TestRequiredValue:

--- a/tests/unit/executor/attack/multi_turn/test_crescendo.py
+++ b/tests/unit/executor/attack/multi_turn/test_crescendo.py
@@ -444,8 +444,8 @@ class TestCrescendoAttackInitialization:
         """Adversarial chat must natively support MULTI_TURN and SYSTEM_PROMPT."""
         from pyrit.prompt_target.common.target_capabilities import CapabilityName
 
-        mock_adversarial_chat.configuration.includes.side_effect = lambda *, capability: capability != CapabilityName(
-            missing_capability
+        mock_adversarial_chat.configuration.includes.side_effect = lambda *, capability: (
+            capability != CapabilityName(missing_capability)
         )
         adversarial_config = AttackAdversarialConfig(target=mock_adversarial_chat)
 

--- a/tests/unit/executor/attack/multi_turn/test_red_teaming.py
+++ b/tests/unit/executor/attack/multi_turn/test_red_teaming.py
@@ -303,8 +303,8 @@ class TestRedTeamingAttackInitialization:
         """Adversarial chat must natively support MULTI_TURN and SYSTEM_PROMPT."""
         from pyrit.prompt_target.common.target_capabilities import CapabilityName
 
-        mock_adversarial_chat.configuration.includes.side_effect = lambda *, capability: capability != CapabilityName(
-            missing_capability
+        mock_adversarial_chat.configuration.includes.side_effect = lambda *, capability: (
+            capability != CapabilityName(missing_capability)
         )
         adversarial_config = AttackAdversarialConfig(target=mock_adversarial_chat)
         scoring_config = AttackScoringConfig(objective_scorer=mock_objective_scorer)

--- a/tests/unit/executor/attack/multi_turn/test_tree_of_attacks.py
+++ b/tests/unit/executor/attack/multi_turn/test_tree_of_attacks.py
@@ -236,8 +236,8 @@ class AttackBuilder:
         )
         target.capabilities.supports_multi_turn = supports_multi_turn
         target.capabilities.output_modalities = frozenset({frozenset(["text"])})
-        target.configuration.includes.side_effect = (
-            lambda capability: capability == CapabilityName.MULTI_TURN and supports_multi_turn
+        target.configuration.includes.side_effect = lambda capability: (
+            capability == CapabilityName.MULTI_TURN and supports_multi_turn
         )
         target.configuration.capabilities.output_modalities = frozenset({frozenset(["text"])})
         return cast("PromptTarget", target)

--- a/tests/unit/scenario/test_psychosocial_harms.py
+++ b/tests/unit/scenario/test_psychosocial_harms.py
@@ -366,8 +366,8 @@ class TestPsychosocialTargetRequirements:
             class_name="NonChatTarget", class_module="test"
         )
         # Configuration reports no EDITABLE_HISTORY support
-        non_chat_target.configuration.includes.side_effect = (
-            lambda *, capability: capability != CapabilityName.EDITABLE_HISTORY
+        non_chat_target.configuration.includes.side_effect = lambda *, capability: (
+            capability != CapabilityName.EDITABLE_HISTORY
         )
 
         with patch.object(Psychosocial, "_resolve_seed_groups", return_value=mock_resolved_seed_data):

--- a/tests/unit/setup/test_pyrit_initializer.py
+++ b/tests/unit/setup/test_pyrit_initializer.py
@@ -22,13 +22,13 @@ class TestPyRITInitializerBase:
         reset_default_values()
         # Clean up any test globals
         if hasattr(sys.modules["__main__"], "test_var"):
-            delattr(sys.modules["__main__"], "test_var")
+            del sys.modules["__main__"].test_var
 
     def teardown_method(self) -> None:
         """Clean up after each test."""
         reset_default_values()
         if hasattr(sys.modules["__main__"], "test_var"):
-            delattr(sys.modules["__main__"], "test_var")
+            del sys.modules["__main__"].test_var
 
     def test_cannot_instantiate_abstract_class(self):
         """Test that PyRITInitializer cannot be instantiated directly."""
@@ -121,13 +121,13 @@ class TestInitializeWithTracking:
         """Clear default values before each test."""
         reset_default_values()
         if hasattr(sys.modules["__main__"], "tracked_var"):
-            delattr(sys.modules["__main__"], "tracked_var")
+            del sys.modules["__main__"].tracked_var
 
     def teardown_method(self) -> None:
         """Clean up after each test."""
         reset_default_values()
         if hasattr(sys.modules["__main__"], "tracked_var"):
-            delattr(sys.modules["__main__"], "tracked_var")
+            del sys.modules["__main__"].tracked_var
 
     async def test_initialize_with_tracking_calls_initialize(self):
         """Test that initialize_with_tracking_async calls initialize method."""


### PR DESCRIPTION
## Description

Follow-up fixes for recently merged dependabot bumps:

- **ruff 0.14.4 -> 0.15.15** (#1839) delattr -> del change from `ruff format`
- **ruff 0.14.4 -> 0.15.15** (#1839) introduced new `D420` errors (docstring section ordering). Reordered docstring sections to the conventional `Args` -> `Returns` -> `Raises` order in:
  - `pyrit/common/data_url_converter.py`
  - `pyrit/common/utils.py` (also removed a duplicated `Args`/`Returns` block)
  - `pyrit/models/score.py`
  - `pyrit/prompt_target/azure_ml_chat_target.py`
- **ty-pre-commit v0.0.32 -> v0.0.40** (#1840) — reverting to `v0.0.32`. CI runs `ty` incrementally on PRs but fully on `main`, so the bump passed PR checks and only broke after merging to `main`. Reverting until the new violations are addressed separately.

## Tests and Documentation

No functional changes. Verified locally with:

- `ruff check` — all checks pass
- `pre-commit run --all-files` — passes