### PR TITLE
FIX: Clear stale conversation_id when opening another attack from history

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -88,21 +88,27 @@ jest.mock("./components/Chat/ChatWindow", () => {
   const MockChatWindow = ({
     onNewAttack,
     activeTarget,
+    attackResultId,
     conversationId,
+    activeConversationId,
     onConversationCreated,
     onSelectConversation,
     labels,
   }: {
     onNewAttack: () => void;
     activeTarget: unknown;
+    attackResultId: string | null;
     conversationId: string | null;
+    activeConversationId: string | null;
     onConversationCreated: (attackResultId: string, conversationId: string) => void;
     onSelectConversation: (convId: string) => void;
     labels: Record<string, string>;
   }) => {
     return (
       <div data-testid="chat-window">
+        <span data-testid="attack-result-id">{attackResultId ?? "none"}</span>
         <span data-testid="conversation-id">{conversationId ?? "none"}</span>
+        <span data-testid="active-conversation-id">{activeConversationId ?? "none"}</span>
         <span data-testid="has-target">{activeTarget ? "yes" : "no"}</span>
         <span data-testid="labels-operator">{labels.operator ?? ""}</span>
         <span data-testid="labels-json">{JSON.stringify(labels)}</span>
@@ -180,6 +186,12 @@ jest.mock("./components/History/AttackHistory", () => {
           data-testid="open-attack"
         >
           Open Attack
+        </button>
+        <button
+          onClick={() => onOpenAttack("ar-attack-2")}
+          data-testid="open-attack-2"
+        >
+          Open Attack 2
         </button>
       </div>
     );
@@ -417,6 +429,58 @@ describe("App", () => {
     await waitFor(() => expect(mockGetAttack).toHaveBeenCalledWith("ar-attack-1"));
     // Conversation should be cleared on error
     await waitFor(() => expect(screen.getByTestId("conversation-id")).toHaveTextContent("none"));
+  });
+
+  it("clears activeConversationId synchronously before fetching a new attack", async () => {
+    // Repro: in attack A the user branched into a related conversation, so
+    // activeConversationId points to a conv that does NOT belong to attack B.
+    // When the user clicks Open Attack on B, App.tsx must clear the stale
+    // conv id *before* flipping attackResultId — otherwise ChatWindow renders
+    // with (attackResultId=B, activeConversationId=A_conv) during the in-flight
+    // getAttack and issues GET /messages?conversation_id=A_conv → 400.
+
+    // Defer getAttack so we can inspect the intermediate render before it resolves.
+    let resolveGetAttack: (value: unknown) => void = () => {};
+    mockGetAttack.mockImplementation(
+      () => new Promise((resolve) => { resolveGetAttack = resolve })
+    );
+
+    render(<App />);
+
+    // Simulate: user is already on attack A with a branched conv selected.
+    fireEvent.click(screen.getByTestId("nav-chat"));
+    fireEvent.click(screen.getByTestId("set-conversation"));      // attack A, main conv-123
+    // Resolve the (unrelated) getAttack triggered earlier to keep state quiet
+    // — actually nothing called it yet because set-conversation routes through
+    // onConversationCreated, not handleOpenAttack. Proceed.
+    fireEvent.click(screen.getByTestId("select-conversation"));   // branched conv-456 in attack A
+    expect(screen.getByTestId("attack-result-id")).toHaveTextContent("ar-123");
+    expect(screen.getByTestId("active-conversation-id")).toHaveTextContent("conv-456");
+
+    // User clicks Open Attack on attack B in history.
+    fireEvent.click(screen.getByTestId("nav-history"));
+    fireEvent.click(screen.getByTestId("open-attack-2"));        // ar-attack-2
+
+    // BEFORE getAttack resolves: ChatWindow must NOT see the stale conv id
+    // alongside the new attack id. This is the invariant the fix establishes.
+    expect(screen.getByTestId("main-layout")).toHaveAttribute(
+      "data-current-view",
+      "chat"
+    );
+    expect(screen.getByTestId("attack-result-id")).toHaveTextContent("ar-attack-2");
+    expect(screen.getByTestId("active-conversation-id")).toHaveTextContent("none");
+    expect(screen.getByTestId("conversation-id")).toHaveTextContent("none");
+
+    // After getAttack resolves: the conv id belonging to attack B is committed.
+    resolveGetAttack({
+      attack_result_id: "ar-attack-2",
+      conversation_id: "attack-conv-2",
+      labels: {},
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("active-conversation-id")).toHaveTextContent("attack-conv-2")
+    );
+    expect(screen.getByTestId("conversation-id")).toHaveTextContent("attack-conv-2");
   });
 
   it("merges default labels from backend version API", async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -143,6 +143,19 @@ function App() {
   }, [])
 
   const handleOpenAttack = useCallback(async (openAttackResultId: string) => {
+    // Synchronously clear per-attack state before flipping attackResultId so
+    // ChatWindow does not fetch /messages with a conv_id that belonged to the
+    // previously loaded attack while getAttack is in flight. The branched-
+    // conversation case (activeConversationId pointing to a related conv of
+    // the old attack) would otherwise produce a 400 from the backend.
+    // Skip clearing when re-opening the same attack to avoid a redundant reload.
+    if (openAttackResultId !== attackResultId) {
+      setConversationId(null)
+      setActiveConversationId(null)
+      setAttackLabels(null)
+      setAttackTarget(null)
+      setRelatedConversationCount(0)
+    }
     setAttackResultId(openAttackResultId)
     setIsLoadingAttack(true)
     setCurrentView('chat')
@@ -159,7 +172,7 @@ function App() {
     } finally {
       setIsLoadingAttack(false)
     }
-  }, [clearAttackState])
+  }, [attackResultId, clearAttackState])
 
   const toggleTheme = () => {
     setIsDarkMode(!isDarkMode)


### PR DESCRIPTION
## Problem

When the user opens an attack **B** from Attack History while sitting on a *branched* (related) conversation of attack **A**, the frontend issues:

```
GET /api/attacks/{B}/messages?conversation_id={A_conv}
```

(seen twice in devtools per navigation). The backend correctly rejects with `400 Conversation X is not part of attack Y`, then the UI recovers and shows the right conversation. The symptom is purely console / network pollution — no broken UX — but the noise hides real errors and surfaces a real race.

**Repro:** in Chat, branch into a new conversation in attack A → Attack History → click *Open attack* on attack B → devtools network shows two 400s.

## Root cause

`App.handleOpenAttack` flipped `attackResultId` synchronously but only updated `activeConversationId` after `await attacksApi.getAttack(...)`. During that gap, `ChatWindow` rendered with:

| prop | value |
|---|---|
| `attackResultId` | **B** (new) |
| `activeConversationId` | **A_conv** (stale — branched conv from the previous attack, never cleared) |

`ChatWindow`'s message-fetch effect (`[activeConversationId, attackResultId, loadConversation]`) saw both truthy, neither guard applied, and fired `loadConversation(B, A_conv)` → 400. React 18 StrictMode's double-invoke produced the two 400s seen in dev; in production it would be one.

## Fix

`handleOpenAttack` now synchronously nulls `conversationId`, `activeConversationId`, `attackLabels`, `attackTarget`, and `relatedConversationCount` **before** flipping `attackResultId`, but only when the attack id actually changes (so re-opening the same attack is still a no-op reload-wise). `ChatWindow`''s existing `if (!attackResultId || !activeConversationId) return` guard then naturally suppresses the bad fetch, and the loading state is already wired through `isLoadingAttack`.

This mirrors the existing convention in `handleNewAttack` / `clearAttackState`, which already moves these fields together.

### Why not also gate on a fetched conversation list?

Considered an alternative ("fetch `/conversations` first, then commit attack id"), but it added a redundant round-trip and a bigger refactor with no behavior win — the `conversation_id` returned by `getAttack` is by construction a member of the loaded attack, so membership is already trivially correct once we stop showing the stale value during the in-flight window.

## Test

Added `App.test.tsx` regression `clears activeConversationId synchronously before fetching a new attack`. Uses a deferred `mockGetAttack` to assert that immediately after clicking *Open Attack* on a different attack, `ChatWindow` sees `attackResultId="ar-attack-2"` paired with `active-conversation-id="none"` (not the previously selected branched `conv-456`); after the promise resolves, the new conv id is committed.

**Empirically verified to catch the regression:** reverting `App.tsx` to `HEAD~1` and re-running the test fails at the exact invariant with `Expected "none", Received "conv-456"`.

Required exposing `attackResultId` and `activeConversationId` as `data-testid` attrs on the existing `MockChatWindow`, and adding a second `open-attack-2` button to `MockAttackHistory` so the test can simulate switching to a *different* attack.

## Verification

- `App.test.tsx` — 21/21 pass
- `ChatWindow.test.tsx` — 63/63 pass (no behavior regression)
- `eslint` — clean on touched files
- `tsc --noEmit` — clean

## Files

- `frontend/src/App.tsx` — synchronous clear in `handleOpenAttack`; add `attackResultId` to the `useCallback` deps.
- `frontend/src/App.test.tsx` — expose `attackResultId` + `activeConversationId` on `MockChatWindow`; add second history button; add regression test.

No backend changes — the 400 is correct server-side behavior.