### PR TITLE
FIX: Fixing Myst ToC

### DIFF
--- a/doc/myst.yml
+++ b/doc/myst.yml
@@ -193,7 +193,6 @@ project:
         - file: api/pyrit_executor_core.md
         - file: api/pyrit_executor_promptgen.md
         - file: api/pyrit_executor_workflow.md
-        - file: api/pyrit_identifiers.md
         - file: api/pyrit_memory.md
         - file: api/pyrit_message_normalizer.md
         - file: api/pyrit_models.md


### PR DESCRIPTION
## Description

Fixes a general documentation-validation failure in CI:

```
[myst.yml] File referenced in myst.yml TOC not found: 'api/pyrit_identifiers.md'
```

### Root cause
PR #2111 removed the top-level `pyrit/identifiers/` deprecation-shim module. Those identifier types now live under `pyrit/models/identifiers/` and are documented as part of `pyrit_models.md`. As a result the API generator (`build_scripts/gen_api_md.py`) no longer emits `doc/api/pyrit_identifiers.md`, but `doc/myst.yml` still referenced it in the API Reference TOC, so `build_scripts/validate_docs.py` failed.

### Fix
Remove the stale `api/pyrit_identifiers.md` entry from `doc/myst.yml`.

### Verification
- `python build_scripts/validate_docs.py` → all validations pass (156 file references OK, no orphaned files).
- `pre-commit` (incl. Validate Documentation Structure) passes on the change.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>