### PR TITLE
MAINT: Simplifying Rapid Response and Cyber

### DIFF
--- a/pyrit/scenario/core/matrix_atomic_attack_builder.py
+++ b/pyrit/scenario/core/matrix_atomic_attack_builder.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from pyrit.prompt_converter import PromptConverter
     from pyrit.prompt_target import PromptTarget
     from pyrit.scenario.core.attack_technique_factory import AttackTechniqueFactory
+    from pyrit.scenario.core.scenario_context import ScenarioContext
     from pyrit.score import Scorer
     from pyrit.score.true_false.true_false_scorer import TrueFalseScorer
 
@@ -119,6 +120,77 @@ def build_baseline_atomic_attack(
         attack_technique=AttackTechnique(attack=attack),
         seed_groups=seed_groups,
         memory_labels=memory_labels or {},
+    )
+
+
+def resolve_technique_factories(*, context: ScenarioContext) -> dict[str, AttackTechniqueFactory]:
+    """
+    Resolve a run's selected strategies to their registered ``AttackTechniqueFactory`` instances.
+
+    Reads the ``AttackTechniqueRegistry`` singleton and keeps only the factories whose name
+    matches a selected strategy, preserving selection order. Strategies with no registered
+    factory are silently dropped so the caller can proceed with whatever techniques exist.
+
+    Args:
+        context (ScenarioContext): The resolved runtime inputs for this run.
+
+    Returns:
+        dict[str, AttackTechniqueFactory]: Mapping of technique name to factory, ordered by
+        the selected strategies.
+    """
+    from pyrit.registry.components.attack_technique_registry import AttackTechniqueRegistry
+
+    all_factories = AttackTechniqueRegistry.get_registry_singleton().get_factories_or_raise()
+    return {
+        strategy.value: all_factories[strategy.value]
+        for strategy in context.scenario_strategies
+        if strategy.value in all_factories
+    }
+
+
+def build_matrix_atomic_attacks(
+    *,
+    context: ScenarioContext,
+    objective_scorer: Scorer,
+    display_group_fn: Callable[[MatrixCombo], str] | None = None,
+    strategy_converters: dict[str, list[PromptConverter]] | None = None,
+) -> list[AtomicAttack]:
+    """
+    Build a matrix-shaped scenario's atomic attacks from its resolved context in one call.
+
+    This is the zero-boilerplate path for scenarios whose construction is the plain
+    technique × dataset cross-product: it resolves the selected strategies to factories
+    (``resolve_technique_factories``) and hands them to ``MatrixAtomicAttackBuilder``
+    with the context's target, labels, and per-dataset seed groups. The baseline is emitted
+    centrally by ``Scenario._get_atomic_attacks_async``, so this never prepends one.
+
+    Scenarios needing extra axes (adversarial targets, caching, converter stacks) call
+    ``MatrixAtomicAttackBuilder`` directly instead.
+
+    Args:
+        context (ScenarioContext): The resolved runtime inputs for this run.
+        objective_scorer (Scorer): The scorer applied to each produced atomic attack.
+        display_group_fn (Callable[[MatrixCombo], str] | None): Builds each ``display_group``.
+            Defaults to grouping by technique name.
+        strategy_converters (dict[str, list[PromptConverter]] | None): Optional mapping from
+            technique name to converters appended after that technique's converters. Pass a
+            scenario's ``self._strategy_converters`` so per-technique converter overrides are
+            preserved.
+
+    Returns:
+        list[AtomicAttack]: The generated atomic attacks (no baseline).
+    """
+    builder = MatrixAtomicAttackBuilder(
+        objective_target=context.objective_target,
+        objective_scorer=objective_scorer,
+        memory_labels=context.memory_labels,
+    )
+    return builder.build(
+        technique_factories=resolve_technique_factories(context=context),
+        dataset_groups=context.seed_groups_by_dataset,
+        display_group_fn=display_group_fn,
+        strategy_converters=strategy_converters,
+        include_baseline=False,
     )
 
 

--- a/pyrit/scenario/scenarios/airt/cyber.py
+++ b/pyrit/scenario/scenarios/airt/cyber.py
@@ -11,11 +11,14 @@ from pyrit.common import apply_defaults
 from pyrit.common.deprecation import print_deprecation_message  # Deprecated. Will be removed in 0.16.0.
 from pyrit.common.path import SCORER_SEED_PROMPT_PATH
 from pyrit.scenario.core.dataset_configuration import DatasetAttackConfiguration
+from pyrit.scenario.core.matrix_atomic_attack_builder import build_matrix_atomic_attacks
 from pyrit.scenario.core.scenario import Scenario
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from pyrit.scenario.core.atomic_attack import AtomicAttack
+    from pyrit.scenario.core.scenario_context import ScenarioContext
     from pyrit.scenario.core.scenario_strategy import ScenarioStrategy
     from pyrit.score import TrueFalseScorer
 
@@ -116,3 +119,22 @@ class Cyber(Scenario):
                 removed_in="0.16.0",
             )
             self._legacy_include_baseline = include_baseline
+
+    async def _build_atomic_attacks_async(self, *, context: ScenarioContext) -> list[AtomicAttack]:
+        """
+        Build the technique × dataset atomic attacks for Cyber, grouped by technique.
+
+        The baseline is emitted centrally by the base ``_get_atomic_attacks_async`` bridge, so
+        this override never prepends one.
+
+        Args:
+            context (ScenarioContext): The resolved runtime inputs for this run.
+
+        Returns:
+            list[AtomicAttack]: The generated atomic attacks.
+        """
+        return build_matrix_atomic_attacks(
+            context=context,
+            objective_scorer=self._objective_scorer,
+            strategy_converters=self._strategy_converters,
+        )

--- a/pyrit/scenario/scenarios/airt/rapid_response.py
+++ b/pyrit/scenario/scenarios/airt/rapid_response.py
@@ -18,9 +18,12 @@ from typing import TYPE_CHECKING
 
 from pyrit.common import apply_defaults
 from pyrit.scenario.core.dataset_configuration import CompoundDatasetAttackConfiguration
+from pyrit.scenario.core.matrix_atomic_attack_builder import build_matrix_atomic_attacks
 from pyrit.scenario.core.scenario import Scenario
 
 if TYPE_CHECKING:
+    from pyrit.scenario.core.atomic_attack import AtomicAttack
+    from pyrit.scenario.core.scenario_context import ScenarioContext
     from pyrit.scenario.core.scenario_strategy import ScenarioStrategy
     from pyrit.score import TrueFalseScorer
 
@@ -108,11 +111,23 @@ class RapidResponse(Scenario):
             scenario_result_id=scenario_result_id,
         )
 
-    def _build_display_group(self, *, technique_name: str, seed_group_name: str) -> str:
+    async def _build_atomic_attacks_async(self, *, context: ScenarioContext) -> list[AtomicAttack]:
         """
-        Group results by harm category (dataset) rather than technique.
+        Build the technique × harm-category atomic attacks, grouped by harm category.
+
+        Results group by harm category (the dataset name) rather than technique so per-category
+        ASR rolls up naturally. The baseline is emitted centrally by the base
+        ``_get_atomic_attacks_async`` bridge, so this override never prepends one.
+
+        Args:
+            context (ScenarioContext): The resolved runtime inputs for this run.
 
         Returns:
-            str: The seed group name used as the display group.
+            list[AtomicAttack]: The generated atomic attacks.
         """
-        return seed_group_name
+        return build_matrix_atomic_attacks(
+            context=context,
+            objective_scorer=self._objective_scorer,
+            display_group_fn=lambda combo: combo.dataset_name,
+            strategy_converters=self._strategy_converters,
+        )

--- a/pyrit/scenario/scenarios/benchmark/adversarial.py
+++ b/pyrit/scenario/scenarios/benchmark/adversarial.py
@@ -21,7 +21,10 @@ from pyrit.models.parameter import Parameter
 from pyrit.registry import AttackTechniqueRegistry, TargetRegistry
 from pyrit.registry.tag_query import TagQuery
 from pyrit.scenario.core.dataset_configuration import DatasetAttackConfiguration
-from pyrit.scenario.core.matrix_atomic_attack_builder import MatrixAtomicAttackBuilder
+from pyrit.scenario.core.matrix_atomic_attack_builder import (
+    MatrixAtomicAttackBuilder,
+    resolve_technique_factories,
+)
 from pyrit.scenario.core.scenario import BaselineAttackPolicy, Scenario
 
 if TYPE_CHECKING:
@@ -229,12 +232,7 @@ class AdversarialBenchmark(Scenario):
             )
 
         resolved_targets = self._resolve_adversarial_targets(target_names=target_names)
-        all_factories = AttackTechniqueRegistry.get_registry_singleton().get_factories_or_raise()
-        technique_factories = {
-            strategy.value: all_factories[strategy.value]
-            for strategy in context.scenario_strategies
-            if strategy.value in all_factories
-        }
+        technique_factories = resolve_technique_factories(context=context)
 
         builder = MatrixAtomicAttackBuilder(
             objective_target=context.objective_target,

--- a/tests/unit/scenario/airt/test_rapid_response.py
+++ b/tests/unit/scenario/airt/test_rapid_response.py
@@ -510,29 +510,6 @@ class TestRapidResponseAttackGeneration:
 
 
 # ===========================================================================
-# _build_display_group tests
-# ===========================================================================
-
-
-@pytest.mark.usefixtures(*FIXTURES)
-class TestBuildDisplayGroup:
-    def test_rapid_response_groups_by_seed_group_name(self, mock_objective_scorer):
-        scenario = RapidResponse(
-            objective_scorer=mock_objective_scorer,
-        )
-        result = scenario._build_display_group(technique_name="prompt_sending", seed_group_name="hate")
-        assert result == "hate"
-
-    def test_rapid_response_ignores_technique_name(self, mock_objective_scorer):
-        scenario = RapidResponse(
-            objective_scorer=mock_objective_scorer,
-        )
-        r1 = scenario._build_display_group(technique_name="prompt_sending", seed_group_name="hate")
-        r2 = scenario._build_display_group(technique_name="tap", seed_group_name="hate")
-        assert r1 == r2 == "hate"
-
-
-# ===========================================================================
 # Core techniques factory tests
 # ===========================================================================
 

--- a/tests/unit/scenario/core/test_matrix_atomic_attack_builder.py
+++ b/tests/unit/scenario/core/test_matrix_atomic_attack_builder.py
@@ -15,6 +15,7 @@ cross-product for scenarios whose attacks form such a grid. These tests pin the 
 * optional baseline emission from the flattened seed groups.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -26,7 +27,10 @@ from pyrit.scenario.core.matrix_atomic_attack_builder import (
     MatrixAtomicAttackBuilder,
     MatrixCombo,
     build_baseline_atomic_attack,
+    build_matrix_atomic_attacks,
+    resolve_technique_factories,
 )
+from pyrit.scenario.core.scenario_context import ScenarioContext
 from pyrit.score import TrueFalseScorer
 
 
@@ -322,3 +326,106 @@ class TestMatrixStrategyConverters:
             dataset_groups={"ds": [_seed_group(objective="o1")]},
         )
         assert factory.create.call_args.kwargs["extra_request_converters"] is None
+
+
+def _strategy(value: str) -> SimpleNamespace:
+    """A minimal strategy stand-in exposing the ``.value`` the resolver reads."""
+    return SimpleNamespace(value=value)
+
+
+def _context(*, strategies, seed_groups_by_dataset=None) -> ScenarioContext:
+    return ScenarioContext(
+        objective_target=MagicMock(spec=PromptTarget),
+        scenario_strategies=strategies,
+        dataset_config=MagicMock(),
+        memory_labels={"op": "unit"},
+        seed_groups_by_dataset=seed_groups_by_dataset or {},
+    )
+
+
+def _patch_registry(factories: dict):
+    registry = MagicMock()
+    registry.get_factories_or_raise.return_value = factories
+    return patch(
+        "pyrit.registry.components.attack_technique_registry.AttackTechniqueRegistry.get_registry_singleton",
+        return_value=registry,
+    )
+
+
+@pytest.mark.usefixtures("patch_central_database")
+class TestResolveTechniqueFactories:
+    """``resolve_technique_factories`` filters the registry to the selected strategies."""
+
+    def test_keeps_only_selected_in_order(self):
+        factories = {
+            "alpha": _mock_factory(name="alpha"),
+            "beta": _mock_factory(name="beta"),
+            "gamma": _mock_factory(name="gamma"),
+        }
+        context = _context(strategies=[_strategy("beta"), _strategy("alpha")])
+        with _patch_registry(factories):
+            resolved = resolve_technique_factories(context=context)
+        assert list(resolved.keys()) == ["beta", "alpha"]
+
+    def test_drops_strategies_without_factory(self):
+        factories = {"alpha": _mock_factory(name="alpha")}
+        context = _context(strategies=[_strategy("alpha"), _strategy("missing")])
+        with _patch_registry(factories):
+            resolved = resolve_technique_factories(context=context)
+        assert list(resolved.keys()) == ["alpha"]
+
+
+@pytest.mark.usefixtures("patch_central_database")
+class TestBuildMatrixAtomicAttacks:
+    """``build_matrix_atomic_attacks`` wires the context into the builder in one call."""
+
+    def test_builds_cross_product_grouped_by_technique(self):
+        context = _context(
+            strategies=[_strategy("tech")],
+            seed_groups_by_dataset={"ds": [_seed_group(objective="o1")]},
+        )
+        with _patch_registry({"tech": _mock_factory(name="tech")}):
+            result = build_matrix_atomic_attacks(context=context, objective_scorer=MagicMock(spec=TrueFalseScorer))
+        assert [a.atomic_attack_name for a in result] == ["tech_ds"]
+        assert result[0].display_group == "tech"
+
+    def test_custom_display_group_fn(self):
+        context = _context(
+            strategies=[_strategy("tech")],
+            seed_groups_by_dataset={"ds": [_seed_group(objective="o1")]},
+        )
+        with _patch_registry({"tech": _mock_factory(name="tech")}):
+            result = build_matrix_atomic_attacks(
+                context=context,
+                objective_scorer=MagicMock(spec=TrueFalseScorer),
+                display_group_fn=lambda combo: combo.dataset_name,
+            )
+        assert result[0].display_group == "ds"
+
+    def test_no_baseline_emitted(self):
+        context = _context(
+            strategies=[_strategy("tech")],
+            seed_groups_by_dataset={"ds": [_seed_group(objective="o1")]},
+        )
+        with _patch_registry({"tech": _mock_factory(name="tech")}):
+            result = build_matrix_atomic_attacks(context=context, objective_scorer=MagicMock(spec=TrueFalseScorer))
+        assert all(a.atomic_attack_name != "baseline" for a in result)
+
+    def test_strategy_converters_forwarded(self):
+        from pyrit.prompt_converter import PromptConverter
+
+        context = _context(
+            strategies=[_strategy("tech")],
+            seed_groups_by_dataset={"ds": [_seed_group(objective="o1")]},
+        )
+        factory = _mock_factory(name="tech")
+        converter = MagicMock(spec=PromptConverter)
+        with _patch_registry({"tech": factory}):
+            build_matrix_atomic_attacks(
+                context=context,
+                objective_scorer=MagicMock(spec=TrueFalseScorer),
+                strategy_converters={"tech": [converter]},
+            )
+        extra = factory.create.call_args.kwargs["extra_request_converters"]
+        assert extra is not None
+        assert len(extra) == 1


### PR DESCRIPTION
This is Phase C of the scenario simplification effort ([design gist](https://gist.github.com/rlundeen2/d2fa5f91eb411ba9b1d0bbf98412f700)): it migrates the two simple scenarios, `Cyber` and `RapidResponse`, off the inherited base-class default cross-product and onto composition. Both now override `_build_atomic_attacks_async` with a single call to a new shared helper, `build_matrix_atomic_attacks`, backed by `resolve_technique_factories` (which `AdversarialBenchmark` also reuses to drop its inline factory-resolution block). These free, opt-in helpers keep the base `Scenario` uncoupled from the matrix shape while avoiding per-scenario boilerplate, and unblock the base-default deletions planned for Phase D. Includes unit tests for both helpers and removes the now-obsolete `RapidResponse` display-group test.