### PR TITLE
FIX: sanitize metadata file name in `azure_blob_storage_target`

### DIFF
--- a/pyrit/prompt_target/azure_blob_storage_target.py
+++ b/pyrit/prompt_target/azure_blob_storage_target.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 import logging
+import posixpath
 from enum import Enum
 from typing import ClassVar
 from urllib.parse import urlparse
@@ -251,7 +252,7 @@ class AzureBlobStorageTarget(PromptTarget):
         # default file name is <conversation_id>.txt, but can be overridden by prompt metadata
         file_name = f"{request.conversation_id}.txt"
         if request.prompt_metadata.get("file_name"):
-            file_name = str(request.prompt_metadata["file_name"])
+            file_name = self._sanitize_file_name(str(request.prompt_metadata["file_name"]))
 
         data = str.encode(request.converted_value)
         blob_url = self._container_url + "/" + file_name
@@ -263,3 +264,24 @@ class AzureBlobStorageTarget(PromptTarget):
         )
 
         return [response]
+
+    @staticmethod
+    def _sanitize_file_name(file_name: str) -> str:
+        """
+        Validate that *file_name* is a bare leaf name with no path components.
+
+        Guards against path traversal (e.g. ``../../other/x``) that would let a
+        caller-supplied ``file_name`` escape the configured container prefix.
+
+        Args:
+            file_name (str): The caller-supplied file name from prompt metadata.
+
+        Returns:
+            str: The validated file name, unchanged.
+
+        Raises:
+            ValueError: If *file_name* contains path separators or traversal segments.
+        """
+        if file_name != posixpath.basename(file_name) or file_name in (".", "..") or "\\" in file_name:
+            raise ValueError(f"Invalid file_name '{file_name}': must be a bare filename without path separators.")
+        return file_name

--- a/tests/unit/prompt_target/target/test_prompt_target_azure_blob_storage.py
+++ b/tests/unit/prompt_target/target/test_prompt_target_azure_blob_storage.py
@@ -240,3 +240,35 @@ async def test_upload_blob_async_raises_when_client_async_none(azure_blob_storag
                 await azure_blob_storage_target._upload_blob_async(
                     file_name="test.txt", data=b"hello", content_type="text/plain"
                 )
+
+
+@pytest.mark.parametrize(
+    "file_name",
+    ["../../admin/stolen.txt", "sub/dir/file.txt", "..", ".", "dir\\file.txt", "/abs.txt"],
+)
+def test_sanitize_file_name_rejects_path_traversal(file_name):
+    """Caller-supplied file_name with path components must be rejected (CWE-22 hardening)."""
+    with pytest.raises(ValueError, match="bare filename"):
+        AzureBlobStorageTarget._sanitize_file_name(file_name)
+
+
+def test_sanitize_file_name_allows_bare_name():
+    """A plain leaf file name passes through unchanged."""
+    assert AzureBlobStorageTarget._sanitize_file_name("results.txt") == "results.txt"
+
+
+async def test_send_prompt_async_rejects_traversal_file_name(
+    azure_blob_storage_target: AzureBlobStorageTarget,
+    sample_entries: MutableSequence[MessagePiece],
+):
+    """A traversal file_name in prompt metadata is refused before any upload."""
+    message_piece = sample_entries[0]
+    message_piece.converted_value = "Test content"
+    message_piece.prompt_metadata = {"file_name": "../../admin/stolen.txt"}
+    request = Message(message_pieces=[message_piece])
+
+    with patch.object(AzureBlobStorageTarget, "_upload_blob_async", new_callable=AsyncMock) as mock_upload:
+        with pytest.raises(ValueError, match="bare filename"):
+            await azure_blob_storage_target.send_prompt_async(message=request)
+
+    mock_upload.assert_not_called()


### PR DESCRIPTION
## Description
`AzureBlobStorageTarget` lets a prompt override the blob name via `prompt_metadata["file_name"]`, and that value was concatenated unsanitized into the blob path. A value like `../../team-b/results.txt` is canonicalized by Azure to escape the configured container prefix, allowing a write/overwrite outside the intended location. This validates `file_name` at the boundary and rejects anything that isn't a bare leaf name.

This is **defense-in-depth, not a live exploit** in PyRIT's current trust model: whoever sets `file_name` already holds the container credential, so no privilege boundary is crossed today. It matters for a shared multi-tenant deployment that relies on prefix-based isolation between teams; the fix hardens that boundary before it is depended upon.

## Changes
- **`pyrit/prompt_target/azure_blob_storage_target.py`**
  - Add `_sanitize_file_name()` — rejects path separators and traversal (`file_name != posixpath.basename(file_name)`, plus `.`/`..` and backslash checks) with a `ValueError`.
  - Apply it where `prompt_metadata["file_name"]` is read, so a bad name fails before any upload (write primitive is blocked at the source, not at each consumer of the resulting URL).

## Tests
- **`tests/unit/prompt_target/target/test_prompt_target_azure_blob_storage.py`**
  - Parametrized rejection test (`../../admin/stolen.txt`, `sub/dir/file.txt`, `..`, `.`, `dir\file.txt`, `/abs.txt`).
  - Pass-through test for a plain leaf name.
  - End-to-end test asserting a traversal `file_name` raises and `_upload_blob_async` is never called.