### PR TITLE
MAINT post-0.14.0 release update to 0.15.0.dev0

### DIFF
--- a/.github/docs-versions.yml
+++ b/.github/docs-versions.yml
@@ -8,13 +8,16 @@
 # To add a new release version: append an entry under `versions:`, and update
 # `default:` / `stable:` if the new release should become the landing page.
 
-default: "0.13.0"  # served at the site root (microsoft.github.io/PyRIT/)
-stable: "0.13.0"   # served at /stable/ and shown as "(stable)" in the picker
+default: "0.14.0"  # served at the site root (microsoft.github.io/PyRIT/)
+stable: "0.14.0"   # served at /stable/ and shown as "(stable)" in the picker
 
 versions:
   - slug: latest
     name: "latest (dev, main)"
     ref: main
+  - slug: "0.14.0"
+    name: "0.14.0"
+    ref: releases/v0.14.0
   - slug: "0.13.0"
     name: "0.13.0"
     ref: releases/v0.13.0

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyrit-frontend",
-  "version": "0.14.0-dev.0",
+  "version": "0.15.0-dev.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyrit"
-version = "0.14.0.dev0"
+version = "0.15.0.dev0"
 description = "The Python Risk Identification Tool for LLMs (PyRIT) is a library used to assess the robustness of LLMs"
 authors = [
     { name = "Microsoft AI Red Team", email = "airedteam@microsoft.com" },

--- a/pyrit/__init__.py
+++ b/pyrit/__init__.py
@@ -6,7 +6,7 @@ __name__ = "pyrit"
 # NOTE: __version__ must be set before imports below to avoid circular import issues.
 # Submodules (e.g., component_identifier, memory_models) reference pyrit.__version__
 # and get imported transitively during the .common import chain.
-__version__ = "0.14.0.dev0"
+__version__ = "0.15.0.dev0"
 
 from .common import turn_off_transformers_warning  # noqa: F401
 from .show_versions import show_versions  # noqa: F401


### PR DESCRIPTION
## Description

Routine post-release maintenance following the v0.14.0 release (Step 9 of the [release process](https://github.com/microsoft/PyRIT/blob/main/doc/contributing/10_release_process.md)). Mirrors the previous post-release bump in #1630.

**Dev version bump (0.14.0 → next dev cycle):**

- `pyrit/__init__.py`: `__version__ = "0.15.0.dev0"`
- `pyproject.toml`: `version = "0.15.0.dev0"`
- `frontend/package.json`: `"version": "0.15.0-dev.0"`

**Docs version picker (`.github/docs-versions.yml`):**

- Point `default`/`stable` to `"0.14.0"` so the published v0.14.0 docs are served at the site root and under `/stable/`.
- Add a `"0.14.0"` entry (`ref: releases/v0.14.0`) to the build matrix so the version is actually built and selectable in the picker.

No functional code changes.

## Tests and Documentation

No tests required — version-string and docs-config changes only. The `releases/v0.14.0` ref referenced by the new docs-picker entry exists on `origin`, so the docs build matrix can resolve it. JupyText was not run (no notebook or code-sample changes).
