### PR TITLE
REFACTOR: Promote scorer-initializer module constants to ClassVar (21 items)

### DIFF
--- a/pyrit/setup/initializers/components/scorers.py
+++ b/pyrit/setup/initializers/components/scorers.py
@@ -19,7 +19,7 @@ scorers reference core scorers via these best tags.
 import logging
 from collections.abc import Callable, Sequence
 from enum import Enum
-from typing import TYPE_CHECKING, TypeVar, cast
+from typing import TYPE_CHECKING, ClassVar, TypeVar, cast
 
 from azure.ai.contentsafety.models import TextCategory
 
@@ -76,8 +76,6 @@ class ScorerInitializerTags(str, Enum):
 
 
 # Target registry names used by scorer configurations.
-MAIN_SCORER_TARGET: str = "objective_scorer_chat"
-FALLBACK_SCORER_TARGET: str = "openai_chat"
 GPT4O_TARGET: str = "azure_openai_gpt4o"
 GPT4O_TEMP0_TARGET: str = "azure_openai_gpt4o_temp0"
 GPT4O_TEMP9_TARGET: str = "azure_openai_gpt4o_temp9"
@@ -87,49 +85,11 @@ GPT4O_UNSAFE_TEMP9_TARGET: str = "azure_gpt4o_unsafe_chat_temp9"
 GPT5_4_TARGET: str = "azure_openai_gpt5_4"
 GPT5_1_TARGET: str = "azure_openai_gpt5_1"
 
-# Scorer registry names.
-MAIN: str = "main"
-""""
-The main scorer is an inverted refusal scorer based on the main scorer target (objective_scorer_chat).
-"""
-FALLBACK: str = "fallback"
-"""
-The fallback scorer is an inverted refusal scorer based on the fallback scorer target (openai_chat).
-It is usually used when the main scorer cannot be created due to missing targets.
-And allows for a user to get a working scorer even if they only have an openai_chat target in their environment.
-"""
-
-REFUSAL_GPT4O_OBJECTIVE_STRICT: str = "refusal_gpt4o_objective_strict"
-REFUSAL_GPT4O_OBJECTIVE_LENIENT: str = "refusal_gpt4o_objective_lenient"
-REFUSAL_GPT4O_NO_OBJECTIVE_STRICT: str = "refusal_gpt4o_no_objective_strict"
-REFUSAL_GPT4O_NO_OBJECTIVE_LENIENT: str = "refusal_gpt4o_no_objective_lenient"
+# Scorer registry names referenced by ScorerInitializer._PREFERRED_BEST.
 REFUSAL_GPT5_4: str = "refusal_gpt5_4"
-REFUSAL_GPT5_1: str = "refusal_gpt5_1"
-REFUSAL_GPT4O_UNSAFE: str = "refusal_gpt4o_unsafe"
-INVERTED_REFUSAL: str = "inverted_refusal"
-ACS_THRESHOLD_01: str = "acs_threshold_01"
 ACS_THRESHOLD_05: str = "acs_threshold_05"
-ACS_THRESHOLD_07: str = "acs_threshold_07"
-ACS_WITH_REFUSAL: str = "acs_with_refusal"
 SCALE_GPT4O_TEMP9_THRESHOLD_09: str = "scale_gpt4o_temp9_threshold_09"
-SCALE_AND_REFUSAL: str = "scale_and_refusal"
-ACS_HATE: str = "acs_hate"
-ACS_SELF_HARM: str = "acs_self_harm"
-ACS_SEXUAL: str = "acs_sexual"
-ACS_VIOLENCE: str = "acs_violence"
-TASK_ACHIEVED_GPT4O_TEMP9: str = "task_achieved_gpt4o_temp9"
 TASK_ACHIEVED_REFINED_GPT4O_TEMP9: str = "task_achieved_refined_gpt4o_temp9"
-
-
-# Preferred name for each BEST_* category tag. If the preferred name
-# is not registered, the first available scorer in that category is used.
-_PREFERRED_BEST: dict[str, tuple[str, str]] = {
-    # best_tag → (preferred_scorer_name, category_tag)
-    ScorerInitializerTags.BEST_REFUSAL: (REFUSAL_GPT5_4, ScorerInitializerTags.REFUSAL),
-    ScorerInitializerTags.BEST_SCALE: (SCALE_GPT4O_TEMP9_THRESHOLD_09, ScorerInitializerTags.SCALE),
-    ScorerInitializerTags.BEST_ACS_THRESHOLD: (ACS_THRESHOLD_05, ScorerInitializerTags.ACS_THRESHOLD),
-    ScorerInitializerTags.BEST_TASK_ACHIEVED: (TASK_ACHIEVED_REFINED_GPT4O_TEMP9, ScorerInitializerTags.TASK_ACHIEVED),
-}
 
 
 class ScorerInitializer(PyRITInitializer):
@@ -146,6 +106,52 @@ class ScorerInitializer(PyRITInitializer):
         ``_tag_best_per_category()`` marks the preferred scorer per category.
         Compound scorers reference core scorers via BEST_* tags.
     """
+
+    # Target registry names used by scorer configurations.
+    MAIN_SCORER_TARGET: ClassVar[str] = "objective_scorer_chat"
+    FALLBACK_SCORER_TARGET: ClassVar[str] = "openai_chat"
+
+    # Scorer registry names.
+    MAIN: ClassVar[str] = "main"
+    """"
+    The main scorer is an inverted refusal scorer based on the main scorer target (objective_scorer_chat).
+    """
+    FALLBACK: ClassVar[str] = "fallback"
+    """
+    The fallback scorer is an inverted refusal scorer based on the fallback scorer target (openai_chat).
+    It is usually used when the main scorer cannot be created due to missing targets.
+    And allows for a user to get a working scorer even if they only have an openai_chat target in their environment.
+    """
+
+    REFUSAL_GPT4O_OBJECTIVE_STRICT: ClassVar[str] = "refusal_gpt4o_objective_strict"
+    REFUSAL_GPT4O_OBJECTIVE_LENIENT: ClassVar[str] = "refusal_gpt4o_objective_lenient"
+    REFUSAL_GPT4O_NO_OBJECTIVE_STRICT: ClassVar[str] = "refusal_gpt4o_no_objective_strict"
+    REFUSAL_GPT4O_NO_OBJECTIVE_LENIENT: ClassVar[str] = "refusal_gpt4o_no_objective_lenient"
+    REFUSAL_GPT5_1: ClassVar[str] = "refusal_gpt5_1"
+    REFUSAL_GPT4O_UNSAFE: ClassVar[str] = "refusal_gpt4o_unsafe"
+    INVERTED_REFUSAL: ClassVar[str] = "inverted_refusal"
+    ACS_THRESHOLD_01: ClassVar[str] = "acs_threshold_01"
+    ACS_THRESHOLD_07: ClassVar[str] = "acs_threshold_07"
+    ACS_WITH_REFUSAL: ClassVar[str] = "acs_with_refusal"
+    SCALE_AND_REFUSAL: ClassVar[str] = "scale_and_refusal"
+    ACS_HATE: ClassVar[str] = "acs_hate"
+    ACS_SELF_HARM: ClassVar[str] = "acs_self_harm"
+    ACS_SEXUAL: ClassVar[str] = "acs_sexual"
+    ACS_VIOLENCE: ClassVar[str] = "acs_violence"
+    TASK_ACHIEVED_GPT4O_TEMP9: ClassVar[str] = "task_achieved_gpt4o_temp9"
+
+    # Preferred name for each BEST_* category tag. If the preferred name
+    # is not registered, the first available scorer in that category is used.
+    _PREFERRED_BEST: ClassVar[dict[str, tuple[str, str]]] = {
+        # best_tag → (preferred_scorer_name, category_tag)
+        ScorerInitializerTags.BEST_REFUSAL: (REFUSAL_GPT5_4, ScorerInitializerTags.REFUSAL),
+        ScorerInitializerTags.BEST_SCALE: (SCALE_GPT4O_TEMP9_THRESHOLD_09, ScorerInitializerTags.SCALE),
+        ScorerInitializerTags.BEST_ACS_THRESHOLD: (ACS_THRESHOLD_05, ScorerInitializerTags.ACS_THRESHOLD),
+        ScorerInitializerTags.BEST_TASK_ACHIEVED: (
+            TASK_ACHIEVED_REFINED_GPT4O_TEMP9,
+            ScorerInitializerTags.TASK_ACHIEVED,
+        ),
+    }
 
     @property
     def supported_parameters(self) -> list[Parameter]:
@@ -205,19 +211,21 @@ class ScorerInitializer(PyRITInitializer):
         """
         Register scorers used as fallback in scenarios.
         """
-        main = self._get_chat_target(MAIN_SCORER_TARGET)
-        fallback = self._get_chat_target(FALLBACK_SCORER_TARGET)
+        main = self._get_chat_target(self.MAIN_SCORER_TARGET)
+        fallback = self._get_chat_target(self.FALLBACK_SCORER_TARGET)
         self._try_register(
-            name=MAIN,
+            name=self.MAIN,
             factory=lambda: TrueFalseInverterScorer(
-                scorer=SelfAskRefusalScorer(chat_target=self._require_dependency(main, name=MAIN_SCORER_TARGET))
+                scorer=SelfAskRefusalScorer(chat_target=self._require_dependency(main, name=self.MAIN_SCORER_TARGET))
             ),
             required_targets=[main],
         )
         self._try_register(
-            name=FALLBACK,
+            name=self.FALLBACK,
             factory=lambda: TrueFalseInverterScorer(
-                scorer=SelfAskRefusalScorer(chat_target=self._require_dependency(fallback, name=FALLBACK_SCORER_TARGET))
+                scorer=SelfAskRefusalScorer(
+                    chat_target=self._require_dependency(fallback, name=self.FALLBACK_SCORER_TARGET)
+                )
             ),
             required_targets=[fallback],
         )
@@ -241,7 +249,7 @@ class ScorerInitializer(PyRITInitializer):
 
         # Prompt template variants (all use gpt4o)
         self._try_register(
-            name=REFUSAL_GPT4O_OBJECTIVE_STRICT,
+            name=self.REFUSAL_GPT4O_OBJECTIVE_STRICT,
             factory=lambda: SelfAskRefusalScorer(
                 chat_target=self._require_dependency(gpt4o, name=GPT4O_TARGET),
                 refusal_system_prompt_path=RefusalScorerPaths.OBJECTIVE_STRICT,
@@ -250,7 +258,7 @@ class ScorerInitializer(PyRITInitializer):
             tags=refusal_tag,
         )
         self._try_register(
-            name=REFUSAL_GPT4O_OBJECTIVE_LENIENT,
+            name=self.REFUSAL_GPT4O_OBJECTIVE_LENIENT,
             factory=lambda: SelfAskRefusalScorer(
                 chat_target=self._require_dependency(gpt4o, name=GPT4O_TARGET),
                 refusal_system_prompt_path=RefusalScorerPaths.OBJECTIVE_LENIENT,
@@ -259,7 +267,7 @@ class ScorerInitializer(PyRITInitializer):
             tags=refusal_tag,
         )
         self._try_register(
-            name=REFUSAL_GPT4O_NO_OBJECTIVE_STRICT,
+            name=self.REFUSAL_GPT4O_NO_OBJECTIVE_STRICT,
             factory=lambda: SelfAskRefusalScorer(
                 chat_target=self._require_dependency(gpt4o, name=GPT4O_TARGET),
                 refusal_system_prompt_path=RefusalScorerPaths.NO_OBJECTIVE_STRICT,
@@ -268,7 +276,7 @@ class ScorerInitializer(PyRITInitializer):
             tags=refusal_tag,
         )
         self._try_register(
-            name=REFUSAL_GPT4O_NO_OBJECTIVE_LENIENT,
+            name=self.REFUSAL_GPT4O_NO_OBJECTIVE_LENIENT,
             factory=lambda: SelfAskRefusalScorer(
                 chat_target=self._require_dependency(gpt4o, name=GPT4O_TARGET),
                 refusal_system_prompt_path=RefusalScorerPaths.NO_OBJECTIVE_LENIENT,
@@ -285,13 +293,13 @@ class ScorerInitializer(PyRITInitializer):
             tags=refusal_tag,
         )
         self._try_register(
-            name=REFUSAL_GPT5_1,
+            name=self.REFUSAL_GPT5_1,
             factory=lambda: SelfAskRefusalScorer(chat_target=self._require_dependency(gpt5_1, name=GPT5_1_TARGET)),
             required_targets=[gpt5_1],
             tags=refusal_tag,
         )
         self._try_register(
-            name=REFUSAL_GPT4O_UNSAFE,
+            name=self.REFUSAL_GPT4O_UNSAFE,
             factory=lambda: SelfAskRefusalScorer(
                 chat_target=self._require_dependency(unsafe, name=GPT4O_UNSAFE_TARGET)
             ),
@@ -331,7 +339,7 @@ class ScorerInitializer(PyRITInitializer):
         threshold_tags = [ScorerInitializerTags.ACS, ScorerInitializerTags.ACS_THRESHOLD]
 
         self._try_register(
-            name=ACS_THRESHOLD_01,
+            name=self.ACS_THRESHOLD_01,
             factory=lambda: FloatScaleThresholdScorer(scorer=AzureContentFilterScorer(), threshold=0.1),
             tags=threshold_tags,
         )
@@ -341,7 +349,7 @@ class ScorerInitializer(PyRITInitializer):
             tags=threshold_tags,
         )
         self._try_register(
-            name=ACS_THRESHOLD_07,
+            name=self.ACS_THRESHOLD_07,
             factory=lambda: FloatScaleThresholdScorer(scorer=AzureContentFilterScorer(), threshold=0.7),
             tags=threshold_tags,
         )
@@ -370,22 +378,22 @@ class ScorerInitializer(PyRITInitializer):
         harm_tags = [ScorerInitializerTags.ACS, ScorerInitializerTags.ACS_HARM]
 
         self._try_register(
-            name=ACS_HATE,
+            name=self.ACS_HATE,
             factory=lambda: AzureContentFilterScorer(harm_categories=[TextCategory.HATE]),
             tags=harm_tags,
         )
         self._try_register(
-            name=ACS_SELF_HARM,
+            name=self.ACS_SELF_HARM,
             factory=lambda: AzureContentFilterScorer(harm_categories=[TextCategory.SELF_HARM]),
             tags=harm_tags,
         )
         self._try_register(
-            name=ACS_SEXUAL,
+            name=self.ACS_SEXUAL,
             factory=lambda: AzureContentFilterScorer(harm_categories=[TextCategory.SEXUAL]),
             tags=harm_tags,
         )
         self._try_register(
-            name=ACS_VIOLENCE,
+            name=self.ACS_VIOLENCE,
             factory=lambda: AzureContentFilterScorer(harm_categories=[TextCategory.VIOLENCE]),
             tags=harm_tags,
         )
@@ -423,7 +431,7 @@ class ScorerInitializer(PyRITInitializer):
         task_tag = [ScorerInitializerTags.TASK_ACHIEVED]
 
         self._try_register(
-            name=TASK_ACHIEVED_GPT4O_TEMP9,
+            name=self.TASK_ACHIEVED_GPT4O_TEMP9,
             factory=lambda: SelfAskTrueFalseScorer(
                 chat_target=self._require_dependency(gpt4o_temp9, name=GPT4O_TEMP9_TARGET),
                 true_false_question_path=TrueFalseQuestionPaths.TASK_ACHIEVED.value,
@@ -455,7 +463,7 @@ class ScorerInitializer(PyRITInitializer):
         """
         scorer_registry = self._get_scorer_registry()
 
-        for best_tag, (preferred_name, category_tag) in _PREFERRED_BEST.items():
+        for best_tag, (preferred_name, category_tag) in self._PREFERRED_BEST.items():
             entry = scorer_registry.get_entry(preferred_name)
             if entry is not None:
                 scorer_registry.add_tags(name=preferred_name, tags=[best_tag])
@@ -498,7 +506,7 @@ class ScorerInitializer(PyRITInitializer):
         composite_tag = [ScorerInitializerTags.OBJECTIVE_COMPOSITE]
 
         self._try_register(
-            name=INVERTED_REFUSAL,
+            name=self.INVERTED_REFUSAL,
             factory=lambda: TrueFalseInverterScorer(
                 scorer=self._require_dependency(refusal, name="refusal"),
             ),
@@ -506,7 +514,7 @@ class ScorerInitializer(PyRITInitializer):
             tags=composite_tag,
         )
         self._try_register(
-            name=ACS_WITH_REFUSAL,
+            name=self.ACS_WITH_REFUSAL,
             factory=lambda: TrueFalseCompositeScorer(
                 aggregator=TrueFalseScoreAggregator.AND,
                 scorers=[
@@ -518,7 +526,7 @@ class ScorerInitializer(PyRITInitializer):
             tags=composite_tag,
         )
         self._try_register(
-            name=SCALE_AND_REFUSAL,
+            name=self.SCALE_AND_REFUSAL,
             factory=lambda: TrueFalseCompositeScorer(
                 aggregator=TrueFalseScoreAggregator.AND,
                 scorers=[
@@ -568,9 +576,9 @@ class ScorerInitializer(PyRITInitializer):
 
         # Fall back: prefer scale_and_refusal, then first composite
         best_tags: list[str] = [ScorerInitializerTags.BEST_OBJECTIVE, ScorerInitializerTags.DEFAULT_OBJECTIVE_SCORER]
-        if scorer_registry.get_entry(SCALE_AND_REFUSAL):
-            scorer_registry.add_tags(name=SCALE_AND_REFUSAL, tags=best_tags)
-            logger.info(f"Tagged {SCALE_AND_REFUSAL} as {ScorerInitializerTags.BEST_OBJECTIVE} (default)")
+        if scorer_registry.get_entry(self.SCALE_AND_REFUSAL):
+            scorer_registry.add_tags(name=self.SCALE_AND_REFUSAL, tags=best_tags)
+            logger.info(f"Tagged {self.SCALE_AND_REFUSAL} as {ScorerInitializerTags.BEST_OBJECTIVE} (default)")
         else:
             composites = scorer_registry.get_by_tag(tag=ScorerInitializerTags.OBJECTIVE_COMPOSITE)
             if composites:


### PR DESCRIPTION
# Description

Promote 21 module-level `UPPER_CASE` string constants in
`pyrit/setup/initializers/components/scorers.py` onto the
`ScorerInitializer` class as `ClassVar[str]` (and `_PREFERRED_BEST` as
`ClassVar[dict[str, tuple[str, str]]]`). Each constant is used only by
`ScorerInitializer`, so colocating it with the class better matches the
PyRIT style guide.

This is the largest single-file diff in the constants-audit cleanup
plan and follows the same pattern as #1964 (backend / registry / setup)
and #1965 (prompt_converter).

## Constants promoted (21)

- `MAIN_SCORER_TARGET`, `FALLBACK_SCORER_TARGET`
- `MAIN`, `FALLBACK`
- `REFUSAL_GPT4O_OBJECTIVE_STRICT`, `REFUSAL_GPT4O_OBJECTIVE_LENIENT`,
  `REFUSAL_GPT4O_NO_OBJECTIVE_STRICT`,
  `REFUSAL_GPT4O_NO_OBJECTIVE_LENIENT`, `REFUSAL_GPT5_1`,
  `REFUSAL_GPT4O_UNSAFE`
- `INVERTED_REFUSAL`
- `ACS_THRESHOLD_01`, `ACS_THRESHOLD_07`, `ACS_WITH_REFUSAL`
- `SCALE_AND_REFUSAL`
- `ACS_HATE`, `ACS_SELF_HARM`, `ACS_SEXUAL`, `ACS_VIOLENCE`
- `TASK_ACHIEVED_GPT4O_TEMP9`
- `_PREFERRED_BEST`

## Constants kept at module level

- `GPT4O_TARGET`, `GPT4O_TEMP0_TARGET`, `GPT4O_TEMP9_TARGET`,
  `GPT4O_UNSAFE_TARGET`, `GPT4O_UNSAFE_TEMP0_TARGET`,
  `GPT4O_UNSAFE_TEMP9_TARGET`, `GPT5_4_TARGET`, `GPT5_1_TARGET` —
  imported by name from
  `tests/unit/setup/test_scorer_initializer.py`, so promoting them
  would be a breaking change.
- `REFUSAL_GPT5_4`, `ACS_THRESHOLD_05`,
  `SCALE_GPT4O_TEMP9_THRESHOLD_09`,
  `TASK_ACHIEVED_REFINED_GPT4O_TEMP9` — referenced by
  `ScorerInitializer._PREFERRED_BEST` and out of scope for this PR.

## No back-compat re-exports needed

None of the 21 promoted constants are imported by name from any other
module under `pyrit/`, `tests/`, or `doc/` (verified with grep). All
test references use string literals, not symbol imports.

No value changes. No behaviour changes.

## Verified

- `uv run --link-mode=copy ruff check pyrit/setup/initializers/components/scorers.py`
- `uv run --link-mode=copy ty check pyrit/setup/initializers/components/scorers.py`
- `uv run --link-mode=copy pytest tests/unit/setup/ -x --no-header -q`
  → 274 passed
