### PR TITLE
DOC: cross-OS troubleshooting + per-OS ODBC install steps

### DIFF
--- a/doc/getting_started/troubleshooting/azure_sql_db.md
+++ b/doc/getting_started/troubleshooting/azure_sql_db.md
@@ -108,7 +108,47 @@ ALTER ROLE db_datawriter ADD MEMBER [user@domain.com];
 
 ## 6. Configure Local Environment
 
-Connecting PyRIT to an Azure SQL Server database requires ODBC, PyODBC and Microsoft's [ODBC Driver for SQL Server](https://learn.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server?view=sql-server-ver16) to be installed in your local environment. Consult PyODBC's [documentation](https://github.com/mkleehammer/pyodbc/wiki) for detailed instruction on.
+Connecting PyRIT to an Azure SQL Server database requires the **Microsoft ODBC Driver 18 for SQL Server**, which on macOS and Linux depends on **unixODBC**. The `pyodbc` Python package is already installed as a PyRIT dependency.
+
+Install the driver for your OS:
+
+::::{tab-set}
+
+:::{tab-item} Windows
+Download and install the [Microsoft ODBC Driver 18 for SQL Server](https://learn.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server) MSI from Microsoft.
+:::
+
+:::{tab-item} macOS
+Install via [Homebrew](https://brew.sh):
+
+```bash
+brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
+brew install msodbcsql18 mssql-tools18
+```
+:::
+
+:::{tab-item} Linux (Ubuntu / Debian)
+```bash
+# Install unixODBC
+sudo apt-get update
+sudo apt-get install -y unixodbc unixodbc-dev
+
+# Add the Microsoft package repository
+curl -sSL -O https://packages.microsoft.com/config/ubuntu/$(grep VERSION_ID /etc/os-release | cut -d '"' -f 2)/packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+rm packages-microsoft-prod.deb
+
+# Install the driver
+sudo apt-get update
+sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
+```
+
+For other Linux distributions (RHEL, SUSE, Alpine), see [Microsoft's installation guide](https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server).
+:::
+
+::::
+
+See [PyODBC's documentation](https://github.com/mkleehammer/pyodbc/wiki) for further details.
 
 ## 7. Testing
 

--- a/doc/getting_started/troubleshooting/local_dev.md
+++ b/doc/getting_started/troubleshooting/local_dev.md
@@ -6,24 +6,49 @@ Common issues when setting up PyRIT for local development.
 
 ### uv command not found
 
-Make sure uv is in your PATH. Restart PowerShell after installation.
+Make sure uv is in your `PATH`. Restart your terminal (PowerShell, bash, zsh, etc.) after installing uv so the updated `PATH` is picked up.
 
 ### Import errors
 
 Ensure you're using `uv run python` or have activated the virtual environment:
 
+::::{tab-set}
+
+:::{tab-item} PowerShell (Windows)
 ```powershell
 .\.venv\Scripts\Activate.ps1
 ```
+:::
+
+:::{tab-item} Bash (macOS / Linux)
+```bash
+source .venv/bin/activate
+```
+:::
+
+::::
 
 ### Dependency conflicts
 
 Try regenerating the lock file:
 
+::::{tab-set}
+
+:::{tab-item} PowerShell (Windows)
 ```powershell
 Remove-Item uv.lock
 uv sync
 ```
+:::
+
+:::{tab-item} Bash (macOS / Linux)
+```bash
+rm uv.lock
+uv sync
+```
+:::
+
+::::
 
 ### Module not found errors
 

--- a/doc/getting_started/troubleshooting/local_dev.md
+++ b/doc/getting_started/troubleshooting/local_dev.md
@@ -30,25 +30,12 @@ source .venv/bin/activate
 
 ### Dependency conflicts
 
-Try regenerating the lock file:
+Try regenerating the lock file (`rm` works in PowerShell as an alias for `Remove-Item`, so the same commands work everywhere):
 
-::::{tab-set}
-
-:::{tab-item} PowerShell (Windows)
-```powershell
-Remove-Item uv.lock
-uv sync
-```
-:::
-
-:::{tab-item} Bash (macOS / Linux)
 ```bash
 rm uv.lock
 uv sync
 ```
-:::
-
-::::
 
 ### Module not found errors
 


### PR DESCRIPTION
Issue #480 asks for macOS-friendly setup instructions. Investigation showed the original blockers (aria2, pyodbc/unixODBC) are largely solved already: aria2 isn't used by PyRIT anymore, and `uv sync` plus the unit-test suite work on a stock macOS GitHub runner with no system-package installs (the `macos-latest` matrix already passes 9550 unit tests on Python 3.10-3.14). The remaining gaps are documentation: the local-dev troubleshooting guide assumes Windows/PowerShell, and the Azure SQL backend doc doesn't tell macOS or Linux users which packages to install.

This PR fixes those two gaps:

- `troubleshooting/local_dev.md` - replaces Windows-only PowerShell snippets with tab-sets covering PowerShell (Windows) and Bash (macOS/Linux) for venv activation. Collapses `rm uv.lock` into a single snippet since `rm` is a PowerShell alias for `Remove-Item`. Generalizes ""Restart PowerShell"" to ""Restart your terminal"".

- `troubleshooting/azure_sql_db.md` section 6 - replaces the truncated paragraph (which only linked out) with concrete per-OS install commands: MSI download for Windows, Homebrew tap + `msodbcsql18` for macOS, and apt + unixODBC + Microsoft package repo for Ubuntu/Debian. Clarifies that `pyodbc` itself is already installed as a PyRIT dependency, so users only need the system ODBC driver.

Scope notes:
- Issue #480 also asks for macOS CI support. The macOS unit-test pipeline already exists and passes (#1407). Extending macOS and Windows to the integration / e2e / partner pipelines is a larger workstream that will be tracked in a follow-up issue.
- No code or test changes here. Pre-commit hooks pass on both edited files.

Closes #480.