### PR TITLE
FIX: CLI display underlying model

### DIFF
--- a/pyrit/output/scenario_result/pretty.py
+++ b/pyrit/output/scenario_result/pretty.py
@@ -170,7 +170,11 @@ class PrettyScenarioResultPrinter(ScenarioResultPrinterBase):
         lines.append(self._format_colored(f"{self._indent}🎯 Target Information", Style.BRIGHT))
         target_id = result.objective_target_identifier
         target_type = target_id.class_name if target_id else "Unknown"
-        target_model = target_id.params.get("model_name", "Unknown") if target_id else "Unknown"
+        target_model = (
+            (target_id.params.get("underlying_model_name") or target_id.params.get("model_name") or "Unknown")
+            if target_id
+            else "Unknown"
+        )
         target_endpoint = target_id.params.get("endpoint", "Unknown") if target_id else "Unknown"
 
         lines.append(self._format_colored(f"{self._indent * 2}• Target Type: {target_type}", Fore.CYAN))

--- a/tests/unit/output/scenario_result/test_pretty.py
+++ b/tests/unit/output/scenario_result/test_pretty.py
@@ -96,6 +96,25 @@ async def test_write_async_with_unknown_target_when_no_params(printer, capsys):
     assert "Target Endpoint: Unknown" in out
 
 
+async def test_write_async_prefers_underlying_model_over_deployment_name(printer, capsys):
+    result = _scenario_result(
+        target_params={"model_name": "pyrit-github-gpt4", "underlying_model_name": "gpt-4o"},
+    )
+    await printer.write_async(result)
+    out = capsys.readouterr().out
+    assert "Target Model: gpt-4o" in out
+    assert "pyrit-github-gpt4" not in out
+
+
+async def test_write_async_falls_back_to_model_name_without_underlying_model(printer, capsys):
+    result = _scenario_result(
+        target_params={"model_name": "pyrit-github-gpt4"},
+    )
+    await printer.write_async(result)
+    out = capsys.readouterr().out
+    assert "Target Model: pyrit-github-gpt4" in out
+
+
 async def test_write_async_renders_scorer_section_when_scorer_identifier_present(printer, monkeypatch, capsys):
     # Stub the scorer printer's render_async so we don't depend on real evaluation data.
     async def fake_render_async(*, scorer_identifier, harm_category=None):


### PR DESCRIPTION
## Summary
The scenario pretty-printer (`pyrit/output/scenario_result/pretty.py`) displayed the target's `model_name` for the `Target Model` line, which for Azure OpenAI targets is the *deployment name* (e.g. `pyrit-github-gpt4`) rather than the actual model.

This makes it prefer `underlying_model_name` and fall back to `model_name`, matching the CLI target-list behavior in `pyrit/cli/_output.py` (`underlying_model_name or model_name`). Now a scenario report shows e.g. `Target Model: gpt-4o`.

## Changes
- `pretty.py`: prefer `underlying_model_name` with fallback to `model_name` for the displayed target model.
- `test_pretty.py`: added coverage for the underlying-model preference and the deployment-name fallback.

## Testing
- `pytest tests/unit/output/scenario_result/test_pretty.py` (15 passed)