### PR TITLE
MAINT: Deprecate MemoryExporter and export_conversations methods

### DIFF
--- a/pyrit/memory/__init__.py
+++ b/pyrit/memory/__init__.py
@@ -10,7 +10,6 @@ This package defines the core `MemoryInterface` and concrete implementations for
 from pyrit.memory.azure_sql_memory import AzureSQLMemory
 from pyrit.memory.central_memory import CentralMemory
 from pyrit.memory.memory_embedding import MemoryEmbedding
-from pyrit.memory.memory_exporter import MemoryExporter
 from pyrit.memory.memory_interface import MemoryInterface
 from pyrit.memory.memory_models import AttackResultEntry, EmbeddingDataEntry, PromptMemoryEntry, SeedEntry
 from pyrit.memory.sqlite_memory import SQLiteMemory
@@ -27,3 +26,17 @@ __all__ = [
     "PromptMemoryEntry",
     "SeedEntry",
 ]
+
+
+def __getattr__(name: str):  # noqa: N807 - module __getattr__ hook must use this name
+    if name == "MemoryExporter":
+        from pyrit.common.deprecation import print_deprecation_message
+        from pyrit.memory.memory_exporter import MemoryExporter
+
+        print_deprecation_message(
+            old_item="pyrit.memory.MemoryExporter",
+            new_item="the pyrit.output module or direct serialization",
+            removed_in="0.15.0",
+        )
+        return MemoryExporter
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/pyrit/memory/__init__.py
+++ b/pyrit/memory/__init__.py
@@ -7,6 +7,8 @@ Provide functionality for storing and retrieving conversation history and embedd
 This package defines the core `MemoryInterface` and concrete implementations for different storage backends.
 """
 
+from typing import Any
+
 from pyrit.memory.azure_sql_memory import AzureSQLMemory
 from pyrit.memory.central_memory import CentralMemory
 from pyrit.memory.memory_embedding import MemoryEmbedding
@@ -28,7 +30,7 @@ __all__ = [
 ]
 
 
-def __getattr__(name: str):  # noqa: N807 - module __getattr__ hook must use this name
+def __getattr__(name: str) -> Any:  # noqa: N807 - module __getattr__ hook must use this name
     if name == "MemoryExporter":
         from pyrit.common.deprecation import print_deprecation_message
         from pyrit.memory.memory_exporter import MemoryExporter

--- a/pyrit/memory/memory_interface.py
+++ b/pyrit/memory/memory_interface.py
@@ -1591,6 +1591,11 @@ class MemoryInterface(abc.ABC):
         Returns:
             Path: The path to the exported file.
         """
+        print_deprecation_message(
+            old_item="MemoryInterface.export_conversations",
+            new_item="the pyrit.output module or direct serialization of get_message_pieces results",
+            removed_in="0.15.0",
+        )
         data = self.get_message_pieces(
             attack_id=attack_id,
             conversation_id=conversation_id,

--- a/pyrit/memory/sqlite_memory.py
+++ b/pyrit/memory/sqlite_memory.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm.session import Session
 from sqlalchemy.pool import StaticPool
 from sqlalchemy.sql.expression import TextClause
 
+from pyrit.common.deprecation import print_deprecation_message
 from pyrit.common.path import DB_DATA_PATH
 from pyrit.common.singleton import Singleton
 from pyrit.memory.memory_interface import MemoryInterface
@@ -499,6 +500,11 @@ class SQLiteMemory(MemoryInterface, metaclass=Singleton):
         Raises:
             ValueError: If the specified export format is not supported.
         """
+        print_deprecation_message(
+            old_item="SQLiteMemory.export_conversations",
+            new_item="the pyrit.output module or direct serialization of get_message_pieces results",
+            removed_in="0.15.0",
+        )
         # Import here to avoid circular import issues
         from pyrit.memory.memory_exporter import MemoryExporter
 
@@ -585,6 +591,11 @@ class SQLiteMemory(MemoryInterface, metaclass=Singleton):
         Args:
             export_type (str): The format to export the data in (defaults to "json").
         """
+        print_deprecation_message(
+            old_item="SQLiteMemory.export_all_tables",
+            new_item="the pyrit.output module or direct serialization of table query results",
+            removed_in="0.15.0",
+        )
         table_models = self.get_all_table_models()
 
         for model in table_models:


### PR DESCRIPTION
Adds DeprecationWarning emitted at runtime for:
- pyrit.memory.MemoryExporter (via module __getattr__)
- MemoryInterface.export_conversations
- SQLiteMemory.export_conversations
- SQLiteMemory.export_all_tables

These will be removed in 0.15.0. This deprecation pass lands in 0.14.0 so that the breaking removal in PR #1856 can follow in the next release.