### PR TITLE
FIX adaptive scenario: normalize seed sequences to fix technique role collision

### DIFF
--- a/pyrit/models/seeds/attack_seed_group.py
+++ b/pyrit/models/seeds/attack_seed_group.py
@@ -14,6 +14,8 @@ from typing import TYPE_CHECKING
 
 from pyrit.models.seeds.seed_group import SeedGroup
 from pyrit.models.seeds.seed_objective import SeedObjective
+from pyrit.models.seeds.seed_prompt import SeedPrompt
+from pyrit.models.seeds.seed_simulated_conversation import SeedSimulatedConversation
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -173,5 +175,20 @@ class AttackSeedGroup(SeedGroup):
         # all of them with a single new UUID.
         for seed in merged_seeds:
             seed.prompt_group_id = None
+
+        # Normalize prompt sequences to dense, 0-based order preserving relative
+        # ordering. A technique whose seed leads the conversation (e.g. a system
+        # prompt built at ``sequence=-1`` by ``from_system_prompt``) is thereby
+        # prepended cleanly: it lands at sequence 0 and the existing turns shift
+        # up (user 0 -> 1, assistant 1 -> 2, ...), rather than leaving a negative
+        # or sparse sequence. This keeps the merge robust no matter how the base
+        # group was numbered. Skipped when a simulated conversation is present,
+        # since its ``sequence_range`` is absolute and self-consistent.
+        has_simulated = any(isinstance(seed, SeedSimulatedConversation) for seed in merged_seeds)
+        if not has_simulated:
+            prompt_seeds = [seed for seed in merged_seeds if isinstance(seed, SeedPrompt)]
+            rank_by_sequence = {seq: rank for rank, seq in enumerate(sorted({p.sequence for p in prompt_seeds}))}
+            for seed in prompt_seeds:
+                seed.sequence = rank_by_sequence[seed.sequence]
 
         return AttackSeedGroup(seeds=merged_seeds)

--- a/pyrit/models/seeds/attack_technique_seed_group.py
+++ b/pyrit/models/seeds/attack_technique_seed_group.py
@@ -41,6 +41,12 @@ class AttackTechniqueSeedGroup(SeedGroup):
         value is wrapped verbatim (``is_jinja_template=False``), so any literal
         ``{{ ... }}`` in ``system_prompt`` is preserved rather than re-rendered.
 
+        The seed is placed at ``sequence=-1`` so the system framing orders ahead of any
+        user turn. Without it, merging this technique via ``AttackSeedGroup.with_technique``
+        onto a seed group that carries a user prompt at the default ``sequence=0`` would
+        raise ``Inconsistent roles found for sequence 0`` (one ``sequence`` maps to one
+        ``Message``, which requires a single role).
+
         Args:
             system_prompt (str): The system-role instruction text.
             insertion_index (int | None): Where to insert the seed when merging into a
@@ -50,7 +56,9 @@ class AttackTechniqueSeedGroup(SeedGroup):
             AttackTechniqueSeedGroup: A group with a single general-technique system seed.
         """
         return cls(
-            seeds=[SeedPrompt(value=system_prompt, data_type="text", role="system", is_general_technique=True)],
+            seeds=[
+                SeedPrompt(value=system_prompt, data_type="text", role="system", is_general_technique=True, sequence=-1)
+            ],
             insertion_index=insertion_index,
         )
 

--- a/pyrit/models/seeds/attack_technique_seed_group.py
+++ b/pyrit/models/seeds/attack_technique_seed_group.py
@@ -41,11 +41,13 @@ class AttackTechniqueSeedGroup(SeedGroup):
         value is wrapped verbatim (``is_jinja_template=False``), so any literal
         ``{{ ... }}`` in ``system_prompt`` is preserved rather than re-rendered.
 
-        The seed is placed at ``sequence=-1`` so the system framing orders ahead of any
-        user turn. Without it, merging this technique via ``AttackSeedGroup.with_technique``
-        onto a seed group that carries a user prompt at the default ``sequence=0`` would
-        raise ``Inconsistent roles found for sequence 0`` (one ``sequence`` maps to one
-        ``Message``, which requires a single role).
+        The seed is built at ``sequence=-1`` as an internal "lead" marker so it orders ahead of
+        any user turn. When merged via ``AttackSeedGroup.with_technique`` the merged sequences are
+        normalized to dense 0-based order, so the system framing lands at sequence 0 and the
+        objective's turns shift up (user 0 -> 1, assistant 1 -> 2, ...). Without leading it, merging
+        onto a seed group that carries a user prompt at the default ``sequence=0`` would raise
+        ``Inconsistent roles found for sequence 0`` (one ``sequence`` maps to one ``Message``, which
+        requires a single role).
 
         Args:
             system_prompt (str): The system-role instruction text.

--- a/tests/unit/models/test_attack_technique_seed_group.py
+++ b/tests/unit/models/test_attack_technique_seed_group.py
@@ -234,6 +234,7 @@ class TestAttackTechniqueSeedGroupFromSystemPrompt:
         assert isinstance(seed, SeedPrompt)
         assert seed.value == "Follow these rules."
         assert seed.role == "system"
+        assert seed.sequence == -1
         assert seed.data_type == "text"
         assert seed.is_general_technique is True
         assert group.insertion_index is None

--- a/tests/unit/models/test_seed_group.py
+++ b/tests/unit/models/test_seed_group.py
@@ -619,8 +619,8 @@ class TestAttackSeedGroupWithTechnique:
         Reproduces the adaptive-scenario failure: merging the ``flip`` technique (a
         ``from_system_prompt`` system seed) onto a multi-turn objective group whose opening
         turn is a ``user`` prompt at sequence 0 raised ``Inconsistent roles found for
-        sequence 0``. The system seed is ordered at sequence -1 so it sits ahead of the
-        user turn.
+        sequence 0``. The leading system seed is normalized to sequence 0 and the existing
+        turns shift up (user 0 -> 1, assistant 1 -> 2, ...).
         """
         base = AttackSeedGroup(
             seeds=[
@@ -637,10 +637,15 @@ class TestAttackSeedGroupWithTechnique:
         merged._check_invariants()  # should not raise
         system_prompts = [p for p in merged.prompts if p.role == "system"]
         assert len(system_prompts) == 1
-        assert system_prompts[0].sequence == -1
-        # System framing sorts ahead of the sequence-0 user turn.
+        # The leading system seed is normalized to sequence 0 and the base turns shift up.
+        assert system_prompts[0].sequence == 0
         assert merged.prompts[0].role == "system"
-        assert [p.sequence for p in merged.prompts] == [-1, 0, 1, 2]
+        assert [(p.role, p.sequence) for p in merged.prompts] == [
+            ("system", 0),
+            ("user", 1),
+            ("assistant", 2),
+            ("user", 3),
+        ]
 
     def test_raises_when_technique_has_simulated_conversation_and_prompts_overlap(self):
         """Merging a technique with SeedSimulatedConversation into a group with overlapping prompts raises."""

--- a/tests/unit/models/test_seed_group.py
+++ b/tests/unit/models/test_seed_group.py
@@ -612,6 +612,36 @@ class TestAttackSeedGroupWithTechnique:
         assert isinstance(merged, AttackSeedGroup)
         merged._check_invariants()  # should not raise
 
+    def test_system_prompt_technique_merges_onto_user_turn_at_sequence_zero(self):
+        """A ``from_system_prompt`` technique merges onto a group whose first turn is a
+        ``user`` prompt at sequence 0 without a same-sequence role collision.
+
+        Reproduces the adaptive-scenario failure: merging the ``flip`` technique (a
+        ``from_system_prompt`` system seed) onto a multi-turn objective group whose opening
+        turn is a ``user`` prompt at sequence 0 raised ``Inconsistent roles found for
+        sequence 0``. The system seed is ordered at sequence -1 so it sits ahead of the
+        user turn.
+        """
+        base = AttackSeedGroup(
+            seeds=[
+                SeedObjective(value="objective"),
+                SeedPrompt(value="opening user turn", data_type="text", role="user", sequence=0),
+                SeedPrompt(value="assistant reply", data_type="text", role="assistant", sequence=1),
+                SeedPrompt(value="follow-up user turn", data_type="text", role="user", sequence=2),
+            ]
+        )
+        technique = AttackTechniqueSeedGroup.from_system_prompt("Follow these rules.")
+
+        merged = base.with_technique(technique=technique)
+
+        merged._check_invariants()  # should not raise
+        system_prompts = [p for p in merged.prompts if p.role == "system"]
+        assert len(system_prompts) == 1
+        assert system_prompts[0].sequence == -1
+        # System framing sorts ahead of the sequence-0 user turn.
+        assert merged.prompts[0].role == "system"
+        assert [p.sequence for p in merged.prompts] == [-1, 0, 1, 2]
+
     def test_raises_when_technique_has_simulated_conversation_and_prompts_overlap(self):
         """Merging a technique with SeedSimulatedConversation into a group with overlapping prompts raises."""
         base = AttackSeedGroup(

--- a/tests/unit/scenario/scenarios/adaptive/test_dispatcher.py
+++ b/tests/unit/scenario/scenarios/adaptive/test_dispatcher.py
@@ -9,7 +9,13 @@ from pyrit.executor.attack.compound.sequential_attack import (
     SequenceCompletionPolicy,
     SequentialAttack,
 )
-from pyrit.models import AttackOutcome, AttackSeedGroup, SeedObjective
+from pyrit.models import (
+    AttackOutcome,
+    AttackSeedGroup,
+    AttackTechniqueSeedGroup,
+    SeedObjective,
+    SeedPrompt,
+)
 from pyrit.scenario.scenarios.adaptive.dispatcher import (
     ADAPTIVE_ATTEMPT_LABEL,
     AdaptiveTechniqueDispatcher,
@@ -195,6 +201,41 @@ class TestBuildAttackAsync:
         # The merged seed group is forwarded to the child attack.
         outer_sg.with_technique.assert_called_once_with(technique=seed_technique)
         assert attack._child_attacks[0].seed_group is merged_sg
+
+    async def test_merges_real_system_prompt_technique_onto_user_turn_at_sequence_zero(self, target):
+        """Regression for the adaptive role-merge bug, exercised through the real dispatcher path.
+
+        ``build_attack_async`` calls ``AttackSeedGroup.with_technique`` (dispatcher line ~216) to
+        apply a bundle's ``seed_technique`` to the objective's seed group. A ``from_system_prompt``
+        technique merged onto a group whose opening turn is a ``user`` prompt at sequence 0 -- as in
+        the ``airt_hate`` ``escalating_discrimination`` group -- used to raise ``Inconsistent roles
+        found for sequence 0: {system, user}``. Unlike the mocked merge test above, this drives the
+        real merge with real seeds so a future dispatcher or compatibility-gate change can't let the
+        collision slip back in.
+        """
+        seed_group = AttackSeedGroup(
+            seeds=[
+                SeedObjective(value="obj"),
+                SeedPrompt(value="opening user turn", data_type="text", role="user", sequence=0),
+            ]
+        )
+        seed_technique = AttackTechniqueSeedGroup.from_system_prompt("Follow these rules.")
+        bundle = _make_bundle(name="a", outcomes=[AttackOutcome.SUCCESS], seed_technique=seed_technique)
+        dispatcher = AdaptiveTechniqueDispatcher(
+            objective_target=target,
+            techniques={"a": bundle},
+            selector=_StubSelector(technique_order=["a"]),
+        )
+
+        attack = await dispatcher.build_attack_async(seed_group=seed_group)
+
+        execution_group = attack._child_attacks[0].seed_group
+        system_prompts = [p for p in execution_group.prompts if p.role == "system"]
+        assert len(system_prompts) == 1
+        assert system_prompts[0].sequence == -1
+        # System framing sorts ahead of the sequence-0 user turn.
+        assert execution_group.prompts[0].role == "system"
+        assert [p.sequence for p in execution_group.prompts] == [-1, 0]
 
 
 @pytest.mark.usefixtures("patch_central_database")

--- a/tests/unit/scenario/scenarios/adaptive/test_dispatcher.py
+++ b/tests/unit/scenario/scenarios/adaptive/test_dispatcher.py
@@ -232,10 +232,10 @@ class TestBuildAttackAsync:
         execution_group = attack._child_attacks[0].seed_group
         system_prompts = [p for p in execution_group.prompts if p.role == "system"]
         assert len(system_prompts) == 1
-        assert system_prompts[0].sequence == -1
-        # System framing sorts ahead of the sequence-0 user turn.
+        # System framing is normalized to sequence 0; the base user turn shifts to 1.
+        assert system_prompts[0].sequence == 0
         assert execution_group.prompts[0].role == "system"
-        assert [p.sequence for p in execution_group.prompts] == [-1, 0]
+        assert [(p.role, p.sequence) for p in execution_group.prompts] == [("system", 0), ("user", 1)]
 
 
 @pytest.mark.usefixtures("patch_central_database")

--- a/tests/unit/setup/techniques/test_core_techniques.py
+++ b/tests/unit/setup/techniques/test_core_techniques.py
@@ -53,7 +53,8 @@ class TestFlipTechnique:
         Regression for the adaptive scenario: the ``flip`` system seed used to default to
         sequence 0 and collided with a user prompt at sequence 0 (as in the ``airt_hate``
         multi-turn ``escalating_discrimination`` group), raising ``Inconsistent roles found
-        for sequence 0``.
+        for sequence 0``. The leading system seed is now normalized to sequence 0 on merge
+        and the user turn shifts to sequence 1.
         """
         factory = _flip_factory()
         base = AttackSeedGroup(
@@ -67,8 +68,10 @@ class TestFlipTechnique:
 
         system_prompts = [p for p in merged.prompts if p.role == "system"]
         assert len(system_prompts) == 1
-        assert system_prompts[0].sequence == -1
+        # The leading system seed is normalized to sequence 0; the user turn shifts to 1.
+        assert system_prompts[0].sequence == 0
         assert merged.prompts[0].role == "system"
+        assert [p.sequence for p in merged.prompts if p.role == "user"] == [1]
 
     async def test_sends_flipped_framed_objective_and_prepends_system_prompt(self):
         target = MockPromptTarget()

--- a/tests/unit/setup/techniques/test_core_techniques.py
+++ b/tests/unit/setup/techniques/test_core_techniques.py
@@ -16,7 +16,7 @@ import pytest
 from pyrit.executor.attack.core.attack_config import AttackScoringConfig
 from pyrit.executor.attack.core.attack_executor import AttackExecutor
 from pyrit.memory import CentralMemory
-from pyrit.models import AttackSeedGroup, SeedObjective
+from pyrit.models import AttackSeedGroup, SeedObjective, SeedPrompt
 from pyrit.setup.initializers.techniques import core
 from tests.unit.mocks import MockPromptTarget
 
@@ -42,8 +42,33 @@ class TestFlipTechnique:
         assert factory.seed_technique is not None
         seed = factory.seed_technique.seeds[0]
         assert seed.role == "system"
+        assert seed.sequence == -1
         assert seed.is_general_technique is True
         assert "flipping each word" in seed.value
+
+    def test_merges_onto_group_with_user_turn_at_sequence_zero(self):
+        """Merging flip onto a group whose opening turn is a ``user`` prompt at sequence 0
+        must not raise a same-sequence role collision.
+
+        Regression for the adaptive scenario: the ``flip`` system seed used to default to
+        sequence 0 and collided with a user prompt at sequence 0 (as in the ``airt_hate``
+        multi-turn ``escalating_discrimination`` group), raising ``Inconsistent roles found
+        for sequence 0``.
+        """
+        factory = _flip_factory()
+        base = AttackSeedGroup(
+            seeds=[
+                SeedObjective(value=OBJECTIVE),
+                SeedPrompt(value="opening user turn", data_type="text", role="user", sequence=0),
+            ]
+        )
+
+        merged = base.with_technique(technique=factory.seed_technique)
+
+        system_prompts = [p for p in merged.prompts if p.role == "system"]
+        assert len(system_prompts) == 1
+        assert system_prompts[0].sequence == -1
+        assert merged.prompts[0].role == "system"
 
     async def test_sends_flipped_framed_objective_and_prepends_system_prompt(self):
         target = MockPromptTarget()


### PR DESCRIPTION
## Description

`AdaptiveScenario` initialization raised a pydantic `ValidationError` whenever a system-prompt technique (e.g. `flip`, tagged `single_turn`) was merged onto an objective whose opening turn is a `user` prompt at sequence 0:

```
Value error, Inconsistent roles found for sequence 0: {'system', 'user'}
```

This broke the resume cell of `doc/code/scenarios/3_adaptive_scenarios.ipynb` and the adaptive path in `tests/end_to_end`.

Root cause: `AttackTechniqueSeedGroup.from_system_prompt` contributes a system-role seed that, once merged via `AttackSeedGroup.with_technique` onto a group already carrying a `user` prompt at sequence 0 (as in the `airt_hate` multi-turn `escalating_discrimination` group), placed two roles at the same sequence. One `sequence` maps to exactly one `Message`, which requires a single role, so `SeedGroup._enforce_consistent_role` correctly rejects it.

Fix: `with_technique` now normalizes the merged prompt sequences to dense 0-based order, preserving relative order. A leading system seed is prepended cleanly: it lands at sequence 0 and the existing turns shift up (user 0 -> 1, assistant 1 -> 2, ...), rather than depending on a hardcoded negative sequence. This is robust no matter how the base group was numbered. Normalization is skipped when a `SeedSimulatedConversation` is present, since its `sequence_range` is absolute and self-consistent. `from_system_prompt` keeps building its seed at `sequence=-1` as an internal, documented "lead" marker that normalization maps to 0.

The fix stays contained to the `models/seeds` layer; `_enforce_consistent_role` and the dispatcher are untouched.

Note: an earlier revision of this PR ordered the seed at a fixed `sequence=-1`. That was revised to the normalization approach above in response to review feedback that a hardcoded constant is brittle.

## Tests and Documentation

Added and updated focused regression tests (no network; pure model construction plus one dispatcher-level build):

- `test_seed_group.py`: merging a `from_system_prompt` technique onto a user turn at sequence 0 now normalizes to `[system@0, user@1, assistant@2, user@3]` instead of raising.
- `test_dispatcher.py`: drives the real failing call chain (`AdaptiveTechniqueDispatcher.build_attack_async` -> real `AttackSeedGroup.with_technique`) with real seeds, closing the gap left by the pre-existing mocked merge test.
- `test_core_techniques.py`: asserts the real `flip` technique merges to system@0 with the user turn shifted to 1; the factory-shape tests still assert the technique's own pre-merge seed at `sequence=-1` (the lead marker).

Each new test fails with the original `Inconsistent roles found for sequence 0` error when the fix is reverted. Because `with_technique` is a shared chokepoint for all techniques, coverage was run broadly: 1142 `tests/unit/models` plus 2164 across `tests/unit/setup` + `tests/unit/scenario` + `tests/unit/executor` pass. ruff/format/ty and pre-commit hooks are green. No documentation changes were needed; the affected notebook now runs its build step without the ValidationError.