### PR TITLE
REFACTOR: Promote single-class module constants to ClassVar (prompt_converter)

### DIFF
--- a/pyrit/prompt_converter/image_prompt_style_converter.py
+++ b/pyrit/prompt_converter/image_prompt_style_converter.py
@@ -4,7 +4,7 @@
 import logging
 import random
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import yaml
 
@@ -21,9 +21,6 @@ from pyrit.prompt_target import PromptTarget
 
 logger = logging.getLogger(__name__)
 
-IMAGE_PROMPT_STYLE_DIR = Path(CONVERTER_SEED_PROMPT_PATH) / "image_prompt_style"
-SYSTEM_PROMPT_FILENAME = "image_prompt_style_system_prompt.yaml"
-
 
 class ImagePromptStyleConverter(LLMGenericTextConverter):
     """
@@ -33,6 +30,9 @@ class ImagePromptStyleConverter(LLMGenericTextConverter):
     The converter loads a filter YAML file containing style_instructions and a list of variations,
     then uses an LLM to expand the user's objective into a fully styled image generation prompt.
     """
+
+    IMAGE_PROMPT_STYLE_DIR: ClassVar[Path] = Path(CONVERTER_SEED_PROMPT_PATH) / "image_prompt_style"
+    SYSTEM_PROMPT_FILENAME: ClassVar[str] = "image_prompt_style_system_prompt.yaml"
 
     @apply_defaults
     def __init__(
@@ -73,7 +73,7 @@ class ImagePromptStyleConverter(LLMGenericTextConverter):
         self._variation = variation
 
         # Load the shared system prompt template
-        system_prompt_path = IMAGE_PROMPT_STYLE_DIR / SYSTEM_PROMPT_FILENAME
+        system_prompt_path = self.IMAGE_PROMPT_STYLE_DIR / self.SYSTEM_PROMPT_FILENAME
         system_prompt_template = SeedPrompt.from_yaml_file(system_prompt_path)
 
         # Resolve the filter YAML file
@@ -83,7 +83,7 @@ class ImagePromptStyleConverter(LLMGenericTextConverter):
                 raise ValueError(f"Filter path '{filter_path}' does not exist.")
             self._filter_name = resolved_path.stem
         elif filter_name is not None:
-            resolved_path = IMAGE_PROMPT_STYLE_DIR / f"{filter_name}.yaml"
+            resolved_path = self.IMAGE_PROMPT_STYLE_DIR / f"{filter_name}.yaml"
             if not resolved_path.exists():
                 available = self.list_available_filters()
                 raise ValueError(f"Filter '{filter_name}' not found. Available filters: {available}")
@@ -92,7 +92,7 @@ class ImagePromptStyleConverter(LLMGenericTextConverter):
             # No filter specified — pick a random built-in filter
             available = self.list_available_filters()
             self._filter_name = random.choice(available)
-            resolved_path = IMAGE_PROMPT_STYLE_DIR / f"{self._filter_name}.yaml"
+            resolved_path = self.IMAGE_PROMPT_STYLE_DIR / f"{self._filter_name}.yaml"
 
         with open(resolved_path, encoding="utf-8") as f:
             filter_data = yaml.safe_load(f)
@@ -208,7 +208,7 @@ class ImagePromptStyleConverter(LLMGenericTextConverter):
         Returns:
             List of filter names (YAML filenames without extension), excluding the system prompt.
         """
-        return sorted(p.stem for p in IMAGE_PROMPT_STYLE_DIR.glob("*.yaml") if p.name != SYSTEM_PROMPT_FILENAME)
+        return sorted(p.stem for p in cls.IMAGE_PROMPT_STYLE_DIR.glob("*.yaml") if p.name != cls.SYSTEM_PROMPT_FILENAME)
 
     @classmethod
     def list_available_variations(cls, *, filter_name: str) -> list[str]:
@@ -225,7 +225,7 @@ class ImagePromptStyleConverter(LLMGenericTextConverter):
             ValueError: If filter_name does not correspond to an existing YAML file, or if the
                 filter file is malformed.
         """
-        resolved_path = IMAGE_PROMPT_STYLE_DIR / f"{filter_name}.yaml"
+        resolved_path = cls.IMAGE_PROMPT_STYLE_DIR / f"{filter_name}.yaml"
         if not resolved_path.exists():
             available = cls.list_available_filters()
             raise ValueError(f"Filter '{filter_name}' not found. Available filters: {available}")

--- a/pyrit/prompt_converter/scientific_translation_converter.py
+++ b/pyrit/prompt_converter/scientific_translation_converter.py
@@ -3,7 +3,7 @@
 
 import logging
 import pathlib
-from typing import Literal, get_args
+from typing import ClassVar, Literal, get_args
 
 from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import CONVERTER_SEED_PROMPT_PATH
@@ -16,18 +16,6 @@ logger = logging.getLogger(__name__)
 
 # Supported translation modes
 TranslationMode = Literal["academic", "technical", "smiles", "math", "research", "reaction", "combined"]
-TRANSLATION_MODES = set(get_args(TranslationMode))
-
-# Mapping from mode to YAML file name
-MODE_YAML_FILES: dict[str, str] = {
-    "academic": "academic_science_converter.yaml",
-    "technical": "technical_science_converter.yaml",
-    "smiles": "smiles_science_converter.yaml",
-    "math": "math_science_converter.yaml",
-    "research": "research_science_converter.yaml",
-    "reaction": "reaction_science_converter.yaml",
-    "combined": "combined_science_converter.yaml",
-}
 
 
 class ScientificTranslationConverter(LLMGenericTextConverter):
@@ -39,6 +27,19 @@ class ScientificTranslationConverter(LLMGenericTextConverter):
     whether safety filters can be bypassed through scientific translation.
 
     """
+
+    TRANSLATION_MODES: ClassVar[set[str]] = set(get_args(TranslationMode))
+
+    # Mapping from mode to YAML file name
+    MODE_YAML_FILES: ClassVar[dict[str, str]] = {
+        "academic": "academic_science_converter.yaml",
+        "technical": "technical_science_converter.yaml",
+        "smiles": "smiles_science_converter.yaml",
+        "math": "math_science_converter.yaml",
+        "research": "research_science_converter.yaml",
+        "reaction": "reaction_science_converter.yaml",
+        "combined": "combined_science_converter.yaml",
+    }
 
     @apply_defaults
     def __init__(
@@ -75,13 +76,13 @@ class ScientificTranslationConverter(LLMGenericTextConverter):
         # Resolve template: use provided, or load from mode, or error
         if prompt_template is not None:
             resolved_template = prompt_template
-        elif mode in TRANSLATION_MODES:
-            yaml_file = MODE_YAML_FILES[mode]
+        elif mode in self.TRANSLATION_MODES:
+            yaml_file = self.MODE_YAML_FILES[mode]
             resolved_template = SeedPrompt.from_yaml_file(pathlib.Path(CONVERTER_SEED_PROMPT_PATH) / yaml_file)
         else:
             raise ValueError(
                 f"Custom mode '{mode}' requires a prompt_template. "
-                f"Either use a built-in mode from {sorted(TRANSLATION_MODES)} or provide a prompt_template."
+                f"Either use a built-in mode from {sorted(self.TRANSLATION_MODES)} or provide a prompt_template."
             )
 
         super().__init__(

--- a/pyrit/prompt_converter/zalgo_converter.py
+++ b/pyrit/prompt_converter/zalgo_converter.py
@@ -3,15 +3,12 @@
 
 import logging
 import random
+from typing import ClassVar
 
 from pyrit.models import ComponentIdentifier
 from pyrit.prompt_converter.text_selection_strategy import WordSelectionStrategy
 from pyrit.prompt_converter.word_level_converter import WordLevelConverter
 
-# Unicode combining characters for Zalgo effect (U+0300–U+036F)
-ZALGO_MARKS = [chr(code) for code in range(0x0300, 0x036F + 1)]
-# Setting a max intensity so people don't do anything unreasonable
-MAX_INTENSITY = 100
 logger = logging.getLogger(__name__)
 
 
@@ -19,6 +16,11 @@ class ZalgoConverter(WordLevelConverter):
     """
     Converts text into cursed Zalgo text using combining Unicode marks.
     """
+
+    # Unicode combining characters for Zalgo effect (U+0300–U+036F)
+    ZALGO_MARKS: ClassVar[list[str]] = [chr(code) for code in range(0x0300, 0x036F + 1)]
+    # Setting a max intensity so people don't do anything unreasonable
+    MAX_INTENSITY: ClassVar[int] = 100
 
     def __init__(
         self,
@@ -59,10 +61,10 @@ class ZalgoConverter(WordLevelConverter):
         except (TypeError, ValueError):
             raise ValueError(f"Invalid intensity value: {intensity!r} (must be an integer)") from None
 
-        normalized_intensity = max(0, min(intensity, MAX_INTENSITY))
+        normalized_intensity = max(0, min(intensity, self.MAX_INTENSITY))
         if intensity != normalized_intensity:
             logger.warning(
-                f"ZalgoConverter supports intensity between 0 and {MAX_INTENSITY}, "
+                f"ZalgoConverter supports intensity between 0 and {self.MAX_INTENSITY}, "
                 f"but received a value of {intensity}. Normalizing to {normalized_intensity}."
             )
         return normalized_intensity
@@ -81,7 +83,7 @@ class ZalgoConverter(WordLevelConverter):
             return word
 
         def glitch(char: str) -> str:
-            return char + "".join(random.choice(ZALGO_MARKS) for _ in range(random.randint(1, self._intensity)))
+            return char + "".join(random.choice(self.ZALGO_MARKS) for _ in range(random.randint(1, self._intensity)))
 
         return "".join(glitch(c) if c.isalnum() else c for c in word)
 


### PR DESCRIPTION
Promotes module-level constants that are only consumed by a single converter class to `ClassVar` attributes on that class, per `style-guide.instructions.md` lines 222-237 ("Define constants as class attributes, not module-level. Use UPPER_CASE naming.").

This is Part A, PR 2 of a planned series cleaning up constant placement across PyRIT.

## Files touched

- `pyrit/prompt_converter/image_prompt_style_converter.py` — `IMAGE_PROMPT_STYLE_DIR`, `SYSTEM_PROMPT_FILENAME` → `ImagePromptStyleConverter` ClassVars. References in `__init__`, `list_available_filters`, and `list_available_variations` updated to use `self.`/`cls.` lookup.
- `pyrit/prompt_converter/scientific_translation_converter.py` — `TRANSLATION_MODES`, `MODE_YAML_FILES` → `ScientificTranslationConverter` ClassVars.
- `pyrit/prompt_converter/zalgo_converter.py` — `ZALGO_MARKS`, `MAX_INTENSITY` → `ZalgoConverter` ClassVars.

## Behavior

No value changes. No behaviour changes.

## Out of scope (intentional)

- `TranslationMode` Literal type alias in `scientific_translation_converter.py` stays at module scope — PEP 484 type aliases are conventionally module-level and it''s also used in annotations elsewhere.
- `_UNSET = object()` sentinel in `add_image_text_converter.py` stays at module scope — identity-based sentinels must be module-level so `is _UNSET` remains stable across re-imports.

## Verified

- `uv run --link-mode=copy ruff check` — clean
- `uv run --link-mode=copy ty check` — clean
- `uv run --link-mode=copy pytest tests/unit/prompt_converter/test_image_prompt_style_converter.py tests/unit/prompt_converter/test_scientific_translation_converter.py tests/unit/prompt_converter/test_zalgo_converter.py` — 48 passed
