### PR TITLE
FIX outdated default initializers in CoPyRIT

### DIFF
--- a/infra/DEPLOY_NEW_INSTANCE.md
+++ b/infra/DEPLOY_NEW_INSTANCE.md
@@ -24,7 +24,7 @@ within an instance. The trust boundary is Entra group membership.
 | `az login` with Graph permissions | The script creates Entra app registrations, which requires Graph API access. Run `az login --scope https://graph.microsoft.com//.default` |
 | Azure permissions | **Owner** (or Contributor + User Access Administrator) on the subscription, and **Application Administrator** in Entra ID for app registrations and Graph API operations |
 | Container image pushed to ACR | Build and push before deploying (see [Building the Image](#building-the-image)) |
-| A `.env` file with runtime config | Copy and fill in `infra/env.demo.template`. Contains target endpoints and content safety config. `AZURE_SQL_DB_CONNECTION_STRING` and `AZURE_STORAGE_ACCOUNT_DB_DATA_CONTAINER_URL` are auto-injected by the script — you can omit them. Required for the default `target, airt` initializer. Targets can also be created manually in the GUI if deploying with the `target` initializer only |
+| A `.env` file with runtime config | Copy and fill in `infra/env.demo.template`. Contains target endpoints and content safety config. `AZURE_SQL_DB_CONNECTION_STRING` and `AZURE_STORAGE_ACCOUNT_DB_DATA_CONTAINER_URL` are auto-injected by the script — you can omit them. Required for the default `target` initializer. Targets can also be created manually in the GUI if deploying with the `target` initializer only |
 
 ### What the script creates (per-instance)
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -419,7 +419,7 @@ needed in the container.
 
 | .pyrit_conf field | Bicep param | Env var | Notes |
 |-------------------|-------------|---------|-------|
-| `initializers` | `pyritInitializer` | `PYRIT_INITIALIZER` | Default `target, airt`: `target` populates the TargetRegistry (read by the GUI); `airt` loads converter, scorer, and adversarial defaults |
+| `initializers` | `pyritInitializer` | `PYRIT_INITIALIZER` | Default `target`: `target` populates the TargetRegistry (read by the GUI);|
 | `operator` | — | Set per-user in the GUI | |
 | `operation` | — | Set per-user in the GUI | |
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -68,8 +68,8 @@ param sqlDatabaseName string
 // Note: operator and operation are per-user settings configured in the GUI,
 // not deployment-level config.
 
-@description('PyRIT initializer to run. Default "target, airt" registers target configs + attack defaults.')
-param pyritInitializer string = 'target, airt'
+@description('PyRIT initializer to run. Default "target" registers target configs.')
+param pyritInitializer string = 'target'
 
 @description('Key Vault secret name containing the .env file contents (all endpoints, models, and API keys). The secret is mounted as an env var and PyRIT parses it at startup.')
 param envSecretName string = 'env-global'

--- a/infra/parameters.demo.json
+++ b/infra/parameters.demo.json
@@ -29,7 +29,7 @@
       "value": "REPLACE_SQL_DATABASE"
     },
     "pyritInitializer": {
-      "value": "target, airt"
+      "value": "target"
     },
     "envFileContents": {
       "value": "PYRIT_REPLACE_ME=set-via-secure-channel"

--- a/infra/parameters.example.json
+++ b/infra/parameters.example.json
@@ -27,7 +27,7 @@
       "value": "YOUR_DATABASE_NAME"
     },
     "pyritInitializer": {
-      "value": "target, airt"
+      "value": "target"
     },
     "envSecretName": {
       "value": "env-global"


### PR DESCRIPTION
#2100 removed some initializers but did not update the initializer configurations of copyrit which is referencing some of the removed ones, resulting in errors like this on startup:

```
ERROR: Application startup failed. Exiting.
ValueError: Initializer 'airt' not found in registry.
Available initializers: load_default_datasets, preload_scenario_metadata, scorer, target, technique
```
