### PR TITLE
Fix UnicodeDecodeError when reading .pyrit_conf on Windows

### DIFF
--- a/pyrit/cli/_config_reader.py
+++ b/pyrit/cli/_config_reader.py
@@ -75,7 +75,7 @@ def warn_on_client_ignored_blocks(*, config_file: Path | None = None) -> None:
 
     for p in paths:
         try:
-            with open(p) as fh:
+            with open(p, encoding="utf-8") as fh:
                 data = yaml.safe_load(fh)
         except Exception:
             continue
@@ -103,7 +103,7 @@ def _extract_server_url(*, path: Path, yaml_module: Any) -> str | None:
         str | None: The URL string, or ``None`` if absent/malformed.
     """
     try:
-        with open(path) as fh:
+        with open(path, encoding="utf-8") as fh:
             data = yaml_module.safe_load(fh)
         if isinstance(data, dict):
             server_block = data.get("server")

--- a/tests/unit/cli/test_config_reader.py
+++ b/tests/unit/cli/test_config_reader.py
@@ -8,7 +8,7 @@ Unit tests for pyrit.cli._config_reader.
 from unittest.mock import patch
 
 from pyrit.cli import _config_reader
-from pyrit.cli._config_reader import DEFAULT_SERVER_URL, read_server_url
+from pyrit.cli._config_reader import DEFAULT_SERVER_URL, read_server_url, warn_on_client_ignored_blocks
 
 
 def test_default_server_url_constant():
@@ -80,3 +80,11 @@ def test_read_server_url_empty_string_treated_as_missing(tmp_path):
     empty.write_text("server:\n  url: ''\n")
     with patch.object(_config_reader, "_DEFAULT_CONFIG_FILE", tmp_path / "missing.yaml"):
         assert read_server_url(config_file=empty) is None
+
+
+def test_warn_on_client_ignored_blocks_prints_deprecation(tmp_path, capsys):
+    cfg = tmp_path / "conf.yaml"
+    cfg.write_text("scenario:\n  name: test\n", encoding="utf-8")
+    with patch.object(_config_reader, "_DEFAULT_CONFIG_FILE", tmp_path / "missing.yaml"):
+        warn_on_client_ignored_blocks(config_file=cfg)
+    assert "Deprecation" in capsys.readouterr().out


### PR DESCRIPTION
Opens config YAML files with `encoding='utf-8'` instead of relying on the platform default (cp1252 on Windows), which crashes on non-ASCII bytes.