### PR TITLE
FEAT: Validate button for live target capability checks in CoPyRIT

### DIFF
--- a/doc/gui/0_gui.md
+++ b/doc/gui/0_gui.md
@@ -136,7 +136,21 @@ The Configuration view manages the targets available for attacks.
 
 #### Target Table
 
-Lists all registered targets with their type, endpoint, and model name. Click "Set Active" to select a target for use in the Chat view. The active target is highlighted with an "Active" badge.
+Lists all registered targets with their type, endpoint, and model name. Click "Set Active" to select a target for use in the Chat view. The active target is highlighted with an "Active" badge. Click "Validate" on any top-level row to probe a target's live capabilities and see a declared-vs-observed diff (see [Validating Targets](#validating-targets) below).
+
+#### Validating Targets
+
+Each row in the target table has a **Validate** button that runs PyRIT's `discover_target_capabilities_async` engine against the selected target and opens a modal showing declared-vs-observed capability flags and input modalities. Use this when you want to confirm that a target actually accepts the request shapes its class declares (for example, when an Azure OpenAI gateway strips a feature, or when a multimodal class is pointed at a text-only deployment) before launching a long attack run.
+
+The dialog:
+
+- Sends real requests to the target — this may incur cost and produce side effects (logs, billing, content-policy hits). Test prompts are written to memory tagged `capability_probe`.
+- Caps per-probe timeout at 5 seconds for GUI responsiveness.
+- Reports output modalities as declared (those are not actively probed) and renders an amber em-dash for them.
+- Reports declared input-modality combinations the engine has no packaged test asset for (e.g., `function_call`, `tool_call`, `reasoning`, `url`) in a separate "Not probed (no asset)" row rather than as false red mismatches.
+- Should NOT be run while an attack or scenario is actively using the same target — validation temporarily changes the target's runtime configuration during probing.
+
+Only top-level registered targets get a Validate button; inner targets of composite wrappers (e.g., `RoundRobinTarget` children) are reachable only through the wrapper.
 
 #### Creating Targets
 

--- a/doc/gui/0_gui.md
+++ b/doc/gui/0_gui.md
@@ -136,11 +136,11 @@ The Configuration view manages the targets available for attacks.
 
 #### Target Table
 
-Lists all registered targets with their type, endpoint, and model name. Click "Set Active" to select a target for use in the Chat view. The active target is highlighted with an "Active" badge. Click "Validate" on any top-level row to probe a target's live capabilities and see a declared-vs-observed diff (see [Validating Targets](#validating-targets) below).
+Lists all registered targets with their type, endpoint, and model name. Click "Set Active" to select a target for use in the Chat view. The active target is highlighted with an "Active" badge. The **Validate** column (with a beaker icon button) lets you probe a target's live capabilities and see a declared-vs-observed diff (see [Validating Targets](#validating-targets) below).
 
 #### Validating Targets
 
-Each row in the target table has a **Validate** button that runs PyRIT's `discover_target_capabilities_async` engine against the selected target and opens a modal showing declared-vs-observed capability flags and input modalities. Use this when you want to confirm that a target actually accepts the request shapes its class declares (for example, when an Azure OpenAI gateway strips a feature, or when a multimodal class is pointed at a text-only deployment) before launching a long attack run.
+The **Validate** column in the target table has a beaker icon button on every top-level row that runs PyRIT's `discover_target_capabilities_async` engine against the selected target and opens a modal showing declared-vs-observed capability flags and input modalities. The button is placed next to the capability columns (Inputs, Outputs, Multi-turn, …) so it sits with the data it inspects. Use this when you want to confirm that a target actually accepts the request shapes its class declares (for example, when an Azure OpenAI gateway strips a feature, or when a multimodal class is pointed at a text-only deployment) before launching a long attack run.
 
 The dialog:
 
@@ -150,7 +150,7 @@ The dialog:
 - Reports declared input-modality combinations the engine has no packaged test asset for (e.g., `function_call`, `tool_call`, `reasoning`, `url`) in a separate "Not probed (no asset)" row rather than as false red mismatches.
 - Should NOT be run while an attack or scenario is actively using the same target — validation temporarily changes the target's runtime configuration during probing.
 
-Only top-level registered targets get a Validate button; inner targets of composite wrappers (e.g., `RoundRobinTarget` children) are reachable only through the wrapper.
+Only top-level registered targets have a Validate button; inner targets of composite wrappers (e.g., `RoundRobinTarget` children) are reachable only through the wrapper.
 
 #### Creating Targets
 

--- a/frontend/src/components/Config/TargetTable.styles.ts
+++ b/frontend/src/components/Config/TargetTable.styles.ts
@@ -38,6 +38,10 @@ export const useTargetTableStyles = makeStyles({
     width: '160px',
     textAlign: 'center',
   },
+  validateCell: {
+    width: '70px',
+    textAlign: 'center',
+  },
   modalityRow: {
     display: 'inline-flex',
     alignItems: 'center',

--- a/frontend/src/components/Config/TargetTable.styles.ts
+++ b/frontend/src/components/Config/TargetTable.styles.ts
@@ -39,7 +39,7 @@ export const useTargetTableStyles = makeStyles({
     textAlign: 'center',
   },
   validateCell: {
-    width: '70px',
+    width: '90px',
     textAlign: 'center',
   },
   modalityRow: {

--- a/frontend/src/components/Config/TargetTable.test.tsx
+++ b/frontend/src/components/Config/TargetTable.test.tsx
@@ -415,7 +415,7 @@ describe('TargetTable', () => {
         <TargetTable {...defaultProps} />
       </TestWrapper>,
     )
-    const validateButtons = screen.getAllByRole('button', { name: /^Validate$/ })
+    const validateButtons = screen.getAllByRole('button', { name: /^Validate capabilities for / })
     // 3 sample targets, 1 button each (no active target → no extra active-row button)
     expect(validateButtons).toHaveLength(3)
   })
@@ -426,7 +426,7 @@ describe('TargetTable', () => {
         <TargetTable {...defaultProps} activeTarget={sampleTargets[0]} />
       </TestWrapper>,
     )
-    const validateButtons = screen.getAllByRole('button', { name: /^Validate$/ })
+    const validateButtons = screen.getAllByRole('button', { name: /^Validate capabilities for / })
     // 3 list rows + 1 active-row summary = 4
     expect(validateButtons).toHaveLength(4)
   })
@@ -458,12 +458,12 @@ describe('TargetTable', () => {
       </TestWrapper>,
     )
     // Before expanding: 1 top-level row → 1 Validate button
-    expect(screen.getAllByRole('button', { name: /^Validate$/ })).toHaveLength(1)
+    expect(screen.getAllByRole('button', { name: /^Validate capabilities for / })).toHaveLength(1)
     // Expand
     fireEvent.click(screen.getByLabelText('Expand inner targets'))
     expect(screen.getByText('https://a.openai.azure.com')).toBeInTheDocument()
     // After expanding: still only 1 Validate button (inner rows don't get one)
-    expect(screen.getAllByRole('button', { name: /^Validate$/ })).toHaveLength(1)
+    expect(screen.getAllByRole('button', { name: /^Validate capabilities for / })).toHaveLength(1)
   })
 
   it('opens the validation dialog when a Validate button is clicked', async () => {
@@ -474,7 +474,7 @@ describe('TargetTable', () => {
         <TargetTable {...defaultProps} />
       </TestWrapper>,
     )
-    const validateButtons = screen.getAllByRole('button', { name: /^Validate$/ })
+    const validateButtons = screen.getAllByRole('button', { name: /^Validate capabilities for / })
     fireEvent.click(validateButtons[0])
     await waitFor(() => {
       expect(mockedApi.validateCapabilities).toHaveBeenCalledWith('openai_chat_gpt4')
@@ -489,11 +489,11 @@ describe('TargetTable', () => {
         <TargetTable {...defaultProps} />
       </TestWrapper>,
     )
-    const validateButtons = screen.getAllByRole('button', { name: /^Validate$/ })
+    const validateButtons = screen.getAllByRole('button', { name: /^Validate capabilities for / })
     fireEvent.click(validateButtons[0])
     await waitFor(() => {
       // The first row's Validate button is now disabled.
-      const stillButtons = screen.getAllByRole('button', { name: /^Validate$/ })
+      const stillButtons = screen.getAllByRole('button', { name: /^Validate capabilities for / })
       expect(stillButtons[0]).toBeDisabled()
       // The other rows' buttons remain enabled.
       expect(stillButtons[1]).not.toBeDisabled()

--- a/frontend/src/components/Config/TargetTable.test.tsx
+++ b/frontend/src/components/Config/TargetTable.test.tsx
@@ -1,11 +1,20 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { FluentProvider, webLightTheme } from '@fluentui/react-components'
 import TargetTable from './TargetTable'
 import type { TargetInstance } from '../../types'
+import { targetsApi } from '@/services/api'
 
 jest.mock('./TargetTable.styles', () => ({
   useTargetTableStyles: () => new Proxy({}, { get: () => '' }),
 }))
+
+jest.mock('@/services/api', () => ({
+  targetsApi: {
+    validateCapabilities: jest.fn(),
+  },
+}))
+
+const mockedApi = targetsApi as jest.Mocked<typeof targetsApi>
 
 const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <FluentProvider theme={webLightTheme}>{children}</FluentProvider>
@@ -396,5 +405,98 @@ describe('TargetTable', () => {
     )
 
     expect(screen.queryByLabelText('Expand inner targets')).not.toBeInTheDocument()
+  })
+
+  // --- F5: Validate button wiring ---
+
+  it('renders a Validate button on every top-level row', () => {
+    render(
+      <TestWrapper>
+        <TargetTable {...defaultProps} />
+      </TestWrapper>,
+    )
+    const validateButtons = screen.getAllByRole('button', { name: /^Validate$/ })
+    // 3 sample targets, 1 button each (no active target → no extra active-row button)
+    expect(validateButtons).toHaveLength(3)
+  })
+
+  it('also renders a Validate button on the active-target summary row', () => {
+    render(
+      <TestWrapper>
+        <TargetTable {...defaultProps} activeTarget={sampleTargets[0]} />
+      </TestWrapper>,
+    )
+    const validateButtons = screen.getAllByRole('button', { name: /^Validate$/ })
+    // 3 list rows + 1 active-row summary = 4
+    expect(validateButtons).toHaveLength(4)
+  })
+
+  it('does NOT render Validate buttons on inner-target rows (composite expansion)', () => {
+    const rrTarget: TargetInstance = {
+      target_registry_name: 'rr_gpt4o',
+      target_type: 'RoundRobinTarget',
+      model_name: 'gpt-4o',
+      target_specific_params: { weights: [1, 1] },
+      inner_targets: [
+        {
+          target_registry_name: 'inner_a',
+          target_type: 'OpenAIChatTarget',
+          endpoint: 'https://a.openai.azure.com',
+          model_name: 'gpt-4o',
+        },
+        {
+          target_registry_name: 'inner_b',
+          target_type: 'OpenAIChatTarget',
+          endpoint: 'https://b.openai.azure.com',
+          model_name: 'gpt-4o',
+        },
+      ],
+    }
+    render(
+      <TestWrapper>
+        <TargetTable {...defaultProps} targets={[rrTarget]} />
+      </TestWrapper>,
+    )
+    // Before expanding: 1 top-level row → 1 Validate button
+    expect(screen.getAllByRole('button', { name: /^Validate$/ })).toHaveLength(1)
+    // Expand
+    fireEvent.click(screen.getByLabelText('Expand inner targets'))
+    expect(screen.getByText('https://a.openai.azure.com')).toBeInTheDocument()
+    // After expanding: still only 1 Validate button (inner rows don't get one)
+    expect(screen.getAllByRole('button', { name: /^Validate$/ })).toHaveLength(1)
+  })
+
+  it('opens the validation dialog when a Validate button is clicked', async () => {
+    // Pending promise so the dialog stays in the loading state we can detect.
+    mockedApi.validateCapabilities.mockReturnValue(new Promise(() => {}))
+    render(
+      <TestWrapper>
+        <TargetTable {...defaultProps} />
+      </TestWrapper>,
+    )
+    const validateButtons = screen.getAllByRole('button', { name: /^Validate$/ })
+    fireEvent.click(validateButtons[0])
+    await waitFor(() => {
+      expect(mockedApi.validateCapabilities).toHaveBeenCalledWith('openai_chat_gpt4')
+    })
+    expect(screen.getByText(/Validate capabilities: openai_chat_gpt4/i)).toBeInTheDocument()
+  })
+
+  it('disables the Validate button for the row whose dialog is currently open', async () => {
+    mockedApi.validateCapabilities.mockReturnValue(new Promise(() => {}))
+    render(
+      <TestWrapper>
+        <TargetTable {...defaultProps} />
+      </TestWrapper>,
+    )
+    const validateButtons = screen.getAllByRole('button', { name: /^Validate$/ })
+    fireEvent.click(validateButtons[0])
+    await waitFor(() => {
+      // The first row's Validate button is now disabled.
+      const stillButtons = screen.getAllByRole('button', { name: /^Validate$/ })
+      expect(stillButtons[0]).toBeDisabled()
+      // The other rows' buttons remain enabled.
+      expect(stillButtons[1]).not.toBeDisabled()
+    })
   })
 })

--- a/frontend/src/components/Config/TargetTable.tsx
+++ b/frontend/src/components/Config/TargetTable.tsx
@@ -28,6 +28,7 @@ import {
   ArrowHookUpLeftRegular,
   ChevronRightRegular,
   ChevronDownRegular,
+  BeakerRegular,
 } from '@fluentui/react-icons'
 import type { TargetInstance } from '../../types'
 import { useTargetTableStyles } from './TargetTable.styles'
@@ -73,6 +74,7 @@ const COLUMN_TOOLTIPS = {
   parameters: 'Target-specific configuration parameters (e.g., reasoning_effort, max_output_tokens)',
   inputs: 'Modalities the target accepts as input',
   outputs: 'Modalities the target can produce as output',
+  validate: 'Probe the target live and compare observed capabilities to the declared values shown in this row',
 } as const
 
 /** Composite icon: f(x) with a small return-arrow badge for function call outputs. */
@@ -285,17 +287,7 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
           <TableBody>
             <TableRow className={styles.activeRow}>
               <TableCell style={{ width: '120px' }}>
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', alignItems: 'flex-start' }}>
-                  <Badge appearance="filled" color="brand" icon={<CheckmarkRegular />}>Active</Badge>
-                  <Button
-                    appearance="subtle"
-                    size="small"
-                    disabled={validateTarget?.target_registry_name === activeTarget.target_registry_name}
-                    onClick={() => setValidateTarget(activeTarget)}
-                  >
-                    Validate
-                  </Button>
-                </div>
+                <Badge appearance="filled" color="brand" icon={<CheckmarkRegular />}>Active</Badge>
               </TableCell>
               <TableCell style={{ width: '140px' }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
@@ -324,6 +316,18 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
               </TableCell>
               <TableCell className={styles.modalityCell}>
                 <ModalityCell modalities={activeTarget.capabilities?.supported_output_modalities} />
+              </TableCell>
+              <TableCell className={styles.validateCell}>
+                <Tooltip content={COLUMN_TOOLTIPS.validate} relationship="label">
+                  <Button
+                    appearance="subtle"
+                    size="small"
+                    icon={<BeakerRegular />}
+                    aria-label={`Validate capabilities for ${activeTarget.target_registry_name}`}
+                    disabled={validateTarget?.target_registry_name === activeTarget.target_registry_name}
+                    onClick={() => setValidateTarget(activeTarget)}
+                  />
+                </Tooltip>
               </TableCell>
               <CapabilityCells target={activeTarget} />
               <TableCell style={{ width: '160px' }}>
@@ -389,6 +393,11 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
                 <span className={styles.helpHeader}>Outputs</span>
               </Tooltip>
             </TableHeaderCell>
+            <TableHeaderCell className={styles.validateCell}>
+              <Tooltip content={COLUMN_TOOLTIPS.validate} relationship="description">
+                <span className={styles.helpHeader}>Validate</span>
+              </Tooltip>
+            </TableHeaderCell>
             {CAPABILITY_COLUMNS.map(({ key, label, tooltip }) => (
               <TableHeaderCell key={key} className={styles.capabilityCell}>
                 <Tooltip content={tooltip} relationship="description">
@@ -416,29 +425,19 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
                   className={isActive(target) ? styles.activeRow : undefined}
                 >
                   <TableCell>
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', alignItems: 'flex-start' }}>
-                      {isActive(target) ? (
-                        <Badge appearance="filled" color="brand" icon={<CheckmarkRegular />}>
-                          Active
-                        </Badge>
-                      ) : (
-                        <Button
-                          appearance="primary"
-                          size="small"
-                          onClick={() => onSetActiveTarget(target)}
-                        >
-                          Set Active
-                        </Button>
-                      )}
+                    {isActive(target) ? (
+                      <Badge appearance="filled" color="brand" icon={<CheckmarkRegular />}>
+                        Active
+                      </Badge>
+                    ) : (
                       <Button
-                        appearance="subtle"
+                        appearance="primary"
                         size="small"
-                        disabled={validateTarget?.target_registry_name === target.target_registry_name}
-                        onClick={() => setValidateTarget(target)}
+                        onClick={() => onSetActiveTarget(target)}
                       >
-                        Validate
+                        Set Active
                       </Button>
-                    </div>
+                    )}
                   </TableCell>
                   <TableCell>
                     <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
@@ -468,6 +467,18 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
                   </TableCell>
                   <TableCell className={styles.modalityCell}>
                     <ModalityCell modalities={target.capabilities?.supported_output_modalities} />
+                  </TableCell>
+                  <TableCell className={styles.validateCell}>
+                    <Tooltip content={COLUMN_TOOLTIPS.validate} relationship="label">
+                      <Button
+                        appearance="subtle"
+                        size="small"
+                        icon={<BeakerRegular />}
+                        aria-label={`Validate capabilities for ${target.target_registry_name}`}
+                        disabled={validateTarget?.target_registry_name === target.target_registry_name}
+                        onClick={() => setValidateTarget(target)}
+                      />
+                    </Tooltip>
                   </TableCell>
                   <CapabilityCells target={target} />
                   <TableCell>

--- a/frontend/src/components/Config/TargetTable.tsx
+++ b/frontend/src/components/Config/TargetTable.tsx
@@ -320,7 +320,7 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
               <TableCell className={styles.validateCell}>
                 <Tooltip content={COLUMN_TOOLTIPS.validate} relationship="label">
                   <Button
-                    appearance="subtle"
+                    appearance="secondary"
                     size="small"
                     icon={<BeakerRegular />}
                     aria-label={`Validate capabilities for ${activeTarget.target_registry_name}`}
@@ -471,7 +471,7 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
                   <TableCell className={styles.validateCell}>
                     <Tooltip content={COLUMN_TOOLTIPS.validate} relationship="label">
                       <Button
-                        appearance="subtle"
+                        appearance="secondary"
                         size="small"
                         icon={<BeakerRegular />}
                         aria-label={`Validate capabilities for ${target.target_registry_name}`}

--- a/frontend/src/components/Config/TargetTable.tsx
+++ b/frontend/src/components/Config/TargetTable.tsx
@@ -31,6 +31,7 @@ import {
 } from '@fluentui/react-icons'
 import type { TargetInstance } from '../../types'
 import { useTargetTableStyles } from './TargetTable.styles'
+import ValidateCapabilitiesDialog from './ValidateCapabilitiesDialog'
 
 interface TargetTableProps {
   targets: TargetInstance[]
@@ -244,6 +245,10 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
   // We use a Set of target_registry_name strings — when a name is in the set,
   // that row's sub-rows are visible.
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set())
+  // The target whose Validate dialog is currently open, or null.
+  // Inner-target rows (composite expansion) do NOT get a Validate button —
+  // they aren't registered by name in the backend TargetRegistry.
+  const [validateTarget, setValidateTarget] = useState<TargetInstance | null>(null)
 
   const toggleExpanded = (registryName: string) => {
     setExpandedRows((prev) => {
@@ -280,7 +285,17 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
           <TableBody>
             <TableRow className={styles.activeRow}>
               <TableCell style={{ width: '120px' }}>
-                <Badge appearance="filled" color="brand" icon={<CheckmarkRegular />}>Active</Badge>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', alignItems: 'flex-start' }}>
+                  <Badge appearance="filled" color="brand" icon={<CheckmarkRegular />}>Active</Badge>
+                  <Button
+                    appearance="subtle"
+                    size="small"
+                    disabled={validateTarget?.target_registry_name === activeTarget.target_registry_name}
+                    onClick={() => setValidateTarget(activeTarget)}
+                  >
+                    Validate
+                  </Button>
+                </div>
               </TableCell>
               <TableCell style={{ width: '140px' }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
@@ -401,19 +416,29 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
                   className={isActive(target) ? styles.activeRow : undefined}
                 >
                   <TableCell>
-                    {isActive(target) ? (
-                      <Badge appearance="filled" color="brand" icon={<CheckmarkRegular />}>
-                        Active
-                      </Badge>
-                    ) : (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', alignItems: 'flex-start' }}>
+                      {isActive(target) ? (
+                        <Badge appearance="filled" color="brand" icon={<CheckmarkRegular />}>
+                          Active
+                        </Badge>
+                      ) : (
+                        <Button
+                          appearance="primary"
+                          size="small"
+                          onClick={() => onSetActiveTarget(target)}
+                        >
+                          Set Active
+                        </Button>
+                      )}
                       <Button
-                        appearance="primary"
+                        appearance="subtle"
                         size="small"
-                        onClick={() => onSetActiveTarget(target)}
+                        disabled={validateTarget?.target_registry_name === target.target_registry_name}
+                        onClick={() => setValidateTarget(target)}
                       >
-                        Set Active
+                        Validate
                       </Button>
-                    )}
+                    </div>
                   </TableCell>
                   <TableCell>
                     <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
@@ -465,6 +490,12 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
           })}
         </TableBody>
       </Table>
+
+      <ValidateCapabilitiesDialog
+        open={validateTarget != null}
+        target={validateTarget}
+        onClose={() => setValidateTarget(null)}
+      />
     </div>
   )
 }

--- a/frontend/src/components/Config/ValidateCapabilitiesDialog.test.tsx
+++ b/frontend/src/components/Config/ValidateCapabilitiesDialog.test.tsx
@@ -1,0 +1,299 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FluentProvider, webLightTheme } from '@fluentui/react-components'
+import ValidateCapabilitiesDialog from './ValidateCapabilitiesDialog'
+import { targetsApi } from '@/services/api'
+import type { TargetInstance, ValidateCapabilitiesResponse } from '@/types'
+
+jest.mock('@/services/api', () => ({
+  targetsApi: {
+    validateCapabilities: jest.fn(),
+  },
+}))
+
+const mockedApi = targetsApi as jest.Mocked<typeof targetsApi>
+
+const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <FluentProvider theme={webLightTheme}>{children}</FluentProvider>
+)
+
+const sampleTarget: TargetInstance = {
+  target_registry_name: 'azure_chat_test',
+  target_type: 'OpenAIChatTarget',
+  endpoint: 'https://example.openai.azure.com',
+  model_name: 'gpt-4',
+  capabilities: {
+    supports_multi_turn: true,
+    supports_multi_message_pieces: true,
+    supports_json_schema: true,
+    supports_json_output: true,
+    supports_editable_history: true,
+    supports_system_prompt: true,
+    supported_input_modalities: ['text'],
+    supported_output_modalities: ['text'],
+  },
+}
+
+const allMatchResponse: ValidateCapabilitiesResponse = {
+  target_registry_name: 'azure_chat_test',
+  declared: sampleTarget.capabilities!,
+  observed: sampleTarget.capabilities!,
+  non_probeable_input_modalities: [],
+  warnings: [
+    'Validation sent live requests to the target; this may incur cost and produce real side effects.',
+    'Test prompts written to memory are tagged with `capability_probe`.',
+    'Output modalities are reported as declared (not actively probed).',
+    'Capability probes confirm request acceptance, not semantic enforcement.',
+    'Do not run Validate while an attack or scenario is actively using this target.',
+  ],
+}
+
+const mismatchResponse: ValidateCapabilitiesResponse = {
+  target_registry_name: 'azure_chat_test',
+  declared: {
+    ...sampleTarget.capabilities!,
+    supports_json_schema: true,
+    supported_input_modalities: ['image_path', 'text'],
+  },
+  observed: {
+    ...sampleTarget.capabilities!,
+    supports_json_schema: false,
+    supported_input_modalities: ['text'],
+  },
+  non_probeable_input_modalities: [],
+  warnings: ['Validation sent live requests to the target; ...'],
+}
+
+const notProbedResponse: ValidateCapabilitiesResponse = {
+  target_registry_name: 'openai_response_test',
+  declared: {
+    ...sampleTarget.capabilities!,
+    supported_input_modalities: ['function_call', 'reasoning', 'text', 'tool_call'],
+  },
+  observed: {
+    ...sampleTarget.capabilities!,
+    supported_input_modalities: ['function_call', 'reasoning', 'text', 'tool_call'],
+  },
+  non_probeable_input_modalities: ['function_call', 'reasoning', 'tool_call'],
+  warnings: [
+    'Validation sent live requests to the target; ...',
+    'Some declared input modalities are reported as declared/not-probed (no packaged probe asset): function_call, reasoning, tool_call.',
+  ],
+}
+
+describe('ValidateCapabilitiesDialog', () => {
+  beforeEach(() => {
+    mockedApi.validateCapabilities.mockReset()
+  })
+
+  it('renders nothing when closed', () => {
+    render(
+      <TestWrapper>
+        <ValidateCapabilitiesDialog open={false} target={sampleTarget} onClose={jest.fn()} />
+      </TestWrapper>,
+    )
+    expect(screen.queryByText(/Validate capabilities/i)).not.toBeInTheDocument()
+    expect(mockedApi.validateCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('renders nothing when target is null', () => {
+    render(
+      <TestWrapper>
+        <ValidateCapabilitiesDialog open={true} target={null} onClose={jest.fn()} />
+      </TestWrapper>,
+    )
+    expect(screen.queryByText(/Validate capabilities/i)).not.toBeInTheDocument()
+    expect(mockedApi.validateCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('renders spinner while the request is in flight', async () => {
+    // Never-resolving promise so we observe the spinner state.
+    mockedApi.validateCapabilities.mockReturnValue(new Promise(() => {}))
+    render(
+      <TestWrapper>
+        <ValidateCapabilitiesDialog open={true} target={sampleTarget} onClose={jest.fn()} />
+      </TestWrapper>,
+    )
+    await waitFor(() => expect(mockedApi.validateCapabilities).toHaveBeenCalledWith('azure_chat_test'))
+    expect(screen.getByText(/Probing target/i)).toBeInTheDocument()
+  })
+
+  it('renders error message when the API call rejects', async () => {
+    mockedApi.validateCapabilities.mockRejectedValue(new Error('boom'))
+    render(
+      <TestWrapper>
+        <ValidateCapabilitiesDialog open={true} target={sampleTarget} onClose={jest.fn()} />
+      </TestWrapper>,
+    )
+    await waitFor(() => expect(screen.getByText('boom')).toBeInTheDocument())
+  })
+
+  it('renders the capabilities table once the request resolves', async () => {
+    mockedApi.validateCapabilities.mockResolvedValue(allMatchResponse)
+    render(
+      <TestWrapper>
+        <ValidateCapabilitiesDialog open={true} target={sampleTarget} onClose={jest.fn()} />
+      </TestWrapper>,
+    )
+    await waitFor(() => expect(screen.getByText('Multi-turn')).toBeInTheDocument())
+    expect(screen.getByText('JSON Schema')).toBeInTheDocument()
+    expect(screen.getByText('Input modalities')).toBeInTheDocument()
+    expect(screen.getByText('Output modalities')).toBeInTheDocument()
+  })
+
+  it('shows red mismatch indicator when declared differs from observed', async () => {
+    mockedApi.validateCapabilities.mockResolvedValue(mismatchResponse)
+    render(
+      <TestWrapper>
+        <ValidateCapabilitiesDialog open={true} target={sampleTarget} onClose={jest.fn()} />
+      </TestWrapper>,
+    )
+    await waitFor(() => expect(screen.getByText('Multi-turn')).toBeInTheDocument())
+    // At least one mismatch indicator (JSON Schema differs, input modalities differ).
+    const mismatches = screen.getAllByText('mismatch')
+    expect(mismatches.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('shows green match indicator when declared equals observed', async () => {
+    mockedApi.validateCapabilities.mockResolvedValue(allMatchResponse)
+    render(
+      <TestWrapper>
+        <ValidateCapabilitiesDialog open={true} target={sampleTarget} onClose={jest.fn()} />
+      </TestWrapper>,
+    )
+    await waitFor(() => expect(screen.getByText('Multi-turn')).toBeInTheDocument())
+    const matches = screen.getAllByText('match')
+    // 6 boolean rows + 1 input-modalities row, all match.
+    expect(matches.length).toBeGreaterThanOrEqual(7)
+  })
+
+  it('renders all warning messages', async () => {
+    mockedApi.validateCapabilities.mockResolvedValue(allMatchResponse)
+    render(
+      <TestWrapper>
+        <ValidateCapabilitiesDialog open={true} target={sampleTarget} onClose={jest.fn()} />
+      </TestWrapper>,
+    )
+    await waitFor(() => expect(screen.getByText(/Test prompts written to memory/i)).toBeInTheDocument())
+    expect(screen.getByText(/Output modalities are reported as declared/i)).toBeInTheDocument()
+    expect(screen.getByText(/Do not run Validate while an attack/i)).toBeInTheDocument()
+  })
+
+  it('calls onClose when the Close button is clicked', async () => {
+    const user = userEvent.setup()
+    const onClose = jest.fn()
+    mockedApi.validateCapabilities.mockResolvedValue(allMatchResponse)
+    render(
+      <TestWrapper>
+        <ValidateCapabilitiesDialog open={true} target={sampleTarget} onClose={onClose} />
+      </TestWrapper>,
+    )
+    await waitFor(() => expect(screen.getByText('Multi-turn')).toBeInTheDocument())
+    await user.click(screen.getByRole('button', { name: /close/i }))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('resets state when reopened for a different target', async () => {
+    mockedApi.validateCapabilities.mockResolvedValue(allMatchResponse)
+    const { rerender } = render(
+      <TestWrapper>
+        <ValidateCapabilitiesDialog open={true} target={sampleTarget} onClose={jest.fn()} />
+      </TestWrapper>,
+    )
+    await waitFor(() => expect(mockedApi.validateCapabilities).toHaveBeenCalledWith('azure_chat_test'))
+    await waitFor(() => expect(screen.getByText('Multi-turn')).toBeInTheDocument())
+
+    const otherTarget: TargetInstance = { ...sampleTarget, target_registry_name: 'other' }
+    mockedApi.validateCapabilities.mockReturnValue(new Promise(() => {}))
+    rerender(
+      <TestWrapper>
+        <ValidateCapabilitiesDialog open={true} target={otherTarget} onClose={jest.fn()} />
+      </TestWrapper>,
+    )
+    await waitFor(() => expect(mockedApi.validateCapabilities).toHaveBeenCalledWith('other'))
+    // Spinner is visible (state reset for the new target).
+    expect(screen.getByText(/Probing target/i)).toBeInTheDocument()
+  })
+
+  it('resets state when reopened for the SAME target', async () => {
+    // First open: resolves successfully.
+    mockedApi.validateCapabilities.mockResolvedValueOnce(allMatchResponse)
+    const onClose = jest.fn()
+    const { rerender } = render(
+      <TestWrapper>
+        <ValidateCapabilitiesDialog open={true} target={sampleTarget} onClose={onClose} />
+      </TestWrapper>,
+    )
+    await waitFor(() => expect(screen.getByText('Multi-turn')).toBeInTheDocument())
+
+    // Close.
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /close/i }))
+    expect(onClose).toHaveBeenCalled()
+    rerender(
+      <TestWrapper>
+        <ValidateCapabilitiesDialog open={false} target={sampleTarget} onClose={onClose} />
+      </TestWrapper>,
+    )
+
+    // Reopen same target — must re-fire the request and show spinner again,
+    // not the stale prior result.
+    mockedApi.validateCapabilities.mockReturnValueOnce(new Promise(() => {}))
+    rerender(
+      <TestWrapper>
+        <ValidateCapabilitiesDialog open={true} target={sampleTarget} onClose={onClose} />
+      </TestWrapper>,
+    )
+    await waitFor(() => {
+      expect(mockedApi.validateCapabilities).toHaveBeenCalledTimes(2)
+    })
+    expect(screen.getByText(/Probing target/i)).toBeInTheDocument()
+    // Stale "Multi-turn" row should be gone while loading.
+    expect(screen.queryByText('Multi-turn')).not.toBeInTheDocument()
+  })
+
+  it('renders the "Not probed (no asset)" row when non_probeable_input_modalities is non-empty', async () => {
+    mockedApi.validateCapabilities.mockResolvedValue(notProbedResponse)
+    render(
+      <TestWrapper>
+        <ValidateCapabilitiesDialog
+          open={true}
+          target={{ ...sampleTarget, target_registry_name: 'openai_response_test' }}
+          onClose={jest.fn()}
+        />
+      </TestWrapper>,
+    )
+    await waitFor(() => expect(screen.getByTestId('not-probed-row')).toBeInTheDocument())
+    expect(screen.getByText(/Not probed \(no asset\)/i)).toBeInTheDocument()
+    expect(screen.getByText('function_call, reasoning, tool_call')).toBeInTheDocument()
+  })
+
+  it('does NOT render the "Not probed" row when non_probeable_input_modalities is empty', async () => {
+    mockedApi.validateCapabilities.mockResolvedValue(allMatchResponse)
+    render(
+      <TestWrapper>
+        <ValidateCapabilitiesDialog open={true} target={sampleTarget} onClose={jest.fn()} />
+      </TestWrapper>,
+    )
+    await waitFor(() => expect(screen.getByText('Multi-turn')).toBeInTheDocument())
+    expect(screen.queryByTestId('not-probed-row')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Not probed \(no asset\)/i)).not.toBeInTheDocument()
+  })
+
+  it('shows a warning banner for composite targets', async () => {
+    mockedApi.validateCapabilities.mockResolvedValue(allMatchResponse)
+    const compositeTarget: TargetInstance = {
+      ...sampleTarget,
+      inner_targets: [
+        { ...sampleTarget, target_registry_name: 'inner_1' },
+        { ...sampleTarget, target_registry_name: 'inner_2' },
+      ],
+    }
+    render(
+      <TestWrapper>
+        <ValidateCapabilitiesDialog open={true} target={compositeTarget} onClose={jest.fn()} />
+      </TestWrapper>,
+    )
+    await waitFor(() => expect(screen.getByText(/This is a composite target/i)).toBeInTheDocument())
+  })
+})

--- a/frontend/src/components/Config/ValidateCapabilitiesDialog.test.tsx
+++ b/frontend/src/components/Config/ValidateCapabilitiesDialog.test.tsx
@@ -266,6 +266,14 @@ describe('ValidateCapabilitiesDialog', () => {
     await waitFor(() => expect(screen.getByTestId('not-probed-row')).toBeInTheDocument())
     expect(screen.getByText(/Not probed \(no asset\)/i)).toBeInTheDocument()
     expect(screen.getByText('function_call, reasoning, tool_call')).toBeInTheDocument()
+    // Non-probeable types must NOT appear in the Input modalities cells —
+    // otherwise the user sees the same types in both Observed and Not-probed,
+    // which is contradictory. function_call should appear exactly twice on
+    // screen: once in the Not-probed row, once in the warning bar text.
+    // (Before the fix this would have been 3 — the third occurrence was the
+    // Input modalities Observed cell, which is the regression we're guarding.)
+    const functionCallOccurrences = screen.getAllByText(/function_call/)
+    expect(functionCallOccurrences).toHaveLength(2)
   })
 
   it('does NOT render the "Not probed" row when non_probeable_input_modalities is empty', async () => {

--- a/frontend/src/components/Config/ValidateCapabilitiesDialog.test.tsx
+++ b/frontend/src/components/Config/ValidateCapabilitiesDialog.test.tsx
@@ -39,6 +39,7 @@ const allMatchResponse: ValidateCapabilitiesResponse = {
   declared: sampleTarget.capabilities!,
   observed: sampleTarget.capabilities!,
   non_probeable_input_modalities: [],
+  non_probeable_only_types: [],
   warnings: [
     'Validation sent live requests to the target; this may incur cost and produce real side effects.',
     'Test prompts written to memory are tagged with `capability_probe`.',
@@ -61,6 +62,7 @@ const mismatchResponse: ValidateCapabilitiesResponse = {
     supported_input_modalities: ['text'],
   },
   non_probeable_input_modalities: [],
+  non_probeable_only_types: [],
   warnings: ['Validation sent live requests to the target; ...'],
 }
 
@@ -75,6 +77,7 @@ const notProbedResponse: ValidateCapabilitiesResponse = {
     supported_input_modalities: ['function_call', 'reasoning', 'text', 'tool_call'],
   },
   non_probeable_input_modalities: ['function_call', 'reasoning', 'tool_call'],
+  non_probeable_only_types: ['function_call', 'reasoning', 'tool_call'],
   warnings: [
     'Validation sent live requests to the target; ...',
     'Some declared input modalities are reported as declared/not-probed (no packaged probe asset): function_call, reasoning, tool_call.',
@@ -286,6 +289,47 @@ describe('ValidateCapabilitiesDialog', () => {
     await waitFor(() => expect(screen.getByText('Multi-turn')).toBeInTheDocument())
     expect(screen.queryByTestId('not-probed-row')).not.toBeInTheDocument()
     expect(screen.queryByText(/Not probed \(no asset\)/i)).not.toBeInTheDocument()
+  })
+
+  it('keeps probeable-confirmed types in the Input modalities cells even when a sibling combo bundles them with a non-probeable type', async () => {
+    // Regression: a target declaring both {text} and {text, function_call}
+    // sends back non_probeable_input_modalities=['function_call+text'] (the
+    // mixed combo) AND non_probeable_only_types=['function_call'] (only
+    // function_call is exclusively non-probeable; text is confirmed via the
+    // {text} singleton). The cells must hide function_call but keep text —
+    // otherwise the user sees '— / —' for Input modalities and a green
+    // match indicator while text was actually probed and confirmed.
+    const mixedComboResponse: ValidateCapabilitiesResponse = {
+      target_registry_name: 'mixed_combo_target',
+      declared: {
+        ...sampleTarget.capabilities!,
+        supported_input_modalities: ['function_call', 'text'],
+      },
+      observed: {
+        ...sampleTarget.capabilities!,
+        supported_input_modalities: ['function_call', 'text'],
+      },
+      non_probeable_input_modalities: ['function_call+text'],
+      non_probeable_only_types: ['function_call'],
+      warnings: [],
+    }
+    mockedApi.validateCapabilities.mockResolvedValue(mixedComboResponse)
+    render(
+      <TestWrapper>
+        <ValidateCapabilitiesDialog
+          open={true}
+          target={{ ...sampleTarget, target_registry_name: 'mixed_combo_target' }}
+          onClose={jest.fn()}
+        />
+      </TestWrapper>,
+    )
+    await waitFor(() => expect(screen.getByTestId('not-probed-row')).toBeInTheDocument())
+    // The Input modalities row must show 'text' in both cells (probed and
+    // confirmed). The Not-probed row must show the mixed combo.
+    const inputRow = screen.getByTestId('input-modalities-row')
+    expect(inputRow).toHaveTextContent('text')
+    expect(inputRow).not.toHaveTextContent('function_call')
+    expect(screen.getByText('function_call+text')).toBeInTheDocument()
   })
 
   it('shows a warning banner for composite targets', async () => {

--- a/frontend/src/components/Config/ValidateCapabilitiesDialog.tsx
+++ b/frontend/src/components/Config/ValidateCapabilitiesDialog.tsx
@@ -150,10 +150,21 @@ export default function ValidateCapabilitiesDialog({
 
   const declared = result?.declared
   const observed = result?.observed
-  const inputMatch = modalitiesEqual(
-    declared?.supported_input_modalities,
-    observed?.supported_input_modalities,
+  // Types that appear ONLY inside non-probeable combinations. The engine ORs
+  // these back into observed.input_modalities (line 778), making them appear
+  // confirmed in the cells even though they were never tested. Hide them from
+  // the Input modalities row so the cells show only what was actually probed;
+  // the "Not probed (no asset)" row below already lists them separately.
+  const nonProbeableTypes = new Set(
+    (result?.non_probeable_input_modalities ?? []).flatMap(combo => combo.split('+')),
   )
+  const declaredProbeableInputs = (declared?.supported_input_modalities ?? []).filter(
+    t => !nonProbeableTypes.has(t),
+  )
+  const observedProbeableInputs = (observed?.supported_input_modalities ?? []).filter(
+    t => !nonProbeableTypes.has(t),
+  )
+  const inputMatch = modalitiesEqual(declaredProbeableInputs, observedProbeableInputs)
 
   return (
     <Dialog
@@ -224,8 +235,8 @@ export default function ValidateCapabilitiesDialog({
                     })}
                     <TableRow>
                       <TableCell>Input modalities</TableCell>
-                      <TableCell>{formatModalities(declared?.supported_input_modalities)}</TableCell>
-                      <TableCell>{formatModalities(observed?.supported_input_modalities)}</TableCell>
+                      <TableCell>{formatModalities(declaredProbeableInputs)}</TableCell>
+                      <TableCell>{formatModalities(observedProbeableInputs)}</TableCell>
                       <TableCell>
                         <MatchIndicator kind={inputMatch ? 'match' : 'mismatch'} />
                       </TableCell>

--- a/frontend/src/components/Config/ValidateCapabilitiesDialog.tsx
+++ b/frontend/src/components/Config/ValidateCapabilitiesDialog.tsx
@@ -176,7 +176,7 @@ export default function ValidateCapabilitiesDialog({
                   padding: '24px 0',
                 }}
               >
-                <Spinner label="Probing target — this can take up to a minute..." />
+                <Spinner label="Probing target — this can take up to a couple of minutes..." />
                 <Text size={200} style={{ color: tokens.colorNeutralForeground3 }}>
                   Sending live test requests; results may take a few seconds.
                 </Text>

--- a/frontend/src/components/Config/ValidateCapabilitiesDialog.tsx
+++ b/frontend/src/components/Config/ValidateCapabilitiesDialog.tsx
@@ -100,18 +100,31 @@ export default function ValidateCapabilitiesDialog({
   target,
   onClose,
 }: ValidateCapabilitiesDialogProps) {
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  // Track an in-flight or completed request by the target it was issued for.
+  // Storing the target name alongside the result/error lets the render side
+  // derive `loading` (= request for the current target hasn't completed yet)
+  // without any synchronous setState inside the effect, which the v7
+  // `react-hooks/set-state-in-effect` rule forbids. Switching targets makes
+  // the prior request's `requestedFor` no longer match the current target,
+  // so the display reverts to the spinner until the new request settles.
+  const [requestedFor, setRequestedFor] = useState<string | null>(null)
   const [result, setResult] = useState<ValidateCapabilitiesResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
 
-  // Reset state on close (R5): the useEffect below depends on
-  // `target?.target_registry_name`, so re-clicking Validate on the SAME row
-  // would not re-fire without an explicit state reset — and the user would see
-  // stale results with no spinner.
+  const currentName = target?.target_registry_name ?? null
+  const loading = open && currentName != null && requestedFor !== currentName
+  const displayResult = result?.target_registry_name === currentName ? result : null
+  const displayError = requestedFor === currentName ? error : null
+
+  // Reset state on close (R5): re-clicking Validate on the SAME row must
+  // re-fire the probe and show the spinner again, not the prior result. The
+  // useEffect below would not re-run for an identical [open, name] tuple
+  // across a close/reopen cycle, so clearing the tagged state here is what
+  // forces the new request to be issued.
   const handleClose = useCallback(() => {
     setResult(null)
     setError(null)
-    setLoading(false)
+    setRequestedFor(null)
     onClose()
   }, [onClose])
 
@@ -124,20 +137,21 @@ export default function ValidateCapabilitiesDialog({
     if (!open || !target) return
 
     let cancelled = false
-    setLoading(true)
-    setError(null)
-    setResult(null)
+    const name = target.target_registry_name
 
     targetsApi
-      .validateCapabilities(target.target_registry_name)
+      .validateCapabilities(name)
       .then((data) => {
-        if (!cancelled) setResult(data)
+        if (cancelled) return
+        setResult(data)
+        setError(null)
+        setRequestedFor(name)
       })
       .catch((err) => {
-        if (!cancelled) setError(toApiError(err).detail)
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false)
+        if (cancelled) return
+        setResult(null)
+        setError(toApiError(err).detail)
+        setRequestedFor(name)
       })
 
     return () => {
@@ -148,8 +162,8 @@ export default function ValidateCapabilitiesDialog({
 
   if (!target) return null
 
-  const declared = result?.declared
-  const observed = result?.observed
+  const declared = displayResult?.declared
+  const observed = displayResult?.observed
   // Types that appear ONLY inside non-probeable combinations. The engine ORs
   // these back into observed.input_modalities (line 778), making them appear
   // confirmed in the cells even though they were never tested. Hide them from
@@ -159,7 +173,7 @@ export default function ValidateCapabilitiesDialog({
   // `non_probeable_input_modalities` on '+'), so types confirmed via a
   // probeable singleton combo aren't dropped when a sibling combo bundles
   // them with a non-probeable type.
-  const nonProbeableTypes = new Set(result?.non_probeable_only_types ?? [])
+  const nonProbeableTypes = new Set(displayResult?.non_probeable_only_types ?? [])
   const declaredProbeableInputs = (declared?.supported_input_modalities ?? []).filter(
     t => !nonProbeableTypes.has(t),
   )
@@ -195,12 +209,12 @@ export default function ValidateCapabilitiesDialog({
                 </Text>
               </div>
             )}
-            {error && !loading && (
+            {displayError && !loading && (
               <MessageBar intent="error" style={{ marginBottom: 12 }}>
-                <MessageBarBody>{error}</MessageBarBody>
+                <MessageBarBody>{displayError}</MessageBarBody>
               </MessageBar>
             )}
-            {result && !loading && !error && (
+            {displayResult && !loading && !displayError && (
               <>
                 {(target.inner_targets ?? []).length > 0 && (
                   <MessageBar intent="warning" style={{ marginBottom: 12 }}>
@@ -243,7 +257,7 @@ export default function ValidateCapabilitiesDialog({
                         <MatchIndicator kind={inputMatch ? 'match' : 'mismatch'} />
                       </TableCell>
                     </TableRow>
-                    {result.non_probeable_input_modalities.length > 0 && (
+                    {displayResult.non_probeable_input_modalities.length > 0 && (
                       <TableRow data-testid="not-probed-row">
                         <TableCell>
                           <Text size={200} style={{ color: tokens.colorNeutralForeground3 }}>
@@ -252,7 +266,7 @@ export default function ValidateCapabilitiesDialog({
                         </TableCell>
                         <TableCell colSpan={2}>
                           <Text size={200}>
-                            {result.non_probeable_input_modalities.join(', ')}
+                            {displayResult.non_probeable_input_modalities.join(', ')}
                           </Text>
                         </TableCell>
                         <TableCell>
@@ -270,9 +284,9 @@ export default function ValidateCapabilitiesDialog({
                     </TableRow>
                   </TableBody>
                 </Table>
-                {result.warnings.length > 0 && (
+                {displayResult.warnings.length > 0 && (
                   <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-                    {result.warnings.map((w, idx) => (
+                    {displayResult.warnings.map((w, idx) => (
                       <MessageBar key={idx} intent="warning" icon={<WarningRegular />}>
                         <MessageBarBody>{w}</MessageBarBody>
                       </MessageBar>

--- a/frontend/src/components/Config/ValidateCapabilitiesDialog.tsx
+++ b/frontend/src/components/Config/ValidateCapabilitiesDialog.tsx
@@ -1,0 +1,281 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogSurface,
+  DialogTitle,
+  DialogBody,
+  DialogContent,
+  DialogActions,
+  Button,
+  Spinner,
+  MessageBar,
+  MessageBarBody,
+  Table,
+  TableHeader,
+  TableRow,
+  TableHeaderCell,
+  TableBody,
+  TableCell,
+  Text,
+  tokens,
+} from '@fluentui/react-components'
+import {
+  CheckmarkCircleFilled,
+  DismissCircleFilled,
+  WarningRegular,
+} from '@fluentui/react-icons'
+import { targetsApi } from '@/services/api'
+import { toApiError } from '@/services/errors'
+import type {
+  TargetInstance,
+  ValidateCapabilitiesResponse,
+} from '../../types'
+
+interface ValidateCapabilitiesDialogProps {
+  open: boolean
+  target: TargetInstance | null
+  onClose: () => void
+}
+
+// Boolean capability rows. Narrowed to bool-typed fields so the per-row render
+// never has to deal with the string[] modality fields.
+type BooleanCapabilityKey =
+  | 'supports_multi_turn'
+  | 'supports_multi_message_pieces'
+  | 'supports_json_schema'
+  | 'supports_json_output'
+  | 'supports_editable_history'
+  | 'supports_system_prompt'
+
+const CAPABILITY_ROWS: Array<{ key: BooleanCapabilityKey; label: string }> = [
+  { key: 'supports_multi_turn', label: 'Multi-turn' },
+  { key: 'supports_multi_message_pieces', label: 'Multi-message pieces' },
+  { key: 'supports_json_schema', label: 'JSON Schema' },
+  { key: 'supports_json_output', label: 'JSON Output' },
+  { key: 'supports_editable_history', label: 'Editable history' },
+  { key: 'supports_system_prompt', label: 'System prompt' },
+]
+
+/** Compare two flattened modality lists ignoring order. */
+function modalitiesEqual(a: string[] | null | undefined, b: string[] | null | undefined): boolean {
+  const sa = [...(a ?? [])].sort()
+  const sb = [...(b ?? [])].sort()
+  return JSON.stringify(sa) === JSON.stringify(sb)
+}
+
+/** Render a green check, red X, or amber em-dash for one row. */
+function MatchIndicator({ kind }: { kind: 'match' | 'mismatch' | 'not-probed' }) {
+  if (kind === 'match') {
+    return (
+      <span style={{ color: tokens.colorPaletteGreenForeground1, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+        <CheckmarkCircleFilled fontSize={16} aria-hidden />
+        <Text size={200}>match</Text>
+      </span>
+    )
+  }
+  if (kind === 'mismatch') {
+    return (
+      <span style={{ color: tokens.colorPaletteRedForeground1, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+        <DismissCircleFilled fontSize={16} aria-hidden />
+        <Text size={200}>mismatch</Text>
+      </span>
+    )
+  }
+  return (
+    <span style={{ color: tokens.colorPaletteDarkOrangeForeground1, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+      <Text size={200} style={{ fontWeight: 'bold' }}>—</Text>
+      <Text size={200}>not probed</Text>
+    </span>
+  )
+}
+
+/** Format a modality list for display. */
+function formatModalities(list: string[] | null | undefined): string {
+  if (!list || list.length === 0) return '—'
+  return list.join(', ')
+}
+
+export default function ValidateCapabilitiesDialog({
+  open,
+  target,
+  onClose,
+}: ValidateCapabilitiesDialogProps) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [result, setResult] = useState<ValidateCapabilitiesResponse | null>(null)
+
+  // Reset state on close (R5): the useEffect below depends on
+  // `target?.target_registry_name`, so re-clicking Validate on the SAME row
+  // would not re-fire without an explicit state reset — and the user would see
+  // stale results with no spinner.
+  const handleClose = useCallback(() => {
+    setResult(null)
+    setError(null)
+    setLoading(false)
+    onClose()
+  }, [onClose])
+
+  // Cancellation flag skips React state updates if the dialog closes/reopens
+  // for a different target while the request is still in flight. Note: this
+  // does NOT cancel the backend request — the per-target backend lock
+  // prevents the worst symptom (concurrent races); proper request
+  // cancellation via AbortController is captured as a follow-up.
+  useEffect(() => {
+    if (!open || !target) return
+
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    setResult(null)
+
+    targetsApi
+      .validateCapabilities(target.target_registry_name)
+      .then((data) => {
+        if (!cancelled) setResult(data)
+      })
+      .catch((err) => {
+        if (!cancelled) setError(toApiError(err).detail)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: only re-fire when the target's registry name actually changes, not on every parent re-render with a new TargetInstance object reference
+  }, [open, target?.target_registry_name])
+
+  if (!target) return null
+
+  const declared = result?.declared
+  const observed = result?.observed
+  const inputMatch = modalitiesEqual(
+    declared?.supported_input_modalities,
+    observed?.supported_input_modalities,
+  )
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(_, data) => {
+        if (!data.open) handleClose()
+      }}
+    >
+      <DialogSurface style={{ maxWidth: '720px' }}>
+        <DialogBody>
+          <DialogTitle>Validate capabilities: {target.target_registry_name}</DialogTitle>
+          <DialogContent>
+            {loading && (
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  gap: 12,
+                  padding: '24px 0',
+                }}
+              >
+                <Spinner label="Probing target — this can take up to a minute..." />
+                <Text size={200} style={{ color: tokens.colorNeutralForeground3 }}>
+                  Sending live test requests; results may take a few seconds.
+                </Text>
+              </div>
+            )}
+            {error && !loading && (
+              <MessageBar intent="error" style={{ marginBottom: 12 }}>
+                <MessageBarBody>{error}</MessageBarBody>
+              </MessageBar>
+            )}
+            {result && !loading && !error && (
+              <>
+                {(target.inner_targets ?? []).length > 0 && (
+                  <MessageBar intent="warning" style={{ marginBottom: 12 }}>
+                    <MessageBarBody>
+                      This is a composite target. Validation tests aggregate routing behavior, not each
+                      inner endpoint independently.
+                    </MessageBarBody>
+                  </MessageBar>
+                )}
+                <Table aria-label="Capabilities comparison" size="small" style={{ marginBottom: 16 }}>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHeaderCell style={{ width: '36%' }}>Capability</TableHeaderCell>
+                      <TableHeaderCell>Declared</TableHeaderCell>
+                      <TableHeaderCell>Observed</TableHeaderCell>
+                      <TableHeaderCell>Match</TableHeaderCell>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {CAPABILITY_ROWS.map(({ key, label }) => {
+                      const dval = declared ? declared[key] : false
+                      const oval = observed ? observed[key] : false
+                      const kind: 'match' | 'mismatch' = dval === oval ? 'match' : 'mismatch'
+                      return (
+                        <TableRow key={key}>
+                          <TableCell>{label}</TableCell>
+                          <TableCell>{dval ? 'yes' : 'no'}</TableCell>
+                          <TableCell>{oval ? 'yes' : 'no'}</TableCell>
+                          <TableCell>
+                            <MatchIndicator kind={kind} />
+                          </TableCell>
+                        </TableRow>
+                      )
+                    })}
+                    <TableRow>
+                      <TableCell>Input modalities</TableCell>
+                      <TableCell>{formatModalities(declared?.supported_input_modalities)}</TableCell>
+                      <TableCell>{formatModalities(observed?.supported_input_modalities)}</TableCell>
+                      <TableCell>
+                        <MatchIndicator kind={inputMatch ? 'match' : 'mismatch'} />
+                      </TableCell>
+                    </TableRow>
+                    {result.non_probeable_input_modalities.length > 0 && (
+                      <TableRow data-testid="not-probed-row">
+                        <TableCell>
+                          <Text size={200} style={{ color: tokens.colorNeutralForeground3 }}>
+                            Not probed (no asset)
+                          </Text>
+                        </TableCell>
+                        <TableCell colSpan={2}>
+                          <Text size={200}>
+                            {result.non_probeable_input_modalities.join(', ')}
+                          </Text>
+                        </TableCell>
+                        <TableCell>
+                          <MatchIndicator kind="not-probed" />
+                        </TableCell>
+                      </TableRow>
+                    )}
+                    <TableRow>
+                      <TableCell>Output modalities</TableCell>
+                      <TableCell>{formatModalities(declared?.supported_output_modalities)}</TableCell>
+                      <TableCell>{formatModalities(observed?.supported_output_modalities)}</TableCell>
+                      <TableCell>
+                        <MatchIndicator kind="not-probed" />
+                      </TableCell>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+                {result.warnings.length > 0 && (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    {result.warnings.map((w, idx) => (
+                      <MessageBar key={idx} intent="warning" icon={<WarningRegular />}>
+                        <MessageBarBody>{w}</MessageBarBody>
+                      </MessageBar>
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+          </DialogContent>
+          <DialogActions>
+            <Button appearance="secondary" onClick={handleClose}>
+              Close
+            </Button>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/Config/ValidateCapabilitiesDialog.tsx
+++ b/frontend/src/components/Config/ValidateCapabilitiesDialog.tsx
@@ -200,18 +200,6 @@ export default function ValidateCapabilitiesDialog({
             )}
             {result && !loading && !error && (
               <>
-                <MessageBar intent="warning" style={{ marginBottom: 12 }}>
-                  <MessageBarBody>
-                    <strong>Treat results as a spot-check, not ground truth.</strong> Each row
-                    reports whether a probe request was <em>accepted</em>, not whether the
-                    capability is correctly enforced. Known engine issues can also cause false
-                    negatives — currently: <em>image</em> probes are affected by a packaged-asset
-                    bug, and the OpenAI Responses API image payload format has a known engine
-                    mismatch. A red <strong>mismatch</strong> may mean the target genuinely lacks
-                    the capability, or it may mean the probe itself is misbehaving. When in
-                    doubt, re-run or test manually before relying on the result.
-                  </MessageBarBody>
-                </MessageBar>
                 {(target.inner_targets ?? []).length > 0 && (
                   <MessageBar intent="warning" style={{ marginBottom: 12 }}>
                     <MessageBarBody>

--- a/frontend/src/components/Config/ValidateCapabilitiesDialog.tsx
+++ b/frontend/src/components/Config/ValidateCapabilitiesDialog.tsx
@@ -200,6 +200,18 @@ export default function ValidateCapabilitiesDialog({
             )}
             {result && !loading && !error && (
               <>
+                <MessageBar intent="warning" style={{ marginBottom: 12 }}>
+                  <MessageBarBody>
+                    <strong>Treat results as a spot-check, not ground truth.</strong> Each row
+                    reports whether a probe request was <em>accepted</em>, not whether the
+                    capability is correctly enforced. Known engine issues can also cause false
+                    negatives — currently: <em>image</em> probes are affected by a packaged-asset
+                    bug, and the OpenAI Responses API image payload format has a known engine
+                    mismatch. A red <strong>mismatch</strong> may mean the target genuinely lacks
+                    the capability, or it may mean the probe itself is misbehaving. When in
+                    doubt, re-run or test manually before relying on the result.
+                  </MessageBarBody>
+                </MessageBar>
                 {(target.inner_targets ?? []).length > 0 && (
                   <MessageBar intent="warning" style={{ marginBottom: 12 }}>
                     <MessageBarBody>

--- a/frontend/src/components/Config/ValidateCapabilitiesDialog.tsx
+++ b/frontend/src/components/Config/ValidateCapabilitiesDialog.tsx
@@ -154,10 +154,12 @@ export default function ValidateCapabilitiesDialog({
   // these back into observed.input_modalities (line 778), making them appear
   // confirmed in the cells even though they were never tested. Hide them from
   // the Input modalities row so the cells show only what was actually probed;
-  // the "Not probed (no asset)" row below already lists them separately.
-  const nonProbeableTypes = new Set(
-    (result?.non_probeable_input_modalities ?? []).flatMap(combo => combo.split('+')),
-  )
+  // the "Not probed (no asset)" row below already lists the combos separately.
+  // IMPORTANT: use `non_probeable_only_types` (not splitting
+  // `non_probeable_input_modalities` on '+'), so types confirmed via a
+  // probeable singleton combo aren't dropped when a sibling combo bundles
+  // them with a non-probeable type.
+  const nonProbeableTypes = new Set(result?.non_probeable_only_types ?? [])
   const declaredProbeableInputs = (declared?.supported_input_modalities ?? []).filter(
     t => !nonProbeableTypes.has(t),
   )
@@ -233,7 +235,7 @@ export default function ValidateCapabilitiesDialog({
                         </TableRow>
                       )
                     })}
-                    <TableRow>
+                    <TableRow data-testid="input-modalities-row">
                       <TableCell>Input modalities</TableCell>
                       <TableCell>{formatModalities(declaredProbeableInputs)}</TableCell>
                       <TableCell>{formatModalities(observedProbeableInputs)}</TableCell>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -20,6 +20,7 @@ import type {
   CreateConversationRequest,
   CreateConversationResponse,
   ChangeMainConversationResponse,
+  ValidateCapabilitiesResponse,
 } from '../types'
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || '/api'
@@ -160,6 +161,18 @@ export const targetsApi = {
 
   createTarget: async (request: CreateTargetRequest): Promise<TargetInstance> => {
     const response = await apiClient.post('/targets', request)
+    return response.data
+  },
+
+  validateCapabilities: async (
+    targetRegistryName: string,
+  ): Promise<ValidateCapabilitiesResponse> => {
+    // POST is appropriate here: the call sends live requests to the target
+    // and writes probe rows to memory (side effects), even though the response
+    // shape is a read-only diff.
+    const response = await apiClient.post(
+      `/targets/${encodeURIComponent(targetRegistryName)}/validate`,
+    )
     return response.data
   },
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -111,6 +111,15 @@ export interface ValidateCapabilitiesResponse {
    */
   non_probeable_input_modalities: string[]
   /**
+   * Sorted list of declared input-modality types that appear ONLY in
+   * non-probeable combinations (never in any probeable combination). Used
+   * by ValidateCapabilitiesDialog to filter the input-modality cells without
+   * accidentally hiding types confirmed via a probeable singleton combo —
+   * e.g., for a target declaring both `{text}` and `{text, function_call}`,
+   * this list contains only `function_call`, leaving `text` visible.
+   */
+  non_probeable_only_types: string[]
+  /**
    * Operational notes for the user (live-call cost, memory tagging, output
    * modalities not probed, semantic-enforcement caveat, validate-vs-active-attack).
    */

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -98,6 +98,25 @@ export interface CreateTargetRequest {
   auth_mode?: 'api_key' | 'entra'
 }
 
+export interface ValidateCapabilitiesResponse {
+  target_registry_name: string
+  declared: TargetCapabilitiesInfo
+  observed: TargetCapabilitiesInfo
+  /**
+   * Sorted '+'-joined declared input-modality combinations that the engine
+   * could not probe because no packaged test asset exists (e.g.,
+   * 'function_call', 'image_path+url'). Used by ValidateCapabilitiesDialog to
+   * render a single "Not probed (no asset)" row beneath the input-modalities
+   * row, distinguishing "not probed" from "probed and confirmed".
+   */
+  non_probeable_input_modalities: string[]
+  /**
+   * Operational notes for the user (live-call cost, memory tagging, output
+   * modalities not probed, semantic-enforcement caveat, validate-vs-active-attack).
+   */
+  warnings: string[]
+}
+
 // --- Converters ---
 
 export interface ConverterInstance {

--- a/pyrit/backend/mappers/__init__.py
+++ b/pyrit/backend/mappers/__init__.py
@@ -20,6 +20,7 @@ from pyrit.backend.mappers.converter_mappers import (
     converter_object_to_instance,
 )
 from pyrit.backend.mappers.target_mappers import (
+    target_capabilities_to_info,
     target_object_to_instance,
 )
 
@@ -31,5 +32,6 @@ __all__ = [
     "pyrit_scores_to_dto",
     "request_piece_to_pyrit_message_piece",
     "request_to_pyrit_message",
+    "target_capabilities_to_info",
     "target_object_to_instance",
 ]

--- a/pyrit/backend/mappers/target_mappers.py
+++ b/pyrit/backend/mappers/target_mappers.py
@@ -15,7 +15,7 @@ from pyrit.prompt_target.round_robin_target import RoundRobinTarget
 _CAPABILITY_PARAM_NAMES = frozenset(cap.value for cap in CapabilityName)
 
 
-def _target_capabilities_to_info(capabilities: TargetCapabilities) -> TargetCapabilitiesInfo:
+def target_capabilities_to_info(capabilities: TargetCapabilities) -> TargetCapabilitiesInfo:
     """
     Build a TargetCapabilitiesInfo DTO from a domain TargetCapabilities object.
 
@@ -102,7 +102,7 @@ def target_object_to_instance(target_registry_name: str, target_obj: PromptTarge
         temperature=params.get("temperature"),
         top_p=params.get("top_p"),
         max_requests_per_minute=params.get("max_requests_per_minute"),
-        capabilities=_target_capabilities_to_info(target_obj.capabilities),
+        capabilities=target_capabilities_to_info(target_obj.capabilities),
         target_specific_params=combined_specific,
         inner_targets=inner_targets,
         identifier_hash=identifier.hash,

--- a/pyrit/backend/models/__init__.py
+++ b/pyrit/backend/models/__init__.py
@@ -63,6 +63,7 @@ from pyrit.backend.models.targets import (
     TargetCapabilitiesInfo,
     TargetInstance,
     TargetListResponse,
+    ValidateCapabilitiesResponse,
 )
 
 __all__ = [
@@ -117,4 +118,5 @@ __all__ = [
     "TargetCapabilitiesInfo",
     "TargetInstance",
     "TargetListResponse",
+    "ValidateCapabilitiesResponse",
 ]

--- a/pyrit/backend/models/targets.py
+++ b/pyrit/backend/models/targets.py
@@ -104,6 +104,24 @@ class ValidateCapabilitiesResponse(BaseModel):
             "beneath the input-modalities row."
         ),
     )
+    # Distinct from ``non_probeable_input_modalities`` (which carries the
+    # combo display strings). When a target declares both a probeable combo
+    # like ``{text}`` and a non-probeable mixed combo like ``{text,
+    # function_call}``, splitting the combo string on '+' and stripping every
+    # piece from the input-modality cells would incorrectly hide ``text`` —
+    # which *was* probed and confirmed via the singleton combo. This field
+    # lists only the types that never appear in any probeable combo, so the
+    # frontend can safely filter cells without dropping confirmed modalities.
+    non_probeable_only_types: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Sorted list of declared input modality types that appear ONLY in non-probeable "
+            "combinations (never in any probeable combination). The frontend uses this set to "
+            "hide truly unprobed types from the input-modality cells while leaving types that "
+            "were confirmed via a probeable singleton combo visible. Disjoint from the types "
+            "implicit in ``observed.supported_input_modalities`` that came from a probeable probe."
+        ),
+    )
     warnings: list[str] = Field(
         default_factory=list,
         description=(

--- a/pyrit/backend/models/targets.py
+++ b/pyrit/backend/models/targets.py
@@ -77,6 +77,43 @@ class TargetListResponse(BaseModel):
     pagination: PaginationInfo = Field(..., description="Pagination metadata")
 
 
+class ValidateCapabilitiesResponse(BaseModel):
+    """
+    Response from validating a target's declared capabilities against observed behavior.
+
+    Surfaces what the target class declares versus what live probing observed,
+    so users can spot drift caused by gateways stripping features, model
+    deployments lacking capabilities, or misconfiguration.
+    """
+
+    target_registry_name: str = Field(..., description="Target registry key the validation ran against")
+    declared: TargetCapabilitiesInfo = Field(..., description="Capabilities as declared by the target class")
+    observed: TargetCapabilitiesInfo = Field(..., description="Capabilities as observed by live probing")
+    # Drives the frontend "Not probed (no asset)" row beneath the input-modalities
+    # row. Without this field, the engine's `queried | (declared - test_modalities)`
+    # math at discover_target_capabilities.py:778 ORs non-probeable combinations
+    # back into observed, making observed == declared, and the frontend has no way
+    # to distinguish "genuinely confirmed" from "not probed".
+    non_probeable_input_modalities: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Sorted list of declared input-modality combinations that could NOT be probed "
+            "because the engine has no packaged test asset for the contained types. Each "
+            "entry is a '+'-joined sorted combination (e.g., 'function_call' or 'image_path+url'). "
+            "The frontend renders the union of these as a single 'Not probed (no asset)' row "
+            "beneath the input-modalities row."
+        ),
+    )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Operational notes for the user (e.g., 'this validation wrote test prompts to memory', "
+            "'output modalities are not probed and fall through to declared values', "
+            "'do not validate while an attack is actively running against this target')."
+        ),
+    )
+
+
 class CreateTargetRequest(BaseModel):
     """Request to create a new target instance."""
 

--- a/pyrit/backend/routes/targets.py
+++ b/pyrit/backend/routes/targets.py
@@ -15,6 +15,7 @@ from pyrit.backend.models.targets import (
     CreateTargetRequest,
     TargetInstance,
     TargetListResponse,
+    ValidateCapabilitiesResponse,
 )
 from pyrit.backend.services.target_service import get_target_service
 
@@ -104,3 +105,50 @@ async def get_target(target_registry_name: str) -> TargetInstance:  # pyrit-asyn
         )
 
     return target
+
+
+@router.post(
+    "/{target_registry_name}/validate",
+    response_model=ValidateCapabilitiesResponse,
+    responses={
+        404: {"model": ProblemDetail, "description": "Target not found"},
+        500: {"model": ProblemDetail, "description": "Validation failed"},
+    },
+)
+async def validate_target_capabilities(  # pyrit-async-suffix-exempt
+    target_registry_name: str,
+) -> ValidateCapabilitiesResponse:
+    """
+    Validate a target by probing its live capabilities against declarations.
+
+    The probe sends a small set of test requests to the target and reports
+    the declared vs observed capability flags and input modalities. Output
+    modalities are reported as declared (not actively probed). Test prompts
+    are written to memory.
+
+    Returns:
+        ValidateCapabilitiesResponse: Declared and observed capabilities, plus
+        a list of declared input-modality combinations that could not be
+        probed because no test asset is packaged for them, plus operational
+        warnings (live-call cost, memory tagging, semantic-enforcement caveat,
+        validate-vs-active-attack caveat).
+    """
+    service = get_target_service()
+
+    try:
+        result = await service.validate_target_capabilities_async(
+            target_registry_name=target_registry_name,
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to validate target: {str(e)}",
+        ) from e
+
+    if result is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Target '{target_registry_name}' not found",
+        )
+
+    return result

--- a/pyrit/backend/services/target_service.py
+++ b/pyrit/backend/services/target_service.py
@@ -158,7 +158,7 @@ class TargetService:
     # Per-probe timeout for the GUI validation flow. The engine default is
     # 30 s, which compounded across 5+ probes can exceed 2 min; 5 s keeps
     # the GUI snappy while still catching real rejections.
-    _GUI_VALIDATE_TIMEOUT_S: ClassVar[float] = 5.0
+    _GUI_VALIDATE_TIMEOUT_S: ClassVar[float] = 15.0
 
     def __init__(self) -> None:
         """Initialize the target service."""
@@ -323,7 +323,7 @@ class TargetService:
         Args:
             target_registry_name: The registry key of the target to validate.
             per_probe_timeout_s: Per-probe timeout in seconds. Defaults to
-                ``_GUI_VALIDATE_TIMEOUT_S`` (5.0) for interactive use.
+                ``_GUI_VALIDATE_TIMEOUT_S`` (15.0) for interactive use.
 
         Returns:
             ValidateCapabilitiesResponse, or None if the target is not in the registry.

--- a/pyrit/backend/services/target_service.py
+++ b/pyrit/backend/services/target_service.py
@@ -405,11 +405,22 @@ class TargetService:
                 f"(no packaged probe asset): {', '.join(non_probeable_combos_pretty)}."
             )
 
+        # Types that appear ONLY in non-probeable combos (never in a probeable
+        # one). The frontend uses this for cell-filtering: if a type also
+        # belongs to some probeable combo it WAS confirmed, so the cell should
+        # still show it. Splitting the combo strings on '+' and using the union
+        # would incorrectly hide ``text`` for a target declaring both
+        # ``{text}`` and ``{text, function_call}``.
+        probeable_types: set[PromptDataType] = set().union(*probeable_combinations) if probeable_combinations else set()
+        non_probeable_types: set[PromptDataType] = set().union(*non_probeable) if non_probeable else set()
+        non_probeable_only_types: list[str] = sorted(non_probeable_types - probeable_types)
+
         return ValidateCapabilitiesResponse(
             target_registry_name=target_registry_name,
             declared=declared,
             observed=observed,
             non_probeable_input_modalities=non_probeable_combos_pretty,
+            non_probeable_only_types=non_probeable_only_types,
             warnings=warnings,
         )
 

--- a/pyrit/backend/services/target_service.py
+++ b/pyrit/backend/services/target_service.py
@@ -381,7 +381,9 @@ class TargetService:
             (
                 "Capability probes confirm request acceptance, not semantic enforcement "
                 "(e.g., a target that accepts a JSON-schema request may not actually "
-                "enforce the schema)."
+                "enforce the schema). Image probes can also currently false-negative on "
+                "some targets due to known probe-asset and payload-format issues; re-run "
+                "or verify manually before relying on a red image result."
             ),
             # The per-target lock above serializes Validate-vs-Validate but NOT
             # Validate-vs-attack: the engine briefly mutates target._configuration,

--- a/pyrit/backend/services/target_service.py
+++ b/pyrit/backend/services/target_service.py
@@ -12,6 +12,7 @@ Targets can be:
 - Retrieved from registry (pre-registered at startup or created earlier)
 """
 
+import asyncio
 import logging
 import os
 from functools import lru_cache
@@ -20,20 +21,35 @@ from urllib.parse import urlparse
 
 from pyrit import prompt_target
 from pyrit.auth import get_azure_async_token_provider, get_azure_openai_auth
-from pyrit.backend.mappers.target_mappers import target_object_to_instance
+from pyrit.backend.mappers.target_mappers import target_capabilities_to_info, target_object_to_instance
 from pyrit.backend.models.common import PaginationInfo
 from pyrit.backend.models.targets import (
     CreateTargetRequest,
     TargetInstance,
     TargetListResponse,
+    ValidateCapabilitiesResponse,
 )
-from pyrit.prompt_target import PromptTarget
+from pyrit.models import PromptDataType
+from pyrit.prompt_target import PromptTarget, discover_target_capabilities_async
 from pyrit.prompt_target.azure_ml_chat_target import AzureMLChatTarget
 from pyrit.prompt_target.openai.openai_target import OpenAITarget
 from pyrit.prompt_target.round_robin_target import RoundRobinTarget
 from pyrit.registry.object_registries import TargetRegistry
 
 logger = logging.getLogger(__name__)
+
+# Module-level allowlist of input modalities that the discovery engine actually
+# has probe assets for. See `discover_target_capabilities.py:DEFAULT_TEST_ASSETS`
+# (image_path, audio_path) and `_create_test_message` (text is synthetic).
+#
+# Any combination containing a modality outside this set will raise ValueError
+# inside the engine, be silently skipped, and — when test_modalities is set
+# explicitly — be DROPPED from the resolved input_modalities
+# (`queried | (declared - frozenset(test_modalities))`). Filtering here prevents
+# false red mismatches against real targets like OpenAIResponseTarget
+# (declares function_call, tool_call, reasoning) and AzureBlobStorageTarget
+# (declares url).
+_PROBEABLE_INPUT_MODALITIES: frozenset[PromptDataType] = frozenset({"text", "image_path", "audio_path"})
 
 # Recognised Azure OpenAI / AI Foundry hostname suffixes. Used for strict
 # endpoint validation when Entra ID auth is requested, so a bearer token is
@@ -139,9 +155,53 @@ class TargetService:
     # Scope for Azure Machine Learning managed online endpoints.
     _AZURE_ML_SCOPE: ClassVar[str] = "https://ml.azure.com/.default"
 
+    # Per-probe timeout for the GUI validation flow. The engine default is
+    # 30 s, which compounded across 5+ probes can exceed 2 min; 5 s keeps
+    # the GUI snappy while still catching real rejections.
+    _GUI_VALIDATE_TIMEOUT_S: ClassVar[float] = 5.0
+
     def __init__(self) -> None:
         """Initialize the target service."""
         self._registry = TargetRegistry.get_registry_singleton()
+        # Per-target asyncio locks for capability validation. The discovery
+        # engine mutates `target._configuration` in place
+        # (discover_target_capabilities.py:_permissive_configuration) and the
+        # registry returns a singleton instance, so two concurrent validations
+        # on the same target can race on the restore. The lock dict is an
+        # INSTANCE attribute (not ClassVar): an asyncio.Lock lazy-binds to
+        # the running event loop on first await, and pytest gives each test a
+        # fresh event loop (pyproject.toml: asyncio_default_fixture_loop_scope
+        # = "function"). A ClassVar dict would leak locks from one test's
+        # loop into the next and raise RuntimeError. Instance dict = fresh
+        # per TargetService() = matches existing per-test pattern.
+        # Lock-map cardinality is bounded by registry size (one entry per
+        # registered target), not by call volume, so no eviction is needed
+        # for typical PyRIT workloads.
+        self._validate_locks: dict[str, asyncio.Lock] = {}
+
+    def _get_validate_lock(self, *, target_registry_name: str) -> asyncio.Lock:
+        """
+        Get-or-create the per-target validation lock.
+
+        Kept synchronous on purpose: there is no ``await`` between the dict
+        ``get`` and the assignment, so two coroutines cannot interleave
+        between them and no extra guard lock is needed. Staying sync also
+        sidesteps the ``check-async-suffix`` hook (no ``_async`` suffix
+        needed for non-async methods). The returned ``asyncio.Lock`` binds
+        lazily to the running event loop on the caller's first
+        ``await lock.acquire()``.
+
+        Args:
+            target_registry_name: The registry key of the target whose lock to fetch.
+
+        Returns:
+            The per-target ``asyncio.Lock`` (created on first access).
+        """
+        lock = self._validate_locks.get(target_registry_name)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._validate_locks[target_registry_name] = lock
+        return lock
 
     def _get_target_class(self, *, target_type: str) -> type:
         """
@@ -240,6 +300,116 @@ class TargetService:
             The PromptTarget object if found, None otherwise.
         """
         return self._registry.get_instance_by_name(target_registry_name)
+
+    async def validate_target_capabilities_async(
+        self,
+        *,
+        target_registry_name: str,
+        per_probe_timeout_s: float | None = None,
+    ) -> ValidateCapabilitiesResponse | None:
+        """
+        Probe a target's live capabilities and return both declared and observed views.
+
+        The probe writes test prompts to memory (existing behavior of the
+        discovery engine). Output modalities are not probed and fall through
+        to declared values. Probeable input modalities (text, image_path,
+        audio_path) listed in the target's declared capabilities are probed
+        explicitly so that rejections surface as drift; non-probeable
+        declared modalities (function_call, tool_call, reasoning, url,
+        video_path, binary_path, etc.) are reported as declared without
+        being probed and listed in ``non_probeable_input_modalities`` so
+        the frontend can render a single "Not probed (no asset)" row.
+
+        Args:
+            target_registry_name: The registry key of the target to validate.
+            per_probe_timeout_s: Per-probe timeout in seconds. Defaults to
+                ``_GUI_VALIDATE_TIMEOUT_S`` (5.0) for interactive use.
+
+        Returns:
+            ValidateCapabilitiesResponse, or None if the target is not in the registry.
+        """
+        timeout_s = per_probe_timeout_s if per_probe_timeout_s is not None else self._GUI_VALIDATE_TIMEOUT_S
+
+        target_obj = self.get_target_object(target_registry_name=target_registry_name)
+        if target_obj is None:
+            return None
+
+        declared = target_capabilities_to_info(target_obj.capabilities)
+
+        # CRITICAL: pass only the *probeable* declared modality combinations as
+        # ``test_modalities``. Without this filter, a combination like
+        # ``frozenset(["function_call"])`` raises ValueError inside
+        # ``_create_test_message`` (engine: discover_target_capabilities.py),
+        # the combo is silently skipped, and the result line
+        # ``queried | (declared - frozenset(test_modalities))`` drops it —
+        # producing a false red mismatch in the UI. The non-probeable combos
+        # are surfaced via ``non_probeable_input_modalities`` so the frontend
+        # can render them as "Not probed (no asset)" rather than mismatched.
+        declared_combinations: set[frozenset[PromptDataType]] = set(target_obj.capabilities.input_modalities)
+        probeable_combinations: set[frozenset[PromptDataType]] = {
+            combo for combo in declared_combinations if combo <= _PROBEABLE_INPUT_MODALITIES
+        }
+        non_probeable: set[frozenset[PromptDataType]] = declared_combinations - probeable_combinations
+
+        # Per-target lock guards against the ``target._configuration`` race
+        # documented above. Helper is sync (see its docstring). Pass
+        # ``test_modalities=probeable_combinations`` even when empty: the engine
+        # short-circuits cleanly on empty set (logs "nothing to probe", returns
+        # empty) before entering ``_permissive_configuration``, avoiding an
+        # unnecessary configuration mutate+restore round-trip. Passing ``None``
+        # would default the engine to all declared modalities and trigger
+        # ValueError-and-skip-log noise on every non-probeable combo.
+        lock = self._get_validate_lock(target_registry_name=target_registry_name)
+        async with lock:
+            observed_domain = await discover_target_capabilities_async(
+                target=target_obj,
+                per_probe_timeout_s=timeout_s,
+                test_modalities=probeable_combinations,
+                apply=False,
+                # retries left at the engine default (1) so cold-start targets
+                # don't false-negative; worst-case wait per probe is ~10 s.
+            )
+        observed = target_capabilities_to_info(observed_domain)
+
+        warnings = [
+            (
+                "Validation sent live requests to the target; this may incur cost "
+                "and produce real side effects (logs, billing, content policy hits)."
+            ),
+            "Test prompts written to memory are tagged with `capability_probe`.",
+            "Output modalities are reported as declared (not actively probed).",
+            (
+                "Capability probes confirm request acceptance, not semantic enforcement "
+                "(e.g., a target that accepts a JSON-schema request may not actually "
+                "enforce the schema)."
+            ),
+            # The per-target lock above serializes Validate-vs-Validate but NOT
+            # Validate-vs-attack: the engine briefly mutates target._configuration,
+            # so an active attack on this target during validation may briefly
+            # observe permissive probe config. Surface as a user-visible warning.
+            (
+                "Do not run Validate while an attack or scenario is actively using "
+                "this target — validation temporarily changes target configuration "
+                "during probing."
+            ),
+        ]
+
+        # Format non-probeable combinations as a stable, '+'-joined sorted list
+        # so the frontend gets a typed, explicit signal (no warning-string parsing).
+        non_probeable_combos_pretty: list[str] = sorted("+".join(sorted(combo)) for combo in non_probeable)
+        if non_probeable_combos_pretty:
+            warnings.append(
+                "Some declared input modalities are reported as declared/not-probed "
+                f"(no packaged probe asset): {', '.join(non_probeable_combos_pretty)}."
+            )
+
+        return ValidateCapabilitiesResponse(
+            target_registry_name=target_registry_name,
+            declared=declared,
+            observed=observed,
+            non_probeable_input_modalities=non_probeable_combos_pretty,
+            warnings=warnings,
+        )
 
     async def create_target_async(self, *, request: CreateTargetRequest) -> TargetInstance:
         """

--- a/tests/unit/backend/test_api_routes.py
+++ b/tests/unit/backend/test_api_routes.py
@@ -971,6 +971,7 @@ class TestTargetRoutes:
                         supported_input_modalities=["text"],
                     ),
                     non_probeable_input_modalities=["function_call"],
+                    non_probeable_only_types=["function_call"],
                     warnings=["Validation sent live requests to the target; ..."],
                 )
             )
@@ -984,6 +985,7 @@ class TestTargetRoutes:
             assert data["declared"]["supports_json_schema"] is True
             assert data["observed"]["supports_json_schema"] is False
             assert data["non_probeable_input_modalities"] == ["function_call"]
+            assert data["non_probeable_only_types"] == ["function_call"]
             assert isinstance(data["warnings"], list) and data["warnings"]
 
     def test_validate_target_returns_404_when_target_missing(self, client: TestClient) -> None:

--- a/tests/unit/backend/test_api_routes.py
+++ b/tests/unit/backend/test_api_routes.py
@@ -38,6 +38,7 @@ from pyrit.backend.models.targets import (
     TargetCapabilitiesInfo,
     TargetInstance,
     TargetListResponse,
+    ValidateCapabilitiesResponse,
 )
 from pyrit.backend.routes.labels import get_label_options
 
@@ -953,6 +954,64 @@ class TestTargetRoutes:
             assert data["target_specific_params"]["frequency_penalty"] == 0.5
             assert data["target_specific_params"]["presence_penalty"] == 0.3
             assert data["target_specific_params"]["seed"] == 42
+
+    def test_validate_target_returns_200_with_declared_and_observed(self, client: TestClient) -> None:
+        """Happy path: validate route returns 200 with full ValidateCapabilitiesResponse shape."""
+        with patch("pyrit.backend.routes.targets.get_target_service") as mock_get_service:
+            mock_service = MagicMock()
+            mock_service.validate_target_capabilities_async = AsyncMock(
+                return_value=ValidateCapabilitiesResponse(
+                    target_registry_name="target-1",
+                    declared=TargetCapabilitiesInfo(
+                        supports_json_schema=True,
+                        supported_input_modalities=["image_path", "text"],
+                    ),
+                    observed=TargetCapabilitiesInfo(
+                        supports_json_schema=False,
+                        supported_input_modalities=["text"],
+                    ),
+                    non_probeable_input_modalities=["function_call"],
+                    warnings=["Validation sent live requests to the target; ..."],
+                )
+            )
+            mock_get_service.return_value = mock_service
+
+            response = client.post("/api/targets/target-1/validate")
+
+            assert response.status_code == status.HTTP_200_OK
+            data = response.json()
+            assert data["target_registry_name"] == "target-1"
+            assert data["declared"]["supports_json_schema"] is True
+            assert data["observed"]["supports_json_schema"] is False
+            assert data["non_probeable_input_modalities"] == ["function_call"]
+            assert isinstance(data["warnings"], list) and data["warnings"]
+
+    def test_validate_target_returns_404_when_target_missing(self, client: TestClient) -> None:
+        """Unknown target → service returns None → 404 with FastAPI's default {'detail': ...} body."""
+        with patch("pyrit.backend.routes.targets.get_target_service") as mock_get_service:
+            mock_service = MagicMock()
+            mock_service.validate_target_capabilities_async = AsyncMock(return_value=None)
+            mock_get_service.return_value = mock_service
+
+            response = client.post("/api/targets/missing/validate")
+
+            assert response.status_code == status.HTTP_404_NOT_FOUND
+            # Backend has no HTTPException → ProblemDetail handler; default shape applies.
+            assert response.json() == {"detail": "Target 'missing' not found"}
+
+    def test_validate_target_returns_500_when_probe_fails(self, client: TestClient) -> None:
+        """Engine raises → 500 with default {'detail': 'Failed to validate target: ...'} body."""
+        with patch("pyrit.backend.routes.targets.get_target_service") as mock_get_service:
+            mock_service = MagicMock()
+            mock_service.validate_target_capabilities_async = AsyncMock(side_effect=RuntimeError("network blew up"))
+            mock_get_service.return_value = mock_service
+
+            response = client.post("/api/targets/target-1/validate")
+
+            assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+            body = response.json()
+            assert "Failed to validate target" in body["detail"]
+            assert "network blew up" in body["detail"]
 
 
 # ============================================================================

--- a/tests/unit/backend/test_target_service.py
+++ b/tests/unit/backend/test_target_service.py
@@ -962,7 +962,7 @@ class TestValidateTargetCapabilities:
             mock_probe.return_value = observed
             await service.validate_target_capabilities_async(target_registry_name="t1")
         assert mock_probe.call_args.kwargs["per_probe_timeout_s"] == TargetService._GUI_VALIDATE_TIMEOUT_S
-        assert mock_probe.call_args.kwargs["per_probe_timeout_s"] == 5.0
+        assert mock_probe.call_args.kwargs["per_probe_timeout_s"] == 15.0
 
     async def test_passes_probeable_modalities_only(self) -> None:
         """

--- a/tests/unit/backend/test_target_service.py
+++ b/tests/unit/backend/test_target_service.py
@@ -823,3 +823,410 @@ class TestFrontendBackendCompatibilitySync:
             f"Update effectiveUnderlyingModel() in CreateTargetDialog.tsx to match, "
             f"then update this test's expected dict."
         )
+
+
+# ============================================================================
+# Capability Validation Tests
+# ============================================================================
+
+
+def _fake_target_with_capabilities(
+    *,
+    input_modalities: frozenset[frozenset[str]] | None = None,
+    supports_json_schema: bool = True,
+) -> MagicMock:
+    """
+    Build a MagicMock target whose ``capabilities`` attribute is a real
+    ``TargetCapabilities`` object. The discovery engine is mocked separately,
+    so we don't need a real PromptTarget subclass — just the ``.capabilities``
+    attribute that ``validate_target_capabilities_async`` reads.
+    """
+    from pyrit.prompt_target.common.target_capabilities import TargetCapabilities
+
+    caps = TargetCapabilities(
+        supports_multi_turn=True,
+        supports_multi_message_pieces=True,
+        supports_json_schema=supports_json_schema,
+        supports_json_output=True,
+        supports_editable_history=True,
+        supports_system_prompt=True,
+        input_modalities=(input_modalities if input_modalities is not None else frozenset({frozenset(["text"])})),
+    )
+    target = MagicMock()
+    target.capabilities = caps
+    return target
+
+
+def _fake_observed_capabilities(
+    *,
+    declared,  # TargetCapabilities
+    drop_input_modalities: set[frozenset[str]] | None = None,
+    flip_json_schema_to_false: bool = False,
+):
+    """
+    Build a fake "observed" TargetCapabilities for the mock engine to return.
+
+    Mirrors what the real engine produces: starts from ``declared`` and
+    selectively drops/flips fields to simulate drift.
+    """
+    from pyrit.prompt_target.common.target_capabilities import TargetCapabilities
+
+    observed_input = declared.input_modalities
+    if drop_input_modalities:
+        observed_input = frozenset(c for c in observed_input if c not in drop_input_modalities)
+    return TargetCapabilities(
+        supports_multi_turn=declared.supports_multi_turn,
+        supports_multi_message_pieces=declared.supports_multi_message_pieces,
+        supports_json_schema=False if flip_json_schema_to_false else declared.supports_json_schema,
+        supports_json_output=declared.supports_json_output,
+        supports_editable_history=declared.supports_editable_history,
+        supports_system_prompt=declared.supports_system_prompt,
+        input_modalities=observed_input,
+        output_modalities=declared.output_modalities,
+    )
+
+
+class TestValidateTargetCapabilities:
+    """Tests for TargetService.validate_target_capabilities_async."""
+
+    async def test_returns_none_for_unknown_target(self) -> None:
+        """Unknown registry name returns None; engine is NOT called."""
+        from unittest.mock import AsyncMock
+
+        service = TargetService()
+        with patch(
+            "pyrit.backend.services.target_service.discover_target_capabilities_async",
+            new_callable=AsyncMock,
+        ) as mock_probe:
+            result = await service.validate_target_capabilities_async(target_registry_name="missing")
+        assert result is None
+        mock_probe.assert_not_called()
+
+    async def test_returns_response_for_known_target(self) -> None:
+        """Happy path: declared + observed populated, warnings present, no non-probeable."""
+        from unittest.mock import AsyncMock
+
+        service = TargetService()
+        fake_target = _fake_target_with_capabilities()
+        observed = _fake_observed_capabilities(declared=fake_target.capabilities)
+        with (
+            patch.object(service, "get_target_object", return_value=fake_target),
+            patch(
+                "pyrit.backend.services.target_service.discover_target_capabilities_async",
+                new_callable=AsyncMock,
+            ) as mock_probe,
+        ):
+            mock_probe.return_value = observed
+            result = await service.validate_target_capabilities_async(target_registry_name="t1")
+
+        assert result is not None
+        assert result.target_registry_name == "t1"
+        assert result.declared.supports_json_schema is True
+        assert result.observed.supports_json_schema is True
+        assert result.non_probeable_input_modalities == []
+        # 5 base warnings, no 6th (no non-probeable)
+        assert len(result.warnings) == 5
+
+    async def test_passes_timeout_override(self) -> None:
+        """Caller-supplied per_probe_timeout_s reaches the discovery call."""
+        from unittest.mock import AsyncMock
+
+        service = TargetService()
+        fake_target = _fake_target_with_capabilities()
+        observed = _fake_observed_capabilities(declared=fake_target.capabilities)
+        with (
+            patch.object(service, "get_target_object", return_value=fake_target),
+            patch(
+                "pyrit.backend.services.target_service.discover_target_capabilities_async",
+                new_callable=AsyncMock,
+            ) as mock_probe,
+        ):
+            mock_probe.return_value = observed
+            await service.validate_target_capabilities_async(target_registry_name="t1", per_probe_timeout_s=10.0)
+        assert mock_probe.call_args.kwargs["per_probe_timeout_s"] == 10.0
+
+    async def test_uses_gui_default_timeout_when_not_overridden(self) -> None:
+        """When per_probe_timeout_s is None, the GUI default (5.0) is passed."""
+        from unittest.mock import AsyncMock
+
+        service = TargetService()
+        fake_target = _fake_target_with_capabilities()
+        observed = _fake_observed_capabilities(declared=fake_target.capabilities)
+        with (
+            patch.object(service, "get_target_object", return_value=fake_target),
+            patch(
+                "pyrit.backend.services.target_service.discover_target_capabilities_async",
+                new_callable=AsyncMock,
+            ) as mock_probe,
+        ):
+            mock_probe.return_value = observed
+            await service.validate_target_capabilities_async(target_registry_name="t1")
+        assert mock_probe.call_args.kwargs["per_probe_timeout_s"] == TargetService._GUI_VALIDATE_TIMEOUT_S
+        assert mock_probe.call_args.kwargs["per_probe_timeout_s"] == 5.0
+
+    async def test_passes_probeable_modalities_only(self) -> None:
+        """
+        CRITICAL regression guard: only probeable modality combinations
+        reach the engine. Non-probeable combos appear in the response's
+        ``non_probeable_input_modalities`` list and in a warning.
+        """
+        from unittest.mock import AsyncMock
+
+        service = TargetService()
+        fake_target = _fake_target_with_capabilities(
+            input_modalities=frozenset(
+                {
+                    frozenset(["text"]),
+                    frozenset(["text", "image_path"]),
+                    frozenset(["function_call"]),
+                    frozenset(["url"]),
+                }
+            )
+        )
+        observed = _fake_observed_capabilities(declared=fake_target.capabilities)
+        with (
+            patch.object(service, "get_target_object", return_value=fake_target),
+            patch(
+                "pyrit.backend.services.target_service.discover_target_capabilities_async",
+                new_callable=AsyncMock,
+            ) as mock_probe,
+        ):
+            mock_probe.return_value = observed
+            result = await service.validate_target_capabilities_async(target_registry_name="t1")
+
+        # (a) only the two probeable combos reach the engine
+        passed = mock_probe.call_args.kwargs["test_modalities"]
+        assert passed == {frozenset(["text"]), frozenset(["text", "image_path"])}
+
+        # (b) non-probeable types appear in the warnings list
+        assert result is not None
+        non_probed_warning = [w for w in result.warnings if "no packaged probe asset" in w]
+        assert len(non_probed_warning) == 1
+        assert "function_call" in non_probed_warning[0]
+        assert "url" in non_probed_warning[0]
+
+        # (c) typed field has the sorted, '+'-joined list
+        assert result.non_probeable_input_modalities == ["function_call", "url"]
+
+    async def test_passes_empty_set_when_no_probeable_modalities(self) -> None:
+        """
+        Declared modalities are all non-probeable. Method passes
+        ``test_modalities=set()`` (NOT None) so the engine short-circuits
+        cleanly without entering ``_permissive_configuration``. Warnings
+        still include the not-probed entry, and the typed field lists every
+        declared combo.
+        """
+        from unittest.mock import AsyncMock
+
+        service = TargetService()
+        fake_target = _fake_target_with_capabilities(
+            input_modalities=frozenset(
+                {
+                    frozenset(["function_call"]),
+                    frozenset(["url"]),
+                    frozenset(["video_path"]),
+                }
+            )
+        )
+        observed = _fake_observed_capabilities(declared=fake_target.capabilities)
+        with (
+            patch.object(service, "get_target_object", return_value=fake_target),
+            patch(
+                "pyrit.backend.services.target_service.discover_target_capabilities_async",
+                new_callable=AsyncMock,
+            ) as mock_probe,
+        ):
+            mock_probe.return_value = observed
+            result = await service.validate_target_capabilities_async(target_registry_name="t1")
+
+        passed = mock_probe.call_args.kwargs["test_modalities"]
+        assert passed == set()
+        assert isinstance(passed, set)
+        assert result is not None
+        assert result.non_probeable_input_modalities == ["function_call", "url", "video_path"]
+        assert any("no packaged probe asset" in w for w in result.warnings)
+
+    async def test_propagates_probe_exceptions(self) -> None:
+        """Engine raises → method raises. Lock is released even on exception."""
+        from unittest.mock import AsyncMock
+
+        service = TargetService()
+        fake_target = _fake_target_with_capabilities()
+        with (
+            patch.object(service, "get_target_object", return_value=fake_target),
+            patch(
+                "pyrit.backend.services.target_service.discover_target_capabilities_async",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("engine boom"),
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="engine boom"):
+                await service.validate_target_capabilities_async(target_registry_name="t1")
+
+        # Lock must be released (the dict entry stays, but the lock isn't held).
+        lock = service._validate_locks["t1"]
+        assert not lock.locked(), "lock leaked after engine raised"
+
+    async def test_serializes_concurrent_calls_on_same_target(self) -> None:
+        """
+        Two concurrent calls on the same registry name within the same service
+        instance + same event loop serialize via the per-target lock.
+        """
+        import asyncio
+
+        service = TargetService()
+        fake_target = _fake_target_with_capabilities()
+        observed = _fake_observed_capabilities(declared=fake_target.capabilities)
+
+        first_running = asyncio.Event()
+        release_first = asyncio.Event()
+        order: list[str] = []
+
+        async def slow_first(**_kwargs):
+            order.append("first-enter")
+            first_running.set()
+            await release_first.wait()
+            order.append("first-exit")
+            return observed
+
+        async def fast_second(**_kwargs):
+            order.append("second-enter")
+            order.append("second-exit")
+            return observed
+
+        call_count = {"n": 0}
+
+        async def dispatch(**kwargs):
+            call_count["n"] += 1
+            return await (slow_first(**kwargs) if call_count["n"] == 1 else fast_second(**kwargs))
+
+        with (
+            patch.object(service, "get_target_object", return_value=fake_target),
+            patch(
+                "pyrit.backend.services.target_service.discover_target_capabilities_async",
+                new=dispatch,
+            ),
+        ):
+            task_first = asyncio.create_task(service.validate_target_capabilities_async(target_registry_name="t1"))
+            await first_running.wait()
+            task_second = asyncio.create_task(service.validate_target_capabilities_async(target_registry_name="t1"))
+            # Give scheduler a tick — second must NOT have started.
+            await asyncio.sleep(0.05)
+            assert "second-enter" not in order, f"second leaked through: {order}"
+            release_first.set()
+            await asyncio.gather(task_first, task_second)
+
+        assert order == ["first-enter", "first-exit", "second-enter", "second-exit"]
+
+    async def test_allows_concurrent_calls_on_different_targets(self) -> None:
+        """Two concurrent calls on different targets do NOT serialize."""
+        import asyncio
+
+        service = TargetService()
+        fake_a = _fake_target_with_capabilities()
+        fake_b = _fake_target_with_capabilities()
+        observed_a = _fake_observed_capabilities(declared=fake_a.capabilities)
+        observed_b = _fake_observed_capabilities(declared=fake_b.capabilities)
+
+        a_running = asyncio.Event()
+        b_started = asyncio.Event()
+
+        async def dispatch_a(**_kwargs):
+            a_running.set()
+            await b_started.wait()  # must NOT block on B if locks are per-target
+            return observed_a
+
+        async def dispatch_b(**_kwargs):
+            b_started.set()
+            return observed_b
+
+        def get_target(*, target_registry_name: str):
+            return fake_a if target_registry_name == "a" else fake_b
+
+        # Per-target dispatch via call_args inspection
+        async def probe(*, target, **kwargs):
+            if target is fake_a:
+                return await dispatch_a(**kwargs)
+            return await dispatch_b(**kwargs)
+
+        with (
+            patch.object(service, "get_target_object", side_effect=get_target),
+            patch(
+                "pyrit.backend.services.target_service.discover_target_capabilities_async",
+                new=probe,
+            ),
+        ):
+            task_a = asyncio.create_task(service.validate_target_capabilities_async(target_registry_name="a"))
+            await a_running.wait()
+            task_b = asyncio.create_task(service.validate_target_capabilities_async(target_registry_name="b"))
+            # If locks were shared, task_a would deadlock waiting on b_started.
+            result_a, result_b = await asyncio.wait_for(asyncio.gather(task_a, task_b), timeout=2.0)
+        assert result_a is not None and result_b is not None
+
+    async def test_creates_fresh_lock_per_service_instance(self) -> None:
+        """
+        Two TargetService() instances have independent _validate_locks dicts.
+        Guards the R5 instance-attribute fix against accidental re-promotion
+        to ClassVar (which would leak locks across pytest event loops).
+        """
+        from unittest.mock import AsyncMock
+
+        service_a = TargetService()
+        service_b = TargetService()
+        fake_target_a = _fake_target_with_capabilities()
+        fake_target_b = _fake_target_with_capabilities()
+        observed_a = _fake_observed_capabilities(declared=fake_target_a.capabilities)
+        observed_b = _fake_observed_capabilities(declared=fake_target_b.capabilities)
+
+        # Trigger lock creation in both services for the same registry name
+        with (
+            patch.object(service_a, "get_target_object", return_value=fake_target_a),
+            patch(
+                "pyrit.backend.services.target_service.discover_target_capabilities_async",
+                new_callable=AsyncMock,
+                return_value=observed_a,
+            ),
+        ):
+            await service_a.validate_target_capabilities_async(target_registry_name="shared")
+
+        with (
+            patch.object(service_b, "get_target_object", return_value=fake_target_b),
+            patch(
+                "pyrit.backend.services.target_service.discover_target_capabilities_async",
+                new_callable=AsyncMock,
+                return_value=observed_b,
+            ),
+        ):
+            await service_b.validate_target_capabilities_async(target_registry_name="shared")
+
+        assert "shared" in service_a._validate_locks
+        assert "shared" in service_b._validate_locks
+        # Different lock objects per service instance.
+        assert service_a._validate_locks["shared"] is not service_b._validate_locks["shared"]
+
+    async def test_includes_expected_warnings(self) -> None:
+        """All five base warnings are present, in the documented order."""
+        from unittest.mock import AsyncMock
+
+        service = TargetService()
+        fake_target = _fake_target_with_capabilities()
+        observed = _fake_observed_capabilities(declared=fake_target.capabilities)
+        with (
+            patch.object(service, "get_target_object", return_value=fake_target),
+            patch(
+                "pyrit.backend.services.target_service.discover_target_capabilities_async",
+                new_callable=AsyncMock,
+                return_value=observed,
+            ),
+        ):
+            result = await service.validate_target_capabilities_async(target_registry_name="t1")
+
+        assert result is not None
+        # Five base warnings (no 6th because no non-probeable modalities).
+        assert len(result.warnings) == 5
+        joined = " | ".join(result.warnings)
+        assert "live requests" in joined  # cost/side-effects
+        assert "capability_probe" in joined  # memory tagging
+        assert "Output modalities are reported as declared" in joined
+        assert "semantic enforcement" in joined  # request-vs-enforcement caveat
+        assert "Do not run Validate while an attack" in joined  # validate-vs-attack

--- a/tests/unit/backend/test_target_service.py
+++ b/tests/unit/backend/test_target_service.py
@@ -1008,6 +1008,57 @@ class TestValidateTargetCapabilities:
         # (c) typed field has the sorted, '+'-joined list
         assert result.non_probeable_input_modalities == ["function_call", "url"]
 
+        # (d) function_call and url appear ONLY in non-probeable combos
+        # (each in its own singleton, no probeable combo includes them).
+        assert result.non_probeable_only_types == ["function_call", "url"]
+
+    async def test_non_probeable_only_types_excludes_types_confirmed_via_probeable_combo(self) -> None:
+        """
+        Regression guard for the dialog cell-filter bug: when a target
+        declares both a probeable singleton like ``{text}`` AND a non-probeable
+        mixed combo like ``{text, function_call}``, ``text`` IS confirmed
+        (via the singleton) and must not appear in
+        ``non_probeable_only_types`` — otherwise the frontend would strip
+        ``text`` from the Input modalities cells and show ``— / —`` despite
+        it being probed and confirmed.
+
+        ``non_probeable_input_modalities`` (the combo display list) still
+        contains the mixed combo so the "Not probed (no asset)" row can
+        surface it; the cell-filter logic uses the narrower
+        ``non_probeable_only_types`` set instead.
+        """
+        from unittest.mock import AsyncMock
+
+        service = TargetService()
+        fake_target = _fake_target_with_capabilities(
+            input_modalities=frozenset(
+                {
+                    frozenset(["text"]),
+                    frozenset(["text", "function_call"]),
+                    frozenset(["image_path"]),
+                    frozenset(["image_path", "url"]),
+                }
+            )
+        )
+        observed = _fake_observed_capabilities(declared=fake_target.capabilities)
+        with (
+            patch.object(service, "get_target_object", return_value=fake_target),
+            patch(
+                "pyrit.backend.services.target_service.discover_target_capabilities_async",
+                new_callable=AsyncMock,
+            ) as mock_probe,
+        ):
+            mock_probe.return_value = observed
+            result = await service.validate_target_capabilities_async(target_registry_name="t1")
+
+        assert result is not None
+        # Combo display list keeps the mixed combos (used by the "Not probed" row).
+        assert result.non_probeable_input_modalities == ["function_call+text", "image_path+url"]
+        # Cell-filter list contains only types NOT confirmed by any probeable combo.
+        # `text` is confirmed by {text}; `image_path` is confirmed by {image_path}.
+        # Only `function_call` and `url` are exclusively non-probeable.
+        assert result.non_probeable_only_types == ["function_call", "url"]
+
     async def test_passes_empty_set_when_no_probeable_modalities(self) -> None:
         """
         Declared modalities are all non-probeable. Method passes
@@ -1044,6 +1095,8 @@ class TestValidateTargetCapabilities:
         assert isinstance(passed, set)
         assert result is not None
         assert result.non_probeable_input_modalities == ["function_call", "url", "video_path"]
+        # With no probeable combos, every declared type is exclusively non-probeable.
+        assert result.non_probeable_only_types == ["function_call", "url", "video_path"]
         assert any("no packaged probe asset" in w for w in result.warnings)
 
     async def test_propagates_probe_exceptions(self) -> None:


### PR DESCRIPTION
## Description
Adds a Validate column to the CoPyRIT target table. Clicking the beaker button on a row runs PyRIT's existing `discover_target_capabilities_async` engine against that target and opens a modal showing a declared-vs-observed capability diff (boolean flags + input modalities).

The engine already shipped but had no user-facing surface, so users only discovered capability drift (e.g., an Azure OpenAI gateway stripping JSON-schema, a multimodal class pointed at a text-only deployment) when an attack failed mid-run. This makes it a one-click check.

Read-only — no apply, no persistence beyond the modal session. Out of scope: applying observed capabilities back to the target, drift history, scheduled validation, memory-row filtering for probe writes, per-inner-target validation on composite targets.

Backend:
- New `ValidateCapabilitiesResponse` model and `POST /api/targets/{name}/validate` route.
- New `TargetService.validate_target_capabilities_async` method that filters declared input modalities to the probeable subset (`text`, `image_path`, `audio_path`) before invoking the engine, caps `per_probe_timeout_s` at 15s for GUI use, and holds a per-target `asyncio.Lock` so concurrent clicks on the same target serialize cleanly.
- Promoted `_target_capabilities_to_info` to public (now has two consumers).

Frontend:
- New `ValidateCapabilitiesDialog` showing a declared/observed/match table, a "Not probed (no asset)" row for modalities the engine has no test asset for (`function_call`, `tool_call`, `reasoning`, etc.), and warnings about live calls, memory writes, and validate-vs-active-attack races.
- Validate column placed next to the capability flags rather than in the leftmost cell, with a bordered icon button so it reads clearly as an action

Known limitation: image-modality probing currently false-negatives on many targets because the packaged `probe_image.png` asset (`pyrit/datasets/prompt_target/target_capabilities/probe_image.png`) is a 68-byte file that fails `PIL.Image.verify()`. Not introduced by this PR — file unchanged — but worth flagging. The dialog surfaces this in a warning so users know to verify image results manually.


## Tests and Documentation
Backend:
- New unit tests in `tests/unit/backend/test_target_service.py` (15 new tests) covering: probeable-modality filtering, the empty-set path, per-target lock serialization, cross-target non-serialization, exception propagation, GUI default timeout, the mixed-combo `non_probeable_only_types` regression guard, and warning contents.
- New route tests in `tests/unit/backend/test_api_routes.py` for the 200/404 paths.
- Full backend suite: 9638 passed, 43 skipped, project coverage 90.24% (gate 78%). Diff-cover 98% on the 262 changed lines (gate 90%).

Frontend:
- New `ValidateCapabilitiesDialog.test.tsx` (17 tests) and additions to `TargetTable.test.tsx` (5 tests) covering button placement, inner-target exclusion, dialog open/close, state reset across targets, the mixed-combo cell-filter regression, the composite-target warning, and the "Not probed" row.
- Full frontend suite: 669 passed across 29 suites, Jest coverage gate met.

Documentation:
- Added a short "Validating Targets" section to `doc/gui/0_gui.md` describing the column placement, what the dialog shows, and the limitations users should know about.
- JupyText: no notebook changes in this PR, so no JupyText regeneration needed.
