### PR TITLE
MAINT: Group Dependabot security minor patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
         update-types:
           - minor
           - patch
+      security-minor-and-patch:
+        applies-to: security-updates
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: npm
     directory: /frontend
@@ -24,6 +29,11 @@ updates:
       - "microsoft/ai-red-team-dev"
     groups:
       minor-and-patch:
+        update-types:
+          - minor
+          - patch
+      security-minor-and-patch:
+        applies-to: security-updates
         update-types:
           - minor
           - patch
@@ -41,6 +51,11 @@ updates:
         update-types:
           - minor
           - patch
+      security-minor-and-patch:
+        applies-to: security-updates
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: pre-commit
     directory: /
@@ -52,6 +67,11 @@ updates:
       - "microsoft/ai-red-team-dev"
     groups:
       minor-and-patch:
+        update-types:
+          - minor
+          - patch
+      security-minor-and-patch:
+        applies-to: security-updates
         update-types:
           - minor
           - patch
@@ -71,6 +91,11 @@ updates:
         update-types:
           - minor
           - patch
+      security-minor-and-patch:
+        applies-to: security-updates
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: devcontainers
     directory: /
@@ -82,6 +107,11 @@ updates:
       - "microsoft/ai-red-team-dev"
     groups:
       minor-and-patch:
+        update-types:
+          - minor
+          - patch
+      security-minor-and-patch:
+        applies-to: security-updates
         update-types:
           - minor
           - patch


### PR DESCRIPTION
## Description

Adds explicit Dependabot `security-minor-and-patch` groups for each configured ecosystem so minor and patch security updates are grouped separately from normal version updates.

This follows up on the recent separate Dependabot security PRs #2010, #2011, #2012, #2013, and #2015. The existing `minor-and-patch` groups only apply to version updates by default because Dependabot `groups.applies-to` defaults to `version-updates` when omitted. GitHub’s Dependabot options reference documents that `applies-to` supports both `version-updates` and `security-updates`.

Major security updates are intentionally left ungrouped. This keeps higher-risk updates, such as the major `cryptography` bump in #2015, isolated for review while reducing noise for lower-risk minor and patch security fixes.

References:

- Dependabot `groups` option: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--
- Dependabot `applies-to` behavior: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--
- Dependabot security updates: https://docs.github.com/en/code-security/dependabot/dependabot-security-updates

## Tests and Documentation

Validated the Dependabot YAML edit with VS Code diagnostics and `git diff --check`.

No runtime tests or JupyText runs were needed because this change only updates Dependabot configuration.