### PR TITLE
Fix low-contrast .pyrit_conf_example link in dark theme

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pyrit-frontend",
-  "version": "0.15.0-dev.0",
+  "version": "0.14.0-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pyrit-frontend",
-      "version": "0.15.0-dev.0",
+      "version": "0.14.0-dev.0",
       "dependencies": {
         "@azure/msal-browser": "^5.11.0",
         "@azure/msal-react": "^5.4.2",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pyrit-frontend",
-  "version": "0.14.0-dev.0",
+  "version": "0.15.0-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pyrit-frontend",
-      "version": "0.14.0-dev.0",
+      "version": "0.15.0-dev.0",
       "dependencies": {
         "@azure/msal-browser": "^5.11.0",
         "@azure/msal-react": "^5.4.2",

--- a/frontend/src/components/Config/CreateTargetDialog.test.tsx
+++ b/frontend/src/components/Config/CreateTargetDialog.test.tsx
@@ -322,6 +322,21 @@ describe("CreateTargetDialog", () => {
     ).toBeInTheDocument();
   });
 
+  it("should render .pyrit_conf_example as an accessible link", () => {
+    render(
+      <TestWrapper>
+        <CreateTargetDialog {...defaultProps} />
+      </TestWrapper>
+    );
+
+    const link = screen.getByRole("link", { name: ".pyrit_conf_example" });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute(
+      "href",
+      "https://github.com/microsoft/PyRIT/blob/main/.pyrit_conf_example"
+    );
+  });
+
   it("should show field validation errors when submitting form without endpoint", async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/components/Config/CreateTargetDialog.tsx
+++ b/frontend/src/components/Config/CreateTargetDialog.tsx
@@ -9,6 +9,7 @@ import {
   Button,
   Input,
   Label,
+  Link,
   Radio,
   RadioGroup,
   Select,
@@ -348,9 +349,9 @@ export default function CreateTargetDialog({ open, onClose, onCreated }: CreateT
                 Targets can also be auto-populated by adding an initializer (e.g. <code>airt</code>) to your{' '}
                 <code>~/.pyrit/.pyrit_conf</code> file, which reads endpoints from your <code>.env</code> and{' '}
                 <code>.env.local</code> files. See{' '}
-                <a href="https://github.com/microsoft/PyRIT/blob/main/.pyrit_conf_example" target="_blank" rel="noopener noreferrer">
+                <Link href="https://github.com/microsoft/PyRIT/blob/main/.pyrit_conf_example" target="_blank" inline>
                   .pyrit_conf_example
-                </a>.
+                </Link>.
               </Label>
             </form>
           </DialogContent>

--- a/frontend/src/components/Config/TargetConfig.tsx
+++ b/frontend/src/components/Config/TargetConfig.tsx
@@ -3,6 +3,7 @@ import {
   tokens,
   Text,
   Button,
+  Link,
   Spinner,
 } from '@fluentui/react-components'
 import { AddRegular, ArrowSyncRegular } from '@fluentui/react-icons'
@@ -107,9 +108,9 @@ export default function TargetConfig({ activeTarget, onSetActiveTarget }: Target
             to auto-populate targets from your <code>.env</code> and <code>.env.local</code> files.
             For example, add <code>airt</code> to the <code>initializers</code> list to register
             Azure OpenAI targets automatically. See the{' '}
-            <a href="https://github.com/microsoft/PyRIT/blob/main/.pyrit_conf_example" target="_blank" rel="noopener noreferrer">
+            <Link href="https://github.com/microsoft/PyRIT/blob/main/.pyrit_conf_example" target="_blank" inline>
               .pyrit_conf_example
-            </a>{' '}
+            </Link>{' '}
             for details.
           </Text>
           <Button


### PR DESCRIPTION
Replace raw `<a>` tags with Fluent UI `Link` component in `CreateTargetDialog` and `TargetConfig` so the `.pyrit_conf_example` link has sufficient contrast in dark theme.

<img width="1112" height="982" alt="image" src="https://github.com/user-attachments/assets/0d59126c-db39-47c7-bebd-967904fb3d30" />
