### PR TITLE
MAINT: deprecate display_image_response_async

### DIFF
--- a/pyrit/common/display_response.py
+++ b/pyrit/common/display_response.py
@@ -24,6 +24,11 @@ async def display_image_response_async(response_piece: MessagePiece) -> None:
     Raises:
         RuntimeError: If storage IO is not initialized.
     """
+    print_deprecation_message(
+        old_item="pyrit.common.display_response.display_image_response_async",
+        new_item="pyrit.output.conversation.PrettyConversationPrinter",
+        removed_in="0.16.0",
+    )
     memory = CentralMemory.get_memory_instance()
     if (
         response_piece.response_error == "none"
@@ -61,7 +66,7 @@ async def display_image_response(response_piece: MessagePiece) -> None:  # pyrit
     """Delegate to ``display_image_response_async`` (deprecated alias)."""
     print_deprecation_message(
         old_item="pyrit.common.display_response.display_image_response",
-        new_item="pyrit.common.display_response.display_image_response_async",
+        new_item="pyrit.output.conversation.PrettyConversationPrinter",
         removed_in="0.16.0",
     )
     await display_image_response_async(response_piece)

--- a/tests/unit/common/test_display_response.py
+++ b/tests/unit/common/test_display_response.py
@@ -149,6 +149,14 @@ async def test_display_image_azure_and_disk_both_fail(mock_disk_io_cls, mock_ipy
     assert "Failed to read image" in caplog.text
 
 
+async def test_display_image_response_async_emits_warning_and_delegates(_mock_central_memory):
+    piece = MagicMock()
+    piece.response_error = "blocked"
+    piece.converted_value_data_type = "text"
+    with pytest.warns(DeprecationWarning, match="display_image_response_async"):
+        await display_image_response_async(piece)
+
+
 async def test_deprecated_alias_emits_warning_and_delegates(_mock_central_memory):
     piece = MagicMock()
     piece.response_error = "blocked"


### PR DESCRIPTION
I forgot to deprecate this when making the output module. There are no callers, but deprecating along with the sync function.

