### PR TITLE
MAINT: Standardize garak Doctor default strategy to DEFAULT

### DIFF
--- a/pyrit/scenario/scenarios/garak/doctor.py
+++ b/pyrit/scenario/scenarios/garak/doctor.py
@@ -38,7 +38,9 @@ class DoctorStrategy(ScenarioStrategy):
     ALL = ("all", {"all"})
     DEFAULT = ("default", {"default"})
 
-    # Concrete strategies (values match the technique factory names)
+    # Concrete strategies (values match the technique factory names). Both are tagged
+    # "default", so DEFAULT and ALL coincide today; ALL exists so a future non-default
+    # technique would diverge from DEFAULT without another default-strategy change.
     PolicyPuppetry = ("policy_puppetry", {"default"})
     PolicyPuppetryLeet = ("policy_puppetry_leet", {"default"})
 
@@ -134,7 +136,7 @@ class Doctor(Scenario):
         super().__init__(
             version=self.VERSION,
             strategy_class=DoctorStrategy,
-            default_strategy=DoctorStrategy.ALL,
+            default_strategy=DoctorStrategy.DEFAULT,
             default_dataset_config=DatasetAttackConfiguration(dataset_names=["garak_doctor"]),
             objective_scorer=objective_scorer,
             scenario_result_id=scenario_result_id,

--- a/tests/unit/scenario/garak/test_doctor.py
+++ b/tests/unit/scenario/garak/test_doctor.py
@@ -83,6 +83,10 @@ class TestDoctorInitialization:
         config = Doctor(objective_scorer=mock_objective_scorer)._default_dataset_config
         assert config.dataset_names == ["garak_doctor"]
 
+    def test_default_strategy_is_default(self, mock_objective_scorer):
+        scenario = Doctor(objective_scorer=mock_objective_scorer)
+        assert scenario._default_strategy == DoctorStrategy.DEFAULT
+
 
 @pytest.mark.usefixtures("patch_central_database")
 class TestDoctorTechniqueFactories:
@@ -135,12 +139,26 @@ class TestDoctorTechniqueFactories:
 class TestDoctorStrategyExpansion:
     """Tests for Doctor strategy expansion and atomic attack generation."""
 
+    async def test_default_expands_to_concrete_strategies(
+        self, mock_objective_target, mock_objective_scorer, doctor_dataset_config
+    ):
+        """No explicit strategies -> DEFAULT -> both Policy Puppetry techniques."""
+        scenario = Doctor(objective_scorer=mock_objective_scorer)
+        await scenario.initialize_async(
+            objective_target=mock_objective_target,
+            dataset_config=doctor_dataset_config,
+        )
+
+        strategy_values = {s.value for s in scenario._scenario_strategies}
+        assert strategy_values == {"policy_puppetry", "policy_puppetry_leet"}
+
     async def test_all_expands_to_concrete_strategies(
         self, mock_objective_target, mock_objective_scorer, doctor_dataset_config
     ):
         scenario = Doctor(objective_scorer=mock_objective_scorer)
         await scenario.initialize_async(
             objective_target=mock_objective_target,
+            scenario_strategies=[DoctorStrategy.ALL],
             dataset_config=doctor_dataset_config,
         )
 


### PR DESCRIPTION
## Description
Part of standardizing our scenarios.

Flips the garak Doctor scenario's `default_strategy` from ALL to DEFAULT so it matches the convention used by the other standardized scenarios (e.g. WebInjection). DoctorStrategy already defines a DEFAULT aggregate and both concrete techniques (PolicyPuppetry, PolicyPuppetryLeet) are already tagged "default", so DEFAULT and ALL currently resolve to the same two techniques.

This is a behavior-preserving change: a no-strategy run executes the same techniques as before. Its value is consistency and future-proofing — if a non-default technique is added later, ALL and DEFAULT diverge correctly without another change to the default.

VERSION is intentionally left unchanged. The scenario's resume/identity eval-hash is derived from the resolved techniques (plus datasets, params, target, scorer), not from the default_strategy label, so resolving to the same techniques means the hash is unchanged and existing results still resume. Bumping the version would only cause spurious invalidation.



## Tests and Documentation

- Added a test asserting the default strategy is now DoctorStrategy.DEFAULT.
- Added a test that a no-strategy (default) run expands to both Policy Puppetry techniques.
- Made the existing ALL-expansion test pass `DoctorStrategy.ALL` explicitly (previously it relied on the default), so ALL and DEFAULT are both covered.
All doctor unit tests pass; ran ruff, ruff format, and ty clean.

Documentation: none needed — no user-facing docs reference the Doctor default strategy.
