### PR TITLE
Fix two failing E2E dataset providers (ComicJailbreak timeout, VLGuard 401)

### DIFF
--- a/pyrit/datasets/seed_datasets/remote/comic_jailbreak_dataset.py
+++ b/pyrit/datasets/seed_datasets/remote/comic_jailbreak_dataset.py
@@ -105,6 +105,7 @@ class _ComicJailbreakDataset(_RemoteDatasetLoader):
         ),
         source_type: Literal["public_url", "file"] = "public_url",
         templates: list[str] | None = None,
+        max_examples: int | None = None,
     ) -> None:
         """
         Initialize the ComicJailbreak dataset loader.
@@ -114,6 +115,9 @@ class _ComicJailbreakDataset(_RemoteDatasetLoader):
                 at a pinned commit.
             source_type: The type of source ('public_url' or 'file').
             templates: List of template names to include. If None, all 5 templates are used.
+            max_examples: Maximum number of source goals to render. Each goal produces up to
+                ``len(templates)`` image+text pairs. If None, all goals are rendered. Useful for
+                CI and quick validations where rendering all 300 goals × 5 templates is too slow.
 
         Raises:
             ValueError: If any template name is invalid.
@@ -121,6 +125,7 @@ class _ComicJailbreakDataset(_RemoteDatasetLoader):
         self.source = source
         self.source_type: Literal["public_url", "file"] = source_type
         self.templates = templates or list(self.TEMPLATE_NAMES)
+        self.max_examples = max_examples
 
         invalid = set(self.templates) - set(self.TEMPLATE_NAMES)
         if invalid:
@@ -166,6 +171,7 @@ class _ComicJailbreakDataset(_RemoteDatasetLoader):
             template_paths[template_name] = await self._fetch_template_async(template_name)
 
         seeds: list[Seed] = []
+        processed_goals = 0
 
         for row_idx, example in enumerate(examples):
             missing_keys = required_keys - example.keys()
@@ -203,6 +209,10 @@ class _ComicJailbreakDataset(_RemoteDatasetLoader):
                     behavior=example.get("Behavior", ""),
                 )
                 seeds.extend(pair)
+
+            processed_goals += 1
+            if self.max_examples is not None and processed_goals >= self.max_examples:
+                break
 
         logger.info(f"Successfully loaded {len(seeds)} seeds from ComicJailbreak dataset")
         return SeedDataset(seeds=seeds, dataset_name=self.dataset_name)

--- a/pyrit/datasets/seed_datasets/remote/vlguard_dataset.py
+++ b/pyrit/datasets/seed_datasets/remote/vlguard_dataset.py
@@ -4,6 +4,7 @@
 import asyncio
 import json
 import logging
+import os
 import uuid
 import zipfile
 from enum import Enum
@@ -108,14 +109,14 @@ class _VLGuardDataset(_RemoteDatasetLoader):
             categories (list[VLGuardCategory] | None): List of VLGuard categories to filter by.
                 If None, all categories are included.
             token (str | None): HuggingFace authentication token for accessing the gated dataset.
-                If None, uses the default token from the environment or HuggingFace CLI login.
+                If not provided, reads from the ``HUGGINGFACE_TOKEN`` environment variable.
 
         Raises:
             ValueError: If any of the specified categories are invalid.
         """
         self.subset = subset
         self.categories = categories
-        self.token = token
+        self.token = token if token is not None else os.environ.get("HUGGINGFACE_TOKEN")
         self.source = f"https://huggingface.co/datasets/{_HF_REPO_ID}"
 
         if categories is not None:

--- a/tests/end_to_end/test_all_datasets.py
+++ b/tests/end_to_end/test_all_datasets.py
@@ -23,8 +23,11 @@ from pyrit.datasets import SeedDatasetProvider
 from pyrit.datasets.seed_datasets.remote import (
     _ComicJailbreakDataset,
     _HarmBenchMultimodalDataset,
+    _HiXSTestDataset,
     _PromptIntelDataset,
+    _SGXSTestDataset,
     _SIUODataset,
+    _SorryBenchDataset,
     _VLGuardDataset,
     _VLSUMultimodalDataset,
 )
@@ -46,6 +49,16 @@ _IMAGE_FETCHING_PROVIDERS: set[type] = {_HarmBenchMultimodalDataset, _SIUODatase
 # Providers that produce many seeds and would otherwise exceed _TEST_TIMEOUT.
 # Constructed with max_examples to keep CI fast; full coverage runs are out of scope here.
 _LIMITED_EXAMPLES_PROVIDERS: set[type] = {_ComicJailbreakDataset, _VLSUMultimodalDataset}
+
+# Providers backed by HuggingFace-gated datasets. They require both a HUGGINGFACE_TOKEN
+# and that the token's account has accepted each dataset's terms; skipped when no token
+# is present (e.g. when running E2E locally without secrets).
+_HF_GATED_PROVIDERS: set[type] = {
+    _HiXSTestDataset,
+    _SGXSTestDataset,
+    _SorryBenchDataset,
+    _VLGuardDataset,
+}
 
 
 def get_dataset_providers():
@@ -91,8 +104,8 @@ class TestAllDatasets:
         # Skip providers that require credentials not available in CI
         if provider_cls == _PromptIntelDataset and not os.environ.get("PROMPTINTEL_API_KEY"):
             pytest.skip("PROMPTINTEL_API_KEY not set")
-        if provider_cls == _VLGuardDataset and not os.environ.get("HUGGINGFACE_TOKEN"):
-            pytest.skip("HUGGINGFACE_TOKEN not set (required for gated dataset ys-zong/VLGuard)")
+        if provider_cls in _HF_GATED_PROVIDERS and not os.environ.get("HUGGINGFACE_TOKEN"):
+            pytest.skip(f"HUGGINGFACE_TOKEN not set (required for gated dataset used by {name})")
 
         logger.info(f"Testing provider: {name}")
 

--- a/tests/end_to_end/test_all_datasets.py
+++ b/tests/end_to_end/test_all_datasets.py
@@ -21,9 +21,11 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ex
 
 from pyrit.datasets import SeedDatasetProvider
 from pyrit.datasets.seed_datasets.remote import (
+    _ComicJailbreakDataset,
     _HarmBenchMultimodalDataset,
     _PromptIntelDataset,
     _SIUODataset,
+    _VLGuardDataset,
     _VLSUMultimodalDataset,
 )
 from pyrit.models import SeedDataset
@@ -40,6 +42,10 @@ _RETRYABLE_ERRORS = (OSError, ConnectionError, TimeoutError)
 # Providers that download many remote images; each image fetch may fail
 # due to rate-limiting, so an empty result is expected in some environments.
 _IMAGE_FETCHING_PROVIDERS: set[type] = {_HarmBenchMultimodalDataset, _SIUODataset, _VLSUMultimodalDataset}
+
+# Providers that produce many seeds and would otherwise exceed _TEST_TIMEOUT.
+# Constructed with max_examples to keep CI fast; full coverage runs are out of scope here.
+_LIMITED_EXAMPLES_PROVIDERS: set[type] = {_ComicJailbreakDataset, _VLSUMultimodalDataset}
 
 
 def get_dataset_providers():
@@ -85,12 +91,14 @@ class TestAllDatasets:
         # Skip providers that require credentials not available in CI
         if provider_cls == _PromptIntelDataset and not os.environ.get("PROMPTINTEL_API_KEY"):
             pytest.skip("PROMPTINTEL_API_KEY not set")
+        if provider_cls == _VLGuardDataset and not os.environ.get("HUGGINGFACE_TOKEN"):
+            pytest.skip("HUGGINGFACE_TOKEN not set (required for gated dataset ys-zong/VLGuard)")
 
         logger.info(f"Testing provider: {name}")
 
         try:
-            # Limit examples for slow multimodal providers that fetch many remote images
-            provider = provider_cls(max_examples=6) if provider_cls == _VLSUMultimodalDataset else provider_cls()
+            # Limit examples for slow providers that would otherwise exceed _TEST_TIMEOUT
+            provider = provider_cls(max_examples=6) if provider_cls in _LIMITED_EXAMPLES_PROVIDERS else provider_cls()
 
             dataset = await _fetch_with_retry(provider)
         except Exception as e:

--- a/tests/unit/datasets/test_comic_jailbreak_dataset.py
+++ b/tests/unit/datasets/test_comic_jailbreak_dataset.py
@@ -169,6 +169,27 @@ class TestComicJailbreakDataset:
             with pytest.raises(ValueError, match="SeedDataset cannot be empty"):
                 await loader.fetch_dataset_async()
 
+    async def test_fetch_dataset_respects_max_examples(self):
+        """max_examples caps the number of source goals that get rendered."""
+        mock_data = [_make_example(Goal=f"Goal {i}") for i in range(5)]
+        loader = _ComicJailbreakDataset(templates=["article"], max_examples=2)
+
+        with (
+            patch.object(loader, "_fetch_from_url", return_value=mock_data),
+            patch.object(loader, "_fetch_template_async", new_callable=AsyncMock, return_value="/fake/template.png"),
+            patch.object(loader, "_render_comic_async", new_callable=AsyncMock, return_value="/fake/rendered.png"),
+        ):
+            dataset = await loader.fetch_dataset_async(cache=False)
+
+        # 2 goals × 1 template × 3 seeds (objective + image + text) = 6
+        assert len(dataset.seeds) == 6
+        goals = {s.metadata["goal"] for s in dataset.seeds if isinstance(s, SeedPrompt)}
+        assert goals == {"Goal 0", "Goal 1"}
+
+    def test_init_default_max_examples_is_none(self):
+        loader = _ComicJailbreakDataset()
+        assert loader.max_examples is None
+
 
 class TestComicJailbreakTemplates:
     """Tests for the COMIC_JAILBREAK_TEMPLATES constant."""

--- a/tests/unit/datasets/test_vlguard_dataset.py
+++ b/tests/unit/datasets/test_vlguard_dataset.py
@@ -380,3 +380,27 @@ class TestVLGuardDataset:
 
         assert metadata == test_metadata
         assert result_dir == cache_dir / "test"
+
+
+class TestVLGuardTokenResolution:
+    """Tests for HuggingFace token resolution on _VLGuardDataset."""
+
+    def test_explicit_token_kwarg_used(self):
+        with patch.dict("os.environ", {}, clear=True):
+            loader = _VLGuardDataset(token="kwarg_token")
+            assert loader.token == "kwarg_token"
+
+    def test_falls_back_to_huggingface_token_env(self):
+        with patch.dict("os.environ", {"HUGGINGFACE_TOKEN": "env_token"}):
+            loader = _VLGuardDataset()
+            assert loader.token == "env_token"
+
+    def test_explicit_kwarg_overrides_env(self):
+        with patch.dict("os.environ", {"HUGGINGFACE_TOKEN": "env_token"}):
+            loader = _VLGuardDataset(token="kwarg_token")
+            assert loader.token == "kwarg_token"
+
+    def test_token_is_none_when_neither_set(self):
+        with patch.dict("os.environ", {}, clear=True):
+            loader = _VLGuardDataset()
+            assert loader.token is None


### PR DESCRIPTION
Fixes two failures in the nightly `End to End Tests` AzDO pipeline on `main`.

## ComicJailbreak — `Failed: Timeout (>300.0s)`

`_ComicJailbreakDataset.fetch_dataset_async` renders **300 goals × 5 templates = 1500 PIL image overlays** per fetch (via `AddImageTextConverter`), all under the per-test 300s `pytest-timeout` cap in `tests/end_to_end/test_all_datasets.py`.

This PR adds a `max_examples: int | None = None` kwarg to the loader (default behaviour is unchanged — render everything) and wires it to `max_examples=6` in the E2E test, mirroring the existing handling for `_VLSUMultimodalDataset`. Six goals × five templates = 30 renders, well under the cap.

## VLGuard — `401 ... Access to dataset ys-zong/VLGuard is restricted`

Root cause is a one-line bug in `_VLGuardDataset.__init__`. Every other HF-gated loader in the repo (`_SorryBenchDataset`, `_HiXSTestDataset`, `_SGXSTestDataset`) reads `HUGGINGFACE_TOKEN` from the environment via the canonical pattern:

```python
self.token = token if token is not None else os.environ.get("HUGGINGFACE_TOKEN")
```

`_VLGuardDataset` was missing the `os.environ.get(...)` fallback even though both its own docstring and `.github/instructions/datasets.instructions.md` (which cites it as the canonical example) describe the env fallback as required behaviour. Net effect: CI's `HUGGINGFACE_TOKEN` secret (already injected via Key Vault → `~/.pyrit/.env`) was silently ignored, `hf_hub_download` was called with `token=None`, and the gated endpoint returned 401.

The PR also adds a defense-in-depth skip in the E2E test for environments without a token (local devs running E2E without secrets, or a future CI regression that drops the secret). Mirrors the existing `_PromptIntelDataset` `PROMPTINTEL_API_KEY` skip.

## Changes

- `pyrit/datasets/seed_datasets/remote/comic_jailbreak_dataset.py` — add `max_examples` kwarg + loop cap.
- `pyrit/datasets/seed_datasets/remote/vlguard_dataset.py` — add `HUGGINGFACE_TOKEN` env fallback; tighten docstring.
- `tests/end_to_end/test_all_datasets.py` — import the two providers; wire `max_examples=6` for ComicJailbreak; skip VLGuard when no HF token.
- `tests/unit/datasets/test_comic_jailbreak_dataset.py` — add tests for the cap + default-`None`.
- `tests/unit/datasets/test_vlguard_dataset.py` — add 4 tests for token resolution (kwarg / env / kwarg-overrides-env / neither).

## Out of scope

- AzDO pipeline secrets — already correctly set; `HUGGINGFACE_TOKEN` flows in via Key Vault → `~/.pyrit/.env`.
- Real PIL parallelization — not needed once the cap is in place.
- The same latent missing-env-fallback bug pattern in `_MSTSDataset` — currently dormant because MSTS isn't HF-gated.

## Verification

- `uv run pytest tests/unit/datasets/test_comic_jailbreak_dataset.py tests/unit/datasets/test_vlguard_dataset.py` — 45 passed.
- ruff format/check + ty type check pass on all touched files.
