### PR TITLE
REFACTOR: Promote single-class module constants to ClassVar (backend + registry + setup)

### DIFF
--- a/pyrit/backend/middleware/auth.py
+++ b/pyrit/backend/middleware/auth.py
@@ -18,7 +18,7 @@ The middleware:
 import logging
 import os
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, ClassVar
 
 import httpx
 import jwt
@@ -29,13 +29,6 @@ from starlette.responses import JSONResponse, Response
 from starlette.types import ASGIApp
 
 logger = logging.getLogger(__name__)
-
-# Paths that bypass authentication
-_PUBLIC_PATHS = {
-    "/api/health",
-    "/api/auth/config",
-    "/api/media",
-}
 
 
 @dataclass
@@ -50,6 +43,13 @@ class AuthenticatedUser:
 
 class EntraAuthMiddleware(BaseHTTPMiddleware):
     """Validate Entra ID JWTs on every request (except public paths)."""
+
+    # Paths that bypass authentication
+    _PUBLIC_PATHS: ClassVar[set[str]] = {
+        "/api/health",
+        "/api/auth/config",
+        "/api/media",
+    }
 
     def __init__(self, app: ASGIApp) -> None:
         """Initialize the middleware with Entra ID configuration from environment variables."""
@@ -88,7 +88,7 @@ class EntraAuthMiddleware(BaseHTTPMiddleware):
         """
         # Skip auth for public paths and static files
         path = request.url.path
-        if not self._enabled or path in _PUBLIC_PATHS or not path.startswith("/api"):
+        if not self._enabled or path in self._PUBLIC_PATHS or not path.startswith("/api"):
             return await call_next(request)
 
         result = await self._authenticate_request_async(request)

--- a/pyrit/backend/middleware/security_headers.py
+++ b/pyrit/backend/middleware/security_headers.py
@@ -15,6 +15,7 @@ Applied headers:
 """
 
 import logging
+from typing import ClassVar
 
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
@@ -23,29 +24,29 @@ from starlette.types import ASGIApp
 
 logger = logging.getLogger(__name__)
 
-# Swagger / ReDoc paths — these load scripts and styles from CDN,
-# so CSP is skipped in dev mode (production disables these routes entirely).
-_DOCS_PATHS = {"/docs", "/redoc", "/openapi.json"}
-
-# CSP for API responses — as strict as possible.
-_API_CSP = "default-src 'none'; frame-ancestors 'none'"
-
-# CSP for frontend SPA — allows self-hosted scripts and Fluent UI / Griffel
-# runtime style injection ('unsafe-inline' for style-src only).
-_FRONTEND_CSP = (
-    "default-src 'self'; "
-    "script-src 'self'; "
-    "style-src 'self' 'unsafe-inline'; "
-    "img-src 'self' data: https://*.blob.core.windows.net; "
-    "media-src 'self' https://*.blob.core.windows.net; "
-    "font-src 'self' data:; "
-    "connect-src 'self' https://login.microsoftonline.com; "
-    "frame-ancestors 'none'"
-)
-
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     """Inject security response headers on every request."""
+
+    # Swagger / ReDoc paths — these load scripts and styles from CDN,
+    # so CSP is skipped in dev mode (production disables these routes entirely).
+    _DOCS_PATHS: ClassVar[set[str]] = {"/docs", "/redoc", "/openapi.json"}
+
+    # CSP for API responses — as strict as possible.
+    _API_CSP: ClassVar[str] = "default-src 'none'; frame-ancestors 'none'"
+
+    # CSP for frontend SPA — allows self-hosted scripts and Fluent UI / Griffel
+    # runtime style injection ('unsafe-inline' for style-src only).
+    _FRONTEND_CSP: ClassVar[str] = (
+        "default-src 'self'; "
+        "script-src 'self'; "
+        "style-src 'self' 'unsafe-inline'; "
+        "img-src 'self' data: https://*.blob.core.windows.net; "
+        "media-src 'self' https://*.blob.core.windows.net; "
+        "font-src 'self' data:; "
+        "connect-src 'self' https://login.microsoftonline.com; "
+        "frame-ancestors 'none'"
+    )
 
     def __init__(self, app: ASGIApp, dev_mode: bool = False) -> None:
         """
@@ -84,11 +85,11 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
         # --- Path-dependent headers ---
         if path.startswith("/api"):
-            response.headers["Content-Security-Policy"] = _API_CSP
+            response.headers["Content-Security-Policy"] = self._API_CSP
             response.headers["Cache-Control"] = "no-store"
-        elif self._dev_mode and path in _DOCS_PATHS:
+        elif self._dev_mode and path in self._DOCS_PATHS:
             pass  # No CSP — Swagger/ReDoc load from CDN
         else:
-            response.headers["Content-Security-Policy"] = _FRONTEND_CSP
+            response.headers["Content-Security-Policy"] = self._FRONTEND_CSP
 
         return response

--- a/pyrit/backend/services/converter_service.py
+++ b/pyrit/backend/services/converter_service.py
@@ -19,7 +19,7 @@ import re
 import uuid
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Literal, Union, get_args, get_origin
+from typing import Any, ClassVar, Literal, Union, get_args, get_origin
 from urllib.parse import parse_qs, urlparse
 
 from pyrit import prompt_converter
@@ -41,13 +41,6 @@ from pyrit.models import PromptDataType
 from pyrit.prompt_converter import PromptConverter
 from pyrit.prompt_target import PromptTarget
 from pyrit.registry.object_registries import ConverterRegistry
-
-_DATA_TYPE_EXTENSION: dict[str, str] = {
-    "image_path": ".png",
-    "audio_path": ".wav",
-    "video_path": ".mp4",
-    "binary_path": ".bin",
-}
 
 
 def _build_converter_class_registry() -> dict[str, type]:
@@ -221,6 +214,13 @@ class ConverterService:
     API metadata is derived from the converter objects.
     """
 
+    _DATA_TYPE_EXTENSION: ClassVar[dict[str, str]] = {
+        "image_path": ".png",
+        "audio_path": ".wav",
+        "video_path": ".mp4",
+        "binary_path": ".bin",
+    }
+
     def __init__(self) -> None:
         """Initialize the converter service."""
         self._registry = ConverterRegistry.get_registry_singleton()
@@ -375,7 +375,7 @@ class ConverterService:
             elif original_value.startswith("data:"):
                 _, _, value = original_value.partition(",")
 
-                ext = _DATA_TYPE_EXTENSION.get(str(data_type), ".bin")
+                ext = self._DATA_TYPE_EXTENSION.get(str(data_type), ".bin")
 
                 serializer = data_serializer_factory(
                     category="prompt-memory-entries",
@@ -389,7 +389,7 @@ class ConverterService:
                 pass
             else:
                 # Treat as raw base64
-                ext = _DATA_TYPE_EXTENSION.get(str(data_type), ".bin")
+                ext = self._DATA_TYPE_EXTENSION.get(str(data_type), ".bin")
 
                 serializer = data_serializer_factory(
                     category="prompt-memory-entries",

--- a/pyrit/backend/services/target_service.py
+++ b/pyrit/backend/services/target_service.py
@@ -15,7 +15,7 @@ Targets can be:
 import logging
 import os
 from functools import lru_cache
-from typing import Any
+from typing import Any, ClassVar
 from urllib.parse import urlparse
 
 from pyrit import prompt_target
@@ -34,9 +34,6 @@ from pyrit.prompt_target.round_robin_target import RoundRobinTarget
 from pyrit.registry.object_registries import TargetRegistry
 
 logger = logging.getLogger(__name__)
-
-# Scope for Azure Machine Learning managed online endpoints.
-_AZURE_ML_SCOPE = "https://ml.azure.com/.default"
 
 # Recognised Azure OpenAI / AI Foundry hostname suffixes. Used for strict
 # endpoint validation when Entra ID auth is requested, so a bearer token is
@@ -138,6 +135,9 @@ class TargetService:
     Uses TargetRegistry as the sole source of truth.
     API metadata is derived from the target objects' identifiers.
     """
+
+    # Scope for Azure Machine Learning managed online endpoints.
+    _AZURE_ML_SCOPE: ClassVar[str] = "https://ml.azure.com/.default"
 
     def __init__(self) -> None:
         """Initialize the target service."""
@@ -406,7 +406,7 @@ class TargetService:
                     "Entra ID authentication for AzureMLChatTarget requires an AML endpoint "
                     f"(*.inference.ml.azure.com). Got: {endpoint}"
                 )
-            new_params["api_key"] = get_azure_async_token_provider(_AZURE_ML_SCOPE)
+            new_params["api_key"] = get_azure_async_token_provider(TargetService._AZURE_ML_SCOPE)
             return new_params
 
         raise ValueError(

--- a/pyrit/registry/tag_query.py
+++ b/pyrit/registry/tag_query.py
@@ -29,7 +29,7 @@ items expose a ``tags`` attribute (``list[str]`` or ``set[str]``).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Protocol, TypeVar, runtime_checkable
+from typing import TYPE_CHECKING, ClassVar, Protocol, TypeVar, runtime_checkable
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -45,9 +45,6 @@ class Taggable(Protocol):
 
 
 _T = TypeVar("_T", bound=Taggable)
-
-_VALID_OPS = frozenset({"", "and", "or"})
-_OP_FUNC: dict[str, Callable[..., bool]] = {"and": all, "or": any}
 
 
 @dataclass(frozen=True)
@@ -67,6 +64,9 @@ class TagQuery:
         include_any: Tags of which **at least one** must be present (OR).
         exclude_tags: Tags that must **not** be present.
     """
+
+    _VALID_OPS: ClassVar[frozenset[str]] = frozenset({"", "and", "or"})
+    _OP_FUNC: ClassVar[dict[str, Callable[..., bool]]] = {"and": all, "or": any}
 
     include_all: frozenset[str] = frozenset()
     include_any: frozenset[str] = frozenset()
@@ -88,8 +88,8 @@ class TagQuery:
             if not isinstance(val, frozenset):
                 object.__setattr__(self, attr, frozenset(val))
 
-        if self._op not in _VALID_OPS:
-            raise ValueError(f"Invalid TagQuery op {self._op!r}; must be one of {sorted(_VALID_OPS)}")
+        if self._op not in self._VALID_OPS:
+            raise ValueError(f"Invalid TagQuery op {self._op!r}; must be one of {sorted(self._VALID_OPS)}")
         if self._op in ("and", "or") and len(self._children) < 2:
             raise ValueError(f"'{self._op}' TagQuery must have at least 2 children")
         if self._op == "" and self._children:
@@ -166,7 +166,7 @@ class TagQuery:
             Whether the tag set matches.
         """
         if self._op:
-            return _OP_FUNC[self._op](c.matches(tags) for c in self._children)
+            return self._OP_FUNC[self._op](c.matches(tags) for c in self._children)
         return self._matches_leaf(tags)
 
     def _matches_leaf(self, tags: set[str] | frozenset[str]) -> bool:

--- a/pyrit/setup/configuration_loader.py
+++ b/pyrit/setup/configuration_loader.py
@@ -11,7 +11,7 @@ from YAML files and initializes PyRIT accordingly.
 import pathlib
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from pyrit.common.path import DEFAULT_CONFIG_PATH
 from pyrit.common.yaml_loadable import YamlLoadable
@@ -31,13 +31,6 @@ if TYPE_CHECKING:
 # This matches what YAML can represent: primitives, lists, and nested dicts
 YamlPrimitive = str | int | float | bool | None
 YamlValue = YamlPrimitive | list["YamlValue"] | dict[str, "YamlValue"]
-
-# Mapping from snake_case config values to internal constants
-_MEMORY_DB_TYPE_MAP: dict[str, str] = {
-    "in_memory": IN_MEMORY,
-    "sqlite": SQLITE,
-    "azure_sql": AZURE_SQL,
-}
 
 
 @dataclass
@@ -136,6 +129,13 @@ class ConfigurationLoader(YamlLoadable):
         operation: my_operation
     """
 
+    # Mapping from snake_case config values to internal constants
+    _MEMORY_DB_TYPE_MAP: ClassVar[dict[str, str]] = {
+        "in_memory": IN_MEMORY,
+        "sqlite": SQLITE,
+        "azure_sql": AZURE_SQL,
+    }
+
     memory_db_type: str = "sqlite"
     initializers: list[str | dict[str, Any]] = field(default_factory=list)
     initialization_scripts: list[str] | None = None
@@ -171,12 +171,12 @@ class ConfigurationLoader(YamlLoadable):
         normalized = self.memory_db_type.lower().replace("-", "_")
 
         # Also handle PascalCase inputs (e.g., "InMemory" -> "in_memory")
-        if normalized not in _MEMORY_DB_TYPE_MAP:
+        if normalized not in self._MEMORY_DB_TYPE_MAP:
             # Try converting from PascalCase
             normalized = class_name_to_snake_case(self.memory_db_type)
 
-        if normalized not in _MEMORY_DB_TYPE_MAP:
-            valid_types = list(_MEMORY_DB_TYPE_MAP.keys())
+        if normalized not in self._MEMORY_DB_TYPE_MAP:
+            valid_types = list(self._MEMORY_DB_TYPE_MAP.keys())
             raise ValueError(
                 f"Invalid memory_db_type '{self.memory_db_type}'. Must be one of: {', '.join(valid_types)}"
             )
@@ -552,7 +552,7 @@ class ConfigurationLoader(YamlLoadable):
         resolved_env_files = self.resolve_env_files()
 
         # Map snake_case memory_db_type to internal constant
-        internal_memory_db_type = _MEMORY_DB_TYPE_MAP[self.memory_db_type]
+        internal_memory_db_type = self._MEMORY_DB_TYPE_MAP[self.memory_db_type]
 
         await initialize_pyrit_async(
             memory_db_type=internal_memory_db_type,

--- a/tests/unit/backend/test_converter_service.py
+++ b/tests/unit/backend/test_converter_service.py
@@ -5,7 +5,7 @@
 Tests for backend converter service.
 """
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -328,6 +328,73 @@ class TestPreviewConversion:
         assert result.converted_value == "step2_output"
         assert len(result.steps) == 2
         mock_converter2.convert_async.assert_called_with(prompt="step1_output", input_type="text")
+
+    async def test_preview_conversion_persists_data_uri_for_image_path(self) -> None:
+        """Data URIs on *_path types are decoded via the _DATA_TYPE_EXTENSION map and persisted."""
+        service = ConverterService()
+
+        mock_converter = MagicMock()
+        mock_result = MagicMock()
+        mock_result.output_text = "/tmp/persisted.png"
+        mock_result.output_type = "image_path"
+        mock_converter.convert_async = AsyncMock(return_value=mock_result)
+        service._registry.register_instance(mock_converter, name="conv-1")
+
+        mock_serializer = MagicMock()
+        mock_serializer.value = "/tmp/persisted.png"
+        mock_serializer.save_b64_image_async = AsyncMock()
+
+        request = ConverterPreviewRequest(
+            original_value="data:image/png;base64,iVBORw0KGgo=",
+            original_value_data_type="image_path",
+            converter_ids=["conv-1"],
+        )
+
+        with patch(
+            "pyrit.backend.services.converter_service.data_serializer_factory",
+            return_value=mock_serializer,
+        ) as mock_factory:
+            await service.preview_conversion_async(request=request)
+
+        mock_factory.assert_called_once()
+        # ext is the image_path mapping from _DATA_TYPE_EXTENSION
+        assert mock_factory.call_args.kwargs["extension"] == ".png"
+        assert mock_factory.call_args.kwargs["data_type"] == "image_path"
+        mock_serializer.save_b64_image_async.assert_awaited_once_with(data="iVBORw0KGgo=")
+
+    async def test_preview_conversion_persists_raw_base64_for_audio_path(self) -> None:
+        """Values that aren't URLs/data URIs/existing files are treated as raw base64 and persisted."""
+        service = ConverterService()
+
+        mock_converter = MagicMock()
+        mock_result = MagicMock()
+        mock_result.output_text = "/tmp/persisted.wav"
+        mock_result.output_type = "audio_path"
+        mock_converter.convert_async = AsyncMock(return_value=mock_result)
+        service._registry.register_instance(mock_converter, name="conv-1")
+
+        mock_serializer = MagicMock()
+        mock_serializer.value = "/tmp/persisted.wav"
+        mock_serializer.save_b64_image_async = AsyncMock()
+
+        raw_b64 = "UklGRiQAAABXQVZF"
+        request = ConverterPreviewRequest(
+            original_value=raw_b64,
+            original_value_data_type="audio_path",
+            converter_ids=["conv-1"],
+        )
+
+        with patch(
+            "pyrit.backend.services.converter_service.data_serializer_factory",
+            return_value=mock_serializer,
+        ) as mock_factory:
+            await service.preview_conversion_async(request=request)
+
+        mock_factory.assert_called_once()
+        # ext is the audio_path mapping from _DATA_TYPE_EXTENSION
+        assert mock_factory.call_args.kwargs["extension"] == ".wav"
+        assert mock_factory.call_args.kwargs["data_type"] == "audio_path"
+        mock_serializer.save_b64_image_async.assert_awaited_once_with(data=raw_b64)
 
 
 class TestGetConverterObjectsForIds:

--- a/tests/unit/backend/test_security_headers.py
+++ b/tests/unit/backend/test_security_headers.py
@@ -1,0 +1,77 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""
+Tests for the security headers middleware.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from pyrit.backend.middleware.security_headers import SecurityHeadersMiddleware
+
+
+def _build_client(*, dev_mode: bool) -> TestClient:
+    app = FastAPI()
+    app.add_middleware(SecurityHeadersMiddleware, dev_mode=dev_mode)
+
+    @app.get("/api/test")
+    async def api_route() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    @app.get("/")
+    async def frontend_route() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    @app.get("/docs")
+    async def docs_route() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    return TestClient(app)
+
+
+class TestSecurityHeadersMiddleware:
+    """Tests for SecurityHeadersMiddleware."""
+
+    @pytest.fixture
+    def prod_client(self) -> TestClient:
+        return _build_client(dev_mode=False)
+
+    @pytest.fixture
+    def dev_client(self) -> TestClient:
+        return _build_client(dev_mode=True)
+
+    def test_common_headers_applied_to_all_responses(self, prod_client: TestClient) -> None:
+        response = prod_client.get("/api/test")
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+        assert response.headers["X-Frame-Options"] == "DENY"
+        assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+        assert "camera=()" in response.headers["Permissions-Policy"]
+
+    def test_api_path_uses_api_csp_and_no_store(self, prod_client: TestClient) -> None:
+        response = prod_client.get("/api/test")
+        assert response.headers["Content-Security-Policy"] == SecurityHeadersMiddleware._API_CSP
+        assert response.headers["Cache-Control"] == "no-store"
+
+    def test_frontend_path_uses_frontend_csp(self, prod_client: TestClient) -> None:
+        response = prod_client.get("/")
+        assert response.headers["Content-Security-Policy"] == SecurityHeadersMiddleware._FRONTEND_CSP
+        assert "Cache-Control" not in response.headers or response.headers["Cache-Control"] != "no-store"
+
+    def test_docs_path_in_dev_mode_skips_csp(self, dev_client: TestClient) -> None:
+        response = dev_client.get("/docs")
+        assert "Content-Security-Policy" not in response.headers
+
+    def test_docs_path_in_prod_mode_still_gets_frontend_csp(self, prod_client: TestClient) -> None:
+        response = prod_client.get("/docs")
+        assert response.headers["Content-Security-Policy"] == SecurityHeadersMiddleware._FRONTEND_CSP
+
+    def test_hsts_set_in_prod_mode(self, prod_client: TestClient) -> None:
+        response = prod_client.get("/")
+        assert "Strict-Transport-Security" in response.headers
+
+    def test_hsts_omitted_in_dev_mode(self, dev_client: TestClient) -> None:
+        response = dev_client.get("/")
+        assert "Strict-Transport-Security" not in response.headers


### PR DESCRIPTION
Promotes module-level constants that are only consumed by a single class to `ClassVar` attributes on that class, per `style-guide.instructions.md` lines 222-237 ("Define constants as class attributes, not module-level. Use UPPER_CASE naming.").

This is Part A, PR 1 of a planned series cleaning up constant placement across PyRIT. See the audit notes for the full scope.

## Files touched

- `pyrit/backend/middleware/auth.py` — `_PUBLIC_PATHS` → `EntraAuthMiddleware._PUBLIC_PATHS: ClassVar[set[str]]`
- `pyrit/backend/middleware/security_headers.py` — `_DOCS_PATHS`, `_API_CSP`, `_FRONTEND_CSP` → `SecurityHeadersMiddleware` ClassVars
- `pyrit/backend/services/converter_service.py` — `_DATA_TYPE_EXTENSION` → `ConverterService._DATA_TYPE_EXTENSION`
- `pyrit/backend/services/target_service.py` — `_AZURE_ML_SCOPE` → `TargetService._AZURE_ML_SCOPE` (referenced via `TargetService._AZURE_ML_SCOPE` because the call site is `@staticmethod`)
- `pyrit/registry/tag_query.py` — `_VALID_OPS`, `_OP_FUNC` → `TagQuery` ClassVars (`ClassVar` is **required** here because `TagQuery` is `@dataclass(frozen=True)`; without the annotation, the dict/set values would be misinterpreted as default dataclass fields).
- `pyrit/setup/configuration_loader.py` — `_MEMORY_DB_TYPE_MAP` → `ConfigurationLoader._MEMORY_DB_TYPE_MAP: ClassVar[dict[str, str]]` (also a `@dataclass`).

## Behavior

No value changes. No behaviour changes. This is a pure relocation of where a constant lives — same value, same usage, just moved onto the class that uses it.

## Out of scope (deferred)

`_TARGET_CLASS_REGISTRY` and `_CONVERTER_CLASS_REGISTRY` are explicitly **left at module scope**: they're populated by side-effect at import time via decorators, and moving them onto a class would change evaluation timing. They'll be revisited as a separate cleanup.

## Verified

- `uv run --link-mode=copy ruff check` — clean
- `uv run --link-mode=copy ty check` — clean
- `uv run --link-mode=copy pytest tests/unit/backend/ tests/unit/registry/ tests/unit/setup/` — 1160 passed, 5 skipped
