### PR TITLE
FIX: Fix possible SSRF bypass in `_is_azure_blob_url` host parsing

### DIFF
--- a/pyrit/backend/mappers/attack_mappers.py
+++ b/pyrit/backend/mappers/attack_mappers.py
@@ -67,8 +67,8 @@ def _is_azure_blob_url(value: str) -> bool:
     # Azure Blob Storage enforces HTTPS; rejecting HTTP also limits SSRF surface.
     if parsed.scheme != "https":
         return False
-    host = parsed.netloc.split(":")[0]  # strip port
-    return host.endswith(".blob.core.windows.net") and bool(host.split(".")[0])
+    host = parsed.hostname
+    return bool(host) and host.endswith(".blob.core.windows.net") and bool(host.split(".")[0])
 
 
 async def _get_sas_for_container_async(*, container_url: str) -> str:

--- a/tests/unit/backend/test_mappers.py
+++ b/tests/unit/backend/test_mappers.py
@@ -820,6 +820,11 @@ class TestIsAzureBlobUrl:
     def test_local_path_not_detected(self) -> None:
         assert _is_azure_blob_url("/tmp/test.png") is False
 
+    def test_userinfo_spoofed_host_not_detected(self) -> None:
+        # The real host is 127.0.0.1; the blob-looking segment is userinfo and must
+        # not be treated as the host (SSRF bypass regression test).
+        assert _is_azure_blob_url("https://a.blob.core.windows.net:80@127.0.0.1:6666") is False
+
 
 class TestSignBlobUrlAsync:
     """Tests for _sign_blob_url_async helper."""


### PR DESCRIPTION
## Description:
- `_is_azure_blob_url` derived the host by manually splitting `netloc` on `":"`, which mis-parses URLs that embed userinfo (`user@host`). A crafted URL such as `https://a.blob.core.windows.net:80@127.0.0.1:6666` was classified as an allowed Azure Blob URL even though the real host is `127.0.0.1`, letting the allowlist be bypassed and enabling an SSRF via `_sign_blob_url_async`. This replaces the hand-rolled parsing with `urlparse(...).hostname`.

## Changes
- **`pyrit/backend/mappers/attack_mappers.py`** — use `parsed.hostname` (RFC 3986-aware) instead of `parsed.netloc.split(":")[0]`, and add a `bool(host)` guard since `hostname` returns `None` for unparseable input. This is because `netloc.split(":")[0]` stops at the first colon and returns the `user` portion of `user@host`, so the blob-looking credential segment was treated as the host. `.hostname` returns the actual connection target, correctly failing the `.blob.core.windows.net` suffix check.

## Tests and Documentation
- **`tests/unit/backend/test_mappers.py`** — add a regression test asserting the userinfo-spoofed payload is rejected.
