### PR TITLE
MAINT: Add DEFAULT strategy alias to airt.cyber scenario

### DIFF
--- a/doc/scanner/airt.ipynb
+++ b/doc/scanner/airt.ipynb
@@ -373,7 +373,7 @@
     "  --max-dataset-size 1\n",
     "```\n",
     "\n",
-    "**Available strategies:** ALL, MULTI_TURN, red_teaming"
+    "**Available strategies:** ALL, DEFAULT, MULTI_TURN, red_teaming"
    ]
   },
   {

--- a/doc/scanner/airt.py
+++ b/doc/scanner/airt.py
@@ -129,7 +129,7 @@ await output_scenario_async(scenario_result)
 #   --max-dataset-size 1
 # ```
 #
-# **Available strategies:** ALL, MULTI_TURN, red_teaming
+# **Available strategies:** ALL, DEFAULT, MULTI_TURN, red_teaming
 
 # %%
 from pyrit.scenario.airt import Cyber, CyberStrategy

--- a/pyrit/scenario/scenarios/airt/cyber.py
+++ b/pyrit/scenario/scenarios/airt/cyber.py
@@ -23,6 +23,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Techniques Cyber selects from the shared catalog. ``DEFAULT`` is wired to ``any_of("core")``
+# (see _build_cyber_strategy), so adding a technique here that carries the ``core`` tag pulls it
+# into DEFAULT, while a technique lacking ``core`` (e.g. an ``extra``-group technique) would stay
+# in ALL but be silently dropped from DEFAULT. Either case breaks the current DEFAULT == ALL
+# invariant (guarded by test_default_matches_all); revisit the aggregate wiring if that happens.
 _CYBER_TECHNIQUE_NAMES = {"red_teaming"}
 
 
@@ -35,6 +40,9 @@ def _build_cyber_strategy() -> type[ScenarioStrategy]:
     ``AttackTechniqueRegistry``. A plain ``PromptSendingAttack`` baseline is
     prepended automatically by ``Scenario._build_baseline_atomic_attack`` via
     ``BaselineAttackPolicy.Enabled``.
+
+    The ``DEFAULT`` aggregate is the curated default run; for Cyber it expands to the
+    same single ``red_teaming`` technique as ``ALL``.
 
     Returns:
         type[ScenarioStrategy]: The dynamically generated strategy enum class.
@@ -50,6 +58,11 @@ def _build_cyber_strategy() -> type[ScenarioStrategy]:
         class_name="CyberStrategy",
         factories=cyber_factories,
         aggregate_tags={
+            # Cyber curates a single technique (red_teaming) at the scenario level. That
+            # technique carries the canonical ``core`` tag but not the catalog-wide
+            # ``default`` tag, so DEFAULT matches ``core`` here to select it (rather than
+            # tagging red_teaming ``default`` globally, which would alter other scenarios).
+            "default": TagQuery.any_of("core"),
             "multi_turn": TagQuery.any_of("multi_turn"),
         },
     )
@@ -101,7 +114,7 @@ class Cyber(Scenario):
             version=self.VERSION,
             objective_scorer=self._objective_scorer,
             strategy_class=strategy_class,
-            default_strategy=strategy_class("all"),
+            default_strategy=strategy_class("default"),
             default_dataset_config=DatasetAttackConfiguration(dataset_names=["airt_malware"], max_dataset_size=4),
             scenario_result_id=scenario_result_id,
         )

--- a/tests/unit/scenario/airt/test_cyber.py
+++ b/tests/unit/scenario/airt/test_cyber.py
@@ -11,7 +11,7 @@ from pyrit.executor.attack import RedTeamingAttack
 from pyrit.models import ComponentIdentifier, SeedAttackGroup, SeedObjective, SeedPrompt
 from pyrit.prompt_target import PromptTarget
 from pyrit.registry.components.attack_technique_registry import AttackTechniqueRegistry
-from pyrit.scenario.core.dataset_configuration import DatasetAttackConfiguration, DatasetConfiguration
+from pyrit.scenario.core.dataset_configuration import DatasetAttackConfiguration
 from pyrit.scenario.scenarios.airt.cyber import Cyber
 from pyrit.score import TrueFalseScorer
 from pyrit.setup.initializers.techniques import (
@@ -133,13 +133,37 @@ class TestCyberBasic:
         strat = _strategy_class()
         assert Cyber()._strategy_class is strat
 
-    def test_get_default_strategy_returns_all(self):
+    def test_get_default_strategy_returns_default(self):
         strat = _strategy_class()
-        assert Cyber()._default_strategy == strat.ALL
+        assert Cyber()._default_strategy == strat.DEFAULT
+
+    def test_default_aggregate_expands_to_red_teaming(self):
+        """DEFAULT must be non-empty and select the single curated technique.
+
+        Guards against wiring the ``default`` aggregate to a tag ``red_teaming`` lacks
+        (e.g. the catalog ``default`` tag), which would silently make DEFAULT empty and
+        collapse the default run to baseline-only.
+        """
+        strat = _strategy_class()
+        assert "default" in strat.get_aggregate_tags()
+        default_members = strat.expand({strat.DEFAULT})
+        assert default_members == [strat("red_teaming")]
+
+    def test_default_matches_all(self):
+        """DEFAULT must expand to exactly the same techniques as ALL.
+
+        Cyber curates a single technique, so its DEFAULT run is a no-op alias of ALL. Asserting
+        equality (not just subset) guards against a future technique landing in ALL but being
+        silently excluded from DEFAULT (or vice versa) once the aggregate wiring changes.
+        """
+        strat = _strategy_class()
+        assert set(strat.expand({strat.DEFAULT})) == set(strat.expand({strat.ALL}))
 
     def test_default_dataset_config_has_malware_dataset(self):
         config = Cyber()._default_dataset_config
-        assert isinstance(config, DatasetConfiguration)
+        # Concrete DatasetAttackConfiguration (not the base) so the scenario's async
+        # get_attack_groups_by_dataset_async() resolve path is available.
+        assert isinstance(config, DatasetAttackConfiguration)
         names = config.dataset_names
         assert "airt_malware" in names
         assert len(names) == 1
@@ -166,7 +190,7 @@ class TestCyberBasic:
         new_callable=AsyncMock,
         return_value={"malware": _make_seed_groups("malware")},
     )
-    async def test_initialization_defaults_to_all_strategy(
+    async def test_initialization_defaults_to_default_strategy(
         self,
         _mock_groups,
         mock_objective_target,
@@ -174,7 +198,7 @@ class TestCyberBasic:
     ):
         scenario = Cyber(objective_scorer=mock_objective_scorer)
         await scenario.initialize_async(objective_target=mock_objective_target)
-        # ALL expands to red_teaming (the only registered Cyber technique); a
+        # DEFAULT expands to red_teaming (the only registered Cyber technique); a
         # PromptSendingAttack baseline is added separately via the baseline
         # policy, not as a strategy.
         assert len(scenario._scenario_strategies) == 1
@@ -276,7 +300,7 @@ class TestCyberAttackGeneration:
         assert technique_classes == {RedTeamingAttack}
 
     async def test_default_strategy_produces_red_teaming(self, mock_objective_target, mock_objective_scorer):
-        """Default (ALL) should produce RedTeaming. PromptSendingAttack baseline is
+        """Default (DEFAULT) should produce RedTeaming. PromptSendingAttack baseline is
         prepended automatically by BaselineAttackPolicy.Enabled when
         include_baseline=True (the helper here uses include_baseline=False)."""
         attacks = await self._init_and_get_attacks(


### PR DESCRIPTION
## Description
Part of the Standardizing Scenarios effort. This brings `airt.cyber` in line with
the convention the other scenarios follow: a `DEFAULT` strategy aggregate that drives the
default run, with `ALL` kept for the exhaustive run.

Cyber only has one technique today (`red_teaming`), so `DEFAULT` expands to exactly the same
thing as `ALL` — this isn't a behavior change, it's added for cross-scenario convention parity
so `--strategies default` works uniformly everywhere.

One wrinkle worth calling out: `red_teaming` isn't tagged `default` in the shared technique
catalog, so the usual `TagQuery.any_of("default")` would produce an empty aggregate and collapse
the default run to baseline-only. Cyber's `DEFAULT` matches `core` instead, which selects the
curated technique without tagging `red_teaming` globally (that would leak it into other
scenarios' default runs). There's a comment on `_CYBER_TECHNIQUE_NAMES` noting that adding
another `core`-tagged technique would pull it into DEFAULT.

Not a breaking change: the default run produces the same atomic attacks as before (same
`red_teaming` + baseline), so output is byte-identical and `--resume` stays compatible. No
VERSION bump needed.



## Tests and Documentation

Tests (tests/unit/scenario/airt/test_cyber.py):
- default strategy is now DEFAULT (was ALL)
- DEFAULT expands to red_teaming and is non-empty (guards against the empty-aggregate footgun)
- DEFAULT is a subset of ALL
- updated existing assertions/docstrings that referenced ALL

All 25 cyber tests pass; full airt scenario suite (164) green. ruff, ruff format, and ty clean.

Documentation (doc/scanner/airt.py + .ipynb):
- added DEFAULT to the Cyber "Available strategies" list
- ran jupytext to keep the .py and .ipynb in sync