### PR TITLE
FIX Container App health check to validate revision by deployed image tag

### DIFF
--- a/gui-deploy.yml
+++ b/gui-deploy.yml
@@ -176,19 +176,31 @@ stages:
                     inlineScript: |
                       set -euo pipefail
 
-                      FQDN=$(az containerapp show \
-                        --name $(appName) \
-                        --resource-group $(resourceGroup) \
-                        --query "properties.configuration.ingress.fqdn" -o tsv)
+                      IMAGE="$(acrLoginServer)/$(imageName):$(Build.SourceVersion)"
+                      HEALTH=""
 
-                      echo "Testing https://$FQDN/api/health"
+                      for i in {1..5}; do
+                        HEALTH="$(az containerapp revision list \
+                          --resource-group "$(resourceGroup)" \
+                          --name "$(appName)" \
+                          --query "[?properties.template.containers[0].image=='$IMAGE'] | sort_by(@,&properties.createdTime)[-1].properties.healthState" \
+                          -o tsv)"
 
-                      curl --retry 5 --retry-delay 15 --retry-all-errors \
-                        --fail --max-time 10 \
-                        "https://$FQDN/api/health"
+                        echo "Attempt $i/5 - Image: $IMAGE - Health: ${HEALTH:-<not-found>}"
 
-                      echo ""
-                      echo "✅ Test environment health check passed"
+                        if [[ "$HEALTH" == "Healthy" ]]; then
+                          echo "✅ Test environment health check passed"
+                          exit 0
+                        fi
+
+                        if [[ "$i" -lt 5 ]]; then
+                          echo "Revision is not healthy yet. Waiting 2 minutes before retry..."
+                          sleep 120
+                        fi
+                      done
+
+                      echo "❌ Test environment health check failed after 5 attempts"
+                      exit 1
 
   # ──────────────────────────────────────────────
   # Stage 3: Deploy to production (manual trigger)
@@ -247,16 +259,28 @@ stages:
                     inlineScript: |
                       set -euo pipefail
 
-                      FQDN=$(az containerapp show \
-                        --name $(appName) \
-                        --resource-group $(resourceGroup) \
-                        --query "properties.configuration.ingress.fqdn" -o tsv)
+                      IMAGE="$(acrLoginServer)/$(imageName):$(Build.SourceVersion)"
+                      HEALTH=""
 
-                      echo "Testing https://$FQDN/api/health"
+                      for i in {1..5}; do
+                        HEALTH="$(az containerapp revision list \
+                          --resource-group "$(resourceGroup)" \
+                          --name "$(appName)" \
+                          --query "[?properties.template.containers[0].image=='$IMAGE'] | sort_by(@,&properties.createdTime)[-1].properties.healthState" \
+                          -o tsv)"
 
-                      curl --retry 5 --retry-delay 15 --retry-all-errors \
-                        --fail --max-time 10 \
-                        "https://$FQDN/api/health"
+                        echo "Attempt $i/5 - Image: $IMAGE - Health: ${HEALTH:-<not-found>}"
 
-                      echo ""
-                      echo "✅ Production health check passed"
+                        if [[ "$HEALTH" == "Healthy" ]]; then
+                          echo "✅ Production health check passed"
+                          exit 0
+                        fi
+
+                        if [[ "$i" -lt 5 ]]; then
+                          echo "Revision is not healthy yet. Waiting 2 minutes before retry..."
+                          sleep 120
+                        fi
+                      done
+
+                      echo "❌ Production health check failed after 5 attempts"
+                      exit 1


### PR DESCRIPTION
#### Problem
The previous health check validated the Container App’s main FQDN, which can still route to an older healthy revision. As a result, deployments could pass health checks even when the newly deployed revision was unhealthy.

#### Solution
Update health checks (test/prod) to query `az containerapp revision list` for the revision matching the deployed image tag and evaluate its `healthState`.  
Added a retry loop (5 attempts, 2-minute interval) with clear logging, including a wait message before each retry.