### PR TITLE
REFACTOR: Promote multi-turn attack constants & defaults to ClassVar

### DIFF
--- a/pyrit/executor/attack/multi_turn/crescendo.py
+++ b/pyrit/executor/attack/multi_turn/crescendo.py
@@ -8,7 +8,7 @@ import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import EXECUTOR_SEED_PROMPT_PATH
@@ -61,13 +61,6 @@ if TYPE_CHECKING:
     from pyrit.prompt_target.common.prompt_target import PromptTarget
 
 logger = logging.getLogger(__name__)
-
-# Crescendo sets a system prompt on its adversarial target and drives a multi-turn dialogue through it.
-# Both capabilities must be natively supported — adaptation would silently change the semantics
-# (e.g. history-squash normalization would collapse the escalation into a single turn).
-_ADVERSARIAL_REQUIREMENTS = TargetRequirements(
-    native_required=frozenset({CapabilityName.MULTI_TURN, CapabilityName.SYSTEM_PROMPT}),
-)
 
 
 @dataclass
@@ -133,6 +126,16 @@ class CrescendoAttack(MultiTurnAttackStrategy[CrescendoAttackContext, CrescendoA
         native_required=frozenset({CapabilityName.MULTI_TURN}),
     )
 
+    # Crescendo sets a system prompt on its adversarial target and drives a multi-turn dialogue through it.
+    # Both capabilities must be natively supported — adaptation would silently change the semantics
+    # (e.g. history-squash normalization would collapse the escalation into a single turn).
+    _ADVERSARIAL_REQUIREMENTS: ClassVar[TargetRequirements] = TargetRequirements(
+        native_required=frozenset({CapabilityName.MULTI_TURN, CapabilityName.SYSTEM_PROMPT}),
+    )
+
+    DEFAULT_MAX_BACKTRACKS: ClassVar[int] = 10
+    DEFAULT_MAX_TURNS: ClassVar[int] = 10
+
     # Default system prompt template path for Crescendo attack
     DEFAULT_ADVERSARIAL_CHAT_SYSTEM_PROMPT_TEMPLATE_PATH: Path = (
         Path(EXECUTOR_SEED_PROMPT_PATH) / "crescendo" / "crescendo_variant_1.yaml"
@@ -147,8 +150,8 @@ class CrescendoAttack(MultiTurnAttackStrategy[CrescendoAttackContext, CrescendoA
         attack_converter_config: AttackConverterConfig | None = None,
         attack_scoring_config: AttackScoringConfig | None = None,
         prompt_normalizer: PromptNormalizer | None = None,
-        max_backtracks: int = 10,
-        max_turns: int = 10,
+        max_backtracks: int | None = None,
+        max_turns: int | None = None,
         prepended_conversation_config: PrependedConversationConfig | None = None,
     ) -> None:
         """
@@ -163,8 +166,10 @@ class CrescendoAttack(MultiTurnAttackStrategy[CrescendoAttackContext, CrescendoA
                 including request and response converters.
             attack_scoring_config (AttackScoringConfig | None): Configuration for scoring responses.
             prompt_normalizer (PromptNormalizer | None): Normalizer for prompts.
-            max_backtracks (int): Maximum number of backtracks allowed.
-            max_turns (int): Maximum number of turns allowed.
+            max_backtracks (int | None): Maximum number of backtracks allowed. Defaults to
+                ``DEFAULT_MAX_BACKTRACKS`` (10).
+            max_turns (int | None): Maximum number of turns allowed. Defaults to
+                ``DEFAULT_MAX_TURNS`` (10).
             prepended_conversation_config (PrependedConversationConfiguration | None):
                 Configuration for how to process prepended conversations. Controls converter
                 application by role, message normalization, and non-chat target behavior.
@@ -215,7 +220,7 @@ class CrescendoAttack(MultiTurnAttackStrategy[CrescendoAttackContext, CrescendoA
         # (The class-level ``TARGET_REQUIREMENTS`` only covers ``objective_target``;
         # this is a separate target.)
         try:
-            _ADVERSARIAL_REQUIREMENTS.validate(target=self._adversarial_chat)
+            self._ADVERSARIAL_REQUIREMENTS.validate(target=self._adversarial_chat)
         except ValueError as exc:
             raise ValueError(f"CrescendoAttack {exc}") from exc
 
@@ -237,6 +242,11 @@ class CrescendoAttack(MultiTurnAttackStrategy[CrescendoAttackContext, CrescendoA
         )
 
         # Set the maximum number of backtracks and turns
+        if max_backtracks is None:
+            max_backtracks = self.DEFAULT_MAX_BACKTRACKS
+        if max_turns is None:
+            max_turns = self.DEFAULT_MAX_TURNS
+
         if max_backtracks < 0:
             raise ValueError("max_backtracks must be non-negative")
 

--- a/pyrit/executor/attack/multi_turn/pair.py
+++ b/pyrit/executor/attack/multi_turn/pair.py
@@ -10,6 +10,7 @@ parameters (no tree branching, no off-topic pruning) hardcoded.
 """
 
 import logging
+from typing import ClassVar
 
 from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.executor.attack.component import PrependedConversationConfig
@@ -51,6 +52,11 @@ class PAIRAttack(TreeOfAttacksWithPruningAttack):
         [@mehrotra2023tap]
     """
 
+    DEFAULT_TREE_WIDTH: ClassVar[int] = 3
+    DEFAULT_TREE_DEPTH: ClassVar[int] = 5
+    DEFAULT_DESIRED_RESPONSE_PREFIX: ClassVar[str] = "Sure, here is"
+    DEFAULT_BATCH_SIZE: ClassVar[int] = 10
+
     @apply_defaults
     def __init__(
         self,
@@ -60,10 +66,10 @@ class PAIRAttack(TreeOfAttacksWithPruningAttack):
         attack_converter_config: AttackConverterConfig | None = None,
         attack_scoring_config: TAPAttackScoringConfig | None = None,
         prompt_normalizer: PromptNormalizer | None = None,
-        tree_width: int = 3,
-        tree_depth: int = 5,
-        desired_response_prefix: str = "Sure, here is",
-        batch_size: int = 10,
+        tree_width: int | None = None,
+        tree_depth: int | None = None,
+        desired_response_prefix: str | None = None,
+        batch_size: int | None = None,
         prepended_conversation_config: PrependedConversationConfig | None = None,
     ) -> None:
         """
@@ -81,17 +87,26 @@ class PAIRAttack(TreeOfAttacksWithPruningAttack):
                 SelfAskScaleScorer (threshold 0.7) is created. Defaults to None.
             prompt_normalizer (PromptNormalizer | None): The prompt normalizer to use.
                 Defaults to None.
-            tree_width (int): Number of parallel "streams" (N in the PAIR paper).
-                Defaults to 3.
-            tree_depth (int): Maximum refinement iterations per stream (K in the PAIR
-                paper). Defaults to 5.
-            desired_response_prefix (str): Expected prefix for successful responses.
-                Defaults to "Sure, here is".
-            batch_size (int): Number of nodes to process in parallel per batch.
-                Defaults to 10.
+            tree_width (int | None): Number of parallel "streams" (N in the PAIR paper).
+                Defaults to ``DEFAULT_TREE_WIDTH`` (3).
+            tree_depth (int | None): Maximum refinement iterations per stream (K in the PAIR
+                paper). Defaults to ``DEFAULT_TREE_DEPTH`` (5).
+            desired_response_prefix (str | None): Expected prefix for successful responses.
+                Defaults to ``DEFAULT_DESIRED_RESPONSE_PREFIX`` ("Sure, here is").
+            batch_size (int | None): Number of nodes to process in parallel per batch.
+                Defaults to ``DEFAULT_BATCH_SIZE`` (10).
             prepended_conversation_config (PrependedConversationConfig | None):
                 Configuration for prepended-conversation handling. Defaults to None.
         """
+        if tree_width is None:
+            tree_width = self.DEFAULT_TREE_WIDTH
+        if tree_depth is None:
+            tree_depth = self.DEFAULT_TREE_DEPTH
+        if desired_response_prefix is None:
+            desired_response_prefix = self.DEFAULT_DESIRED_RESPONSE_PREFIX
+        if batch_size is None:
+            batch_size = self.DEFAULT_BATCH_SIZE
+
         super().__init__(
             objective_target=objective_target,
             attack_adversarial_config=attack_adversarial_config,

--- a/pyrit/executor/attack/multi_turn/red_teaming.py
+++ b/pyrit/executor/attack/multi_turn/red_teaming.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import enum
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from pyrit.common.apply_defaults import REQUIRED_VALUE, apply_defaults
 from pyrit.common.path import EXECUTOR_RED_TEAM_PATH
@@ -48,13 +48,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# RedTeamingAttack sets a system prompt on its adversarial target and drives a multi-turn dialogue
-# through it. Both capabilities must be natively supported — adaptation would silently change the
-# semantics (e.g. history-squash normalization would collapse the dialogue into a single turn).
-_ADVERSARIAL_REQUIREMENTS = TargetRequirements(
-    native_required=frozenset({CapabilityName.MULTI_TURN, CapabilityName.SYSTEM_PROMPT}),
-)
-
 
 class RTASystemPromptPaths(enum.Enum):
     """Enum for predefined red teaming attack system prompt paths."""
@@ -94,6 +87,15 @@ class RedTeamingAttack(MultiTurnAttackStrategy[MultiTurnAttackContext[Any], Atta
         "that can be passed to the red teaming chat. "
     )
 
+    # RedTeamingAttack sets a system prompt on its adversarial target and drives a multi-turn dialogue
+    # through it. Both capabilities must be natively supported — adaptation would silently change the
+    # semantics (e.g. history-squash normalization would collapse the dialogue into a single turn).
+    _ADVERSARIAL_REQUIREMENTS: ClassVar[TargetRequirements] = TargetRequirements(
+        native_required=frozenset({CapabilityName.MULTI_TURN, CapabilityName.SYSTEM_PROMPT}),
+    )
+
+    DEFAULT_MAX_TURNS: ClassVar[int] = 10
+
     @apply_defaults
     def __init__(
         self,
@@ -103,7 +105,7 @@ class RedTeamingAttack(MultiTurnAttackStrategy[MultiTurnAttackContext[Any], Atta
         attack_converter_config: AttackConverterConfig | None = None,
         attack_scoring_config: AttackScoringConfig | None = None,
         prompt_normalizer: PromptNormalizer | None = None,
-        max_turns: int = 10,
+        max_turns: int | None = None,
         score_last_turn_only: bool = False,
     ) -> None:
         """
@@ -115,7 +117,8 @@ class RedTeamingAttack(MultiTurnAttackStrategy[MultiTurnAttackContext[Any], Atta
             attack_converter_config: Configuration for attack converters. Defaults to None.
             attack_scoring_config: Configuration for attack scoring. Defaults to None.
             prompt_normalizer: The prompt normalizer to use for sending prompts. Defaults to None.
-            max_turns (int): Maximum number of turns for the attack. Defaults to 10.
+            max_turns (int | None): Maximum number of turns for the attack. Defaults to
+                ``DEFAULT_MAX_TURNS`` (10).
             score_last_turn_only (bool): If True, only score the final turn instead of every turn.
                 This reduces LLM calls when intermediate scores are not needed (e.g., for
                 generating simulated conversations). The attack will run for exactly max_turns
@@ -149,7 +152,7 @@ class RedTeamingAttack(MultiTurnAttackStrategy[MultiTurnAttackContext[Any], Atta
         # The adversarial target must natively support multi-turn dialogue and system prompts;
         # the class-level ``TARGET_REQUIREMENTS`` only covers ``objective_target``.
         try:
-            _ADVERSARIAL_REQUIREMENTS.validate(target=self._adversarial_chat)
+            self._ADVERSARIAL_REQUIREMENTS.validate(target=self._adversarial_chat)
         except ValueError as exc:
             raise ValueError(f"RedTeamingAttack {exc}") from exc
 
@@ -169,6 +172,8 @@ class RedTeamingAttack(MultiTurnAttackStrategy[MultiTurnAttackContext[Any], Atta
         self._conversation_manager = ConversationManager(attack_identifier=self.get_identifier())
 
         # set the maximum number of turns for the attack
+        if max_turns is None:
+            max_turns = self.DEFAULT_MAX_TURNS
         if max_turns <= 0:
             raise ValueError("Maximum turns must be a positive integer.")
 

--- a/pyrit/executor/attack/multi_turn/tree_of_attacks.py
+++ b/pyrit/executor/attack/multi_turn/tree_of_attacks.py
@@ -8,7 +8,7 @@ import logging
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, cast, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast, overload
 
 from treelib.tree import Tree
 
@@ -77,14 +77,6 @@ class TAPSystemPromptPaths(enum.Enum):
 
     TEXT_GENERATION = (EXECUTOR_SEED_PROMPT_PATH / "tree_of_attacks" / "adversarial_system_prompt.yaml").resolve()
     IMAGE_GENERATION = (EXECUTOR_SEED_PROMPT_PATH / "tree_of_attacks" / "image_generation.yaml").resolve()
-
-
-# TAP sets a system prompt on its adversarial target and drives a multi-turn dialogue through it.
-# Both capabilities must be natively supported — adaptation would silently change the semantics
-# (e.g. history-squash normalization would collapse the escalation into a single turn).
-_ADVERSARIAL_REQUIREMENTS = TargetRequirements(
-    native_required=frozenset({CapabilityName.MULTI_TURN, CapabilityName.SYSTEM_PROMPT}),
-)
 
 
 class TAPAttackScoringConfig(AttackScoringConfig):
@@ -1290,6 +1282,19 @@ class TreeOfAttacksWithPruningAttack(AttackStrategy[TAPAttackContext, TAPAttackR
         EXECUTOR_SEED_PROMPT_PATH / "tree_of_attacks" / "adversarial_seed_prompt.yaml"
     )
 
+    # TAP sets a system prompt on its adversarial target and drives a multi-turn dialogue through it.
+    # Both capabilities must be natively supported — adaptation would silently change the semantics
+    # (e.g. history-squash normalization would collapse the escalation into a single turn).
+    _ADVERSARIAL_REQUIREMENTS: ClassVar[TargetRequirements] = TargetRequirements(
+        native_required=frozenset({CapabilityName.MULTI_TURN, CapabilityName.SYSTEM_PROMPT}),
+    )
+
+    DEFAULT_TREE_WIDTH: ClassVar[int] = 3
+    DEFAULT_TREE_DEPTH: ClassVar[int] = 5
+    DEFAULT_BRANCHING_FACTOR: ClassVar[int] = 2
+    DEFAULT_DESIRED_RESPONSE_PREFIX: ClassVar[str] = "Sure, here is"
+    DEFAULT_BATCH_SIZE: ClassVar[int] = 10
+
     @apply_defaults
     def __init__(
         self,
@@ -1299,12 +1304,12 @@ class TreeOfAttacksWithPruningAttack(AttackStrategy[TAPAttackContext, TAPAttackR
         attack_converter_config: AttackConverterConfig | None = None,
         attack_scoring_config: TAPAttackScoringConfig | None = None,
         prompt_normalizer: PromptNormalizer | None = None,
-        tree_width: int = 3,
-        tree_depth: int = 5,
-        branching_factor: int = 2,
+        tree_width: int | None = None,
+        tree_depth: int | None = None,
+        branching_factor: int | None = None,
         on_topic_checking_enabled: bool = True,
-        desired_response_prefix: str = "Sure, here is",
-        batch_size: int = 10,
+        desired_response_prefix: str | None = None,
+        batch_size: int | None = None,
         prepended_conversation_config: PrependedConversationConfig | None = None,
     ) -> None:
         """
@@ -1321,12 +1326,17 @@ class TreeOfAttacksWithPruningAttack(AttackStrategy[TAPAttackContext, TAPAttackR
                 Can be either AttackScoringConfig or TAPAttackScoringConfig. If not provided,
                 a default configuration with SelfAskScaleScorer and threshold 0.7 is created.
             prompt_normalizer (PromptNormalizer | None): The prompt normalizer to use. Defaults to None.
-            tree_width (int): Number of branches to explore in parallel at each level. Defaults to 3.
-            tree_depth (int): Maximum number of iterations to perform. Defaults to 5.
-            branching_factor (int): Number of child branches to create from each parent. Defaults to 2.
+            tree_width (int | None): Number of branches to explore in parallel at each level. Defaults to
+                ``DEFAULT_TREE_WIDTH`` (3).
+            tree_depth (int | None): Maximum number of iterations to perform. Defaults to
+                ``DEFAULT_TREE_DEPTH`` (5).
+            branching_factor (int | None): Number of child branches to create from each parent. Defaults to
+                ``DEFAULT_BRANCHING_FACTOR`` (2).
             on_topic_checking_enabled (bool): Whether to check if prompts are on-topic. Defaults to True.
-            desired_response_prefix (str): Expected prefix for successful responses. Defaults to "Sure, here is".
-            batch_size (int): Number of nodes to process in parallel per batch. Defaults to 10.
+            desired_response_prefix (str | None): Expected prefix for successful responses. Defaults to
+                ``DEFAULT_DESIRED_RESPONSE_PREFIX`` ("Sure, here is").
+            batch_size (int | None): Number of nodes to process in parallel per batch. Defaults to
+                ``DEFAULT_BATCH_SIZE`` (10).
             prepended_conversation_config (PrependedConversationConfig | None):
                 Configuration for how to process prepended conversations. Controls converter
                 application by role, message normalization, and non-chat target behavior.
@@ -1345,6 +1355,18 @@ class TreeOfAttacksWithPruningAttack(AttackStrategy[TAPAttackContext, TAPAttackR
             ``score_blocked_content=True`` on the objective scorer (requires
             ``prompt_metadata["partial_content"]`` on the blocked piece).
         """
+        # Apply class-level defaults when caller hasn't overridden
+        if tree_width is None:
+            tree_width = self.DEFAULT_TREE_WIDTH
+        if tree_depth is None:
+            tree_depth = self.DEFAULT_TREE_DEPTH
+        if branching_factor is None:
+            branching_factor = self.DEFAULT_BRANCHING_FACTOR
+        if desired_response_prefix is None:
+            desired_response_prefix = self.DEFAULT_DESIRED_RESPONSE_PREFIX
+        if batch_size is None:
+            batch_size = self.DEFAULT_BATCH_SIZE
+
         # Validate tree parameters
         if tree_depth < 1:
             raise ValueError("The tree depth must be at least 1.")
@@ -1379,7 +1401,7 @@ class TreeOfAttacksWithPruningAttack(AttackStrategy[TAPAttackContext, TAPAttackR
         # (The class-level ``TARGET_REQUIREMENTS`` inherited from ``AttackStrategy``
         # only covers ``objective_target``; this is a separate target.)
         try:
-            _ADVERSARIAL_REQUIREMENTS.validate(target=self._adversarial_chat)
+            self._ADVERSARIAL_REQUIREMENTS.validate(target=self._adversarial_chat)
         except ValueError as exc:
             raise ValueError(f"TreeOfAttacksWithPruningAttack {exc}") from exc
 


### PR DESCRIPTION
Continues the constants-audit cleanup established by #1964 (backend / registry / setup) and #1965 (prompt_converter). This PR combines two tracks for the multi-turn attacks so reviewers see the full picture per attack class:

- **Track A**: promote the module-level `_ADVERSARIAL_REQUIREMENTS` `TargetRequirements` sentinel onto the owning attack class as a `ClassVar`.
- **Track B**: lift hard-coded constructor defaults onto the owning class as `DEFAULT_*` `ClassVar`s, using the sentinel-default pattern (`x: int | None = None`, then `if x is None: x = self.DEFAULT_X`) so values remain inheritable/overridable and stay self-documenting.

## Files

- `pyrit/executor/attack/multi_turn/crescendo.py`
  - `_ADVERSARIAL_REQUIREMENTS` → `CrescendoAttack._ADVERSARIAL_REQUIREMENTS: ClassVar[TargetRequirements]`
  - `max_backtracks: int = 10` → `DEFAULT_MAX_BACKTRACKS: ClassVar[int] = 10`
  - `max_turns: int = 10` → `DEFAULT_MAX_TURNS: ClassVar[int] = 10`

- `pyrit/executor/attack/multi_turn/red_teaming.py`
  - `_ADVERSARIAL_REQUIREMENTS` → `RedTeamingAttack._ADVERSARIAL_REQUIREMENTS: ClassVar[TargetRequirements]`
  - `max_turns: int = 10` → `DEFAULT_MAX_TURNS: ClassVar[int] = 10`

- `pyrit/executor/attack/multi_turn/tree_of_attacks.py`
  - `_ADVERSARIAL_REQUIREMENTS` → `TreeOfAttacksWithPruningAttack._ADVERSARIAL_REQUIREMENTS: ClassVar[TargetRequirements]`
  - `tree_width: int = 3` → `DEFAULT_TREE_WIDTH: ClassVar[int] = 3`
  - `tree_depth: int = 5` → `DEFAULT_TREE_DEPTH: ClassVar[int] = 5`
  - `branching_factor: int = 2` → `DEFAULT_BRANCHING_FACTOR: ClassVar[int] = 2`
  - `desired_response_prefix: str = "Sure, here is"` → `DEFAULT_DESIRED_RESPONSE_PREFIX: ClassVar[str] = "Sure, here is"`
  - `batch_size: int = 10` → `DEFAULT_BATCH_SIZE: ClassVar[int] = 10`

- `pyrit/executor/attack/multi_turn/pair.py` (Track B only — no module-level `_ADVERSARIAL_REQUIREMENTS` existed here)
  - `tree_width: int = 3` → `PAIRAttack.DEFAULT_TREE_WIDTH: ClassVar[int] = 3`
  - `tree_depth: int = 5` → `PAIRAttack.DEFAULT_TREE_DEPTH: ClassVar[int] = 5`
  - `desired_response_prefix: str = "Sure, here is"` → `PAIRAttack.DEFAULT_DESIRED_RESPONSE_PREFIX: ClassVar[str] = "Sure, here is"`
  - `batch_size: int = 10` → `PAIRAttack.DEFAULT_BATCH_SIZE: ClassVar[int] = 10`

Docstrings updated to point at the `DEFAULT_*` symbols (e.g. `tree_width: defaults to ``DEFAULT_TREE_WIDTH`` (3)`). Public call signatures stay keyword-only with the same parameter names; only the defaults moved from inline literals to class attributes.

## No value or behaviour changes

Pure structural rename. All literals preserved; same defaults applied via the sentinel pattern. Validation order is preserved (`is None` substitution runs before existing positive/non-negative range checks).

## Verified

```
uv run --link-mode=copy ruff check pyrit/executor/attack/multi_turn/
uv run --link-mode=copy ty check pyrit/executor/attack/multi_turn/
uv run --link-mode=copy pytest tests/unit/executor/attack/multi_turn/ -x --no-header -q
```

All green — `319 passed` in the multi_turn test suite, ruff/ty clean.
