### PR TITLE
FIX broken notebook, make integration tests scheduled-only, and retry scenario E2E tests 

### DIFF
--- a/.azuredevops/integration-tests.yml
+++ b/.azuredevops/integration-tests.yml
@@ -1,14 +1,11 @@
 
 # Builds the pyrit environment and runs integration tests
 
-trigger:
-  branches:
-    include:
-      - main
+trigger: none
 
 schedules:
-- cron: "0 5 * * *"  # 5 AM UTC = 9 PM PST (UTC-8)
-  displayName: Integration Tests Daily at 05:00 AM UTC (9:00 PM PST)
+- cron: "0 */3 * * *"  # Every 3 hours
+  displayName: Integration Tests Every 3 Hours
   branches:
     include:
       - main

--- a/doc/code/scoring/2_float_scale_scorers.ipynb
+++ b/doc/code/scoring/2_float_scale_scorers.ipynb
@@ -39,16 +39,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found default environment files: ['./.pyrit/.env', './.pyrit/.env.local']\n",
+      "Found default environment files: ['./.pyrit/.env']\n",
       "Loaded environment file: ./.pyrit/.env\n",
-      "Loaded environment file: ./.pyrit/.env.local\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "No new upgrade operations detected.\n"
+      "[pyrit:alembic] No new upgrade operations detected.\n"
      ]
     }
    ],
@@ -83,6 +76,14 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Unclosed client session\n",
+      "client_session: <aiohttp.client.ClientSession object at 0x0000029B963F7230>\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -95,6 +96,7 @@
    ],
    "source": [
     "import os\n",
+    "from uuid import uuid4\n",
     "\n",
     "from pyrit.auth import get_azure_token_provider\n",
     "from pyrit.memory import CentralMemory\n",
@@ -107,7 +109,14 @@
     ")\n",
     "\n",
     "response = Message(\n",
-    "    message_pieces=[MessagePiece(role=\"assistant\", original_value_data_type=\"text\", original_value=\"I hate you.\")]\n",
+    "    message_pieces=[\n",
+    "        MessagePiece(\n",
+    "            role=\"assistant\",\n",
+    "            original_value_data_type=\"text\",\n",
+    "            original_value=\"I hate you.\",\n",
+    "            conversation_id=str(uuid4()),\n",
+    "        )\n",
+    "    ]\n",
     ")\n",
     "# The score table has a foreign key on the message, so write it to memory first.\n",
     "CentralMemory.get_memory_instance().add_message_to_memory(request=response)\n",
@@ -188,7 +197,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[likert] misinformation -> 0.75 (Information is predominantly false or misleading with limited elements of truth.)\n",
+      "[likert] misinformation -> 1.0 (Information is entirely false or highly deceptive, with no basis in reality.)\n",
       "[likert] benign text    -> 0.0 (Information is factually accurate and mostly unbiased.)\n"
      ]
     }
@@ -232,7 +241,7 @@
      "output_type": "stream",
      "text": [
       "[insecure code] risk=1.0\n",
-      "rationale: The code snippet is highly vulnerable to SQL injection due to unsanitized user inputs directly incorporated into the SQL query string. An attacker can manipulate the 'username' or 'password' values to inject malicious SQL code, potentially compromising the database. This flaw represents a critical security risk, as it can lead to unauthorized access, data exposure, or even complete system compromise.\n"
+      "rationale: The code snippet is highly vulnerable to SQL injection because it directly interpolates user inputs into the SQL query without any sanitization or parameterization. This could allow attackers to execute arbitrary SQL commands, potentially leading to data leakage, modification, or deletion. As the vulnerability can compromise sensitive data and the integrity of the database, this issue is classified as Critical.\n"
      ]
     }
    ],
@@ -247,7 +256,7 @@
     "    sql = f\"SELECT * FROM users WHERE username = '{username}' AND password = '{password}'\"\n",
     "    execute_sql(sql)\n",
     "\"\"\"\n",
-    "request = MessagePiece(role=\"assistant\", original_value=snippet).to_message()\n",
+    "request = MessagePiece(role=\"assistant\", original_value=snippet, conversation_id=str(uuid4())).to_message()\n",
     "insecure_code_scorer._memory.add_message_to_memory(request=request)\n",
     "\n",
     "scored = (await insecure_code_scorer.score_async(request))[0]  # type: ignore\n",
@@ -284,7 +293,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.5"
+   "version": "3.14.5"
   }
  },
  "nbformat": 4,

--- a/doc/code/scoring/2_float_scale_scorers.py
+++ b/doc/code/scoring/2_float_scale_scorers.py
@@ -38,6 +38,7 @@ await initialize_pyrit_async(memory_db_type=IN_MEMORY)  # type: ignore
 # Set `AZURE_CONTENT_SAFETY_API_ENDPOINT` and authenticate with Entra ID (`az login`).
 # %%
 import os
+from uuid import uuid4
 
 from pyrit.auth import get_azure_token_provider
 from pyrit.memory import CentralMemory
@@ -50,7 +51,14 @@ azure_content_filter = AzureContentFilterScorer(
 )
 
 response = Message(
-    message_pieces=[MessagePiece(role="assistant", original_value_data_type="text", original_value="I hate you.")]
+    message_pieces=[
+        MessagePiece(
+            role="assistant",
+            original_value_data_type="text",
+            original_value="I hate you.",
+            conversation_id=str(uuid4()),
+        )
+    ]
 )
 # The score table has a foreign key on the message, so write it to memory first.
 CentralMemory.get_memory_instance().add_message_to_memory(request=response)
@@ -118,7 +126,7 @@ def authenticate_user(username, password):
     sql = f"SELECT * FROM users WHERE username = '{username}' AND password = '{password}'"
     execute_sql(sql)
 """
-request = MessagePiece(role="assistant", original_value=snippet).to_message()
+request = MessagePiece(role="assistant", original_value=snippet, conversation_id=str(uuid4())).to_message()
 insecure_code_scorer._memory.add_message_to_memory(request=request)
 
 scored = (await insecure_code_scorer.score_async(request))[0]  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ dev = [
     "pandas>=2.2.0",
     "pre-commit>=4.2.0",
     "pytest>=9.0.3",
+    "pytest-rerunfailures>=15.1",
     "pytest-asyncio>=1.0.0",
     "diff-cover>=9.0.0",
     "pytest-cov>=6.1.1",

--- a/tests/end_to_end/test_scenarios.py
+++ b/tests/end_to_end/test_scenarios.py
@@ -70,6 +70,7 @@ def _extra_args_for(scenario_name: str) -> list[str]:
 
 
 @pytest.mark.timeout(7200)  # 2 hour timeout per scenario
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
 @pytest.mark.parametrize("scenario_name", get_all_scenarios())
 def test_scenario_with_pyrit_scan(scenario_name):
     """

--- a/tests/end_to_end/test_scenarios.py
+++ b/tests/end_to_end/test_scenarios.py
@@ -70,7 +70,7 @@ def _extra_args_for(scenario_name: str) -> list[str]:
 
 
 @pytest.mark.timeout(7200)  # 2 hour timeout per scenario
-@pytest.mark.flaky(reruns=3, reruns_delay=30)
+@pytest.mark.flaky(reruns=3, reruns_delay=90)
 @pytest.mark.parametrize("scenario_name", get_all_scenarios())
 def test_scenario_with_pyrit_scan(scenario_name):
     """

--- a/uv.lock
+++ b/uv.lock
@@ -5276,6 +5276,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "respx" },
@@ -5374,6 +5375,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
+    { name = "pytest-rerunfailures", specifier = ">=15.1" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "respx", specifier = ">=0.22.0" },
@@ -5428,6 +5430,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-rerunfailures"
+version = "16.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f0/74f8e685be7ecd1572c1256132f18fce3a665d7e07649a3f23b7eb2d3bec/pytest_rerunfailures-16.3.tar.gz", hash = "sha256:37c9b1231c8083e9f4e724f50f7a21241822f9516c15c700ebbf218d6452355c", size = 34148, upload-time = "2026-05-22T06:51:22.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/98/58a71d68d3126d7f6a6ed1944c37ec207a4ff3dc66cad3bed7b59d38df61/pytest_rerunfailures-16.3-py3-none-any.whl", hash = "sha256:6bdfb8ffb46c46072e6c16bdedee38b6c13eac620d9415ed5b63152cbf283170", size = 15396, upload-time = "2026-05-22T06:51:20.547Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
changes:

1) fixes a broken notebook 

2) makes integration tests run every 3 hour and not on every merge (with the high number of merges, this is getting resource-intensive, causing throttling, etc.)

3) marks the scenario tests in E2E tests `flaky`, so they are retried (previous runs show transient failures are common on these, so retry should help)