### PR TITLE
DOC: Correct four citations in references.bib to published venues

### DIFF
--- a/doc/references.bib
+++ b/doc/references.bib
@@ -99,9 +99,12 @@
 @article{inie2025summon,
   title     = {Summon a Demon and Bind it: A Grounded Theory of {LLM} Red Teaming},
   author    = {Nanna Inie and Jonathan Stray and Leon Derczynski},
-  journal   = {PLoS ONE},
+  journal   = {PLOS ONE},
+  volume    = {20},
+  number    = {1},
+  pages     = {e0314658},
   year      = {2025},
-  url       = {https://arxiv.org/abs/2311.06237},
+  url       = {https://doi.org/10.1371/journal.pone.0314658},
 }
 
 @misc{vantaylor2024socialbias,
@@ -633,17 +636,19 @@
   url       = {https://arxiv.org/abs/2501.10057},
 }
 
-@article{zong2024vlguard,
+@inproceedings{zong2024vlguard,
   title     = {Safety Fine-Tuning at (Almost) No Cost: A Baseline for Vision Large Language Models},
   author    = {Yongshuo Zong and Ondrej Bohdal and Tingyang Yu and Yongxin Yang and Timothy Hospedales},
-  journal   = {arXiv preprint arXiv:2402.02207},
+  booktitle = {Proceedings of the 41st International Conference on Machine Learning (ICML)},
+  pages     = {62867--62891},
   year      = {2024},
-  url       = {https://arxiv.org/abs/2402.02207},
+  publisher = {PMLR},
+  url       = {https://proceedings.mlr.press/v235/zong24a.html},
 }
 
 @article{lopez2024pyrit,
   title     = {{PyRIT}: A Framework for Security Risk Identification and Red Teaming in Generative {AI} Systems},
-  author    = {Gary D. Lopez Munoz and Amanda J. Minnich and Roman Lutz and Richard Lundeen and Raja Sekhar Rao Dheekonda and Nina Chikanov and Bolor-Erdene Jagdagdorj and Martin Pouliot and Shiven Chawla and Whitney Maxwell and Blake Bullwinkel and Katherine Pratt and Joris de Gruyter and Charlotte Siska and Pete Bryan and Tori Westerhoff and Chang Kawaguchi and Christian Seifert and Ram Shankar Siva Kumar and Yonatan Zunger},
+  author    = {Gary D. {Lopez Munoz} and Amanda J. Minnich and Roman Lutz and Richard Lundeen and Raja Sekhar Rao Dheekonda and Nina Chikanov and Bolor-Erdene Jagdagdorj and Martin Pouliot and Shiven Chawla and Whitney Maxwell and Blake Bullwinkel and Katherine Pratt and Joris de Gruyter and Charlotte Siska and Pete Bryan and Tori Westerhoff and Chang Kawaguchi and Christian Seifert and Ram Shankar Siva Kumar and Yonatan Zunger},
   journal   = {arXiv preprint arXiv:2410.02828},
   year      = {2024},
   url       = {https://arxiv.org/abs/2410.02828},
@@ -667,12 +672,13 @@
   note      = {Introduces the {SIUO} (Safe Inputs but Unsafe Output) benchmark},
 }
 
-@misc{darkbench2025,
-  title     = {{DarkBench}: A Comprehensive Benchmark for Dark Design Patterns in Large Language Models},
-  author    = {{Apart Research}},
+@inproceedings{darkbench2025,
+  title     = {{DarkBench}: Benchmarking Dark Patterns in Large Language Models},
+  author    = {Esben Kran and Hieu Minh Nguyen and Akash Kundu and Sami Jawhar and Jinsuk Park and Mateusz Maria Jurewicz},
+  booktitle = {International Conference on Learning Representations (ICLR)},
   year      = {2025},
-  url       = {https://darkbench.ai/},
-  note      = {OpenReview: https://openreview.net/forum?id=odjMSBSWRt},
+  url       = {https://arxiv.org/abs/2503.10728},
+  note      = {Oral presentation at ICLR 2025},
 }
 
 @misc{embracethered2025sneakybits,


### PR DESCRIPTION
## Description

A colleague compared their paper's bibliography against `doc/references.bib` and flagged four entries where our versions were weaker or wrong. I verified each one against authoritative sources (arXiv API, CrossRef, PMLR proceedings, PLOS) and updated them to their published forms. Citation keys are unchanged, so all existing `{cite}` references in the docs still resolve.

The fixes:

- **`darkbench2025`** (most important, it was outright wrong): `@misc` -> `@inproceedings`. Corrected a fabricated title ("A Comprehensive Benchmark for Dark Design Patterns...") to the real one, "Benchmarking Dark Patterns in Large Language Models", replaced the placeholder author `{Apart Research}` with the six actual authors, and cited ICLR 2025 (Oral) + arXiv 2503.10728. Confirmed via the arXiv API, which lists the authors and the note "Accepted as an Oral paper at ICLR 2025".
- **`zong2024vlguard`**: `@article` -> `@inproceedings`. Now cites ICML 2024 (PMLR v235, pp. 62867-62891) instead of the arXiv preprint. This mirrors the precedent set in #2104 (arXiv -> proceedings for `mazeika2023tdc`).
- **`inie2025summon`**: Added `volume=20`, `number=1`, `pages=e0314658`, and the DOI URL; normalized `PLoS ONE` to `PLOS ONE`. Confirmed via CrossRef (published 2025-01-15).
- **`lopez2024pyrit`**: Braced the compound surname as `{Lopez Munoz}` so BibTeX does not parse it as just "Munoz". This is our own lead author.

## Notes for reviewers

Two judgment calls worth a look:

- **DarkBench author names**: I used the canonical published forms (`Hieu Minh Nguyen`, `Mateusz Maria Jurewicz`) rather than the shortened variants (`Jord Nguyen`, `Mateusz Jurewicz`) that appear in some citations. Easy to switch if you prefer the short forms.
- **OpenReview id**: The old entry carried `note = {OpenReview: ...odjMSBSWRt}`, but that id 404s. Rather than propagate a broken link, I dropped it in favor of `note = {Oral presentation at ICLR 2025}`. The real ICLR 2025 forum appears to be `Vz1uCY5aG4`, but I could not fully confirm it via API (OpenReview blocks automated access), so I left it out.

## Tests and Documentation

No code changes; this is a bibliography-only edit. Pre-commit hooks passed on commit. No JupyText run needed (no notebooks or `.py` doc files touched).