### PR TITLE
FIX: Tighten CLI backend health-check validation

### DIFF
--- a/pyrit/cli/api_client.py
+++ b/pyrit/cli/api_client.py
@@ -92,7 +92,10 @@ class PyRITApiClient:
         try:
             client = self._get_client()
             resp = await client.get("/api/health")
-            return resp.status_code == 200
+            if resp.status_code != 200:
+                return False
+            payload = resp.json()
+            return payload.get("status") == "healthy" and payload.get("service") == "pyrit-backend"
         except httpx.ConnectError:
             return False
         except Exception:

--- a/tests/unit/cli/test_api_client.py
+++ b/tests/unit/cli/test_api_client.py
@@ -168,9 +168,20 @@ def test_get_client_raises_when_not_opened():
 
 
 async def test_health_check_returns_true_on_200(client, mock_httpx_client):
-    mock_httpx_client.get.return_value = _make_response(status_code=200)
+    mock_httpx_client.get.return_value = _make_response(
+        status_code=200,
+        json_data={"status": "healthy", "service": "pyrit-backend"},
+    )
     assert await client.health_check_async() is True
     mock_httpx_client.get.assert_awaited_once_with("/api/health")
+
+
+async def test_health_check_returns_false_for_unrelated_service(client, mock_httpx_client):
+    mock_httpx_client.get.return_value = _make_response(
+        status_code=200,
+        json_data={"status": "ok", "service": "another-service"},
+    )
+    assert await client.health_check_async() is False
 
 
 async def test_health_check_returns_false_on_non_200(client, mock_httpx_client):


### PR DESCRIPTION
## Description

The CLI's backend readiness probe (`PyRITApiClient.health_check_async`) previously treated any HTTP 200 from `/api/health` as "backend ready." That check is too loose: an unrelated process listening on the same host/port can return 200 and be mistaken for a live PyRIT backend, so the CLI could happily proceed against the wrong server.

This tightens the probe to confirm the responder's identity, not just its status code. After verifying the response is 200, it parses the JSON payload and requires both `status == "healthy"` and `service == "pyrit-backend"` before reporting the backend as ready. A non-200 response, or a 200 from any other service (mismatched or missing fields), now correctly reports "not ready." Connection errors continue to be handled as before.

## Tests and Documentation

Tests: `tests/unit/cli/test_api_client.py`
- `test_health_check_returns_true_on_200` now returns the identifying payload (`status`/`service`) so the stricter check passes.
- New `test_health_check_returns_false_for_unrelated_service` asserts a 200 from a different service (`{"status": "ok", "service": "another-service"}`) is rejected.
- `test_health_check_returns_false_on_non_200` is unchanged.
- `uv run pytest tests/unit/cli/test_api_client.py -q` -> 30 passed.

Documentation: No doc or notebook changes; this is a client-side behavior fix covered by the unit tests above. I also ran `uv run jupytext --execute --to notebook doc/scanner/1_pyrit_scan.py` and saw no regression attributable to this change.