### PR TITLE
REFACTOR: De-dup scorer output_key defaults onto Scorer base as ClassVars

### DIFF
--- a/pyrit/score/float_scale/float_scale_scorer.py
+++ b/pyrit/score/float_scale/float_scale_scorer.py
@@ -141,11 +141,11 @@ class FloatScaleScorer(Scorer):
         prepended_text_message_piece: str | None = None,
         category: str | UUID | None = None,
         objective: str | None = None,
-        score_value_output_key: str = "score_value",
-        rationale_output_key: str = "rationale",
-        description_output_key: str = "description",
-        metadata_output_key: str = "metadata",
-        category_output_key: str = "category",
+        score_value_output_key: str | None = None,
+        rationale_output_key: str | None = None,
+        description_output_key: str | None = None,
+        metadata_output_key: str | None = None,
+        category_output_key: str | None = None,
         attack_identifier: ComponentIdentifier | None = None,
     ) -> UnvalidatedScore:
         score: UnvalidatedScore | None = None

--- a/pyrit/score/float_scale/self_ask_general_float_scale_scorer.py
+++ b/pyrit/score/float_scale/self_ask_general_float_scale_scorer.py
@@ -36,11 +36,11 @@ class SelfAskGeneralFloatScaleScorer(FloatScaleScorer):
         min_value: int = 0,
         max_value: int = 100,
         validator: ScorerPromptValidator | None = None,
-        score_value_output_key: str = "score_value",
-        rationale_output_key: str = "rationale",
-        description_output_key: str = "description",
-        metadata_output_key: str = "metadata",
-        category_output_key: str = "category",
+        score_value_output_key: str | None = None,
+        rationale_output_key: str | None = None,
+        description_output_key: str | None = None,
+        metadata_output_key: str | None = None,
+        category_output_key: str | None = None,
     ) -> None:
         """
         Initialize the SelfAskGeneralFloatScaleScorer.
@@ -64,11 +64,16 @@ class SelfAskGeneralFloatScaleScorer(FloatScaleScorer):
             max_value (int): Maximum of the model's native scale. Defaults to 100.
             validator (ScorerPromptValidator | None): Custom validator. If omitted, a default
                 validator will be used requiring text input and an objective.
-            score_value_output_key (str): JSON key for the score value. Defaults to "score_value".
-            rationale_output_key (str): JSON key for the rationale. Defaults to "rationale".
-            description_output_key (str): JSON key for the description. Defaults to "description".
-            metadata_output_key (str): JSON key for the metadata. Defaults to "metadata".
-            category_output_key (str): JSON key for the category. Defaults to "category".
+            score_value_output_key (str | None): JSON key for the score value. Defaults to
+                ``DEFAULT_SCORE_VALUE_OUTPUT_KEY`` ("score_value").
+            rationale_output_key (str | None): JSON key for the rationale. Defaults to
+                ``DEFAULT_RATIONALE_OUTPUT_KEY`` ("rationale").
+            description_output_key (str | None): JSON key for the description. Defaults to
+                ``DEFAULT_DESCRIPTION_OUTPUT_KEY`` ("description").
+            metadata_output_key (str | None): JSON key for the metadata. Defaults to
+                ``DEFAULT_METADATA_OUTPUT_KEY`` ("metadata").
+            category_output_key (str | None): JSON key for the category. Defaults to
+                ``DEFAULT_CATEGORY_OUTPUT_KEY`` ("category").
 
         Raises:
             ValueError: If system_prompt_format_string is not provided or empty.
@@ -87,11 +92,21 @@ class SelfAskGeneralFloatScaleScorer(FloatScaleScorer):
         self._score_category = category
         self._min_value = min_value
         self._max_value = max_value
-        self._score_value_output_key = score_value_output_key
-        self._rationale_output_key = rationale_output_key
-        self._description_output_key = description_output_key
-        self._metadata_output_key = metadata_output_key
-        self._category_output_key = category_output_key
+        self._score_value_output_key = (
+            score_value_output_key if score_value_output_key is not None else self.DEFAULT_SCORE_VALUE_OUTPUT_KEY
+        )
+        self._rationale_output_key = (
+            rationale_output_key if rationale_output_key is not None else self.DEFAULT_RATIONALE_OUTPUT_KEY
+        )
+        self._description_output_key = (
+            description_output_key if description_output_key is not None else self.DEFAULT_DESCRIPTION_OUTPUT_KEY
+        )
+        self._metadata_output_key = (
+            metadata_output_key if metadata_output_key is not None else self.DEFAULT_METADATA_OUTPUT_KEY
+        )
+        self._category_output_key = (
+            category_output_key if category_output_key is not None else self.DEFAULT_CATEGORY_OUTPUT_KEY
+        )
 
     def _build_identifier(self) -> ComponentIdentifier:
         """

--- a/pyrit/score/scorer.py
+++ b/pyrit/score/scorer.py
@@ -72,6 +72,15 @@ class Scorer(Identifiable, abc.ABC):
     #: validate it.
     TARGET_REQUIREMENTS: ClassVar[TargetRequirements] = TargetRequirements()
 
+    #: Default JSON keys parsed from the LLM scoring response in
+    #: ``_score_value_with_llm_async``. Subclasses and callers may pass
+    #: overrides through that method or their own constructors.
+    DEFAULT_SCORE_VALUE_OUTPUT_KEY: ClassVar[str] = "score_value"
+    DEFAULT_RATIONALE_OUTPUT_KEY: ClassVar[str] = "rationale"
+    DEFAULT_DESCRIPTION_OUTPUT_KEY: ClassVar[str] = "description"
+    DEFAULT_METADATA_OUTPUT_KEY: ClassVar[str] = "metadata"
+    DEFAULT_CATEGORY_OUTPUT_KEY: ClassVar[str] = "category"
+
     _identifier: ComponentIdentifier | None = None
 
     #: When True, blocked responses that contain partial content
@@ -671,11 +680,11 @@ class Scorer(Identifiable, abc.ABC):
         prepended_text_message_piece: str | None = None,
         category: Sequence[str] | str | None = None,
         objective: str | None = None,
-        score_value_output_key: str = "score_value",
-        rationale_output_key: str = "rationale",
-        description_output_key: str = "description",
-        metadata_output_key: str = "metadata",
-        category_output_key: str = "category",
+        score_value_output_key: str | None = None,
+        rationale_output_key: str | None = None,
+        description_output_key: str | None = None,
+        metadata_output_key: str | None = None,
+        category_output_key: str | None = None,
         attack_identifier: ComponentIdentifier | None = None,
     ) -> UnvalidatedScore:
         """
@@ -700,16 +709,16 @@ class Scorer(Identifiable, abc.ABC):
                 the JSON response if not provided. Defaults to None.
             objective (str | None): A description of the objective that is associated with the score,
                 used for contextualizing the result. Defaults to None.
-            score_value_output_key (str): The key in the JSON response that contains the score value.
-                Defaults to "score_value".
-            rationale_output_key (str): The key in the JSON response that contains the rationale.
-                Defaults to "rationale".
-            description_output_key (str): The key in the JSON response that contains the description.
-                Defaults to "description".
-            metadata_output_key (str): The key in the JSON response that contains the metadata.
-                Defaults to "metadata".
-            category_output_key (str): The key in the JSON response that contains the category.
-                Defaults to "category".
+            score_value_output_key (str | None): The key in the JSON response that contains the score value.
+                Defaults to ``DEFAULT_SCORE_VALUE_OUTPUT_KEY`` ("score_value").
+            rationale_output_key (str | None): The key in the JSON response that contains the rationale.
+                Defaults to ``DEFAULT_RATIONALE_OUTPUT_KEY`` ("rationale").
+            description_output_key (str | None): The key in the JSON response that contains the description.
+                Defaults to ``DEFAULT_DESCRIPTION_OUTPUT_KEY`` ("description").
+            metadata_output_key (str | None): The key in the JSON response that contains the metadata.
+                Defaults to ``DEFAULT_METADATA_OUTPUT_KEY`` ("metadata").
+            category_output_key (str | None): The key in the JSON response that contains the category.
+                Defaults to ``DEFAULT_CATEGORY_OUTPUT_KEY`` ("category").
             attack_identifier (ComponentIdentifier | None): The attack identifier.
                 Defaults to None.
 
@@ -722,6 +731,17 @@ class Scorer(Identifiable, abc.ABC):
             InvalidJsonException: If the response is not valid JSON.
             Exception: For other unexpected errors during scoring.
         """
+        if score_value_output_key is None:
+            score_value_output_key = self.DEFAULT_SCORE_VALUE_OUTPUT_KEY
+        if rationale_output_key is None:
+            rationale_output_key = self.DEFAULT_RATIONALE_OUTPUT_KEY
+        if description_output_key is None:
+            description_output_key = self.DEFAULT_DESCRIPTION_OUTPUT_KEY
+        if metadata_output_key is None:
+            metadata_output_key = self.DEFAULT_METADATA_OUTPUT_KEY
+        if category_output_key is None:
+            category_output_key = self.DEFAULT_CATEGORY_OUTPUT_KEY
+
         conversation_id = str(uuid.uuid4())
 
         prompt_target.set_system_prompt(

--- a/pyrit/score/true_false/self_ask_general_true_false_scorer.py
+++ b/pyrit/score/true_false/self_ask_general_true_false_scorer.py
@@ -39,11 +39,11 @@ class SelfAskGeneralTrueFalseScorer(TrueFalseScorer):
         category: str | None = None,
         validator: ScorerPromptValidator | None = None,
         score_aggregator: TrueFalseAggregatorFunc = TrueFalseScoreAggregator.OR,
-        score_value_output_key: str = "score_value",
-        rationale_output_key: str = "rationale",
-        description_output_key: str = "description",
-        metadata_output_key: str = "metadata",
-        category_output_key: str = "category",
+        score_value_output_key: str | None = None,
+        rationale_output_key: str | None = None,
+        description_output_key: str | None = None,
+        metadata_output_key: str | None = None,
+        category_output_key: str | None = None,
     ) -> None:
         """
         Initialize the SelfAskGeneralTrueFalseScorer.
@@ -67,11 +67,16 @@ class SelfAskGeneralTrueFalseScorer(TrueFalseScorer):
                 validator will be used requiring text input and an objective.
             score_aggregator (TrueFalseAggregatorFunc): Aggregator for combining scores. Defaults to
                 TrueFalseScoreAggregator.OR.
-            score_value_output_key (str): JSON key for the score value. Defaults to "score_value".
-            rationale_output_key (str): JSON key for the rationale. Defaults to "rationale".
-            description_output_key (str): JSON key for the description. Defaults to "description".
-            metadata_output_key (str): JSON key for the metadata. Defaults to "metadata".
-            category_output_key (str): JSON key for the category. Defaults to "category".
+            score_value_output_key (str | None): JSON key for the score value. Defaults to
+                ``DEFAULT_SCORE_VALUE_OUTPUT_KEY`` ("score_value").
+            rationale_output_key (str | None): JSON key for the rationale. Defaults to
+                ``DEFAULT_RATIONALE_OUTPUT_KEY`` ("rationale").
+            description_output_key (str | None): JSON key for the description. Defaults to
+                ``DEFAULT_DESCRIPTION_OUTPUT_KEY`` ("description").
+            metadata_output_key (str | None): JSON key for the metadata. Defaults to
+                ``DEFAULT_METADATA_OUTPUT_KEY`` ("metadata").
+            category_output_key (str | None): JSON key for the category. Defaults to
+                ``DEFAULT_CATEGORY_OUTPUT_KEY`` ("category").
 
         Raises:
             ValueError: If system_prompt_format_string is not provided or empty.
@@ -88,11 +93,21 @@ class SelfAskGeneralTrueFalseScorer(TrueFalseScorer):
         self._prompt_format_string = prompt_format_string
 
         self._score_category = category
-        self._score_value_output_key = score_value_output_key
-        self._rationale_output_key = rationale_output_key
-        self._description_output_key = description_output_key
-        self._metadata_output_key = metadata_output_key
-        self._category_output_key = category_output_key
+        self._score_value_output_key = (
+            score_value_output_key if score_value_output_key is not None else self.DEFAULT_SCORE_VALUE_OUTPUT_KEY
+        )
+        self._rationale_output_key = (
+            rationale_output_key if rationale_output_key is not None else self.DEFAULT_RATIONALE_OUTPUT_KEY
+        )
+        self._description_output_key = (
+            description_output_key if description_output_key is not None else self.DEFAULT_DESCRIPTION_OUTPUT_KEY
+        )
+        self._metadata_output_key = (
+            metadata_output_key if metadata_output_key is not None else self.DEFAULT_METADATA_OUTPUT_KEY
+        )
+        self._category_output_key = (
+            category_output_key if category_output_key is not None else self.DEFAULT_CATEGORY_OUTPUT_KEY
+        )
 
     def _build_identifier(self) -> ComponentIdentifier:
         """


### PR DESCRIPTION
# REFACTOR: De-dup scorer `output_key` defaults onto `Scorer` base as `ClassVar`s

## Scope

Part of the constants-audit cleanup (see PRs #1964 and #1965 for the established pattern). PR B-2 of the staged plan.

## What changed

The same five string defaults for the LLM scoring JSON-response key names were duplicated across four sibling classes:

- `score_value_output_key = "score_value"`
- `rationale_output_key = "rationale"`
- `description_output_key = "description"`
- `metadata_output_key = "metadata"`
- `category_output_key = "category"`

They are now declared once on the `Scorer` base as `ClassVar[str]`:

```python
class Scorer(Identifiable, abc.ABC):
    DEFAULT_SCORE_VALUE_OUTPUT_KEY: ClassVar[str] = "score_value"
    DEFAULT_RATIONALE_OUTPUT_KEY: ClassVar[str] = "rationale"
    DEFAULT_DESCRIPTION_OUTPUT_KEY: ClassVar[str] = "description"
    DEFAULT_METADATA_OUTPUT_KEY: ClassVar[str] = "metadata"
    DEFAULT_CATEGORY_OUTPUT_KEY: ClassVar[str] = "category"
```

Touched files:

- `pyrit/score/scorer.py` — promote constants; `_score_value_with_llm_async` now uses the sentinel pattern (`str | None = None`, resolved to `self.DEFAULT_*_OUTPUT_KEY`).
- `pyrit/score/float_scale/float_scale_scorer.py` — override signature widened to `str | None = None`; the override forwards values through to `super()` which resolves the sentinel.
- `pyrit/score/float_scale/self_ask_general_float_scale_scorer.py` — constructor now uses the sentinel pattern; `self._*_output_key` is resolved from the class default when no value is provided.
- `pyrit/score/true_false/self_ask_general_true_false_scorer.py` — same constructor change.

## Behavioural compatibility

- `SelfAskGeneralTrueFalseScorer()` (no kwargs) still produces `self._score_value_output_key == "score_value"`, etc.
- `SelfAskGeneralTrueFalseScorer(score_value_output_key="custom")` still produces `self._score_value_output_key == "custom"`.
- Other internal callers of `_score_value_with_llm_async` that omit these args (e.g. `SelfAskTrueFalseScorer`, `SelfAskRefusalScorer`, `SelfAskQuestionAnswerScorer`, `SelfAskCategoryScorer`, `SelfAskScaleScorer`, `SelfAskLikertScorer`, `InsecureCodeScorer`) get the same resolved defaults as before.

No value changes. No behaviour changes.

## Verified

- `uv run --link-mode=copy ruff check pyrit/score/` — clean.
- `uv run --link-mode=copy ty check pyrit/score/` — no new diagnostics (one pre-existing `cv2` optional-import warning in `video_scorer.py`).
- `uv run --link-mode=copy pytest tests/unit/score/ -x --no-header -q` — `1184 passed, 16 skipped`.
