### PR TITLE
MAINT: Consolidate Ruff per-file-ignores; drop dead pyrit/ui config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -393,13 +393,10 @@ notice-rgx = "Copyright \\(c\\) Microsoft Corporation\\.\\s*\\n.*Licensed under 
 # LOG: notebooks use root logger for convenience
 # PLE1142: top-level await is valid in Jupyter notebooks
 "doc/**" = ["ANN", "CPY001", "TCH", "E402", "E501", "PGH003", "A", "ERA001", "LOG", "PLE1142"]
-"pyrit/{auxiliary_attacks,ui}/**/*.py" = ["B905", "D101", "D102", "D103", "D104", "D105", "D106", "D107", "D401", "D404", "D417", "D418", "DOC102", "DOC201", "DOC202", "DOC402", "DOC501", "N", "PERF", "SIM101", "SIM108"]
 # Backend API routes raise HTTPException handled by FastAPI, not true exceptions
 "pyrit/backend/**/*.py" = ["DOC501", "B008"]
 # Vendored GCG attack code — external project with its own style
-"pyrit/auxiliary_attacks/**/*.py" = ["A", "B905", "D", "DOC", "SIM101", "SIM108"]
-# UI code has incomplete docstrings (external contributor code)
-"pyrit/ui/**/*.py" = ["D", "DOC201", "DOC501"]
+"pyrit/auxiliary_attacks/**/*.py" = ["A", "B905", "D", "DOC", "N", "PERF", "SIM101", "SIM108"]
 "pyrit/__init__.py" = ["D104"]
 # Allow broad pytest.raises(Exception) in tests
 "tests/**/*.py" = ["ANN", "B017"]


### PR DESCRIPTION
## Description

The `[tool.ruff.lint.per-file-ignores]` table had grown redundant and partly stale. This is a pure, behavior-preserving cleanup of that table; it does not change what gets linted anywhere.

Specifically:
- Removed the redundant combined `"pyrit/{auxiliary_attacks,ui}/**/*.py"` entry. Ruff unions ignores across all matching patterns, so its granular `D1xx`/`D4xx`/`DOCxxx` codes were already covered by the dedicated `auxiliary_attacks` entry's `D`/`DOC` prefixes. Its only non-redundant codes, `N` and `PERF`, were folded into that entry, which is now `["A", "B905", "D", "DOC", "N", "PERF", "SIM101", "SIM108"]`.
- Removed the dead `"pyrit/ui/**/*.py"` entry. `pyrit/ui/` does not exist, so both it and the `ui` branch of the combined pattern matched zero files.

Net effect: three lines removed and one entry updated, while `auxiliary_attacks` (vendored GCG attack code) keeps the exact same effective ignore set.

## Tests and Documentation

Config-only change; no code, tests, or docs are affected, and JupyText is not applicable.

Behavior was verified unchanged two independent ways:
- Parsed Ruff's fully-resolved config (`ruff check --show-settings`) before and after. The effective ignore set for an `auxiliary_attacks` file is byte-identical (the same 86 fully-expanded rule codes), and every other matcher (doc, backend, tests, etc.) is unchanged.
- `ruff check pyrit/auxiliary_attacks pyrit/backend --statistics` returns identical results before and after (the same 9 pre-existing D421 in `pyrit/backend`, which are out of scope for this PR).