### PR TITLE
MAINT: suppress ty missing-override-decorator rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,12 @@ unused-ignore-comment = "warn"
 unused-type-ignore-comment = "warn"
 # Allow empty function bodies during development
 empty-body = "ignore"
+# ty 0.0.43 (bumped from 0.0.32 in #1919) activated this rule under
+# [tool.ty.rules] all = "error". Adopting @override across pyrit/ would require
+# the typing_extensions backport on Python 3.10/3.11 (typing.override is 3.12+),
+# which adds a direct dep and ongoing import-path friction. Suppressing the
+# rule keeps the codebase consistent with the existing pragmatic ignores above.
+missing-override-decorator = "ignore"
 
 [tool.ty.analysis]
 respect-type-ignore-comments = true


### PR DESCRIPTION
<!--- Please add one of the following as a prefix to the pull request title: -->
<!--- DOC for documentation changes -->
<!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
<!--- FIX for bug fixes -->
<!--- TEST for adding tests -->
<!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
<!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->

## Description

#1919 bumped `allganize/ty-pre-commit` from v0.0.32 to v0.0.43, and the newer ty release activated the `missing-override-decorator` rule. Under PyRIT's existing `[tool.ty.rules] all = "error"` config that turned 735 method overrides across 287 files in `pyrit/` into hard CI errors, which has been blocking `main` and every open PR (#1884 in particular).

This change suppresses the rule with a one-line entry under `[tool.ty.rules]`, alongside the existing pragmatic ignores (`unresolved-import`, `possibly-missing-attribute`, `empty-body`). The accompanying comment explains why we don't just adopt `@override` everywhere instead:

- `typing.override` is Python 3.12+. PyRIT supports 3.10+, so adopting it would require `from typing_extensions import override` on every site.
- `typing_extensions` is currently installed only transitively (via Azure SDK, SQLAlchemy, pydantic, etc.) -- adopting would mean a new direct runtime dep.
- It's an ongoing footgun: copy-pastes from 3.12-only examples that write `from typing import override` would silently break 3.10/3.11.

If the team later wants the override safety check back, that can be a separate, incremental effort (e.g., per-package PRs) -- at which point this single line is trivial to remove.

Note: this PR only addresses the `missing-override-decorator` fallout. The ty hook on `main` is also failing on a handful of unrelated diagnostics (`possibly-unresolved-reference` in `pyrit/auth/copilot_authenticator.py`, `unresolved-attribute` in `pyrit/output/score/pretty.py`, `invalid-attribute-override` in `pyrit/scenario/scenarios/adaptive/text_adaptive.py`, `deprecated` `os.system` in `pyrit/cli/pyrit_shell.py`). Those are pre-existing and out of scope here; happy to clean them up in a follow-up.

## Tests and Documentation

No code changes, so no new tests or docs needed. Verified locally on this worktree:

- `uv run --link-mode=copy pre-commit run ty-check --all-files` -- 0 `missing-override-decorator` errors (down from 735).
- `uv run --link-mode=copy ruff check pyrit/ tests/ doc/` clean.
- `uv run --link-mode=copy ruff format --check pyrit/ tests/ doc/` clean (1264 files).
- `uv run --link-mode=copy pytest tests/unit -n 8 -q` -- 9359 passed, 124 skipped.