### PR TITLE
MAINT: Fix [project.optional-dependencies] all drift

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,6 @@ speech = [
 # all includes all functional dependencies excluding the ones from the "dev" dependency group
 all = [
     "accelerate>=1.7.0",
-    "av>=14.0.0",
     "azure-ai-ml>=1.32.0",
     "azure-cognitiveservices-speech>=1.44.0",
     "flask>=3.1.3",
@@ -150,10 +149,9 @@ all = [
     "ollama>=0.5.1",
     "opencv-python>=4.11.0.86",
     "playwright>=1.49.0",
+    "pyarrow>=22.0.0; python_version >= '3.14'",
     "spacy>=3.8.13,!=3.8.14",  # 3.8.14 missing cp314 wheels
     "torch>=2.7.0",
-    "types-PyYAML>=6.0.12.20250516",
-    "types-requests>=2.31.0.20250515",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -5197,7 +5197,6 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "accelerate" },
-    { name = "av" },
     { name = "azure-ai-ml" },
     { name = "azure-cognitiveservices-speech" },
     { name = "flask" },
@@ -5206,10 +5205,9 @@ all = [
     { name = "ollama" },
     { name = "opencv-python" },
     { name = "playwright" },
+    { name = "pyarrow", marker = "python_full_version >= '3.14'" },
     { name = "spacy" },
     { name = "torch" },
-    { name = "types-pyyaml" },
-    { name = "types-requests" },
 ]
 fairness-bias = [
     { name = "spacy" },
@@ -5280,7 +5278,6 @@ requires-dist = [
     { name = "appdirs", specifier = ">=1.4.0" },
     { name = "art", specifier = ">=6.5.0" },
     { name = "av", specifier = ">=14.0.0" },
-    { name = "av", marker = "extra == 'all'", specifier = ">=14.0.0" },
     { name = "azure-ai-contentsafety", specifier = ">=1.0.0" },
     { name = "azure-ai-ml", marker = "extra == 'all'", specifier = ">=1.32.0" },
     { name = "azure-ai-ml", marker = "extra == 'gcg'", specifier = ">=1.32.0" },
@@ -5314,6 +5311,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "playwright", marker = "extra == 'all'", specifier = ">=1.49.0" },
     { name = "playwright", marker = "extra == 'playwright'", specifier = ">=1.49.0" },
+    { name = "pyarrow", marker = "python_full_version >= '3.14' and extra == 'all'", specifier = ">=22.0.0" },
     { name = "pyarrow", marker = "python_full_version >= '3.14' and extra == 'gcg'", specifier = ">=22.0.0" },
     { name = "pydantic", specifier = ">=2.11.5" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8.0" },
@@ -5338,8 +5336,6 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "transformers", specifier = ">=5.0.0rc3" },
     { name = "treelib", specifier = ">=1.7.1" },
-    { name = "types-pyyaml", marker = "extra == 'all'", specifier = ">=6.0.12.20250516" },
-    { name = "types-requests", marker = "extra == 'all'", specifier = ">=2.31.0.20250515" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]


### PR DESCRIPTION
## Description

The `[project.optional-dependencies] all` extra had drifted from being a clean union of the feature extras. This PR brings it back in line so that `pip install pyrit[all]` actually gives users every feature dep (and nothing dev-only).

The audit surfaced five items: one missing constraint, one redundant entry (already a hard dep), and three dev-only leaks. I applied four of those; `sentencepiece` was intentionally left out (gcg-only, narrow scope, separate concern).

**Added**

- `pyarrow>=22.0.0; python_version >= '3.14'` — propagated from `gcg`. Without this, on Python 3.14 the resolver picks a pyarrow that lacks cp314 wheels and falls back to a source build that fails.

**Removed**

- `av>=14.0.0` — already a hard dep in `[project] dependencies`. Listing it in `all` is incorrect; `all` is meant to be the union of *optional* extras only.
- `types-PyYAML>=6.0.12.20250516`, `types-requests>=2.31.0.20250515` — type stubs have no runtime effect. They belong only in `[dependency-groups] dev` (where they already are).

**Intentionally not propagated**

- `sentencepiece>=0.2.0` (from `gcg`) — gcg is a specialized extra we want to keep narrow; out of scope for this PR.

**Kept by design (already in `all`)**

- `ipykernel`, `jupyter` — convenience deps for notebook users running `pyrit[all]`, even though they only otherwise appear in `[dependency-groups] dev`.

The companion `uv.lock` regeneration was minimal: only the `all`-extra `requires-dist` entries shifted. No transitive bumps.

## Tests and Documentation

No code or doc changes; tests are not applicable. Verification:

- `uv lock --link-mode=copy` — resolved 325 packages in 8.79s; 2 insertions / 6 deletions in `uv.lock`, all of them reflecting only the `all`-extra delta.
- `uv sync --link-mode=copy --extra all` — succeeded.
- `pre-commit run --files pyproject.toml uv.lock` — passed.
