### PR TITLE
FIX: Make CLI/output encoding safe on Windows consoles

### DIFF
--- a/pyrit/cli/_output.py
+++ b/pyrit/cli/_output.py
@@ -345,6 +345,10 @@ def print_scenario_run_progress(*, run: ScenarioRunSummary, total_techniques: in
         bar_width = 30
         filled = int(bar_width * techniques_done / effective_total)
         bar = "█" * filled + "░" * (bar_width - filled)
+        try:
+            bar.encode(sys.stdout.encoding or "utf-8")
+        except (LookupError, UnicodeEncodeError):
+            bar = "#" * filled + "-" * (bar_width - filled)
         parts.append(f"[{bar}] techniques: {techniques_done}/{effective_total} ({pct}%)")
     else:
         parts.append(f"techniques: {techniques_done}")

--- a/pyrit/output/sink.py
+++ b/pyrit/output/sink.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 import asyncio
+import sys
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Literal
@@ -41,7 +42,12 @@ class StdoutSink(Sink):
         Args:
             data (str): The text to print.
         """
-        print(data, end="")
+        encoding = sys.stdout.encoding or "utf-8"
+        try:
+            data.encode(encoding)
+        except (LookupError, UnicodeEncodeError):
+            data = data.encode(encoding, errors="replace").decode(encoding)
+        sys.stdout.write(data)
 
 
 class FileSink(Sink):

--- a/tests/unit/cli/test_output.py
+++ b/tests/unit/cli/test_output.py
@@ -389,6 +389,24 @@ def test_print_scenario_run_progress_with_known_totals(capsys):
     assert "attacks" not in captured.out
 
 
+def test_print_scenario_run_progress_uses_ascii_for_limited_console():
+    run = _make_run(
+        status=ScenarioRunState.IN_PROGRESS,
+        total_attacks=10,
+        completed_attacks=5,
+        objective_achieved_rate=30,
+        techniques_used=["s1"],
+    )
+    stdout = MagicMock()
+    stdout.encoding = "cp1252"
+
+    with patch.object(_output.sys, "stdout", stdout):
+        _output.print_scenario_run_progress(run=run, total_techniques=2)
+
+    line = stdout.write.call_args.args[0]
+    assert "[###############---------------]" in line
+
+
 def test_print_scenario_run_progress_no_techniques(capsys):
     run = _make_run(
         status=ScenarioRunState.CREATED,

--- a/tests/unit/output/test_sink.py
+++ b/tests/unit/output/test_sink.py
@@ -31,6 +31,17 @@ async def test_stdout_sink_no_trailing_newline(capsys):
     assert captured.out == "line1line2"
 
 
+async def test_stdout_sink_replaces_unsupported_unicode():
+    stdout = MagicMock()
+    stdout.encoding = "cp1252"
+    sink = StdoutSink()
+
+    with patch("pyrit.output.sink.sys.stdout", stdout):
+        await sink.write_async("📊─")
+
+    stdout.write.assert_called_once_with("??")
+
+
 async def test_file_sink_writes_to_file():
     with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as f:
         path = Path(f.name)


### PR DESCRIPTION
## Description

Running the scanner CLI and output sinks on a limited Windows console (for example a cp1252 or plain ASCII code page) can crash with `UnicodeEncodeError` when non-ASCII text reaches stdout. Two spots are affected: the scenario run progress bar renders with Unicode block characters, and `StdoutSink` can be handed arbitrary Unicode from scenario output.

This change makes both paths degrade gracefully instead of crashing:

- `pyrit/cli/_output.py`: before emitting the progress bar, probe whether the Unicode bar encodes under the current `sys.stdout.encoding`. If it does not (`LookupError` or `UnicodeEncodeError`), fall back to an ASCII bar using `#` and `-`.
- `pyrit/output/sink.py`: `StdoutSink.write_async` now checks whether the data is representable in the console encoding and, if not, writes it back through `errors="replace"` so unencodable characters become a placeholder rather than raising. This also switches from `print` to `sys.stdout.write`.

Both fallbacks are no-ops on UTF-8 consoles, so normal output is unchanged.

## Tests and Documentation

Added focused unit tests:

- `test_print_scenario_run_progress_uses_ascii_for_limited_console` - with a cp1252 stdout, asserts the progress bar renders the ASCII `[###...---]` form.
- `test_stdout_sink_replaces_unsupported_unicode` - with a cp1252 stdout, asserts an emoji plus box-drawing dash is written as a replacement placeholder rather than raising.

Targeted unit runs pass: `tests/unit/cli/test_output.py` and `tests/unit/output/test_sink.py` (50 passed). The behavior was additionally verified end to end against a real cp1252 `errors="strict"` stdout wrapper, confirming the pre-patch `UnicodeEncodeError`, the ASCII progress-bar fallback, and the `errors="replace"` sink behavior, with plain ASCII output passing through untouched.

JupyText note: the related scanner notebooks (`doc/scanner/1_pyrit_scan.py`, `doc/scanner/benchmark.py`) were not executed as part of this validation because of a pre-existing local environment issue unrelated to this change (a stale `~/.pyrit/.pyrit_conf` referencing a removed `airt` initializer prevents the backend from starting, and an ipykernel/IPython combination is incompatible with the local Python 3.14 kernel). Neither is caused by this diff.