### PR TITLE
Improve sidebar active tab contrast in dark theme

### DIFF
--- a/frontend/src/components/Sidebar/Navigation.styles.ts
+++ b/frontend/src/components/Sidebar/Navigation.styles.ts
@@ -20,6 +20,10 @@ export const useNavigationStyles = makeStyles({
     '&[data-active="true"]': {
       backgroundColor: tokens.colorBrandBackground2,
       borderRadius: tokens.borderRadiusMedium,
+      color: tokens.colorBrandForeground1,
+      borderLeftWidth: '3px',
+      borderLeftStyle: 'solid',
+      borderLeftColor: tokens.colorBrandForeground1,
     },
   },
   spacer: {

--- a/frontend/src/components/Sidebar/Navigation.test.tsx
+++ b/frontend/src/components/Sidebar/Navigation.test.tsx
@@ -23,6 +23,17 @@ describe("Navigation", () => {
     jest.clearAllMocks();
   });
 
+  it("marks only the current view button as active", () => {
+    renderWithProvider(
+      <Navigation {...defaultProps} currentView="config" />
+    );
+
+    expect(screen.getByTitle("Configuration")).toHaveAttribute("data-active", "true");
+    expect(screen.getByTitle("Home")).toHaveAttribute("data-active", "false");
+    expect(screen.getByTitle("Chat")).toHaveAttribute("data-active", "false");
+    expect(screen.getByTitle("Attack History")).toHaveAttribute("data-active", "false");
+  });
+
   it("renders the home button", () => {
     renderWithProvider(<Navigation {...defaultProps} />);
 

--- a/frontend/src/components/Sidebar/Navigation.test.tsx
+++ b/frontend/src/components/Sidebar/Navigation.test.tsx
@@ -23,17 +23,6 @@ describe("Navigation", () => {
     jest.clearAllMocks();
   });
 
-  it("marks only the current view button as active", () => {
-    renderWithProvider(
-      <Navigation {...defaultProps} currentView="config" />
-    );
-
-    expect(screen.getByTitle("Configuration")).toHaveAttribute("data-active", "true");
-    expect(screen.getByTitle("Home")).toHaveAttribute("data-active", "false");
-    expect(screen.getByTitle("Chat")).toHaveAttribute("data-active", "false");
-    expect(screen.getByTitle("Attack History")).toHaveAttribute("data-active", "false");
-  });
-
   it("renders the home button", () => {
     renderWithProvider(<Navigation {...defaultProps} />);
 


### PR DESCRIPTION
Add a left accent border and branded icon color to the active navigation button so the selected tab is clearly distinguishable in dark theme.