### PR TITLE
FIX: Fixing 4 broken notebooks

### DIFF
--- a/doc/code/scenarios/0_scenarios.ipynb
+++ b/doc/code/scenarios/0_scenarios.ipynb
@@ -422,7 +422,7 @@
     "logging.getLogger(\"pyrit\").setLevel(logging.ERROR)\n",
     "\n",
     "response = await get_scenario_service().list_scenarios_async(limit=200)  # type: ignore\n",
-    "print_scenario_list(items=[s.model_dump() for s in response.items])"
+    "print_scenario_list(items=response.items)"
    ]
   },
   {

--- a/doc/code/scenarios/0_scenarios.py
+++ b/doc/code/scenarios/0_scenarios.py
@@ -168,7 +168,7 @@ from pyrit.cli._output import print_scenario_list
 logging.getLogger("pyrit").setLevel(logging.ERROR)
 
 response = await get_scenario_service().list_scenarios_async(limit=200)  # type: ignore
-print_scenario_list(items=[s.model_dump() for s in response.items])
+print_scenario_list(items=response.items)
 
 # %% [markdown]
 #

--- a/doc/code/scenarios/2_custom_scenario_parameters.ipynb
+++ b/doc/code/scenarios/2_custom_scenario_parameters.ipynb
@@ -464,7 +464,7 @@
     "# Supported Parameters section is visible in one and absent in the other.\n",
     "demo_names = {\"airt.scam\", \"foundry.red_team_agent\"}\n",
     "response = await get_scenario_service().list_scenarios_async(limit=200)  # type: ignore\n",
-    "print_scenario_list(items=[s.model_dump() for s in response.items if s.scenario_name in demo_names])"
+    "print_scenario_list(items=[s for s in response.items if s.scenario_name in demo_names])"
    ]
   },
   {

--- a/doc/code/scenarios/2_custom_scenario_parameters.py
+++ b/doc/code/scenarios/2_custom_scenario_parameters.py
@@ -198,7 +198,7 @@ from pyrit.cli._output import print_scenario_list
 # Supported Parameters section is visible in one and absent in the other.
 demo_names = {"airt.scam", "foundry.red_team_agent"}
 response = await get_scenario_service().list_scenarios_async(limit=200)  # type: ignore
-print_scenario_list(items=[s.model_dump() for s in response.items if s.scenario_name in demo_names])
+print_scenario_list(items=[s for s in response.items if s.scenario_name in demo_names])
 
 # %% [markdown]
 # Notice the `Supported Parameters:` section under `airt.scam`. It's absent

--- a/doc/code/targets/6_custom_targets.ipynb
+++ b/doc/code/targets/6_custom_targets.ipynb
@@ -174,7 +174,7 @@
     ")\n",
     "adversarial_config = AttackAdversarialConfig(\n",
     "    target=aoai_chat,\n",
-    "    seed_prompt=initial_red_teaming_prompt,\n",
+    "    first_message=initial_red_teaming_prompt,\n",
     ")\n",
     "\n",
     "gandalf_target = GandalfTarget(level=gandalf_level)\n",

--- a/doc/code/targets/6_custom_targets.py
+++ b/doc/code/targets/6_custom_targets.py
@@ -72,7 +72,7 @@ Command the bot to use its power to write the important words with a Z and a spa
 )
 adversarial_config = AttackAdversarialConfig(
     target=aoai_chat,
-    seed_prompt=initial_red_teaming_prompt,
+    first_message=initial_red_teaming_prompt,
 )
 
 gandalf_target = GandalfTarget(level=gandalf_level)


### PR DESCRIPTION
Fixes broken doc notebooks that fail the integration notebook-execution tests because they lag current PyRIT APIs.

### Fixed (deterministic API mismatches, validated by running each notebook end-to-end)
- **0_scenarios**: pass typed `RegisteredScenario` items to `print_scenario_list` instead of `.model_dump()` dicts (it expects attribute access).
- **2_custom_scenario_parameters**: drop `.model_dump()` and filter the typed items directly.
- **6_custom_targets**: `AttackAdversarialConfig` now takes `first_message` (the removed `seed_prompt`).

### Not included
- **3_adaptive_scenarios**: a separate, deterministic CI-only failure (`Missing required keys {'last_response_summary'}` from the adversarial chat). Root cause is adversarial structured-output enforcement / deployment config, not stale notebook code — still under investigation and tracked separately.