### PR TITLE
MAINT: Harden frontend npm config (npm audit + min-release-age)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,6 @@ doc/_autosummary/
 
 # Custom user instructions
 .github/instructions/user-custom.instructions.md
+
+# Impeccable skill local cache
+.impeccable/

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,3 +1,7 @@
 # Pin npm registry — satisfies CSSC CFS0001 (sibling .npmrc required).
 registry=https://registry.npmjs.org/
 legacy-peer-deps=true
+
+min-release-age=7
+audit=true
+audit-level=high


### PR DESCRIPTION
## Description

Config-only maintenance for the frontend's npm supply-chain posture, plus a small housekeeping ignore.

**`frontend/.npmrc`** — three settings appended; the existing registry pin on line 1 (CSSC CFS0001) is left untouched:

- `min-release-age=7`: refuse package versions younger than 7 days, to dodge freshly-published malicious releases (supply-chain mitigation against attackers who publish a compromised version hoping it is pulled in before detection/yanking).
- `audit=true`: run `npm audit` automatically on install so known vulnerabilities surface immediately.
- `audit-level=high`: only high/critical advisories cause a non-zero (CI-failing) exit, keeping the signal actionable.

**`.gitignore`** — ignore the `.impeccable/` directory, a local per-session cache created by tooling. It is not part of PyRIT and should never be committed.

## Tests and Documentation

No code or tests changed — these are configuration-only changes. JupyText is not applicable (no docs or notebooks were touched).