### PR TITLE
REFACTOR: Promote printer dimension defaults (width / blur_radius / font_size) to ClassVar on printer base

### DIFF
--- a/pyrit/output/attack_result/markdown.py
+++ b/pyrit/output/attack_result/markdown.py
@@ -28,7 +28,7 @@ class MarkdownAttackResultPrinter(AttackResultPrinterBase):
         conversation_printer: MarkdownConversationPrinter | None = None,
         score_printer: MarkdownScorePrinter | None = None,
         blur_images: bool = False,
-        blur_radius: int = 20,
+        blur_radius: int | None = None,
         blurred_dir: str | os.PathLike[str] | None = None,
     ) -> None:
         """
@@ -45,12 +45,14 @@ class MarkdownAttackResultPrinter(AttackResultPrinterBase):
             blur_images (bool): If True, write a blurred copy of each referenced
                 image and link to it instead of the original. Forwarded to the default
                 conversation printer when one is not supplied. Defaults to False.
-            blur_radius (int): Gaussian blur radius applied when ``blur_images`` is True.
-                Defaults to 20.
+            blur_radius (int | None): Gaussian blur radius applied when ``blur_images`` is True.
+                Defaults to ``DEFAULT_BLUR_RADIUS`` (20).
             blurred_dir (str | PathLike | None): Directory to write blurred copies into
                 when ``blur_images`` is True. Defaults to None (sibling of the original).
         """
         super().__init__(sink=sink)
+        if blur_radius is None:
+            blur_radius = self.DEFAULT_BLUR_RADIUS
         self._display_inline = display_inline
         self._score_printer = score_printer or MarkdownScorePrinter(sink=sink)
         self._conversation_printer = conversation_printer or MarkdownConversationPrinter(
@@ -342,7 +344,7 @@ class MarkdownAttackResultMemoryPrinter(MarkdownAttackResultPrinter):
         sink: Sink | None = None,
         display_inline: bool = True,
         blur_images: bool = False,
-        blur_radius: int = 20,
+        blur_radius: int | None = None,
         blurred_dir: str | os.PathLike[str] | None = None,
     ) -> None:
         """
@@ -354,8 +356,8 @@ class MarkdownAttackResultMemoryPrinter(MarkdownAttackResultPrinter):
                 All output is routed through the sink. Defaults to True.
             blur_images (bool): If True, write a blurred copy of each referenced
                 image and link to it instead of the original. Defaults to False.
-            blur_radius (int): Gaussian blur radius applied when ``blur_images`` is True.
-                Defaults to 20.
+            blur_radius (int | None): Gaussian blur radius applied when ``blur_images`` is True.
+                Defaults to ``DEFAULT_BLUR_RADIUS`` (20).
             blurred_dir (str | PathLike | None): Directory to write blurred copies into.
                 Defaults to None (sibling of the original).
         """

--- a/pyrit/output/attack_result/pretty.py
+++ b/pyrit/output/attack_result/pretty.py
@@ -26,20 +26,20 @@ class PrettyAttackResultPrinter(AttackResultPrinterBase):
         self,
         *,
         sink: Sink | None = None,
-        width: int = 100,
+        width: int | None = None,
         indent_size: int = 2,
         enable_colors: bool = True,
         conversation_printer: PrettyConversationPrinter | None = None,
         score_printer: PrettyScorePrinter | None = None,
         blur_images: bool = False,
-        blur_radius: int = 20,
+        blur_radius: int | None = None,
     ) -> None:
         """
         Initialize the pretty printer.
 
         Args:
             sink (Sink | None): Output sink. Defaults to StdoutSink().
-            width (int): Maximum width for text wrapping. Defaults to 100.
+            width (int | None): Maximum width for text wrapping. Defaults to ``DEFAULT_WIDTH`` (100).
             indent_size (int): Number of spaces for indentation. Defaults to 2.
             enable_colors (bool): Whether to enable ANSI color output. Defaults to True.
             conversation_printer (PrettyConversationPrinter | None): Conversation printer.
@@ -49,10 +49,14 @@ class PrettyAttackResultPrinter(AttackResultPrinterBase):
             blur_images (bool): If True, apply a Gaussian blur to image outputs before
                 displaying them. Forwarded to the default conversation printer when one
                 is not supplied. Defaults to False.
-            blur_radius (int): Gaussian blur radius applied when ``blur_images`` is True.
-                Defaults to 20.
+            blur_radius (int | None): Gaussian blur radius applied when ``blur_images`` is True.
+                Defaults to ``DEFAULT_BLUR_RADIUS`` (20).
         """
         super().__init__(sink=sink)
+        if width is None:
+            width = self.DEFAULT_WIDTH
+        if blur_radius is None:
+            blur_radius = self.DEFAULT_BLUR_RADIUS
         self._width = width
         self._indent = " " * indent_size
         self._enable_colors = enable_colors
@@ -461,24 +465,24 @@ class PrettyAttackResultMemoryPrinter(PrettyAttackResultPrinter):
         self,
         *,
         sink: Sink | None = None,
-        width: int = 100,
+        width: int | None = None,
         indent_size: int = 2,
         enable_colors: bool = True,
         blur_images: bool = False,
-        blur_radius: int = 20,
+        blur_radius: int | None = None,
     ) -> None:
         """
         Initialize the pretty printer with CentralMemory data source.
 
         Args:
             sink (Sink | None): Output sink. Defaults to StdoutSink().
-            width (int): Maximum width for text wrapping. Defaults to 100.
+            width (int | None): Maximum width for text wrapping. Defaults to ``DEFAULT_WIDTH`` (100).
             indent_size (int): Number of spaces for indentation. Defaults to 2.
             enable_colors (bool): Whether to enable ANSI color output. Defaults to True.
             blur_images (bool): If True, apply a Gaussian blur to image outputs before
                 displaying them. Defaults to False.
-            blur_radius (int): Gaussian blur radius applied when ``blur_images`` is True.
-                Defaults to 20.
+            blur_radius (int | None): Gaussian blur radius applied when ``blur_images`` is True.
+                Defaults to ``DEFAULT_BLUR_RADIUS`` (20).
         """
         from pyrit.memory import CentralMemory
         from pyrit.output.conversation.pretty import PrettyConversationMemoryPrinter

--- a/pyrit/output/base.py
+++ b/pyrit/output/base.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, ClassVar
 
 from pyrit.output.sink import Sink, StdoutSink
 
@@ -15,6 +15,9 @@ class PrinterBase(ABC):
     ``write_async`` is concrete: it calls ``render_async`` then routes
     the result through the configured sink.
     """
+
+    DEFAULT_WIDTH: ClassVar[int] = 100
+    DEFAULT_BLUR_RADIUS: ClassVar[int] = 20
 
     def __init__(self, *, sink: Sink | None = None) -> None:
         """

--- a/pyrit/output/conversation/markdown.py
+++ b/pyrit/output/conversation/markdown.py
@@ -28,7 +28,7 @@ class MarkdownConversationPrinter(ConversationPrinterBase):
         sink: Sink | None = None,
         score_printer: MarkdownScorePrinter | None = None,
         blur_images: bool = False,
-        blur_radius: int = 20,
+        blur_radius: int | None = None,
         blurred_dir: str | os.PathLike[str] | None = None,
     ) -> None:
         """
@@ -44,14 +44,16 @@ class MarkdownConversationPrinter(ConversationPrinterBase):
                 Note: blurred files are cached by path. If the original image content
                 changes but the blurred file already exists, the stale blurred copy
                 is reused. Callers are responsible for cleaning up blurred artifacts.
-            blur_radius (int): Gaussian blur radius applied when ``blur_images`` is True.
-                Defaults to 20.
+            blur_radius (int | None): Gaussian blur radius applied when ``blur_images`` is True.
+                Defaults to ``DEFAULT_BLUR_RADIUS`` (20).
             blurred_dir (str | PathLike | None): Directory to write blurred copies into.
                 When None (default), blurred files are written as ``<stem>_blurred.png``
                 next to the original. When set, blurred files are written under this
                 directory using the original basename plus ``_blurred.png``.
         """
         super().__init__(sink=sink)
+        if blur_radius is None:
+            blur_radius = self.DEFAULT_BLUR_RADIUS
         self._score_printer = score_printer or MarkdownScorePrinter(sink=sink)
         self._blur_images = blur_images
         self._blur_radius = blur_radius
@@ -385,7 +387,7 @@ class MarkdownConversationMemoryPrinter(MarkdownConversationPrinter):
         sink: Sink | None = None,
         score_printer: MarkdownScorePrinter | None = None,
         blur_images: bool = False,
-        blur_radius: int = 20,
+        blur_radius: int | None = None,
         blurred_dir: str | os.PathLike[str] | None = None,
     ) -> None:
         """
@@ -396,8 +398,8 @@ class MarkdownConversationMemoryPrinter(MarkdownConversationPrinter):
             score_printer (MarkdownScorePrinter | None): Score printer for inline score rendering.
             blur_images (bool): If True, write a blurred copy next to each image and
                 link to it instead of the original. Defaults to False.
-            blur_radius (int): Gaussian blur radius applied when ``blur_images`` is True.
-                Defaults to 20.
+            blur_radius (int | None): Gaussian blur radius applied when ``blur_images`` is True.
+                Defaults to ``DEFAULT_BLUR_RADIUS`` (20).
             blurred_dir (str | PathLike | None): Directory to write blurred copies into.
                 Defaults to None (sibling of the original).
         """

--- a/pyrit/output/conversation/pretty.py
+++ b/pyrit/output/conversation/pretty.py
@@ -27,19 +27,19 @@ class PrettyConversationPrinter(ConversationPrinterBase):
         self,
         *,
         sink: Sink | None = None,
-        width: int = 100,
+        width: int | None = None,
         indent_size: int = 2,
         enable_colors: bool = True,
         score_printer: PrettyScorePrinter | None = None,
         blur_images: bool = False,
-        blur_radius: int = 20,
+        blur_radius: int | None = None,
     ) -> None:
         """
         Initialize the pretty conversation printer.
 
         Args:
             sink (Sink | None): Output sink. Defaults to StdoutSink().
-            width (int): Maximum width for text wrapping. Defaults to 100.
+            width (int | None): Maximum width for text wrapping. Defaults to ``DEFAULT_WIDTH`` (100).
             indent_size (int): Number of spaces for indentation. Defaults to 2.
             enable_colors (bool): Whether to enable ANSI color output. Defaults to True.
             score_printer (PrettyScorePrinter | None): Score printer for inline score rendering.
@@ -47,10 +47,14 @@ class PrettyConversationPrinter(ConversationPrinterBase):
             blur_images (bool): If True, apply a Gaussian blur to image outputs before
                 displaying them. Useful for reducing reviewer exposure to unsafe imagery
                 while still allowing the general content to be inspected. Defaults to False.
-            blur_radius (int): Gaussian blur radius applied when ``blur_images`` is True.
-                Defaults to 20.
+            blur_radius (int | None): Gaussian blur radius applied when ``blur_images`` is True.
+                Defaults to ``DEFAULT_BLUR_RADIUS`` (20).
         """
         super().__init__(sink=sink)
+        if width is None:
+            width = self.DEFAULT_WIDTH
+        if blur_radius is None:
+            blur_radius = self.DEFAULT_BLUR_RADIUS
         self._width = width
         self._indent = " " * indent_size
         self._enable_colors = enable_colors
@@ -254,26 +258,26 @@ class PrettyConversationMemoryPrinter(PrettyConversationPrinter):
         self,
         *,
         sink: Sink | None = None,
-        width: int = 100,
+        width: int | None = None,
         indent_size: int = 2,
         enable_colors: bool = True,
         score_printer: PrettyScorePrinter | None = None,
         blur_images: bool = False,
-        blur_radius: int = 20,
+        blur_radius: int | None = None,
     ) -> None:
         """
         Initialize the pretty conversation printer with CentralMemory data source.
 
         Args:
             sink (Sink | None): Output sink. Defaults to StdoutSink().
-            width (int): Maximum width for text wrapping. Defaults to 100.
+            width (int | None): Maximum width for text wrapping. Defaults to ``DEFAULT_WIDTH`` (100).
             indent_size (int): Number of spaces for indentation. Defaults to 2.
             enable_colors (bool): Whether to enable ANSI color output. Defaults to True.
             score_printer (PrettyScorePrinter | None): Score printer for inline score rendering.
             blur_images (bool): If True, apply a Gaussian blur to image outputs before
                 displaying them. Defaults to False.
-            blur_radius (int): Gaussian blur radius applied when ``blur_images`` is True.
-                Defaults to 20.
+            blur_radius (int | None): Gaussian blur radius applied when ``blur_images`` is True.
+                Defaults to ``DEFAULT_BLUR_RADIUS`` (20).
         """
         super().__init__(
             sink=sink,

--- a/pyrit/output/helpers.py
+++ b/pyrit/output/helpers.py
@@ -31,7 +31,7 @@ async def output_attack_async(
     include_pruned_conversations: bool = False,
     include_adversarial_conversation: bool = False,
     blur_images: bool = False,
-    blur_radius: int = 20,
+    blur_radius: int | None = None,
     blurred_dir: str | os.PathLike[str] | None = None,
 ) -> None:
     """
@@ -56,8 +56,8 @@ async def output_attack_async(
             is logged and a plain-text link to the original is emitted instead of an
             inline image — the original is not silently rendered.
             Defaults to False.
-        blur_radius (int): Gaussian blur radius applied when ``blur_images`` is True.
-            Defaults to 20.
+        blur_radius (int | None): Gaussian blur radius applied when ``blur_images`` is True.
+            Defaults to ``PrinterBase.DEFAULT_BLUR_RADIUS`` (20).
         blurred_dir (str | PathLike | None): For "markdown" output, directory to write
             blurred copies into. Defaults to None (sibling of the original). Ignored
             when ``format != "markdown"``.
@@ -152,7 +152,7 @@ async def output_conversation_async(
     include_scores: bool = False,
     include_reasoning_trace: bool = False,
     blur_images: bool = False,
-    blur_radius: int = 20,
+    blur_radius: int | None = None,
 ) -> None:
     """
     Print a conversation message history in the specified format.
@@ -171,8 +171,8 @@ async def output_conversation_async(
             not to enforce access control. If blurring fails for any reason, a warning
             is logged and the original is shown (pretty path only).
             Defaults to False.
-        blur_radius (int): Gaussian blur radius applied when ``blur_images`` is True.
-            Defaults to 20.
+        blur_radius (int | None): Gaussian blur radius applied when ``blur_images`` is True.
+            Defaults to ``PrinterBase.DEFAULT_BLUR_RADIUS`` (20).
 
     Raises:
         ValueError: If ``format`` is not a supported value.

--- a/pyrit/output/scenario_result/pretty.py
+++ b/pyrit/output/scenario_result/pretty.py
@@ -25,7 +25,7 @@ class PrettyScenarioResultPrinter(ScenarioResultPrinterBase):
         self,
         *,
         sink: Sink | None = None,
-        width: int = 100,
+        width: int | None = None,
         indent_size: int = 2,
         enable_colors: bool = True,
         scorer_printer: ScorerPrinterBase | None = None,
@@ -36,7 +36,7 @@ class PrettyScenarioResultPrinter(ScenarioResultPrinterBase):
 
         Args:
             sink (Sink | None): Output sink. Defaults to StdoutSink().
-            width (int): Maximum width for text wrapping. Defaults to 100.
+            width (int | None): Maximum width for text wrapping. Defaults to ``DEFAULT_WIDTH`` (100).
             indent_size (int): Number of spaces for indentation. Defaults to 2.
             enable_colors (bool): Whether to enable ANSI color output. Defaults to True.
             scorer_printer (ScorerPrinterBase | None): Scorer printer for rendering scorer
@@ -47,6 +47,8 @@ class PrettyScenarioResultPrinter(ScenarioResultPrinterBase):
                 preserves insertion order.
         """
         super().__init__(sink=sink)
+        if width is None:
+            width = self.DEFAULT_WIDTH
         self._width = width
         self._indent = " " * indent_size
         self._enable_colors = enable_colors
@@ -267,7 +269,7 @@ class PrettyScenarioResultMemoryPrinter(PrettyScenarioResultPrinter):
         self,
         *,
         sink: Sink | None = None,
-        width: int = 100,
+        width: int | None = None,
         indent_size: int = 2,
         enable_colors: bool = True,
         sort_groups_by_success_rate: bool = False,
@@ -277,7 +279,7 @@ class PrettyScenarioResultMemoryPrinter(PrettyScenarioResultPrinter):
 
         Args:
             sink (Sink | None): Output sink. Defaults to StdoutSink().
-            width (int): Maximum width for text wrapping. Defaults to 100.
+            width (int | None): Maximum width for text wrapping. Defaults to ``DEFAULT_WIDTH`` (100).
             indent_size (int): Number of spaces for indentation. Defaults to 2.
             enable_colors (bool): Whether to enable ANSI color output. Defaults to True.
             sort_groups_by_success_rate (bool): When True, the Per-Group Breakdown is sorted

--- a/pyrit/output/score/pretty.py
+++ b/pyrit/output/score/pretty.py
@@ -20,18 +20,20 @@ class PrettyScorePrinter(PrinterBase):
     """
 
     def __init__(
-        self, *, sink: Sink | None = None, width: int = 100, indent_size: int = 2, enable_colors: bool = True
+        self, *, sink: Sink | None = None, width: int | None = None, indent_size: int = 2, enable_colors: bool = True
     ) -> None:
         """
         Initialize the pretty score printer.
 
         Args:
             sink (Sink | None): Output sink. Defaults to StdoutSink().
-            width (int): Maximum width for text wrapping. Defaults to 100.
+            width (int | None): Maximum width for text wrapping. Defaults to ``DEFAULT_WIDTH`` (100).
             indent_size (int): Number of spaces for indentation. Defaults to 2.
             enable_colors (bool): Whether to enable ANSI color output. Defaults to True.
         """
         super().__init__(sink=sink)
+        if width is None:
+            width = self.DEFAULT_WIDTH
         self._width = width
         self._indent = " " * indent_size
         self._enable_colors = enable_colors


### PR DESCRIPTION
## Summary

Promotes printer dimension defaults (`width = 100`, `blur_radius = 20`) from per-constructor hard-coded literals to `ClassVar[int]` attributes on `PrinterBase` in `pyrit/output/base.py`:

- `DEFAULT_WIDTH: ClassVar[int] = 100`
- `DEFAULT_BLUR_RADIUS: ClassVar[int] = 20`

Subclass constructors now use the sentinel-default pattern (`width: int | None = None`, resolved to `self.DEFAULT_WIDTH` at the point of consumption). Docstrings reference `DEFAULT_WIDTH` / `DEFAULT_BLUR_RADIUS` (with the value in parentheses).

This is part of the ongoing constants-audit cleanup (continuation of the pattern established in #1964 and #1965).

### Scope

Touched only `pyrit/output/`:

- `base.py` — added `DEFAULT_WIDTH` and `DEFAULT_BLUR_RADIUS` ClassVars on `PrinterBase`.
- `attack_result/pretty.py`, `attack_result/markdown.py`
- `conversation/pretty.py`, `conversation/markdown.py`
- `scenario_result/pretty.py`
- `score/pretty.py`
- `helpers.py` — `output_attack_async` and `output_conversation_async` now take `blur_radius: int | None = None` and forward `None` to the printer (printer sentinels resolve the default).

### Notes

- The kickoff doc mentioned a `font_size = 15` default in printer files, but there are no `font_size` references anywhere in `pyrit/output/`. (The `font_size = 15` hits in the repo are in `pyrit/prompt_converter/`, out of scope for this PR.) Only `DEFAULT_WIDTH` and `DEFAULT_BLUR_RADIUS` are promoted here.
- All `width` and `blur_radius` defaults in `pyrit/output/` were already consistent (100 and 20 respectively) — no diverging values to preserve.

No value changes. No behaviour changes.

Verified: `ruff check pyrit/output/`, `ty check pyrit/output/`, `pytest tests/unit/output/` (173 passed).
