### PR TITLE
MAINT: fix remaining pre-commit failures on main (ty + reST roles)

### DIFF
--- a/pyrit/auth/copilot_authenticator.py
+++ b/pyrit/auth/copilot_authenticator.py
@@ -380,6 +380,7 @@ class CopilotAuthenticator(Authenticator):
         async with async_playwright() as playwright:
             browser = None
             context = None
+            page = None
 
             try:
                 logger.info(f"Launching browser for authentication (headless={self._headless})...")

--- a/pyrit/auxiliary_attacks/gcg/data.py
+++ b/pyrit/auxiliary_attacks/gcg/data.py
@@ -3,7 +3,7 @@
 
 """CSV → goals/targets loader for the GCG attack.
 
-Decoupled from :class:`GCGGenerator` so that callers with goals and targets
+Decoupled from ``GCGGenerator`` so that callers with goals and targets
 already in memory can pass them straight into ``execute_async`` without going
 through ``pandas`` or any filesystem access.
 """
@@ -34,7 +34,7 @@ def load_goals_and_targets(
             ``train_data`` falls back to whatever default the legacy loader
             returns (an empty list today).
         random_seed (int): Seed used to shuffle the training rows. Defaults
-            to ``42`` to match :class:`GCGAlgorithmConfig`'s default.
+            to ``42`` to match ``GCGAlgorithmConfig``'s default.
 
     Returns:
         tuple[list[str], list[str], list[str], list[str]]:

--- a/pyrit/auxiliary_attacks/gcg/experiments/run.py
+++ b/pyrit/auxiliary_attacks/gcg/experiments/run.py
@@ -1,10 +1,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-"""Thin CLI wrapper around :meth:`GCGGenerator.execute_async` for AzureML jobs.
+"""Thin CLI wrapper around ``GCGGenerator.execute_async`` for AzureML jobs.
 
-The notebook (or any user) builds a :class:`GCGConfig` (strategy) and a
-:class:`GCGDataConfig` (data) locally, serializes both with their respective
+The notebook (or any user) builds a ``GCGConfig`` (strategy) and a
+``GCGDataConfig`` (data) locally, serializes both with their respective
 ``to_json_file`` methods, ships them to Azure ML as job inputs, and the job's
 command line is::
 
@@ -14,7 +14,7 @@ command line is::
         --output-dir ${{outputs.results}}
 
 This file deserializes both configs inside the job, loads goals/targets from
-the configured CSV, and runs the attack via a fresh :class:`GCGGenerator`.
+the configured CSV, and runs the attack via a fresh ``GCGGenerator``.
 """
 
 import argparse

--- a/pyrit/cli/pyrit_shell.py
+++ b/pyrit/cli/pyrit_shell.py
@@ -572,7 +572,7 @@ class PyRITShell(cmd.Cmd):
         """Clear the screen."""
         import os
 
-        os.system("cls" if os.name == "nt" else "clear")
+        os.system("cls" if os.name == "nt" else "clear")  # type: ignore[ty:deprecated]
 
     # Shortcuts and aliases
     do_quit = do_exit

--- a/pyrit/output/score/pretty.py
+++ b/pyrit/output/score/pretty.py
@@ -65,9 +65,7 @@ class PrettyScorePrinter(PrinterBase):
         """
         lines: list[str] = []
         indent = self._indent * indent_level
-        scorer_name = (
-            score.scorer_class_identifier.class_name if score.scorer_class_identifier else None
-        ) or "Unknown"
+        scorer_name = (score.scorer_class_identifier.class_name if score.scorer_class_identifier else None) or "Unknown"
         lines.append(f"{indent}Scorer: {scorer_name}\n")
         lines.append(self._format_colored(f"{indent}• Category: {score.score_category or 'N/A'}", Fore.LIGHTMAGENTA_EX))
         lines.append(self._format_colored(f"{indent}• Type: {score.score_type}", Fore.CYAN))

--- a/pyrit/output/score/pretty.py
+++ b/pyrit/output/score/pretty.py
@@ -65,7 +65,9 @@ class PrettyScorePrinter(PrinterBase):
         """
         lines: list[str] = []
         indent = self._indent * indent_level
-        scorer_name = score.scorer_class_identifier.class_name
+        scorer_name = (
+            score.scorer_class_identifier.class_name if score.scorer_class_identifier else None
+        ) or "Unknown"
         lines.append(f"{indent}Scorer: {scorer_name}\n")
         lines.append(self._format_colored(f"{indent}• Category: {score.score_category or 'N/A'}", Fore.LIGHTMAGENTA_EX))
         lines.append(self._format_colored(f"{indent}• Type: {score.score_type}", Fore.CYAN))

--- a/pyrit/scenario/scenarios/adaptive/text_adaptive.py
+++ b/pyrit/scenario/scenarios/adaptive/text_adaptive.py
@@ -94,7 +94,7 @@ class TextAdaptive(AdaptiveScenario):
 
     _cached_strategy_class: ClassVar[type[ScenarioStrategy] | None] = None
 
-    VERSION: int = 1
+    VERSION: ClassVar[int] = 1
 
     @classmethod
     def _atomic_attack_prefix(cls) -> str:

--- a/pyrit/setup/initializers/components/scenario_techniques.py
+++ b/pyrit/setup/initializers/components/scenario_techniques.py
@@ -5,9 +5,9 @@
 Scenario technique initializer.
 
 This module owns the canonical catalog of scenario attack techniques as a
-flat list of self-describing :class:`AttackTechniqueFactory` instances and
-registers them into the singleton :class:`AttackTechniqueRegistry` via
-:class:`ScenarioTechniqueInitializer`.
+flat list of self-describing ``AttackTechniqueFactory`` instances and
+registers them into the singleton ``AttackTechniqueRegistry`` via
+``ScenarioTechniqueInitializer``.
 
 Per-name registration is idempotent: pre-existing entries in the registry are
 not overwritten.
@@ -41,14 +41,14 @@ def build_scenario_technique_factories() -> list[AttackTechniqueFactory]:
 
     Factories that need an adversarial chat target do not bake one in; the
     default adversarial target is resolved lazily inside
-    :meth:`AttackTechniqueFactory.create` via
+    ``AttackTechniqueFactory.create`` via
     ``get_default_adversarial_target()``. Scenarios may also pass
     ``attack_adversarial_config_override`` at create time (but only when the
     factory did not bake one in at construction).
 
     A bare ``PromptSendingAttack`` factory is intentionally omitted from the
     catalog: every scenario whose ``BASELINE_ATTACK_POLICY`` is
-    :attr:`BaselineAttackPolicy.Enabled` already auto-prepends an equivalent
+    ``BaselineAttackPolicy.Enabled`` already auto-prepends an equivalent
     baseline atomic attack via ``Scenario._build_baseline_atomic_attack``.
 
     Returns:
@@ -120,7 +120,7 @@ class ScenarioTechniqueInitializer(PyRITInitializer):
     ``Scenario._build_baseline_atomic_attack``) already covers that case.
 
     Registration is per-name idempotent: pre-existing entries in
-    :class:`AttackTechniqueRegistry` are not overwritten.
+    ``AttackTechniqueRegistry`` are not overwritten.
     """
 
     async def initialize_async(self) -> None:


### PR DESCRIPTION
## Description

Unblocks `main` CI (currently RED on commit `309b7a54`) and downstream PRs that depend on it (notably #1884, the typing modernization sweep). Companion to #1935, which cleared the dominant `missing-override-decorator` bucket.

Two pre-commit hooks fail on `main` today; this PR clears both.

### ty (type check) -- 5 errors -> 0

- `pyrit/auth/copilot_authenticator.py`: pre-initialize `page = None` alongside the existing `browser` / `context` pre-init. The `finally` block already references all three, but `page` was only assigned inside the `try` -- so an exception from `chromium.launch` or `new_context` (before line 391) would dereference an unbound local. Real latent bug, not just a type lint.
- `pyrit/output/score/pretty.py`: guard `score.scorer_class_identifier` for `None` and fall back to `"Unknown"`, mirroring the existing convention in `pyrit/models/score.py`.
- `pyrit/scenario/scenarios/adaptive/text_adaptive.py`: annotate `VERSION` as `ClassVar[int] = 1` so it matches the parent `AdaptiveScenario.VERSION: ClassVar[int]` and satisfies LSP. `ClassVar` was already imported.
- `pyrit/cli/pyrit_shell.py`: suppress the `os.system` soft-deprecation with `# type: ignore[ty:deprecated]` (PyRIT's mypy-style convention; a `subprocess.run` rewrite would need `shell=True` for the Windows `cls` builtin, which is strictly worse).

### Reject Sphinx reST cross-reference roles -- 12 hits -> 0

Replace `:class:`, `:meth:`, and `:attr:` Sphinx roles with double-backtick code spans per PyRIT's MyST docstring convention:

- `pyrit/auxiliary_attacks/gcg/data.py` (2)
- `pyrit/auxiliary_attacks/gcg/experiments/run.py` (4)
- `pyrit/setup/initializers/components/scenario_techniques.py` (6)

### Deferred (out of scope)

The same `ty` run surfaces 9 `unused-type-ignore-comment` **warnings** across `pyrit/datasets/seed_datasets/remote/{jbb_behaviors,sorry_bench,red_team_social_bias}_dataset.py`, `pyrit/prompt_target/openai/_openai_realtime_streaming_session.py`, and `pyrit/scenario/scenarios/foundry/red_team_agent.py`. These are warnings (not errors) and do not fail the hook -- left for a follow-up sweep to keep this PR surgical.

## Tests and Documentation

No new tests; this is a CI / static-analysis fix. The `copilot_authenticator.py` change is a defensive pre-init for the exception path -- behavior on the happy path is unchanged.

Verified locally:

- `uv run --link-mode=copy pre-commit run ty-check --all-files` -- clean
- `uv run --link-mode=copy pre-commit run check-no-rest-roles --all-files` -- clean
- `uv run --link-mode=copy ruff check pyrit/ tests/ doc/` -- clean
- `uv run --link-mode=copy pytest tests/unit -n 8 -q` -- 9364 passed, 124 skipped
