### PR TITLE
MAINT: Bring GCG under Ruff and ty checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,8 +88,8 @@ repos:
         # dependencies (tqdm etc). The third-party ty-pre-commit hook installs
         # ty in an isolated env without project deps, which causes spurious
         # ``unresolved-import`` errors now that the rule is set to ``error``.
-        entry: uv run --link-mode=copy ty check
+        # Include optional modules in the environment, including GCG's torch imports.
+        entry: uv run --extra all --link-mode=copy ty check
         language: system
         files: ^pyrit/
-        exclude: ^pyrit/executor/promptgen/gcg/
         types: [python]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,7 +214,7 @@ replace-imports-with-any = [
 ]
 
 [tool.ty.src]
-exclude = ["doc/code/", "pyrit/executor/promptgen/gcg/"]
+exclude = ["doc/code/"]
 
 # Relax type checking for HuggingFace module
 [[tool.ty.overrides]]
@@ -428,8 +428,6 @@ notice-rgx = "Copyright \\(c\\) Microsoft Corporation\\.\\s*\\n.*Licensed under 
 "doc/**" = ["ANN", "CPY001", "TCH", "E402", "E501", "PGH003", "A", "ERA001", "LOG", "PLE1142"]
 # Backend API routes raise HTTPException handled by FastAPI, not true exceptions
 "pyrit/backend/**/*.py" = ["DOC501", "B008"]
-# Vendored GCG attack code — external project with its own style
-"pyrit/executor/promptgen/gcg/**/*.py" = ["A", "B905", "D", "DOC", "N", "PERF", "SIM101", "SIM108"]
 "pyrit/__init__.py" = ["D104"]
 # Allow broad pytest.raises(Exception) in tests
 "tests/**/*.py" = ["ANN", "B017"]

--- a/pyrit/executor/promptgen/gcg/__init__.py
+++ b/pyrit/executor/promptgen/gcg/__init__.py
@@ -1,14 +1,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-"""Public API for the Greedy Coordinate Gradient (GCG) adversarial-suffix generator.
+"""
+Public API for the Greedy Coordinate Gradient (GCG) adversarial-suffix generator.
 
 The primary entry point is ``GCG`` (alias for ``GCGGenerator``), a
 ``pyrit.executor.promptgen.core.PromptGeneratorStrategy`` that produces
 adversarial suffixes via the GCG algorithm.
 
 Example:
-
     from pyrit.executor.promptgen.gcg import (
         GCG,
         GCGAlgorithmConfig,

--- a/pyrit/executor/promptgen/gcg/attack/__init__.py
+++ b/pyrit/executor/promptgen/gcg/attack/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+"""Attack implementations used by the GCG prompt generator."""

--- a/pyrit/executor/promptgen/gcg/attack/base/__init__.py
+++ b/pyrit/executor/promptgen/gcg/attack/base/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+"""Shared attack-management primitives for GCG."""

--- a/pyrit/executor/promptgen/gcg/attack/base/attack_manager.py
+++ b/pyrit/executor/promptgen/gcg/attack/base/attack_manager.py
@@ -10,30 +10,33 @@ import math
 import random
 import time
 from copy import deepcopy
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pandas as pd
 import torch
 import torch.multiprocessing as mp
 import torch.nn as nn
-from transformers import (
-    AutoModelForCausalLM,
-    AutoTokenizer,
-    GPT2LMHeadModel,
-    GPTJForCausalLM,
-    GPTNeoXForCausalLM,
-    LlamaForCausalLM,
-    MistralForCausalLM,
-    MixtralForCausalLM,
-    Phi3ForCausalLM,
-)
+from transformers.models.auto.modeling_auto import AutoModelForCausalLM
+from transformers.models.auto.tokenization_auto import AutoTokenizer
+from transformers.models.gpt2.modeling_gpt2 import GPT2LMHeadModel
+from transformers.models.gpt_neox.modeling_gpt_neox import GPTNeoXForCausalLM
+from transformers.models.gptj.modeling_gptj import GPTJForCausalLM
+from transformers.models.llama.modeling_llama import LlamaForCausalLM
+from transformers.models.mistral.modeling_mistral import MistralForCausalLM
+from transformers.models.mixtral.modeling_mixtral import MixtralForCausalLM
+from transformers.models.phi3.modeling_phi3 import Phi3ForCausalLM
 
 from pyrit.executor.promptgen.gcg.experiments.log import (
     log_gpu_memory,
     log_loss,
     log_table_summary,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from transformers import PreTrainedModel, PreTrainedTokenizerBase
 
 logger = logging.getLogger(__name__)
 
@@ -50,18 +53,35 @@ _DEFAULT_TEST_PREFIXES: list[str] = [
 
 
 class NpEncoder(json.JSONEncoder):
-    def default(self, obj: Any) -> Any:
-        if isinstance(obj, np.integer):
-            return int(obj)
-        if isinstance(obj, np.floating):
-            return float(obj)
-        if isinstance(obj, np.ndarray):
-            return obj.tolist()
-        return json.JSONEncoder.default(self, obj)
+    """Encode NumPy scalar and array values for JSON output."""
+
+    def default(self, o: Any) -> Any:
+        """
+        Convert supported NumPy values to JSON-compatible Python values.
+
+        Returns:
+            Any: The converted value.
+        """
+        if isinstance(o, np.integer):
+            return int(o)
+        if isinstance(o, np.floating):
+            return float(o)
+        if isinstance(o, np.ndarray):
+            return o.tolist()
+        return json.JSONEncoder.default(self, o)
 
 
 def get_embedding_layer(model: Any) -> Any:
-    if isinstance(model, GPTJForCausalLM) or isinstance(model, GPT2LMHeadModel):
+    """
+    Return the token embedding layer for a supported causal language model.
+
+    Returns:
+        Any: The model's token embedding layer.
+
+    Raises:
+        ValueError: If the model architecture is unsupported.
+    """
+    if isinstance(model, (GPTJForCausalLM, GPT2LMHeadModel)):
         return model.transformer.wte
     if isinstance(model, LlamaForCausalLM):
         return model.model.embed_tokens
@@ -73,13 +93,22 @@ def get_embedding_layer(model: Any) -> Any:
 
 
 def get_embedding_matrix(model: Any) -> Any:
-    if isinstance(model, GPTJForCausalLM) or isinstance(model, GPT2LMHeadModel):
+    """
+    Return the token embedding matrix for a supported causal language model.
+
+    Returns:
+        Any: The model's token embedding matrix.
+
+    Raises:
+        ValueError: If the model architecture is unsupported.
+    """
+    if isinstance(model, (GPTJForCausalLM, GPT2LMHeadModel)):
         return model.transformer.wte.weight
     if isinstance(model, LlamaForCausalLM):
         return model.model.embed_tokens.weight
     if isinstance(model, GPTNeoXForCausalLM):
         return model.base_model.embed_in.weight  # type: ignore[union-attr, unused-ignore]
-    if isinstance(model, MixtralForCausalLM) or isinstance(model, MistralForCausalLM):
+    if isinstance(model, (MixtralForCausalLM, MistralForCausalLM)):
         return model.model.embed_tokens.weight
     if isinstance(model, Phi3ForCausalLM):
         return model.model.embed_tokens.weight
@@ -87,13 +116,22 @@ def get_embedding_matrix(model: Any) -> Any:
 
 
 def get_embeddings(model: Any, input_ids: torch.Tensor) -> Any:
-    if isinstance(model, GPTJForCausalLM) or isinstance(model, GPT2LMHeadModel):
+    """
+    Embed input token ids with a supported causal language model.
+
+    Returns:
+        Any: The embedded token tensor.
+
+    Raises:
+        ValueError: If the model architecture is unsupported.
+    """
+    if isinstance(model, (GPTJForCausalLM, GPT2LMHeadModel)):
         return model.transformer.wte(input_ids).half()
     if isinstance(model, LlamaForCausalLM):
         return model.model.embed_tokens(input_ids)
     if isinstance(model, GPTNeoXForCausalLM):
         return model.base_model.embed_in(input_ids).half()  # type: ignore[operator, unused-ignore]
-    if isinstance(model, MixtralForCausalLM) or isinstance(model, MistralForCausalLM):
+    if isinstance(model, (MixtralForCausalLM, MistralForCausalLM)):
         return model.model.embed_tokens(input_ids)
     if isinstance(model, Phi3ForCausalLM):
         return model.model.embed_tokens(input_ids)
@@ -101,13 +139,12 @@ def get_embeddings(model: Any, input_ids: torch.Tensor) -> Any:
 
 
 def get_nonascii_toks(tokenizer: Any, device: str = "cpu") -> torch.Tensor:
+    """Return tokenizer ids that are non-ASCII or represent special tokens."""
+
     def is_ascii(s: str) -> bool:
         return s.isascii() and s.isprintable()
 
-    ascii_toks = []
-    for i in range(3, tokenizer.vocab_size):
-        if not is_ascii(tokenizer.decode([i])):
-            ascii_toks.append(i)
+    ascii_toks = [i for i in range(3, tokenizer.vocab_size) if not is_ascii(tokenizer.decode([i]))]
 
     if tokenizer.bos_token_id is not None:
         ascii_toks.append(tokenizer.bos_token_id)
@@ -135,7 +172,7 @@ class AttackPrompt:
         test_prefixes: list[str] | None = None,
     ) -> None:
         """
-        Initializes the AttackPrompt object with the provided parameters.
+        Initialize the attack prompt with the provided parameters.
 
         Args:
             goal (str):
@@ -231,6 +268,12 @@ class AttackPrompt:
 
     @torch.no_grad()  # type: ignore[misc, untyped-decorator, unused-ignore]
     def generate(self, model: Any, gen_config: Any = None) -> torch.Tensor:
+        """
+        Generate a model continuation from the current attack prompt.
+
+        Returns:
+            torch.Tensor: Generated continuation token ids.
+        """
         if gen_config is None:
             gen_config = model.generation_config
             gen_config.max_new_tokens = 16
@@ -246,9 +289,21 @@ class AttackPrompt:
         return output_ids[self._assistant_role_slice.stop :]  # type: ignore[no-any-return, unused-ignore]
 
     def generate_str(self, model: Any, gen_config: Any = None) -> Any:
+        """
+        Generate and decode a model continuation.
+
+        Returns:
+            Any: The decoded continuation.
+        """
         return self.tokenizer.decode(self.generate(model, gen_config))
 
     def test(self, model: Any, gen_config: Any = None) -> tuple[bool, int]:
+        """
+        Test whether the current prompt jailbreaks and matches its target.
+
+        Returns:
+            tuple[bool, int]: Jailbreak and exact-match indicators.
+        """
         if gen_config is None:
             gen_config = model.generation_config
             gen_config.max_new_tokens = self.test_new_toks
@@ -260,14 +315,30 @@ class AttackPrompt:
 
     @torch.no_grad()  # type: ignore[misc, untyped-decorator, unused-ignore]
     def test_loss(self, model: Any) -> float:
+        """
+        Compute the mean target loss for the current prompt.
+
+        Returns:
+            float: Mean target loss.
+        """
         logits, ids = self.logits(model, return_ids=True)
         return self.target_loss(logits, ids).mean().item()  # type: ignore[no-any-return, unused-ignore]
 
     def grad(self, model: Any) -> torch.Tensor:
+        """Compute gradients for the current attack prompt."""
         raise NotImplementedError("Gradient function not yet implemented")
 
     @torch.no_grad()  # type: ignore[misc, untyped-decorator, unused-ignore]
     def logits(self, model: Any, test_controls: Any = None, return_ids: bool = False) -> Any:
+        """
+        Compute logits for one or more candidate controls.
+
+        Returns:
+            Any: Model logits, optionally paired with their token ids.
+
+        Raises:
+            ValueError: If candidate controls have an invalid type or shape.
+        """
         pad_tok = -1
         if test_controls is None:
             test_controls = self.control_toks
@@ -275,9 +346,13 @@ class AttackPrompt:
             if len(test_controls.shape) == 1:
                 test_controls = test_controls.unsqueeze(0)
             test_ids = test_controls.to(model.device)
-        elif not isinstance(test_controls, list):
-            test_controls = [test_controls]
-        elif isinstance(test_controls[0], str):
+        else:
+            if not isinstance(test_controls, list):
+                test_controls = [test_controls]
+            if not test_controls or not isinstance(test_controls[0], str):
+                raise ValueError(
+                    f"test_controls must be a list of strings or a tensor of token ids, got {type(test_controls)}"
+                )
             max_len = self._control_slice.stop - self._control_slice.start
             test_ids = [
                 torch.tensor(self.tokenizer(control, add_special_tokens=False).input_ids[:max_len], device=model.device)
@@ -288,10 +363,6 @@ class AttackPrompt:
                 pad_tok += 1
             nested_ids = torch.nested.nested_tensor(test_ids)
             test_ids = torch.nested.to_padded_tensor(nested_ids, pad_tok, (len(test_ids), max_len))
-        else:
-            raise ValueError(
-                f"test_controls must be a list of strings or a tensor of token ids, got {type(test_controls)}"
-            )
 
         if not (test_ids[0].shape[0] == self._control_slice.stop - self._control_slice.start):
             raise ValueError(
@@ -308,10 +379,7 @@ class AttackPrompt:
         ids = torch.scatter(
             self.input_ids.unsqueeze(0).repeat(test_ids.shape[0], 1).to(model.device), 1, locs, test_ids
         )
-        if pad_tok >= 0:
-            attn_mask = (ids != pad_tok).type(ids.dtype)
-        else:
-            attn_mask = None
+        attn_mask = (ids != pad_tok).type(ids.dtype) if pad_tok >= 0 else None
 
         if return_ids:
             del locs, test_ids
@@ -324,12 +392,24 @@ class AttackPrompt:
         return logits
 
     def target_loss(self, logits: torch.Tensor, ids: torch.Tensor) -> torch.Tensor:
+        """
+        Compute unreduced cross-entropy loss over target tokens.
+
+        Returns:
+            torch.Tensor: Per-token target losses.
+        """
         crit = nn.CrossEntropyLoss(reduction="none")
         loss_slice = slice(self._target_slice.start - 1, self._target_slice.stop - 1)
         result: torch.Tensor = crit(logits[:, loss_slice, :].transpose(1, 2), ids[:, self._target_slice])
         return result
 
     def control_loss(self, logits: torch.Tensor, ids: torch.Tensor) -> torch.Tensor:
+        """
+        Compute unreduced cross-entropy loss over control tokens.
+
+        Returns:
+            torch.Tensor: Per-token control losses.
+        """
         crit = nn.CrossEntropyLoss(reduction="none")
         loss_slice = slice(self._control_slice.start - 1, self._control_slice.stop - 1)
         result: torch.Tensor = crit(logits[:, loss_slice, :].transpose(1, 2), ids[:, self._control_slice])
@@ -337,14 +417,17 @@ class AttackPrompt:
 
     @property
     def assistant_str(self) -> Any:
+        """The decoded assistant-role prefix."""
         return self.tokenizer.decode(self.input_ids[self._assistant_role_slice]).strip()
 
     @property
     def assistant_toks(self) -> torch.Tensor:
+        """The assistant-role token ids."""
         return self.input_ids[self._assistant_role_slice]
 
     @property
     def goal_str(self) -> Any:
+        """The decoded attack goal."""
         return self.tokenizer.decode(self.input_ids[self._goal_slice]).strip()
 
     @goal_str.setter
@@ -354,10 +437,12 @@ class AttackPrompt:
 
     @property
     def goal_toks(self) -> torch.Tensor:
+        """The attack goal token ids."""
         return self.input_ids[self._goal_slice]
 
     @property
     def target_str(self) -> Any:
+        """The decoded target response prefix."""
         return self.tokenizer.decode(self.input_ids[self._target_slice]).strip()
 
     @target_str.setter
@@ -367,10 +452,12 @@ class AttackPrompt:
 
     @property
     def target_toks(self) -> torch.Tensor:
+        """The target response token ids."""
         return self.input_ids[self._target_slice]
 
     @property
     def control_str(self) -> Any:
+        """The decoded adversarial control suffix."""
         return self.tokenizer.decode(self.input_ids[self._control_slice]).strip()
 
     @control_str.setter
@@ -380,6 +467,7 @@ class AttackPrompt:
 
     @property
     def control_toks(self) -> torch.Tensor:
+        """The adversarial control token ids."""
         return self.input_ids[self._control_slice]
 
     @control_toks.setter
@@ -389,18 +477,22 @@ class AttackPrompt:
 
     @property
     def prompt(self) -> Any:
+        """The decoded goal and control prompt."""
         return self.tokenizer.decode(self.input_ids[self._goal_slice.start : self._control_slice.stop])
 
     @property
     def input_toks(self) -> torch.Tensor:
+        """All input token ids."""
         return self.input_ids
 
     @property
     def input_str(self) -> Any:
+        """The decoded model input."""
         return self.tokenizer.decode(self.input_ids)
 
     @property
     def eval_str(self) -> str:
+        """The decoded input used for evaluation."""
         return (  # type: ignore[no-any-return, unused-ignore]
             self.tokenizer.decode(self.input_ids[: self._assistant_role_slice.stop])
             .replace("<s>", "")
@@ -421,7 +513,7 @@ class PromptManager:
         managers: dict[str, type[AttackPrompt]] | None = None,
     ) -> None:
         """
-        Initializes the PromptManager object with the provided parameters.
+        Initialize the prompt manager with the provided parameters.
 
         Args:
             goals (list[str]):
@@ -436,9 +528,15 @@ class PromptManager:
                 A list of prefixes to test the attack (default is _DEFAULT_TEST_PREFIXES).
             managers (dict, optional):
                 A dictionary of manager objects, required to create the prompts.
+
+        Raises:
+            ValueError: If managers are missing, goals and targets differ in
+                length, or no goal-target pair is provided.
         """
         if test_prefixes is None:
             test_prefixes = list(_DEFAULT_TEST_PREFIXES)
+        if managers is None:
+            raise ValueError("PromptManager requires a managers mapping")
         if len(goals) != len(targets):
             raise ValueError("Length of goals and targets must match")
         if len(goals) == 0:
@@ -447,12 +545,19 @@ class PromptManager:
         self.tokenizer = tokenizer
 
         self._prompts = [
-            managers["AP"](goal, target, tokenizer, control_init, test_prefixes) for goal, target in zip(goals, targets)
+            managers["AP"](goal, target, tokenizer, control_init, test_prefixes)
+            for goal, target in zip(goals, targets, strict=True)
         ]
 
         self._nonascii_toks = get_nonascii_toks(tokenizer, device="cpu")
 
     def generate(self, model: Any, gen_config: Any = None) -> list[torch.Tensor]:
+        """
+        Generate continuations for all managed prompts.
+
+        Returns:
+            list[torch.Tensor]: Generated continuation token ids.
+        """
         if gen_config is None:
             gen_config = model.generation_config
             gen_config.max_new_tokens = 16
@@ -460,55 +565,107 @@ class PromptManager:
         return [prompt.generate(model, gen_config) for prompt in self._prompts]
 
     def generate_str(self, model: Any, gen_config: Any = None) -> list[str]:
+        """
+        Generate decoded continuations for all managed prompts.
+
+        Returns:
+            list[str]: Decoded continuations.
+        """
         return [self.tokenizer.decode(output_toks) for output_toks in self.generate(model, gen_config)]
 
     def test(self, model: Any, gen_config: Any = None) -> list[tuple[bool, int]]:
+        """
+        Test all managed prompts for jailbreak and target matching.
+
+        Returns:
+            list[tuple[bool, int]]: Jailbreak and exact-match indicators.
+        """
         return [prompt.test(model, gen_config) for prompt in self._prompts]
 
     def test_loss(self, model: Any) -> list[float]:
+        """
+        Compute target losses for all managed prompts.
+
+        Returns:
+            list[float]: Mean target losses.
+        """
         return [prompt.test_loss(model) for prompt in self._prompts]
 
     def grad(self, model: Any) -> torch.Tensor:
-        return sum(prompt.grad(model) for prompt in self._prompts)  # type: ignore[return-value, unused-ignore]
+        """
+        Sum gradients across all managed prompts.
+
+        Returns:
+            torch.Tensor: Aggregated prompt gradients.
+        """
+        return torch.stack([prompt.grad(model) for prompt in self._prompts]).sum(dim=0)
 
     def logits(self, model: Any, test_controls: Any = None, return_ids: bool = False) -> Any:
+        """
+        Compute logits for all managed prompts.
+
+        Returns:
+            Any: Prompt logits, optionally paired with token ids.
+        """
         vals = [prompt.logits(model, test_controls, return_ids) for prompt in self._prompts]
         if return_ids:
             return [val[0] for val in vals], [val[1] for val in vals]
         return vals
 
     def target_loss(self, logits: list[torch.Tensor], ids: list[torch.Tensor]) -> torch.Tensor:
+        """
+        Compute the mean target loss across all managed prompts.
+
+        Returns:
+            torch.Tensor: Mean target losses for each candidate.
+        """
         return torch.cat(
             [
-                prompt.target_loss(logit, id).mean(dim=1).unsqueeze(1)
-                for prompt, logit, id in zip(self._prompts, logits, ids)
+                prompt.target_loss(logit, token_ids).mean(dim=1).unsqueeze(1)
+                for prompt, logit, token_ids in zip(self._prompts, logits, ids, strict=True)
             ],
             dim=1,
         ).mean(dim=1)
 
     def control_loss(self, logits: list[torch.Tensor], ids: list[torch.Tensor]) -> torch.Tensor:
+        """
+        Compute the mean control loss across all managed prompts.
+
+        Returns:
+            torch.Tensor: Mean control losses for each candidate.
+        """
         return torch.cat(
             [
-                prompt.control_loss(logit, id).mean(dim=1).unsqueeze(1)
-                for prompt, logit, id in zip(self._prompts, logits, ids)
+                prompt.control_loss(logit, token_ids).mean(dim=1).unsqueeze(1)
+                for prompt, logit, token_ids in zip(self._prompts, logits, ids, strict=True)
             ],
             dim=1,
         ).mean(dim=1)
 
     def sample_control(self, *args: Any, **kwargs: Any) -> Any:
+        """Sample candidate controls for the current prompt state."""
         raise NotImplementedError("Sampling control tokens not yet implemented")
 
     def __len__(self) -> int:
+        """Return the number of managed prompts."""
         return len(self._prompts)
 
     def __getitem__(self, i: int) -> AttackPrompt:
+        """Return the prompt at the requested index."""
         return self._prompts[i]
 
-    def __iter__(self) -> Any:
+    def __iter__(self) -> Iterator[AttackPrompt]:
+        """
+        Iterate over managed prompts.
+
+        Returns:
+            Iterator[AttackPrompt]: An iterator over attack prompts.
+        """
         return iter(self._prompts)
 
     @property
     def control_toks(self) -> torch.Tensor:
+        """The shared control token ids."""
         return self._prompts[0].control_toks
 
     @control_toks.setter
@@ -518,6 +675,7 @@ class PromptManager:
 
     @property
     def control_str(self) -> str:
+        """The shared decoded control suffix."""
         return self._prompts[0].control_str  # type: ignore[no-any-return, unused-ignore]
 
     @control_str.setter
@@ -527,6 +685,7 @@ class PromptManager:
 
     @property
     def disallowed_toks(self) -> torch.Tensor:
+        """The token ids excluded from candidate controls."""
         return self._nonascii_toks
 
 
@@ -547,7 +706,7 @@ class MultiPromptAttack:
         test_workers: list[ModelWorker] | None = None,
     ) -> None:
         """
-        Initializes the MultiPromptAttack object with the provided parameters.
+        Initialize the multi-prompt attack with the provided parameters.
 
         Args:
             goals (list[str]):
@@ -570,6 +729,9 @@ class MultiPromptAttack:
                 The list of test targets of the attack
             test_workers (list of Worker objects, optional):
                 The list of test workers used in the attack
+
+        Raises:
+            ValueError: If the managers mapping is missing.
         """
         if test_prefixes is None:
             test_prefixes = list(_DEFAULT_TEST_PREFIXES)
@@ -579,6 +741,8 @@ class MultiPromptAttack:
             test_targets = []
         if test_workers is None:
             test_workers = []
+        if managers is None:
+            raise ValueError("MultiPromptAttack requires a managers mapping")
         self.goals = goals
         self.targets = targets
         self.workers = workers
@@ -596,6 +760,7 @@ class MultiPromptAttack:
 
     @property
     def control_str(self) -> Any:
+        """The shared decoded control suffix."""
         return self.prompts[0].control_str
 
     @control_str.setter
@@ -605,6 +770,7 @@ class MultiPromptAttack:
 
     @property
     def control_toks(self) -> list[torch.Tensor]:
+        """The control token ids for each tokenizer."""
         return [prompts.control_toks for prompts in self.prompts]
 
     @control_toks.setter
@@ -621,6 +787,12 @@ class MultiPromptAttack:
         filter_cand: bool = True,
         curr_control: str | None = None,
     ) -> list[str]:
+        """
+        Decode candidates and retain controls whose token length is stable.
+
+        Returns:
+            list[str]: Decoded candidate controls.
+        """
         cands, count = [], 0
         worker = self.workers[worker_index]
 
@@ -647,6 +819,7 @@ class MultiPromptAttack:
         return cands
 
     def step(self, *args: Any, **kwargs: Any) -> tuple[str, float]:
+        """Execute one attack optimization step."""
         raise NotImplementedError("Attack step function not yet implemented")
 
     def run(
@@ -667,9 +840,16 @@ class MultiPromptAttack:
         filter_cand: bool = True,
         verbose: bool = True,
     ) -> tuple[str, float, int]:
-        def P(e: float, e_prime: float, k: int) -> bool:
-            T = max(1 - float(k + 1) / (n_steps + anneal_from), 1.0e-7)
-            return True if e_prime < e else math.exp(-(e_prime - e) / T) >= random.random()
+        """
+        Run iterative optimization.
+
+        Returns:
+            tuple[str, float, int]: The final control, loss, and step count.
+        """
+
+        def acceptance_probability(e: float, e_prime: float, k: int) -> bool:
+            temperature = max(1 - float(k + 1) / (n_steps + anneal_from), 1.0e-7)
+            return e_prime < e or math.exp(-(e_prime - e) / temperature) >= random.random()
 
         if target_weight is None:
 
@@ -720,7 +900,7 @@ class MultiPromptAttack:
                 verbose=verbose,
             )
             runtime = time.time() - start
-            keep_control = True if not anneal else P(prev_loss, loss, i + anneal_from)
+            keep_control = True if not anneal else acceptance_probability(prev_loss, loss, i + anneal_from)
             if keep_control:
                 self.control_str = control
 
@@ -752,6 +932,13 @@ class MultiPromptAttack:
     def test(
         self, workers: list[ModelWorker], prompts: list[PromptManager], include_loss: bool = False
     ) -> tuple[list[list[bool]], list[list[int]], list[list[float]]]:
+        """
+        Test prompts across workers and optionally collect their losses.
+
+        Returns:
+            tuple[list[list[bool]], list[list[int]], list[list[float]]]:
+                Jailbreak, exact-match, and loss results.
+        """
         for j, worker in enumerate(workers):
             worker(prompts[j], "test", worker.model)
         model_tests = np.array([worker.results.get() for worker in workers])
@@ -766,6 +953,13 @@ class MultiPromptAttack:
         return model_tests_jb, model_tests_mb, model_tests_loss
 
     def test_all(self) -> tuple[list[list[bool]], list[list[int]], list[list[float]]]:
+        """
+        Test training and held-out prompts across all workers.
+
+        Returns:
+            tuple[list[list[bool]], list[list[int]], list[list[float]]]:
+                Jailbreak, exact-match, and loss results.
+        """
         all_workers = self.workers + self.test_workers
         all_prompts = [
             self.managers["PM"](
@@ -781,6 +975,12 @@ class MultiPromptAttack:
         return self.test(all_workers, all_prompts, include_loss=True)
 
     def parse_results(self, results: Any) -> tuple[Any, Any, Any, Any]:
+        """
+        Partition results by training and held-out models and goals.
+
+        Returns:
+            tuple[Any, Any, Any, Any]: The four aggregate result partitions.
+        """
         x = len(self.workers)
         i = len(self.goals)
         id_id = results[:x, :i].sum()
@@ -799,6 +999,12 @@ class MultiPromptAttack:
         model_tests: tuple[list[list[bool]], list[list[int]], list[list[float]]],
         verbose: bool = True,
     ) -> None:
+        """
+        Write one optimization step and its evaluations to the attack log.
+
+        Raises:
+            ValueError: If no logfile path is configured.
+        """
         prompt_tests_jb, prompt_tests_mb, model_tests_loss = list(map(np.array, model_tests))
         all_goal_strs = self.goals + self.test_goals
         all_workers = self.workers + self.test_workers
@@ -818,12 +1024,15 @@ class MultiPromptAttack:
         n_em = self.parse_results(prompt_tests_mb)
         n_loss = self.parse_results(model_tests_loss)
         total_tests = self.parse_results(np.ones(prompt_tests_jb.shape, dtype=int))
-        n_loss = [lo / t if t > 0 else 0 for lo, t in zip(n_loss, total_tests)]  # type: ignore[assignment, unused-ignore]
+        n_loss = [lo / total if total > 0 else 0 for lo, total in zip(n_loss, total_tests, strict=True)]
 
         tests["n_passed"] = n_passed
         tests["n_em"] = n_em
         tests["n_loss"] = n_loss
         tests["total"] = total_tests
+
+        if self.logfile is None:
+            raise ValueError("Cannot log an attack without a logfile path")
 
         with open(self.logfile) as f:
             log = json.load(f)
@@ -882,7 +1091,7 @@ class ProgressiveMultiPromptAttack:
         **kwargs: Any,
     ) -> None:
         """
-        Initializes the ProgressiveMultiPromptAttack object with the provided parameters.
+        Initialize the progressive multi-prompt attack.
 
         Args:
             goals (list[str]):
@@ -909,6 +1118,11 @@ class ProgressiveMultiPromptAttack:
                 The list of test targets of the attack
             test_workers (list[Worker], optional):
                 The list of test workers used in the attack
+            **kwargs (Any): Additional multi-prompt attack options prefixed
+                with ``mpa_``.
+
+        Raises:
+            ValueError: If the managers mapping is missing.
         """
         if test_prefixes is None:
             test_prefixes = list(_DEFAULT_TEST_PREFIXES)
@@ -918,6 +1132,8 @@ class ProgressiveMultiPromptAttack:
             test_targets = []
         if test_workers is None:
             test_workers = []
+        if managers is None:
+            raise ValueError("ProgressiveMultiPromptAttack requires a managers mapping")
         self.goals = goals
         self.targets = targets
         self.workers = workers
@@ -973,6 +1189,7 @@ class ProgressiveMultiPromptAttack:
 
     @staticmethod
     def filter_mpa_kwargs(**kwargs: Any) -> dict[str, Any]:
+        """Return options whose names use the ``mpa_`` prefix."""
         mpa_kwargs: dict[str, Any] = {}
         for key in kwargs:
             if key.startswith("mpa_"):
@@ -996,7 +1213,7 @@ class ProgressiveMultiPromptAttack:
         filter_cand: bool = True,
     ) -> tuple[str, int]:
         """
-        Executes the progressive multi prompt attack.
+        Execute the progressive multi-prompt attack.
 
         Args:
             n_steps (int, optional):
@@ -1009,10 +1226,10 @@ class ProgressiveMultiPromptAttack:
                 The temperature for sampling (default is 1)
             allow_non_ascii (bool, optional):
                 Whether to allow non-ASCII characters (default is False)
-            target_weight
-                The weight assigned to the target
-            control_weight
-                The weight assigned to the control
+            target_weight (float | None):
+                The weight assigned to the target.
+            control_weight (float | None):
+                The weight assigned to the control.
             anneal (bool, optional):
                 Whether to anneal the temperature (default is True)
             test_steps (int, optional):
@@ -1025,6 +1242,9 @@ class ProgressiveMultiPromptAttack:
                 Whether to print verbose output (default is True)
             filter_cand (bool, optional):
                 Whether to filter candidates whose lengths changed after re-tokenization (default is True)
+
+        Returns:
+            tuple[str, int]: The final control suffix and completed step count.
         """
         if self.logfile is not None:
             with open(self.logfile) as f:
@@ -1128,7 +1348,7 @@ class IndividualPromptAttack:
         **kwargs: Any,
     ) -> None:
         """
-        Initializes the IndividualPromptAttack object with the provided parameters.
+        Initialize the individual-prompt attack.
 
         Args:
             goals (list):
@@ -1151,6 +1371,11 @@ class IndividualPromptAttack:
                 The list of test targets of the attack
             test_workers (list, optional):
                 The list of test workers used in the attack
+            **kwargs (Any): Additional multi-prompt attack options prefixed
+                with ``mpa_``.
+
+        Raises:
+            ValueError: If the managers mapping is missing.
         """
         if test_prefixes is None:
             test_prefixes = list(_DEFAULT_TEST_PREFIXES)
@@ -1160,6 +1385,8 @@ class IndividualPromptAttack:
             test_targets = []
         if test_workers is None:
             test_workers = []
+        if managers is None:
+            raise ValueError("IndividualPromptAttack requires a managers mapping")
         self.goals = goals
         self.targets = targets
         self.workers = workers
@@ -1212,6 +1439,7 @@ class IndividualPromptAttack:
 
     @staticmethod
     def filter_mpa_kwargs(**kwargs: Any) -> dict[str, Any]:
+        """Return options whose names use the ``mpa_`` prefix."""
         mpa_kwargs: dict[str, Any] = {}
         for key in kwargs:
             if key.startswith("mpa_"):
@@ -1235,7 +1463,7 @@ class IndividualPromptAttack:
         filter_cand: bool = True,
     ) -> tuple[str, int]:
         """
-        Executes the individual prompt attack.
+        Execute the individual-prompt attack.
 
         Args:
             n_steps (int, optional):
@@ -1264,6 +1492,9 @@ class IndividualPromptAttack:
                 Whether to print verbose output (default is True)
             filter_cand (bool, optional):
                 Whether to filter candidates (default is True)
+
+        Returns:
+            tuple[str, int]: The final control suffix and configured step count.
         """
         if self.logfile is not None:
             with open(self.logfile) as f:
@@ -1340,7 +1571,7 @@ class EvaluateAttack:
         **kwargs: Any,
     ) -> None:
         """
-        Initializes the EvaluateAttack object with the provided parameters.
+        Initialize attack evaluation from generated result controls.
 
         Args:
             goals (list):
@@ -1363,6 +1594,11 @@ class EvaluateAttack:
                 The list of test targets of the attack
             test_workers (list, optional):
                 The list of test workers used in the attack
+            **kwargs (Any): Additional multi-prompt attack options prefixed
+                with ``mpa_``.
+
+        Raises:
+            ValueError: If managers are missing or the worker count is not one.
         """
         if test_prefixes is None:
             test_prefixes = list(_DEFAULT_TEST_PREFIXES)
@@ -1372,6 +1608,8 @@ class EvaluateAttack:
             test_targets = []
         if test_workers is None:
             test_workers = []
+        if managers is None:
+            raise ValueError("EvaluateAttack requires a managers mapping")
         self.goals = goals
         self.targets = targets
         self.workers = workers
@@ -1426,6 +1664,7 @@ class EvaluateAttack:
 
     @staticmethod
     def filter_mpa_kwargs(**kwargs: Any) -> dict[str, Any]:
+        """Return options whose names use the ``mpa_`` prefix."""
         mpa_kwargs: dict[str, Any] = {}
         for key in kwargs:
             if key.startswith("mpa_"):
@@ -1443,6 +1682,14 @@ class EvaluateAttack:
     ) -> tuple[
         list[list[bool]], list[list[bool]], list[list[bool]], list[list[bool]], list[list[str]], list[list[str]]
     ]:
+        """
+        Evaluate saved controls against training and held-out goals.
+
+        Returns:
+            tuple[list[list[bool]], list[list[bool]], list[list[bool]],
+            list[list[bool]], list[list[str]], list[list[str]]]: Training and
+                held-out jailbreak, exact-match, and generated-text results.
+        """
         model, tokenizer = self.workers[0].model, self.workers[0].tokenizer
         tokenizer.padding_side = "left"
 
@@ -1457,10 +1704,14 @@ class EvaluateAttack:
 
         total_jb, total_em, total_outputs = [], [], []
         test_total_jb, test_total_em, test_total_outputs = [], [], []
+        curr_jb: list[bool] = []
+        curr_em: list[bool] = []
+        all_outputs: list[str] = []
         prev_control = "haha"
         for step, control in enumerate(controls):
             for mode, goals, targets in zip(
-                *[("Train", "Test"), (self.goals, self.test_goals), (self.targets, self.test_targets)]
+                *[("Train", "Test"), (self.goals, self.test_goals), (self.targets, self.test_targets)],
+                strict=True,
             ):
                 if control != prev_control and len(goals) > 0:
                     attack = self.managers["MPA"](
@@ -1503,7 +1754,7 @@ class EvaluateAttack:
                         torch.cuda.empty_cache()
 
                     curr_jb, curr_em = [], []
-                    for gen_str, target in zip(all_outputs, targets):
+                    for gen_str, target in zip(all_outputs, targets, strict=True):
                         jailbroken = not any(prefix in gen_str for prefix in self.test_prefixes)
                         em = target in gen_str
                         curr_jb.append(jailbroken)
@@ -1531,6 +1782,8 @@ class EvaluateAttack:
 
 
 class ModelWorker:
+    """Run model operations in a dedicated multiprocessing worker."""
+
     def __init__(
         self,
         model_path: str,
@@ -1539,13 +1792,15 @@ class ModelWorker:
         tokenizer: Any,
         device: str,
     ) -> None:
-        self.model = (
+        """Load a model and prepare its worker queues."""
+        model = cast(
+            "PreTrainedModel",
             AutoModelForCausalLM.from_pretrained(
                 model_path, token=token, torch_dtype=torch.float16, trust_remote_code=False, **model_kwargs
-            )
-            .to(device)  # type: ignore[arg-type, unused-ignore]
-            .eval()
+            ),
         )
+        move_to_device = cast("Callable[[torch.device], PreTrainedModel]", model.to)
+        self.model = move_to_device(torch.device(device)).eval()
         self.tokenizer = tokenizer
         self.tasks: mp.JoinableQueue[Any] = mp.JoinableQueue()
         self.results: mp.JoinableQueue[Any] = mp.JoinableQueue()
@@ -1553,6 +1808,7 @@ class ModelWorker:
 
     @staticmethod
     def run(model: Any, tasks: mp.JoinableQueue[Any], results: mp.JoinableQueue[Any]) -> None:
+        """Process queued model operations until a stop sentinel arrives."""
         while True:
             task = tasks.get()
             if task is None:
@@ -1576,12 +1832,24 @@ class ModelWorker:
             tasks.task_done()
 
     def start(self) -> ModelWorker:
+        """
+        Start the model worker process.
+
+        Returns:
+            ModelWorker: This worker.
+        """
         self.process = mp.Process(target=ModelWorker.run, args=(self.model, self.tasks, self.results))
         self.process.start()
         logger.info(f"Started worker {self.process.pid} for model {self.model.name_or_path}")
         return self
 
     def stop(self) -> ModelWorker:
+        """
+        Stop the model worker process and release cached CUDA memory.
+
+        Returns:
+            ModelWorker: This worker.
+        """
         self.tasks.put(None)
         if self.process is not None:
             self.process.join()
@@ -1589,15 +1857,33 @@ class ModelWorker:
         return self
 
     def __call__(self, ob: Any, fn: str, *args: Any, **kwargs: Any) -> ModelWorker:
+        """
+        Queue an operation for execution by this worker.
+
+        Returns:
+            ModelWorker: This worker.
+        """
         self.tasks.put((deepcopy(ob), fn, args, kwargs))
         return self
 
 
-def get_workers(params: Any, eval: bool = False) -> tuple[list[ModelWorker], list[ModelWorker]]:
+def get_workers(params: Any, evaluation: bool = False) -> tuple[list[ModelWorker], list[ModelWorker]]:
+    """
+    Load and optionally start training and held-out model workers.
+
+    Returns:
+        tuple[list[ModelWorker], list[ModelWorker]]: Training and held-out workers.
+
+    Raises:
+        ValueError: If a tokenizer does not define a chat template.
+    """
     tokenizers = []
     for i in range(len(params.tokenizer_paths)):
-        tokenizer = AutoTokenizer.from_pretrained(  # type: ignore[no-untyped-call, unused-ignore]
-            params.tokenizer_paths[i], token=params.token, trust_remote_code=False, **params.tokenizer_kwargs[i]
+        tokenizer = cast(
+            "PreTrainedTokenizerBase",
+            AutoTokenizer.from_pretrained(
+                params.tokenizer_paths[i], token=params.token, trust_remote_code=False, **params.tokenizer_kwargs[i]
+            ),
         )
         if "oasst-sft-6-llama-30b" in params.tokenizer_paths[i]:
             tokenizer.bos_token_id = 1
@@ -1638,7 +1924,7 @@ def get_workers(params: Any, eval: bool = False) -> tuple[list[ModelWorker], lis
         )
         for i in range(len(params.model_paths))
     ]
-    if not eval:
+    if not evaluation:
         for worker in workers:
             worker.start()
 
@@ -1650,6 +1936,16 @@ def get_workers(params: Any, eval: bool = False) -> tuple[list[ModelWorker], lis
 
 
 def get_goals_and_targets(params: Any) -> tuple[list[str], list[str], list[str], list[str]]:
+    """
+    Load training and held-out goals and targets from parameters or CSV files.
+
+    Returns:
+        tuple[list[str], list[str], list[str], list[str]]: Training goals,
+            training targets, held-out goals, and held-out targets.
+
+    Raises:
+        ValueError: If a goal list and its corresponding target list differ in length.
+    """
     train_goals = getattr(params, "goals", [])
     train_targets = getattr(params, "targets", [])
     test_goals = getattr(params, "test_goals", [])

--- a/pyrit/executor/promptgen/gcg/attack/gcg/__init__.py
+++ b/pyrit/executor/promptgen/gcg/attack/gcg/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+"""Greedy Coordinate Gradient attack implementation."""

--- a/pyrit/executor/promptgen/gcg/attack/gcg/gcg_attack.py
+++ b/pyrit/executor/promptgen/gcg/attack/gcg/gcg_attack.py
@@ -35,7 +35,7 @@ def token_gradients(
     loss_slice: slice,
 ) -> torch.Tensor:
     """
-    Computes gradients of the loss with respect to the coordinates.
+    Compute gradients of the loss with respect to the coordinates.
 
     Args:
         model (Any): The transformer model to be used.
@@ -46,6 +46,9 @@ def token_gradients(
 
     Returns:
         torch.Tensor: The gradients of each token in the input_slice with respect to the loss.
+
+    Raises:
+        RuntimeError: If backpropagation does not produce token gradients.
     """
     embed_weights = get_embedding_matrix(model)
     one_hot = torch.zeros(
@@ -69,6 +72,8 @@ def token_gradients(
 
     loss.backward()
 
+    if one_hot.grad is None:
+        raise RuntimeError("Model backward pass did not produce token gradients")
     return one_hot.grad.clone()
 
 
@@ -148,6 +153,7 @@ class GCGMultiPromptAttack(MultiPromptAttack):
         loss: LossFunction | None = None,
         candidate_filter: CandidateFilter | None = None,
     ) -> None:
+        """Initialize a GCG attack with optional algorithm extensions."""
         super().__init__(
             goals,
             targets,
@@ -180,7 +186,7 @@ class GCGMultiPromptAttack(MultiPromptAttack):
         candidate_filter = getattr(self, "_candidate_filter", None)
         if candidate_filter is not None:
             return candidate_filter
-        return LengthPreservingFilter(filter=filter_cand)
+        return LengthPreservingFilter(enabled=filter_cand)
 
     def _sample_control_candidates(
         self,
@@ -254,7 +260,14 @@ class GCGMultiPromptAttack(MultiPromptAttack):
 
         Returns:
             tuple[str, float]: The best control string and its normalized loss.
+
+        Raises:
+            RuntimeError: If workers produce no aggregate gradient.
+            ValueError: If no model worker is configured.
         """
+        if not self.workers:
+            raise ValueError("GCG optimization requires at least one worker")
+
         main_device = self.models[0].device
         control_cands = []
         loss_function = self._resolve_loss(target_weight=target_weight, control_weight=control_weight)
@@ -290,9 +303,13 @@ class GCGMultiPromptAttack(MultiPromptAttack):
             else:
                 grad += new_grad
 
+        if grad is None:
+            raise RuntimeError("GCG workers did not produce an aggregate gradient")
+
+        last_worker_index = len(self.workers) - 1
         with torch.no_grad():
             control_cand = self._sample_control_candidates(
-                worker_index=j,
+                worker_index=last_worker_index,
                 gradient=grad,
                 batch_size=batch_size,
                 topk=topk,
@@ -301,7 +318,7 @@ class GCGMultiPromptAttack(MultiPromptAttack):
             )
             control_cands.append(
                 self._filter_control_candidates(
-                    worker_index=j,
+                    worker_index=last_worker_index,
                     control_cand=control_cand,
                     filter_cand=filter_cand,
                 )
@@ -315,30 +332,27 @@ class GCGMultiPromptAttack(MultiPromptAttack):
             for j, cand in enumerate(control_cands):
                 # Looping through the prompts at this level is less elegant, but
                 # we can manage VRAM better this way
-                progress = (
-                    tqdm(range(len(self.prompts[0])), total=len(self.prompts[0]))
-                    if verbose
-                    else enumerate(self.prompts[0])
-                )
-                for i in progress:
+                progress = tqdm(range(len(self.prompts[0])), total=len(self.prompts[0])) if verbose else None
+                prompt_indices = progress if progress is not None else range(len(self.prompts[0]))
+                for i in prompt_indices:
                     for k, worker in enumerate(self.workers):
                         worker(self.prompts[k][i], "logits", worker.model, cand, return_ids=True)
-                    logits, ids = zip(*[worker.results.get() for worker in self.workers])
+                    logits, ids = zip(*[worker.results.get() for worker in self.workers], strict=True)
                     loss[j * batch_size : (j + 1) * batch_size] += sum(
                         loss_function.compute_loss(
                             logits=logit,
-                            token_ids=id,
+                            token_ids=token_ids,
                             target_slice=self.prompts[k][i]._target_slice,
                             control_slice=self.prompts[k][i]._control_slice,
                         ).to(main_device)
-                        for k, (logit, id) in enumerate(zip(logits, ids))
+                        for k, (logit, token_ids) in enumerate(zip(logits, ids, strict=True))
                     )
                     del logits, ids
                     gc.collect()
 
-                    if verbose:
-                        progress.set_description(  # type: ignore[union-attr]
-                            f"loss={loss[j * batch_size : (j + 1) * batch_size].min().item() / (i + 1):.4f}"  # type: ignore[operator]
+                    if progress is not None:
+                        progress.set_description(
+                            f"loss={loss[j * batch_size : (j + 1) * batch_size].min().item() / (i + 1):.4f}"
                         )
 
             min_idx = loss.argmin()

--- a/pyrit/executor/promptgen/gcg/config.py
+++ b/pyrit/executor/promptgen/gcg/config.py
@@ -1,7 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-"""Typed configuration objects for the Greedy Coordinate Gradient (GCG) attack.
+"""
+Typed configuration objects for the Greedy Coordinate Gradient (GCG) attack.
 
 A minimal call is::
 
@@ -45,7 +46,8 @@ def _default_tokenizer_kwargs() -> dict[str, Any]:
 
 @dataclass
 class GCGModelConfig:
-    """Identity and loading options for a single HuggingFace model used by GCG.
+    """
+    Identity and loading options for a single HuggingFace model used by GCG.
 
     Attributes:
         name (str): HuggingFace model identifier such as
@@ -67,13 +69,20 @@ class GCGModelConfig:
     tokenizer_kwargs: dict[str, Any] = field(default_factory=_default_tokenizer_kwargs)
 
     def __post_init__(self) -> None:
+        """
+        Validate the model identifier.
+
+        Raises:
+            ValueError: If the model identifier is empty.
+        """
         if not self.name:
             raise ValueError("GCGModelConfig.name must be a non-empty HuggingFace model identifier.")
 
 
 @dataclass
 class GCGDataConfig:
-    """Goal/target dataset configuration for the GCG attack.
+    """
+    Goal/target dataset configuration for the GCG attack.
 
     Used as a typed bundle for AML transport (a job ships its data config as
     a separate JSON file alongside the strategy ``GCGConfig``). Library
@@ -96,18 +105,37 @@ class GCGDataConfig:
     n_test_data: int = 0
 
     def __post_init__(self) -> None:
+        """
+        Validate requested dataset row counts.
+
+        Raises:
+            ValueError: If either requested row count is negative.
+        """
         if self.n_train_data < 0:
             raise ValueError(f"GCGDataConfig.n_train_data must be >= 0, got {self.n_train_data}.")
         if self.n_test_data < 0:
             raise ValueError(f"GCGDataConfig.n_test_data must be >= 0, got {self.n_test_data}.")
 
     def to_json(self) -> str:
-        """Serialize this config to a JSON string."""
+        """
+        Serialize this config to a JSON string.
+
+        Returns:
+            str: A pretty-printed JSON representation.
+        """
         return json.dumps(asdict(self), indent=2)
 
     @classmethod
     def from_json(cls, payload: str) -> GCGDataConfig:
-        """Deserialize a config previously produced by ``to_json``."""
+        """
+        Deserialize a config previously produced by ``to_json``.
+
+        Returns:
+            GCGDataConfig: The deserialized data configuration.
+
+        Raises:
+            ValueError: If the payload is not valid JSON.
+        """
         try:
             data = json.loads(payload)
         except json.JSONDecodeError as e:
@@ -116,7 +144,12 @@ class GCGDataConfig:
 
     @classmethod
     def from_json_file(cls, path: str | Path) -> GCGDataConfig:
-        """Load a config from a JSON file."""
+        """
+        Load a config from a JSON file.
+
+        Returns:
+            GCGDataConfig: The deserialized data configuration.
+        """
         with open(path) as f:
             return cls.from_json(f.read())
 
@@ -128,7 +161,8 @@ class GCGDataConfig:
 
 @dataclass
 class GCGAlgorithmConfig:
-    """Hyper-parameters of the GCG optimization loop.
+    """
+    Hyper-parameters of the GCG optimization loop.
 
     Attributes:
         n_steps (int): Number of optimization steps per goal. Defaults to 500.
@@ -186,6 +220,12 @@ class GCGAlgorithmConfig:
     suffix_init: SuffixInitializer | None = None
 
     def __post_init__(self) -> None:
+        """
+        Validate optimization hyperparameters and extension implementations.
+
+        Raises:
+            ValueError: If a hyperparameter or extension is invalid.
+        """
         if self.n_steps <= 0:
             raise ValueError(f"GCGAlgorithmConfig.n_steps must be > 0, got {self.n_steps}.")
         if self.test_steps <= 0:
@@ -231,7 +271,8 @@ class GCGAlgorithmConfig:
 
 @dataclass
 class GCGStrategyConfig:
-    """High-level strategy flags that pick which attack class is used.
+    """
+    High-level strategy flags that pick which attack class is used.
 
     Attributes:
         transfer (bool): If True, run a ``ProgressiveMultiPromptAttack`` (the
@@ -257,13 +298,20 @@ class GCGStrategyConfig:
     stop_on_success: bool = False
 
     def __post_init__(self) -> None:
+        """
+        Validate progressive strategy dependencies.
+
+        Raises:
+            ValueError: If progressive behavior is enabled without transfer.
+        """
         if not self.transfer and (self.progressive_goals or self.progressive_models):
             raise ValueError("GCGStrategyConfig.progressive_goals/progressive_models require transfer=True.")
 
 
 @dataclass
 class GCGOutputConfig:
-    """Where the run writes its log/result artefacts.
+    """
+    Where the run writes its log/result artefacts.
 
     Attributes:
         result_prefix (str): Prefix for the per-run JSON log file. The actual
@@ -282,7 +330,8 @@ class GCGOutputConfig:
 
 @dataclass
 class GCGConfig:
-    """Top-level strategy configuration for one GCG attack run.
+    """
+    Top-level strategy configuration for one GCG attack run.
 
     Bundles everything ``pyrit.executor.promptgen.gcg.GCGGenerator``'s
     constructor needs. Per-execution data (goals, targets) is **not** here —
@@ -314,11 +363,18 @@ class GCGConfig:
     hf_token: str | None = None
 
     def __post_init__(self) -> None:
+        """
+        Validate that at least one model is configured.
+
+        Raises:
+            ValueError: If no model is configured.
+        """
         if not self.models:
             raise ValueError("GCGConfig.models must contain at least one GCGModelConfig.")
 
     def to_json(self) -> str:
-        """Serialize this config to a JSON string.
+        """
+        Serialize this config to a JSON string.
 
         Used by the AzureML transport: the notebook builds a ``GCGConfig`` locally,
         serializes it into the AML job's inputs, and ``experiments/run.py``
@@ -331,7 +387,8 @@ class GCGConfig:
 
     @classmethod
     def from_json(cls, payload: str) -> GCGConfig:
-        """Deserialize a config previously produced by ``to_json``.
+        """
+        Deserialize a config previously produced by ``to_json``.
 
         Args:
             payload (str): JSON document matching the shape produced by
@@ -352,7 +409,8 @@ class GCGConfig:
 
     @classmethod
     def from_json_file(cls, path: str | Path) -> GCGConfig:
-        """Load a config from a JSON file produced by ``to_json_file``.
+        """
+        Load a config from a JSON file produced by ``to_json_file``.
 
         Args:
             path (str | Path): Filesystem path to a JSON config file.
@@ -364,7 +422,8 @@ class GCGConfig:
             return cls.from_json(f.read())
 
     def to_json_file(self, path: str | Path) -> None:
-        """Write this config to a JSON file.
+        """
+        Write this config to a JSON file.
 
         Args:
             path (str | Path): Filesystem path to write to.

--- a/pyrit/executor/promptgen/gcg/data.py
+++ b/pyrit/executor/promptgen/gcg/data.py
@@ -1,7 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-"""CSV → goals/targets loader for the GCG attack.
+"""
+CSV → goals/targets loader for the GCG attack.
 
 Decoupled from ``GCGGenerator`` so that callers with goals and targets
 already in memory can pass them straight into ``execute_async`` without going
@@ -24,7 +25,8 @@ if TYPE_CHECKING:
 def load_goals_and_targets(
     *, data: GCGDataConfig, random_seed: int = 42
 ) -> tuple[list[str], list[str], list[str], list[str]]:
-    """Load training and held-out goal/target lists from CSV(s).
+    """
+    Load training and held-out goal/target lists from CSV(s).
 
     Wraps the existing pandas-based ``get_goals_and_targets`` so the caller
     sees a typed signature instead of a free-form params object.

--- a/pyrit/executor/promptgen/gcg/default_implementations.py
+++ b/pyrit/executor/promptgen/gcg/default_implementations.py
@@ -1,7 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-"""Default concrete implementations of the four GCG extension protocols.
+"""
+Default concrete implementations of the four GCG extension protocols.
 
 Each class in this module reproduces the byte-identical behavior of the
 legacy GCG attack code path it replaces:
@@ -32,7 +33,8 @@ logger = logging.getLogger(__name__)
 
 
 class StandardGCGSampling:
-    """Top-k by ``-gradient``, uniform pick within top-k at one random position per row.
+    """
+    Top-k by ``-gradient``, uniform pick within top-k at one random position per row.
 
     The standard GCG sampling rule: for each of ``batch_size`` candidate
     rows, pick one of the ``control_length`` positions, then replace the
@@ -56,7 +58,8 @@ class StandardGCGSampling:
         allow_non_ascii: bool,
         non_ascii_tokens: torch.Tensor,
     ) -> torch.Tensor:
-        """Sample ``batch_size`` candidate suffix token sequences.
+        """
+        Sample ``batch_size`` candidate suffix token sequences.
 
         Args:
             gradient (torch.Tensor): Aggregated gradient over the control
@@ -102,7 +105,8 @@ class StandardGCGSampling:
 
 
 class CrossEntropyLoss:
-    """Weighted token-level cross-entropy on the target and control slices.
+    """
+    Weighted token-level cross-entropy on the target and control slices.
 
     Per candidate: ``target_weight * CE(target_slice) + control_weight *
     CE(control_slice)``, where each cross-entropy term is reduced over its
@@ -124,7 +128,8 @@ class CrossEntropyLoss:
     """
 
     def __init__(self, *, target_weight: float = 1.0, control_weight: float = 0.0) -> None:
-        """Initialize the cross-entropy loss with target / control weights.
+        """
+        Initialize the cross-entropy loss with target / control weights.
 
         Args:
             target_weight (float): Weight on the target-slice cross-entropy.
@@ -156,7 +161,8 @@ class CrossEntropyLoss:
         target_slice: slice,
         control_slice: slice,
     ) -> torch.Tensor:
-        """Compute the per-candidate weighted cross-entropy loss.
+        """
+        Compute the per-candidate weighted cross-entropy loss.
 
         Args:
             logits (torch.Tensor): Model logits for the candidate batch
@@ -171,6 +177,9 @@ class CrossEntropyLoss:
         Returns:
             torch.Tensor: Per-candidate scalar loss with shape
             ``(batch_size,)``.
+
+        Raises:
+            RuntimeError: If the instance has no enabled loss term.
         """
         criterion = nn.CrossEntropyLoss(reduction="none")
         total: torch.Tensor | None = None
@@ -203,7 +212,8 @@ class CrossEntropyLoss:
 
 
 class LengthPreservingFilter:
-    """Decodes each candidate token row and drops any whose decoded string
+    """
+    Decodes each candidate token row and drops any whose decoded string
     either (a) equals ``current_control`` or (b) re-tokenizes to a different
     token count, padding dropped rows by repeating the last accepted
     candidate.
@@ -220,17 +230,27 @@ class LengthPreservingFilter:
     ``pyrit/executor/promptgen/gcg/attack/base/attack_manager.py``.
     """
 
-    def __init__(self, *, filter: bool = True) -> None:
-        """Initialize the filter.
+    def __init__(self, *, enabled: bool = True, **legacy_options: bool) -> None:
+        """
+        Initialize the filter.
 
         Args:
-            filter (bool): When True, drop candidates that equal
+            enabled (bool): When True, drop candidates that equal
                 ``current_control`` or re-tokenize to a different length,
                 padding the result with the last accepted candidate. When
                 False, decode every row and return them all unchanged.
                 Defaults to True.
+            **legacy_options (bool): Supports the legacy ``filter`` keyword.
+
+        Raises:
+            TypeError: If an unknown option is provided.
         """
-        self._filter = filter
+        if "filter" in legacy_options:
+            enabled = legacy_options.pop("filter")
+        if legacy_options:
+            unexpected = next(iter(legacy_options))
+            raise TypeError(f"Unexpected LengthPreservingFilter option: {unexpected}")
+        self._filter = enabled
 
     def filter_candidates(
         self,
@@ -239,7 +259,8 @@ class LengthPreservingFilter:
         tokenizer: Any,
         current_control: str,
     ) -> list[str]:
-        """Decode and filter a batch of candidate suffix token tensors.
+        """
+        Decode and filter a batch of candidate suffix token tensors.
 
         Args:
             candidate_tokens (torch.Tensor): Sampled candidate suffixes
@@ -281,7 +302,8 @@ class LengthPreservingFilter:
 
 
 class LiteralStringInit:
-    """Returns the configured literal suffix verbatim; ignores the tokenizer.
+    """
+    Returns the configured literal suffix verbatim; ignores the tokenizer.
 
     Encapsulates the current ``control_init`` plumbing — a literal string
     threaded through ``AttackPrompt.__init__``, ``PromptManager.__init__``,
@@ -296,7 +318,8 @@ class LiteralStringInit:
     """
 
     def __init__(self, *, suffix: str) -> None:
-        """Initialize the literal-string suffix initializer.
+        """
+        Initialize the literal-string suffix initializer.
 
         Args:
             suffix (str): The literal suffix string to return on every
@@ -310,7 +333,8 @@ class LiteralStringInit:
         self._suffix = suffix
 
     def make_initial_suffix(self, *, tokenizer: Any) -> str:
-        """Return the configured suffix string.
+        """
+        Return the configured suffix string.
 
         Args:
             tokenizer (Any): Ignored. Present to match the protocol

--- a/pyrit/executor/promptgen/gcg/default_implementations.py
+++ b/pyrit/executor/promptgen/gcg/default_implementations.py
@@ -230,27 +230,31 @@ class LengthPreservingFilter:
     ``pyrit/executor/promptgen/gcg/attack/base/attack_manager.py``.
     """
 
-    def __init__(self, *, enabled: bool = True, **legacy_options: bool) -> None:
+    def __init__(self, *, enabled: bool | None = None, **legacy_options: bool) -> None:
         """
         Initialize the filter.
 
         Args:
-            enabled (bool): When True, drop candidates that equal
+            enabled (bool | None): When True, drop candidates that equal
                 ``current_control`` or re-tokenize to a different length,
                 padding the result with the last accepted candidate. When
                 False, decode every row and return them all unchanged.
-                Defaults to True.
+                Defaults to None, which enables filtering unless the legacy
+                ``filter`` option is supplied.
             **legacy_options (bool): Supports the legacy ``filter`` keyword.
 
         Raises:
-            TypeError: If an unknown option is provided.
+            TypeError: If both ``enabled`` and ``filter`` are provided or an
+                unknown option is provided.
         """
         if "filter" in legacy_options:
+            if enabled is not None:
+                raise TypeError("Specify either 'enabled' or 'filter', not both")
             enabled = legacy_options.pop("filter")
         if legacy_options:
             unexpected = next(iter(legacy_options))
             raise TypeError(f"Unexpected LengthPreservingFilter option: {unexpected}")
-        self._filter = enabled
+        self._filter = True if enabled is None else enabled
 
     def filter_candidates(
         self,

--- a/pyrit/executor/promptgen/gcg/experiments/__init__.py
+++ b/pyrit/executor/promptgen/gcg/experiments/__init__.py
@@ -1,2 +1,3 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+"""Experiment entry points and logging helpers for GCG."""

--- a/pyrit/executor/promptgen/gcg/experiments/run.py
+++ b/pyrit/executor/promptgen/gcg/experiments/run.py
@@ -1,7 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-"""Thin CLI wrapper around ``GCGGenerator.execute_async`` for AzureML jobs.
+"""
+Thin CLI wrapper around ``GCGGenerator.execute_async`` for AzureML jobs.
 
 The notebook (or any user) builds a ``GCGConfig`` (strategy) and a
 ``GCGDataConfig`` (data) locally, serializes both with their respective
@@ -71,7 +72,12 @@ def _parse_arguments() -> argparse.Namespace:
 
 
 def _resolve_output(*, output: GCGOutputConfig, output_dir: str | None) -> GCGOutputConfig:
-    """Combine ``output_dir`` with the basename of the config's existing result_prefix."""
+    """
+    Combine ``output_dir`` with the basename of the existing result prefix.
+
+    Returns:
+        GCGOutputConfig: The resolved output configuration.
+    """
     if output_dir is None:
         return output
     base = Path(output.result_prefix).name or "gcg_suffix"

--- a/pyrit/executor/promptgen/gcg/extension_protocols.py
+++ b/pyrit/executor/promptgen/gcg/extension_protocols.py
@@ -1,7 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-"""Typing-only extension points for the Greedy Coordinate Gradient (GCG) attack.
+"""
+Typing-only extension points for the Greedy Coordinate Gradient (GCG) attack.
 
 This module defines four ``runtime_checkable`` ``Protocol``s that mark the four
 algorithmic seams inside the GCG optimization loop where a future caller may
@@ -40,7 +41,8 @@ if TYPE_CHECKING:
 
 @runtime_checkable
 class SamplingStrategy(Protocol):
-    """Proposes a batch of candidate suffix token sequences from the gradient.
+    """
+    Proposes a batch of candidate suffix token sequences from the gradient.
 
     Invoked once per GCG optimization step, after the per-worker gradients have
     been aggregated. The implementation receives the aggregated gradient over
@@ -75,7 +77,8 @@ class SamplingStrategy(Protocol):
         allow_non_ascii: bool,
         non_ascii_tokens: torch.Tensor,
     ) -> torch.Tensor:
-        """Sample ``batch_size`` candidate suffix token sequences.
+        """
+        Sample ``batch_size`` candidate suffix token sequences.
 
         Args:
             gradient (torch.Tensor): Aggregated gradient over the control
@@ -109,7 +112,8 @@ class SamplingStrategy(Protocol):
 
 @runtime_checkable
 class LossFunction(Protocol):
-    """Scores a batch of candidate suffixes against the target completion.
+    """
+    Scores a batch of candidate suffixes against the target completion.
 
     Invoked once per worker per training prompt per candidate batch during the
     search pass. The implementation receives the model's logits for the
@@ -148,7 +152,8 @@ class LossFunction(Protocol):
         target_slice: slice,
         control_slice: slice,
     ) -> torch.Tensor:
-        """Compute the per-candidate loss for a candidate batch.
+        """
+        Compute the per-candidate loss for a candidate batch.
 
         Args:
             logits (torch.Tensor): Model logits for the candidate batch with
@@ -170,7 +175,8 @@ class LossFunction(Protocol):
 
 @runtime_checkable
 class CandidateFilter(Protocol):
-    """Decodes and prunes a batch of candidate suffix token tensors.
+    """
+    Decodes and prunes a batch of candidate suffix token tensors.
 
     Invoked once per worker per optimization step, immediately after sampling.
     The implementation receives the raw sampled token tensor and the worker's
@@ -205,7 +211,8 @@ class CandidateFilter(Protocol):
         tokenizer: Any,
         current_control: str,
     ) -> list[str]:
-        """Decode and filter a batch of candidate suffix token tensors.
+        """
+        Decode and filter a batch of candidate suffix token tensors.
 
         Args:
             candidate_tokens (torch.Tensor): Sampled candidate suffixes with
@@ -228,7 +235,8 @@ class CandidateFilter(Protocol):
 
 @runtime_checkable
 class SuffixInitializer(Protocol):
-    """Produces the initial suffix string fed into the optimization loop.
+    """
+    Produces the initial suffix string fed into the optimization loop.
 
     Invoked once at attack-setup time. The returned string is threaded through
     the existing ``control_init`` parameter of ``AttackPrompt`` /
@@ -259,7 +267,8 @@ class SuffixInitializer(Protocol):
     """
 
     def make_initial_suffix(self, *, tokenizer: Any) -> str:
-        """Return the initial suffix string for the optimization loop.
+        """
+        Return the initial suffix string for the optimization loop.
 
         Args:
             tokenizer (Any): A HuggingFace-style tokenizer the implementation

--- a/pyrit/executor/promptgen/gcg/generator.py
+++ b/pyrit/executor/promptgen/gcg/generator.py
@@ -1,7 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-"""GCGGenerator — typed PromptGeneratorStrategy implementation of the
+"""
+GCGGenerator — typed PromptGeneratorStrategy implementation of the
 Greedy Coordinate Gradient adversarial-suffix attack.
 
 Follows the same lifecycle/identity pattern as ``FuzzerGenerator`` and
@@ -19,7 +20,6 @@ Follows the same lifecycle/identity pattern as ``FuzzerGenerator`` and
   results can be traced back to the exact configuration that produced them.
 
 Example:
-
     generator = GCGGenerator(
         models=[GCGModelConfig(name="meta-llama/Llama-2-7b-chat-hf")],
         algorithm=GCGAlgorithmConfig(n_steps=500, batch_size=512),
@@ -71,7 +71,8 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class GCGContext(PromptGeneratorStrategyContext):
-    """Per-execution state for a GCGGenerator run.
+    """
+    Per-execution state for a GCGGenerator run.
 
     Attributes:
         goals (list[str]): Training goal strings (the prompts whose responses
@@ -99,7 +100,8 @@ class GCGContext(PromptGeneratorStrategyContext):
 
 
 class GCGResult(PromptGeneratorStrategyResult):
-    """Result of one GCGGenerator run.
+    """
+    Result of one GCGGenerator run.
 
     Attributes:
         final_suffix (str): The optimized adversarial suffix string. Empty
@@ -128,7 +130,8 @@ class GCGGenerator(
     PromptGeneratorStrategy[GCGContext, GCGResult],
     Identifiable,
 ):
-    """Greedy Coordinate Gradient adversarial-suffix generator.
+    """
+    Greedy Coordinate Gradient adversarial-suffix generator.
 
     Generates a token suffix that, when appended to ``goals``, is optimized to
     elicit ``targets`` from the configured HuggingFace model(s). See the GCG
@@ -180,7 +183,8 @@ class GCGGenerator(
         self._hf_token = hf_token
 
     def _ensure_spawn_start_method(self) -> None:
-        """Ensure torch.multiprocessing uses 'spawn' before workers are spawned.
+        """
+        Ensure torch.multiprocessing uses 'spawn' before workers are spawned.
 
         GCG workers load CUDA models, which is unsafe with the default 'fork'
         start method on Linux. We set 'spawn' on the first GCG run in the
@@ -202,7 +206,12 @@ class GCGGenerator(
             )
 
     def _build_identifier(self) -> ComponentIdentifier:
-        """Build a behavioral identifier exposing model identity + key hyper-params."""
+        """
+        Build a behavioral identifier exposing model identity and hyperparameters.
+
+        Returns:
+            ComponentIdentifier: The generator's behavioral identifier.
+        """
         return ComponentIdentifier.of(
             self,
             params={
@@ -263,7 +272,12 @@ class GCGGenerator(
         context.workers, context.test_workers = await asyncio.to_thread(get_workers, params)
 
     async def _perform_async(self, *, context: GCGContext) -> GCGResult:
-        """Build the attack, run the optimization loop, and read the result back."""
+        """
+        Build the attack, run the optimization loop, and read the result back.
+
+        Returns:
+            GCGResult: The completed optimization result.
+        """
         params = self._to_attack_params(context=context)
         context.logfile_path = self._build_logfile_path()
 
@@ -368,7 +382,12 @@ class GCGGenerator(
         train_targets: list[str],
         test_targets: list[str],
     ) -> tuple[list[str], list[str]]:
-        """Randomly substitute equivalent target phrasings for diversity."""
+        """
+        Randomly substitute equivalent target phrasings for diversity.
+
+        Returns:
+            tuple[list[str], list[str]]: Augmented training and held-out targets.
+        """
 
         def _shorten(s: str) -> str:
             return s.replace("Sure, h", "H")
@@ -381,7 +400,12 @@ class GCGGenerator(
         return train_targets, test_targets
 
     def _to_attack_params(self, *, context: GCGContext) -> Any:
-        """Build the dotted-attribute namespace the internal helpers expect."""
+        """
+        Build the dotted-attribute namespace the internal helpers expect.
+
+        Returns:
+            Any: A namespace containing legacy attack parameters.
+        """
         from types import SimpleNamespace
 
         all_models = self._models + self._test_models
@@ -417,7 +441,12 @@ class GCGGenerator(
         test_workers: list[Any],
         logfile_path: str,
     ) -> Any:
-        """Build the right attack object based on the strategy flags."""
+        """
+        Build the right attack object based on the strategy flags.
+
+        Returns:
+            Any: The configured attack implementation.
+        """
         control_init = self._resolve_control_init(workers=workers)
         if self._strategy.transfer:
             return ProgressiveMultiPromptAttack(
@@ -452,10 +481,17 @@ class GCGGenerator(
         )
 
     def _resolve_control_init(self, *, workers: list[Any]) -> str:
-        """Resolve the initial suffix string for a run.
+        """
+        Resolve the initial suffix string for a run.
 
         Uses the configured ``suffix_init`` extension when provided; otherwise
         falls back to the legacy literal ``control_init`` value.
+
+        Returns:
+            str: The initial adversarial suffix.
+
+        Raises:
+            ValueError: If an initializer needs a tokenizer but no worker exists.
         """
         if self._algorithm.suffix_init is None:
             return self._algorithm.control_init
@@ -465,7 +501,12 @@ class GCGGenerator(
 
     @staticmethod
     def _read_result(*, logfile_path: str, memory_labels: dict[str, str]) -> GCGResult:
-        """Pull final-step values out of the JSON log written during the run."""
+        """
+        Pull final-step values out of the JSON log written during the run.
+
+        Returns:
+            GCGResult: The values parsed from the log, or an empty result if absent.
+        """
         try:
             with open(logfile_path) as f:
                 log = json.load(f)

--- a/tests/unit/executor/promptgen/gcg/test_default_implementations.py
+++ b/tests/unit/executor/promptgen/gcg/test_default_implementations.py
@@ -428,6 +428,10 @@ class TestLengthPreservingFilter:
         assert torch.equal(default_input, legacy_input)
         assert default_input[0, 0].item() == 0
 
+    def test_init_rejects_enabled_and_legacy_filter_together(self) -> None:
+        with pytest.raises(TypeError, match="Specify either 'enabled' or 'filter', not both"):
+            LengthPreservingFilter(enabled=True, filter=False)
+
 
 class TestLiteralStringInit:
     """Parity: ``LiteralStringInit`` vs the literal-string ``control_init``

--- a/tests/unit/executor/promptgen/gcg/test_gcg_core.py
+++ b/tests/unit/executor/promptgen/gcg/test_gcg_core.py
@@ -17,6 +17,7 @@ AttackPrompt = attack_manager_mod.AttackPrompt
 PromptManager = attack_manager_mod.PromptManager
 EvaluateAttack = attack_manager_mod.EvaluateAttack
 IndividualPromptAttack = attack_manager_mod.IndividualPromptAttack
+ModelWorker = attack_manager_mod.ModelWorker
 ProgressiveMultiPromptAttack = attack_manager_mod.ProgressiveMultiPromptAttack
 get_embedding_layer = attack_manager_mod.get_embedding_layer
 get_embedding_matrix = attack_manager_mod.get_embedding_matrix
@@ -503,6 +504,30 @@ class TestGetWorkersChatTemplateValidation:
         with patch.object(attack_manager_mod.AutoTokenizer, "from_pretrained", return_value=bare_tokenizer):
             with pytest.raises(ValueError, match="no chat_template configured"):
                 get_workers(params)
+
+
+def test_model_worker_uses_model_device_dispatch() -> None:
+    model = MagicMock()
+    moved_model = MagicMock()
+    evaluated_model = MagicMock()
+    model.to.return_value = moved_model
+    moved_model.eval.return_value = evaluated_model
+
+    with (
+        patch.object(attack_manager_mod.AutoModelForCausalLM, "from_pretrained", return_value=model),
+        patch.object(attack_manager_mod.mp, "JoinableQueue", side_effect=[MagicMock(), MagicMock()]),
+    ):
+        worker = ModelWorker(
+            model_path="fake/model",
+            token="",
+            model_kwargs={},
+            tokenizer=MagicMock(),
+            device="cpu",
+        )
+
+    model.to.assert_called_once_with(torch.device("cpu"))
+    moved_model.eval.assert_called_once_with()
+    assert worker.model is evaluated_model
 
 
 class _Queue:

--- a/tests/unit/executor/promptgen/gcg/test_gcg_core.py
+++ b/tests/unit/executor/promptgen/gcg/test_gcg_core.py
@@ -31,6 +31,12 @@ GCGMultiPromptAttack = gcg_attack_mod.GCGMultiPromptAttack
 GCGPromptManager = gcg_attack_mod.GCGPromptManager
 token_gradients = gcg_attack_mod.token_gradients
 
+default_implementations_mod = pytest.importorskip(
+    "pyrit.executor.promptgen.gcg.default_implementations",
+    reason="GCG optional dependencies not installed",
+)
+LengthPreservingFilter = default_implementations_mod.LengthPreservingFilter
+
 
 class TestGetFilteredCands:
     """Tests for MultiPromptAttack.get_filtered_cands."""
@@ -309,6 +315,14 @@ class TestEmbeddingHelpers:
 class TestPromptManagerInit:
     """Tests for PromptManager initialization validation."""
 
+    def test_raises_when_managers_are_missing(self) -> None:
+        with pytest.raises(ValueError, match="PromptManager requires a managers mapping"):
+            PromptManager(
+                goals=["goal"],
+                targets=["target"],
+                tokenizer=MagicMock(),
+            )
+
     def test_raises_on_mismatched_goals_targets(self) -> None:
         with pytest.raises(ValueError, match="Length of goals and targets must match"):
             PromptManager(
@@ -330,6 +344,19 @@ class TestPromptManagerInit:
 
 class TestEvaluateAttackInit:
     """Tests for EvaluateAttack initialization validation."""
+
+    @pytest.mark.parametrize(
+        ("attack_class", "expected_message"),
+        [
+            (MultiPromptAttack, "MultiPromptAttack requires a managers mapping"),
+            (ProgressiveMultiPromptAttack, "ProgressiveMultiPromptAttack requires a managers mapping"),
+            (IndividualPromptAttack, "IndividualPromptAttack requires a managers mapping"),
+            (EvaluateAttack, "EvaluateAttack requires a managers mapping"),
+        ],
+    )
+    def test_attack_raises_when_managers_are_missing(self, *, attack_class: type[Any], expected_message: str) -> None:
+        with pytest.raises(ValueError, match=expected_message):
+            attack_class(goals=["goal"], targets=["target"], workers=[])
 
     def test_raises_with_multiple_workers(self) -> None:
         mock_worker1 = MagicMock()
@@ -504,6 +531,31 @@ class TestGetWorkersChatTemplateValidation:
         with patch.object(attack_manager_mod.AutoTokenizer, "from_pretrained", return_value=bare_tokenizer):
             with pytest.raises(ValueError, match="no chat_template configured"):
                 get_workers(params)
+
+    def test_starts_workers_for_training(self) -> None:
+        params = MagicMock()
+        params.tokenizer_paths = ["fake/chat-model"]
+        params.tokenizer_kwargs = [{}]
+        params.model_paths = ["fake/chat-model"]
+        params.model_kwargs = [{}]
+        params.devices = ["cpu"]
+        params.token = ""
+        params.num_train_models = 1
+
+        tokenizer = MagicMock()
+        tokenizer.pad_token = "<pad>"
+        tokenizer.chat_template = "{{ messages[0]['content'] }}"
+        worker = MagicMock()
+
+        with (
+            patch.object(attack_manager_mod.AutoTokenizer, "from_pretrained", return_value=tokenizer),
+            patch.object(attack_manager_mod, "ModelWorker", return_value=worker),
+        ):
+            train_workers, test_workers = attack_manager_mod.get_workers(params, evaluation=False)
+
+        worker.start.assert_called_once_with()
+        assert train_workers == [worker]
+        assert test_workers == []
 
 
 def test_model_worker_uses_model_device_dispatch() -> None:
@@ -991,3 +1043,127 @@ class TestGCGMultiPromptAttackStepWiring:
 
         length = attack._get_control_length(control="test")
         assert length is None
+
+
+def test_attack_prompt_logits_rejects_non_string_controls() -> None:
+    prompt = object.__new__(AttackPrompt)
+    prompt._control_slice = slice(1, 3)
+    prompt.input_ids = torch.tensor([0, 1, 2, 3])
+    prompt.tokenizer = MagicMock()
+    model = MagicMock()
+    model.device = torch.device("cpu")
+
+    with pytest.raises(ValueError, match="list of strings or a tensor"):
+        prompt.logits(model, test_controls=123)
+
+
+def test_attack_prompt_logits_builds_attention_mask() -> None:
+    prompt = object.__new__(AttackPrompt)
+    prompt._control_slice = slice(1, 3)
+    prompt.input_ids = torch.tensor([0, 1, 2, 3])
+    prompt.tokenizer = MagicMock()
+    prompt.tokenizer.return_value.input_ids = [5, 6]
+    model = MagicMock()
+    model.device = torch.device("cpu")
+    model.return_value.logits = torch.randn(1, 4, 8)
+
+    logits = prompt.logits(model, test_controls=["candidate"])
+
+    assert logits.shape == (1, 4, 8)
+    assert torch.equal(model.call_args.kwargs["attention_mask"], torch.ones(1, 4, dtype=torch.long))
+
+
+def test_prompt_manager_grad_sums_prompt_gradients() -> None:
+    prompt_manager = object.__new__(PromptManager)
+    first_prompt = MagicMock()
+    first_prompt.grad.return_value = torch.tensor([1.0, 2.0])
+    second_prompt = MagicMock()
+    second_prompt.grad.return_value = torch.tensor([3.0, 4.0])
+    prompt_manager._prompts = [first_prompt, second_prompt]
+
+    result = prompt_manager.grad(MagicMock())
+
+    assert torch.equal(result, torch.tensor([4.0, 6.0]))
+
+
+def test_multi_prompt_run_anneals_and_accepts_lower_loss() -> None:
+    attack = object.__new__(MultiPromptAttack)
+    prompt_manager = MagicMock()
+    prompt_manager.control_str = "initial"
+    attack.prompts = [prompt_manager]
+    attack.logfile = None
+    attack.step = MagicMock(return_value=("better", 1.0))
+
+    control, loss, steps = attack.run(
+        n_steps=1,
+        prev_loss=2.0,
+        stop_on_success=False,
+        anneal=True,
+    )
+
+    assert (control, loss, steps) == ("better", 1.0, 1)
+
+
+def test_multi_prompt_log_requires_logfile_after_parsing_results() -> None:
+    attack = object.__new__(MultiPromptAttack)
+    attack.goals = []
+    attack.test_goals = []
+    attack.workers = []
+    attack.test_workers = []
+    attack.logfile = None
+
+    with pytest.raises(ValueError, match="without a logfile path"):
+        attack.log(
+            step_num=1,
+            n_steps=1,
+            control="control",
+            loss=1.0,
+            runtime=0.1,
+            model_tests=([[True]], [[1]], [[1.0]]),
+        )
+
+
+def test_evaluate_attack_run_with_no_controls_returns_empty_results() -> None:
+    attack = object.__new__(EvaluateAttack)
+    worker = MagicMock()
+    attack.workers = [worker]
+    attack.logfile = None
+
+    results = attack.run(steps=0, controls=[], batch_size=1)
+
+    assert results == ([], [], [], [], [], [])
+
+
+def test_gcg_step_requires_worker() -> None:
+    attack = object.__new__(GCGMultiPromptAttack)
+    attack.workers = []
+
+    with pytest.raises(ValueError, match="at least one worker"):
+        attack.step()
+
+
+def test_token_gradients_raises_when_backward_produces_no_gradient() -> None:
+    model = MagicMock()
+    model.device = torch.device("cpu")
+    model.return_value.logits = torch.randn(1, 3, 4)
+    loss = MagicMock()
+    loss_function = MagicMock(return_value=loss)
+
+    with (
+        patch.object(gcg_attack_mod, "get_embedding_matrix", return_value=torch.ones(4, 2)),
+        patch.object(gcg_attack_mod, "get_embeddings", return_value=torch.ones(1, 3, 2)),
+        patch.object(gcg_attack_mod.nn, "CrossEntropyLoss", return_value=loss_function),
+        pytest.raises(RuntimeError, match="did not produce token gradients"),
+    ):
+        token_gradients(
+            model,
+            torch.tensor([0, 1, 2]),
+            input_slice=slice(0, 1),
+            target_slice=slice(1, 2),
+            loss_slice=slice(0, 1),
+        )
+
+
+def test_length_preserving_filter_rejects_unknown_option() -> None:
+    with pytest.raises(TypeError, match="Unexpected LengthPreservingFilter option: unexpected"):
+        LengthPreservingFilter(unexpected=True)


### PR DESCRIPTION
## Description

GCG was excluded from repository-wide Ruff and ty enforcement, allowing its implementation to drift from current project standards. This change removes those exclusions and makes the GCG prompt generator pass the same formatting, linting, and type-checking gates as the rest of `pyrit/`.

The cleanup adds precise typing and documentation, replaces suppressed findings with explicit validation, and preserves the legacy `LengthPreservingFilter(filter=...)` keyword while introducing the clearer `enabled` name. It also fixes the non-verbose optimization loop so it iterates prompt indices consistently with the verbose path and adds fail-fast checks for invalid worker and gradient states.

The local ty hook now installs the `all` extra so optional GCG dependencies such as torch are available during checking.

## Tests and Documentation

- `uv run --no-sync pre-commit run check-yaml --files .pre-commit-config.yaml`
- `uv run --no-sync pre-commit run ruff-format --all-files`
- `uv run --no-sync pre-commit run ruff-check --all-files`
- `uv run --no-sync pre-commit run ty-check --all-files`
- `uv run --no-sync pytest -q tests\unit\executor\promptgen\gcg` (172 passed)

Updated GCG API and implementation docstrings as required by the newly enabled Ruff rules. JupyText was not run because no notebook or documentation sample changed.