### PR TITLE
FIX: backend mapper fetches scores from memory after MessagePiece.scores removal

### DIFF
--- a/.github/instructions/test.instructions.md
+++ b/.github/instructions/test.instructions.md
@@ -48,10 +48,20 @@ Most tests should be unit tests. Integration and end-to-end tests are for testin
 
 - Use `unittest.mock.patch` / `patch.object` — not `monkeypatch`
 - Prefer `patch.object(instance, "method", new_callable=AsyncMock)` over broad module-path patches
-- Use `spec=ClassName` on mocks when you need to constrain to a real interface
+- Use `spec=ClassName` on `MagicMock` whenever the mocked object stands in for a real class that has a fixed attribute surface (Pydantic models, dataclasses, domain entities). Without `spec=`, manually assigned attributes (e.g. `mock.foo = []`) silently mask access to attributes that don't exist on the real class — a common cause of regressions when a field is renamed or removed.
 - Use `side_effect` for sequences or raising exceptions
 - For environment variables: `patch.dict("os.environ", {...})`
 - Check calls with `assert_called_once()`, `.call_args`, or `.call_count` — avoid `assert_called_once_with` for complex args, prefer `.call_args` inspection
+
+## Mapper / Serializer / DTO Tests
+
+Code that maps domain models to DTOs (or vice versa) — e.g. `pyrit/backend/mappers/`, custom Pydantic serializers, anything translating persisted records into wire formats — is especially prone to silent breakage when a field is renamed or removed from the source model. Mock-only tests cannot catch this class of regression, because `mock.removed_field` keeps returning whatever you assigned to it (or a fresh `MagicMock`) regardless of the real model's shape.
+
+For every mapper / serializer / DTO conversion:
+
+- Include **at least one test that exercises the mapper with real domain instances** (real Pydantic models, real ORM rows, etc.) instead of `MagicMock`. Use the `sqlite_instance` fixture (with `@pytest.mark.usefixtures("patch_central_database")`) when persistence is part of the round-trip.
+- It is fine to keep mock-based tests for fast coverage of branching logic. The real-object tests are a backstop against field-shape drift, not a replacement for the mock-based suite.
+- When `MagicMock` is unavoidable for a mapper test, pass `spec=RealModelClass` so attempted access to a removed field raises `AttributeError` immediately.
 
 ## Test Structure Preferences
 

--- a/pyrit/backend/mappers/attack_mappers.py
+++ b/pyrit/backend/mappers/attack_mappers.py
@@ -11,6 +11,7 @@ constructs local media endpoint URLs for media content.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import mimetypes
 import time
@@ -36,6 +37,7 @@ from pyrit.backend.models.attacks import (
     TargetInfo,
 )
 from pyrit.common.deprecation import print_deprecation_message
+from pyrit.memory import CentralMemory
 from pyrit.models import MEDIA_PATH_DATA_TYPES, AttackResult, ChatMessageRole, PromptDataType
 from pyrit.models import Message as PyritMessage
 from pyrit.models import MessagePiece as PyritMessagePiece
@@ -44,6 +46,7 @@ from pyrit.models import Score as PyritScore
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from pyrit.memory import MemoryInterface
     from pyrit.models.conversation_stats import ConversationStats
     from pyrit.models.retry_event import RetryEvent
 
@@ -386,7 +389,54 @@ def _build_filename(
     return f"{prefix}_{short_hash}{ext}"
 
 
-async def pyrit_messages_to_dto_async(pyrit_messages: list[PyritMessage]) -> list[Message]:
+def _score_lookup_key(*, piece: PyritMessagePiece) -> str:
+    """
+    Compute the score-lookup key for a piece.
+
+    Scores are linked to the piece's ``original_prompt_id`` (set by
+    ``MemoryInterface.add_scores_to_memory``), which equals ``piece.id``
+    for original pieces and points at the original for duplicates.
+
+    Returns:
+        Stringified piece identifier suitable for matching ``Score.message_piece_id``.
+    """
+    return str(piece.original_prompt_id or piece.id)
+
+
+async def _fetch_scores_by_piece_async(
+    *,
+    pyrit_messages: list[PyritMessage],
+    memory: MemoryInterface | None,
+) -> dict[str, list[PyritScore]]:
+    """
+    Batch-fetch scores for every piece in ``pyrit_messages`` and group by piece id.
+
+    Wrapped in ``asyncio.to_thread`` because ``get_prompt_scores`` is a blocking
+    SQLAlchemy call and ``pyrit_messages_to_dto_async`` runs on the event loop.
+
+    Returns:
+        ``{piece_lookup_key: [Score, ...]}``. Missing keys map to an empty list.
+    """
+    score_lookup_ids = sorted({_score_lookup_key(piece=p) for msg in pyrit_messages for p in msg.message_pieces})
+    if not score_lookup_ids:
+        return {}
+
+    if memory is None:
+        memory = CentralMemory.get_memory_instance()
+
+    fetched = await asyncio.to_thread(memory.get_prompt_scores, prompt_ids=score_lookup_ids)
+
+    grouped: dict[str, list[PyritScore]] = {}
+    for score in fetched:
+        grouped.setdefault(str(score.message_piece_id), []).append(score)
+    return grouped
+
+
+async def pyrit_messages_to_dto_async(
+    pyrit_messages: list[PyritMessage],
+    *,
+    memory: MemoryInterface | None = None,
+) -> list[Message]:
     """
     Translate PyRIT messages to backend Message DTOs.
 
@@ -394,9 +444,16 @@ async def pyrit_messages_to_dto_async(pyrit_messages: list[PyritMessage]) -> lis
     - Local files → ``/api/media?path=...`` (served by the media endpoint)
     - Azure Blob Storage files → signed URLs with SAS tokens
 
+    Scores are fetched from memory (``MessagePiece`` no longer carries them)
+    via a single batched ``get_prompt_scores`` call and attached to their
+    originating piece. Pass ``memory`` explicitly to avoid the
+    ``CentralMemory`` singleton lookup or to inject a fake in tests.
+
     Returns:
         List of Message DTOs for the API.
     """
+    scores_by_piece = await _fetch_scores_by_piece_async(pyrit_messages=pyrit_messages, memory=memory)
+
     messages = []
     for msg in pyrit_messages:
         pieces = []
@@ -413,6 +470,7 @@ async def pyrit_messages_to_dto_async(pyrit_messages: list[PyritMessage]) -> lis
             if conv_val and _is_azure_blob_url(conv_val):
                 conv_val = await _sign_blob_url_async(blob_url=conv_val)
 
+            piece_scores = scores_by_piece.get(_score_lookup_key(piece=p), [])
             pieces.append(
                 MessagePiece(
                     piece_id=str(p.id),
@@ -423,7 +481,7 @@ async def pyrit_messages_to_dto_async(pyrit_messages: list[PyritMessage]) -> lis
                     converted_value=conv_val,
                     converted_value_mime_type=_infer_mime_type(value=p.converted_value, data_type=conv_dtype),
                     prompt_metadata=dict(p.prompt_metadata) if p.prompt_metadata else None,
-                    scores=pyrit_scores_to_dto(p.scores) if p.scores else [],
+                    scores=pyrit_scores_to_dto(piece_scores),
                     response_error=p.response_error or "none",
                     original_filename=_build_filename(
                         data_type=orig_dtype,

--- a/pyrit/backend/services/attack_service.py
+++ b/pyrit/backend/services/attack_service.py
@@ -267,7 +267,7 @@ class AttackService:
 
         # Get messages for this conversation
         pyrit_messages = self._memory.get_conversation(conversation_id=conversation_id)
-        backend_messages = await pyrit_messages_to_dto_async(list(pyrit_messages))
+        backend_messages = await pyrit_messages_to_dto_async(list(pyrit_messages), memory=self._memory)
 
         return ConversationMessagesResponse(
             conversation_id=conversation_id,

--- a/tests/unit/backend/test_attack_service.py
+++ b/tests/unit/backend/test_attack_service.py
@@ -38,6 +38,7 @@ def mock_memory():
     memory.get_conversation.return_value = []
     memory.get_message_pieces.return_value = []
     memory.get_conversation_stats.return_value = {}
+    memory.get_prompt_scores.return_value = []
 
     return memory
 
@@ -131,7 +132,9 @@ def make_mock_piece(
     piece.original_value_data_type = "text"
     piece.response_error = "none"
     piece.timestamp = timestamp or datetime.now(timezone.utc)
-    piece.scores = []
+    # MessagePiece no longer carries scores — they are fetched from memory.
+    # Pin original_prompt_id so the mapper's score-lookup key is deterministic.
+    piece.original_prompt_id = None
     return piece
 
 
@@ -1447,7 +1450,7 @@ class TestMessageBuilding:
         mock_piece.sequence = 0
         mock_piece.role = "user"
         mock_piece.timestamp = datetime.now(timezone.utc)
-        mock_piece.scores = None
+        mock_piece.original_prompt_id = None
 
         mock_msg = MagicMock()
         mock_msg.message_pieces = [mock_piece]

--- a/tests/unit/backend/test_mappers.py
+++ b/tests/unit/backend/test_mappers.py
@@ -102,7 +102,10 @@ def _make_mock_piece(
     p.response_error = "none"
     p.role = "user"
     p.timestamp = datetime.now(timezone.utc)
-    p.scores = []
+    # MessagePiece no longer carries scores — they are fetched from memory.
+    # Set original_prompt_id explicitly so the lookup key is deterministic
+    # (otherwise the auto-generated MagicMock attr is truthy and unpredictable).
+    p.original_prompt_id = None
     return p
 
 
@@ -466,6 +469,16 @@ class TestAttackResultToSummary:
 class TestPyritMessagesToDto:
     """Tests for pyrit_messages_to_dto_async function."""
 
+    @pytest.fixture(autouse=True)
+    def _stub_central_memory(self):
+        """Stub CentralMemory so the mapper's score lookup is a no-op for mock-based tests."""
+        from pyrit.memory import CentralMemory
+
+        stub = MagicMock()
+        stub.get_prompt_scores = MagicMock(return_value=[])
+        with patch.object(CentralMemory, "get_memory_instance", return_value=stub):
+            yield stub
+
     async def test_maps_single_message(self) -> None:
         """Test mapping a single message with one piece."""
         piece = _make_mock_piece(original_value="hi", converted_value="hi")
@@ -646,6 +659,101 @@ class TestPyritMessagesToDto:
 
         assert result[0].pieces[0].original_value == "/tmp/nonexistent.png"
         assert result[0].pieces[0].converted_value == "/tmp/nonexistent.png"
+
+
+@pytest.mark.usefixtures("patch_central_database")
+class TestPyritMessagesToDtoRealObjects:
+    """Regression tests for pyrit_messages_to_dto_async using real domain objects.
+
+    The mock-based ``TestPyritMessagesToDto`` suite above sets ``p.scores = []``
+    directly on a ``MagicMock``, which masks the fact that ``MessagePiece`` no
+    longer carries a ``scores`` attribute. These tests round-trip real
+    ``MessagePiece`` / ``Score`` instances through a real ``SQLiteMemory`` so
+    that any regression to ``p.scores``-style access on the piece (or other
+    drift between the Pydantic model and the mapper) is caught.
+    """
+
+    async def test_scores_are_fetched_from_memory_and_attached(self, sqlite_instance) -> None:
+        """A real MessagePiece + Score round-trips through the mapper with scores attached."""
+        from pyrit.models import Message as RealPyritMessage
+        from pyrit.models import MessagePiece as RealPyritMessagePiece
+        from pyrit.models import Score as RealPyritScore
+
+        piece = RealPyritMessagePiece(role="user", original_value="hi")
+        sqlite_instance.add_message_to_memory(request=RealPyritMessage(message_pieces=[piece]))
+
+        score = RealPyritScore(
+            score_value="0.75",
+            score_type="float_scale",
+            score_category=["bias"],
+            score_rationale="example rationale",
+            message_piece_id=piece.id,
+        )
+        sqlite_instance.add_scores_to_memory(scores=[score])
+
+        reloaded = sqlite_instance.get_conversation(conversation_id=piece.conversation_id)
+        result = await pyrit_messages_to_dto_async(list(reloaded), memory=sqlite_instance)
+
+        assert len(result) == 1
+        dto_pieces = result[0].pieces
+        assert len(dto_pieces) == 1
+        attached = dto_pieces[0].scores
+        assert len(attached) == 1
+        assert attached[0].score_value == "0.75"
+        assert attached[0].score_type == "float_scale"
+        assert attached[0].score_category == ["bias"]
+        assert attached[0].score_rationale == "example rationale"
+
+    async def test_empty_scores_when_none_recorded(self, sqlite_instance) -> None:
+        """A real piece with no scores in memory maps to an empty scores list."""
+        from pyrit.models import Message as RealPyritMessage
+        from pyrit.models import MessagePiece as RealPyritMessagePiece
+
+        piece = RealPyritMessagePiece(role="user", original_value="hi")
+        sqlite_instance.add_message_to_memory(request=RealPyritMessage(message_pieces=[piece]))
+
+        reloaded = sqlite_instance.get_conversation(conversation_id=piece.conversation_id)
+        result = await pyrit_messages_to_dto_async(list(reloaded), memory=sqlite_instance)
+
+        assert result[0].pieces[0].scores == []
+
+    async def test_scores_are_grouped_per_piece_across_multiple_pieces(self, sqlite_instance) -> None:
+        """Scores from a batched fetch are routed to the correct originating piece."""
+        from pyrit.models import Message as RealPyritMessage
+        from pyrit.models import MessagePiece as RealPyritMessagePiece
+        from pyrit.models import Score as RealPyritScore
+
+        conv_id = "real-conv-1"
+        user_piece = RealPyritMessagePiece(role="user", original_value="ask", conversation_id=conv_id)
+        sqlite_instance.add_message_to_memory(request=RealPyritMessage(message_pieces=[user_piece]))
+        assistant_piece = RealPyritMessagePiece(role="assistant", original_value="reply", conversation_id=conv_id)
+        sqlite_instance.add_message_to_memory(request=RealPyritMessage(message_pieces=[assistant_piece]))
+
+        sqlite_instance.add_scores_to_memory(
+            scores=[
+                RealPyritScore(
+                    score_value="true",
+                    score_type="true_false",
+                    score_rationale="refusal detected",
+                    message_piece_id=assistant_piece.id,
+                ),
+                RealPyritScore(
+                    score_value="0.1",
+                    score_type="float_scale",
+                    score_rationale="low severity",
+                    message_piece_id=assistant_piece.id,
+                ),
+            ]
+        )
+
+        reloaded = sqlite_instance.get_conversation(conversation_id=conv_id)
+        result = await pyrit_messages_to_dto_async(list(reloaded), memory=sqlite_instance)
+
+        by_role = {msg.role: msg for msg in result}
+        assert by_role["user"].pieces[0].scores == []
+        assistant_scores = by_role["assistant"].pieces[0].scores
+        assert len(assistant_scores) == 2
+        assert {s.score_value for s in assistant_scores} == {"true", "0.1"}
 
 
 class TestIsAzureBlobUrl:


### PR DESCRIPTION
## Description

The deprecation cleanup in #1951 removed `scores` from `MessagePiece`, but `pyrit_messages_to_dto_async` in the backend still called `p.scores` and so raised `AttributeError` at runtime whenever the GUI / backend asked for a conversation's messages (`AttackService.get_conversation_messages_async`). Reproduced via the GUI: clicking any attack in "Recent operations" yields `GET /api/attacks/{id}/messages?conversation_id=... → 500`. The mock-based mapper tests didn't catch it because `_make_mock_piece` set `p.scores = []` directly on a `MagicMock`.

Quick standalone reproduction against `main` before this fix:

```python
asyncio.run(pyrit_messages_to_dto_async([Message(message_pieces=[MessagePiece(role='user', original_value='hi')])]))
# AttributeError: 'MessagePiece' object has no attribute 'scores'
```

### Approach

Fetch scores from memory in the mapper instead of from the piece:

- A single batched `memory.get_prompt_scores(prompt_ids=...)` call per request, wrapped in `asyncio.to_thread` since it's blocking SQLAlchemy.
- Group results by `Score.message_piece_id` and look them up per piece using `original_prompt_id or id` (matches the rewrite `add_scores_to_memory` does for duplicate pieces, so duplicates correctly inherit their original's scores).
- `pyrit_messages_to_dto_async` now takes an optional `memory: MemoryInterface | None` kwarg. `AttackService` passes its own `self._memory`; default falls back to `CentralMemory.get_memory_instance()`.

The backend DTO intentionally keeps `scores` on `MessagePiece` even though the domain model dropped it: the frontend renders scores inline with each piece, and embedding them in the same payload avoids a per-conversation round-trip and loading states. The DTO and the domain model serve different purposes here.

### Why the existing tests missed this

`_make_mock_piece` returns a `MagicMock` and explicitly sets `p.scores = []`, so `p.scores` always resolved against the mock attribute regardless of the real model's shape. The neighbouring `TestMessageBuilding::test_get_attack_with_messages_translates_correctly` did exercise the full service path but used the same mock pattern. The `frontend/e2e/flows.spec.ts` suite POSTs to `/api/attacks/{id}/messages` but never GETs that route against a real backend, so it didn't catch the 500 either.

To prevent recurrence:
- New `TestPyritMessagesToDtoRealObjects` suite (3 cases) that round-trips real `MessagePiece` / `Score` instances through a real `SQLiteMemory` via `patch_central_database`. Any future regression where the mapper accesses a removed/renamed field will surface there.
- New "Mapper / Serializer / DTO Tests" section in `.github/instructions/test.instructions.md` requiring at least one real-object test per mapper, and strengthened guidance on `spec=` for `MagicMock` standing in for fixed-attribute classes (Pydantic models, dataclasses).

## Tests and Documentation

- Updated `_make_mock_piece` helpers in `test_mappers.py` and `test_attack_service.py` to drop the stale `p.scores = []` and pin `original_prompt_id = None` so the new score-lookup key is deterministic.
- Added an autouse `CentralMemory` stub to the existing `TestPyritMessagesToDto` class so the mock-based tests continue to work without setting up real memory.
- Added `TestPyritMessagesToDtoRealObjects` (3 cases) covering:
  - real piece + real score round-trip, score attached to DTO
  - piece with no scores in memory maps to empty list
  - multiple pieces in one conversation, scores routed to the correct piece
- Verified the fix end-to-end via the GUI on this branch: same DB, same attack, `GET /api/attacks/.../messages` now returns 200 and the conversation view renders.
- `make unit-test` on `tests/unit/backend/` is green (643 passed, 5 skipped).
- `ruff check`, `ruff format`, `ty check`, and full `pre-commit` clean on the touched files.
- Updated `.github/instructions/test.instructions.md` with the mapper/DTO real-object test convention (no other docs needed).
