### PR TITLE
Fix integration test failures: Conversations table PK and stale attack_identifier references

### DIFF
--- a/pyrit/memory/alembic/versions/d4e5f6a7b8c9_fix_conversations_pk_length.py
+++ b/pyrit/memory/alembic/versions/d4e5f6a7b8c9_fix_conversations_pk_length.py
@@ -1,0 +1,47 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""
+Fix Conversations.conversation_id column length for SQL Server compatibility.
+
+SQL Server cannot use VARCHAR(max) as a primary key. The original migration
+created conversation_id as sa.String() (no length), which maps to VARCHAR(max)
+on MSSQL. This migration alters the column to String(36) to match UUID string
+length (36 characters).
+
+Revision ID: d4e5f6a7b8c9
+Revises: b2f4c6a8d1e3
+Create Date: 2026-06-16 12:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d4e5f6a7b8c9"
+down_revision: str = "c3d5e7f9a1b2"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    """Alter conversation_id to String(36) for SQL Server PK compatibility."""
+    with op.batch_alter_table("Conversations") as batch_op:
+        batch_op.alter_column(
+            "conversation_id",
+            existing_type=sa.String(),
+            type_=sa.String(36),
+            existing_nullable=False,
+        )
+
+
+def downgrade() -> None:
+    """Revert conversation_id back to unbounded String."""
+    with op.batch_alter_table("Conversations") as batch_op:
+        batch_op.alter_column(
+            "conversation_id",
+            existing_type=sa.String(36),
+            type_=sa.String(),
+            existing_nullable=False,
+        )

--- a/pyrit/memory/memory_models.py
+++ b/pyrit/memory/memory_models.py
@@ -384,7 +384,7 @@ class ConversationEntry(Base):
     __tablename__ = "Conversations"
     __table_args__ = {"extend_existing": True}
 
-    conversation_id = mapped_column(String, primary_key=True, nullable=False)
+    conversation_id = mapped_column(String(36), primary_key=True, nullable=False)
     target_identifier: Mapped[dict[str, str] | None] = mapped_column(JSON, nullable=True)
 
     # Version of PyRIT used when this entry was created. Nullable for backwards

--- a/tests/integration/mocks.py
+++ b/tests/integration/mocks.py
@@ -67,8 +67,6 @@ class MockPromptTarget(PromptTarget):
                     original_value=system_prompt,
                     converted_value=system_prompt,
                     conversation_id=conversation_id,
-                    attack_identifier=attack_identifier,
-                    labels=labels or {},
                 ).to_message()
             )
 
@@ -82,8 +80,6 @@ class MockPromptTarget(PromptTarget):
                 role="assistant",
                 original_value="default",
                 conversation_id=message.message_pieces[0].conversation_id,
-                attack_identifier=message.message_pieces[0].attack_identifier,
-                labels=message.message_pieces[0].labels,
             ).to_message()
         ]
 

--- a/tests/integration/targets/test_openai_responses_gpt5.py
+++ b/tests/integration/targets/test_openai_responses_gpt5.py
@@ -9,7 +9,7 @@ import uuid
 import jsonschema
 import pytest
 
-from pyrit.models import ComponentIdentifier, MessagePiece
+from pyrit.models import MessagePiece
 from pyrit.prompt_target import OpenAIResponseTarget
 
 
@@ -33,7 +33,6 @@ async def test_openai_responses_gpt5(sqlite_instance, gpt5_args):
         original_value="You are a helpful assistant.",
         original_value_data_type="text",
         conversation_id=conv_id,
-        attack_identifier=ComponentIdentifier.from_dict({"id": str(uuid.uuid4())}),
     )
     sqlite_instance.add_message_to_memory(request=developer_piece.to_message())
 
@@ -64,7 +63,6 @@ async def test_openai_responses_gpt5_json_schema(sqlite_instance, gpt5_args):
         original_value="You are an expert in the lore of cats.",
         original_value_data_type="text",
         conversation_id=conv_id,
-        attack_identifier=ComponentIdentifier.from_dict({"id": str(uuid.uuid4())}),
     )
     sqlite_instance.add_message_to_memory(request=developer_piece.to_message())
 
@@ -115,7 +113,6 @@ async def test_openai_responses_gpt5_json_object(sqlite_instance, gpt5_args):
         original_value="You are an expert in the lore of cats.",
         original_value_data_type="text",
         conversation_id=conv_id,
-        attack_identifier=ComponentIdentifier.from_dict({"id": str(uuid.uuid4())}),
     )
 
     sqlite_instance.add_message_to_memory(request=developer_piece.to_message())


### PR DESCRIPTION
## Problem

Integration tests had 8 ERRORs and 5+ FAILEDs caused by two issues:

1. **`VARCHAR(max)` as primary key in SQL Server** — The `b2f4c6a8d1e3` migration creates `conversation_id` as `sa.String()` (no length), which maps to `VARCHAR(max)` on MSSQL. SQL Server cannot use `VARCHAR(max)` as a primary key (error 1919). This broke all 8 `test_azure_sql_memory_integration` tests.

2. **Stale `attack_identifier` references** — `MessagePiece` now uses `extra='forbid'` and no longer has an `attack_identifier` field, but several integration test files still referenced it. This caused `ValidationError` / `AttributeError` in 5+ tests including the GPT-5 response tests, rate limiting test, and retry timing test.

## Fix

1. Added a new migration (`d4e5f6a7b8c9`) that alters `Conversations.conversation_id` from `String()` to `String(36)`. Updated `ConversationEntry` model to match.

2. Removed `attack_identifier` from `MockPromptTarget` (`set_system_prompt` and `_send_prompt_to_target_async`) and from `MessagePiece` constructors in `test_openai_responses_gpt5.py`.