### PR TITLE
FIX update example conf file so pyrit_scan doesn't fail out of the box

### DIFF
--- a/.pyrit_conf_example
+++ b/.pyrit_conf_example
@@ -46,6 +46,7 @@ memory_db_type: sqlite
 #         - scorer
 initializers:
   - name: simple
+  - name: scenario_technique
   - name: load_default_datasets
   - name: target
     args:


### PR DESCRIPTION
The example conf file is missing an initializer that `pyrit_scan --start-server` depends on. So when a user uses the example conf and run pyrit_scan, they get this error:

Error executing initializer LoadDefaultDatasets: AttackTechniqueRegistry is empty. Register attack technique factories before executing scenarios — for example by running the default ScenarioTechniqueInitializer (pyrit.setup.initializers.components.scenario_techniques), running another initializer that calls AttackTechniqueRegistry.register_from_factories(...), or registering factories directly via AttackTechniqueRegistry.get_registry_singleton(). 
