### PR TITLE
DOC: Update mazeika2023tdc citation to MLR proceedings page

### DIFF
--- a/doc/references.bib
+++ b/doc/references.bib
@@ -68,8 +68,8 @@
   title     = {The Trojan Detection Challenge 2023 ({LLM} Edition)},
   author    = {Mantas Mazeika and Andy Zou and Norman Mu and Long Phan and Zifan Wang and Chunru Yu and Adam Khoja and Fengqing Jiang and Aidan O'Gara and Ellie Sakhaee and Zhen Xiang and Arezoo Rajabi and Dan Hendrycks and Radha Poovendran and Bo Li and David Forsyth},
   year      = {2023},
-  url       = {https://trojandetection.ai/},
-  note      = {NeurIPS 2023 Trojan Detection Challenge competition. No canonical paper write-up; the cited URL is the official competition website.},
+  url       = {https://proceedings.mlr.press/v220/mazeika23a.html},
+  note      = {NeurIPS Trojan Detection Challenge series. Official challenge site may be unavailable; using the proceedings page for archival access.},
 }
 
 @misc{promptfoo2025ccp,


### PR DESCRIPTION
## Description

The `mazeika2023tdc` entry in `doc/references.bib` pointed at the official Trojan Detection Challenge website (`https://trojandetection.ai/`), which can be unavailable and is not a stable archival source.

This updates the entry to cite the PMLR proceedings page instead, which provides durable archival access:

- `url` -> `https://proceedings.mlr.press/v220/mazeika23a.html`
- `note` -> "NeurIPS Trojan Detection Challenge series. Official challenge site may be unavailable; using the proceedings page for archival access."

No other entries were modified.

## Tests and Documentation

N/A. This is a bibliography-only change (`doc/references.bib`); no code or tests are affected.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
