### PR TITLE
FEAT Add DecodingTrust AdvGLUE++ (adversarial robustness) dataset

### DIFF
--- a/pyrit/datasets/seed_datasets/remote/__init__.py
+++ b/pyrit/datasets/seed_datasets/remote/__init__.py
@@ -36,6 +36,11 @@ from pyrit.datasets.seed_datasets.remote.comic_jailbreak_dataset import (
 )
 from pyrit.datasets.seed_datasets.remote.dangerous_qa_dataset import _DangerousQADataset
 from pyrit.datasets.seed_datasets.remote.darkbench_dataset import _DarkBenchDataset
+from pyrit.datasets.seed_datasets.remote.decoding_trust_adv_glue_dataset import (
+    DecodingTrustAdvGLUEModel,
+    DecodingTrustAdvGLUETask,
+    _DecodingTrustAdvGLUEDataset,
+)
 from pyrit.datasets.seed_datasets.remote.decoding_trust_toxicity_dataset import (
     DecodingTrustToxicitySubset,
     _DecodingTrustToxicityDataset,
@@ -132,6 +137,8 @@ __all__ = [
     "AegisHarmCategory",
     "CoCoNotCategory",
     "CoCoNotSplit",
+    "DecodingTrustAdvGLUEModel",
+    "DecodingTrustAdvGLUETask",
     "DecodingTrustToxicitySubset",
     "FigStepCategory",
     "FigStepVariant",
@@ -170,6 +177,7 @@ __all__ = [
     "ComicJailbreakTemplateConfig",
     "_DangerousQADataset",
     "_DarkBenchDataset",
+    "_DecodingTrustAdvGLUEDataset",
     "_DecodingTrustToxicityDataset",
     "_EquityMedQADataset",
     "_FigStepDataset",

--- a/pyrit/datasets/seed_datasets/remote/decoding_trust_adv_glue_dataset.py
+++ b/pyrit/datasets/seed_datasets/remote/decoding_trust_adv_glue_dataset.py
@@ -1,0 +1,382 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import logging
+from collections.abc import Sequence
+from enum import Enum
+from typing import Any, cast
+
+from pyrit.datasets.seed_datasets.remote.remote_dataset_loader import (
+    _RemoteDatasetLoader,
+)
+from pyrit.models import SeedDataset, SeedPrompt, SeedUnion
+
+logger = logging.getLogger(__name__)
+
+
+# Pinned commit SHA of AI-secure/DecodingTrust `main` (2024-09-16); the same
+# revision the DecodingTrust Toxicity loader pins. Pinning prevents silent
+# upstream changes from altering the prompt set.
+_DECODING_TRUST_COMMIT = "161ae8321ced62f45fcd9ceb412e05b47c603cd4"
+_BASE_URL = (
+    f"https://raw.githubusercontent.com/AI-secure/DecodingTrust/{_DECODING_TRUST_COMMIT}/data/adv-glue-plus-plus/data/"
+)
+
+# The six GLUE tasks published in each AdvGLUE++ file. Each maps to the key used
+# in the source JSON objects.
+_TASK_KEYS: tuple[str, ...] = ("sst2", "qqp", "mnli", "mnli-mm", "qnli", "rte")
+
+# How to compose the adversarial input text for the two-/dual-field tasks when a
+# record stores its parts separately instead of a pre-joined ``sentence``. Each
+# entry maps a task to ``(trigger_field, [(label, source_field), ...])``: a record
+# is in "component form" when ``trigger_field`` is present, and the text is built
+# as ``"label1: value1 label2: value2"`` — the exact format DecodingTrust uses for
+# its pre-composed ``sentence`` values. sst2 is single-field and always ships a
+# pre-composed ``sentence``, so it is intentionally absent here.
+_COMPONENT_TEMPLATES: dict[str, tuple[str, tuple[tuple[str, str], ...]]] = {
+    "mnli": ("premise", (("premise", "premise"), ("hypothesis", "hypothesis"))),
+    "mnli-mm": ("premise", (("premise", "premise"), ("hypothesis", "hypothesis"))),
+    "rte": ("sentence1", (("premise", "sentence1"), ("hypothesis", "sentence2"))),
+    "qqp": ("question1", (("question1", "question1"), ("question2", "question2"))),
+    "qnli": ("question", (("question", "question"), ("sentence", "sentence"))),
+}
+
+# Per-task human-readable label maps (the `label` field is the *gold* label of
+# the clean example; the adversarial `sentence` tries to flip a model away from
+# it). Kept for provenance in per-seed metadata; not required to build a prompt.
+_LABEL_NAMES: dict[str, dict[int, str]] = {
+    "sst2": {0: "negative", 1: "positive"},
+    "qqp": {0: "not_duplicate", 1: "duplicate"},
+    "mnli": {0: "entailment", 1: "neutral", 2: "contradiction"},
+    "mnli-mm": {0: "entailment", 1: "neutral", 2: "contradiction"},
+    "qnli": {0: "entailment", 1: "not_entailment"},
+    "rte": {0: "entailment", 1: "not_entailment"},
+}
+
+
+class DecodingTrustAdvGLUEModel(Enum):
+    """
+    Which surrogate model's AdvGLUE++ adversarial set to load.
+
+    AdvGLUE++ crafts word-level adversarial perturbations against three
+    open-source models and studies their transfer to GPT-3.5/GPT-4. Each value
+    selects the corresponding source file; ``ALL`` fetches and concatenates all
+    three.
+    """
+
+    ALPACA = "alpaca"
+    VICUNA = "vicuna"
+    STABLE_VICUNA = "stable-vicuna"
+    ALL = "all"
+
+
+class DecodingTrustAdvGLUETask(Enum):
+    """A GLUE task within the AdvGLUE++ adversarial set."""
+
+    SST2 = "sst2"
+    QQP = "qqp"
+    MNLI = "mnli"
+    MNLI_MM = "mnli-mm"
+    QNLI = "qnli"
+    RTE = "rte"
+
+
+class _DecodingTrustAdvGLUEDataset(_RemoteDatasetLoader):
+    """
+    Loader for the Adversarial Robustness (AdvGLUE++) perspective of DecodingTrust.
+
+    DecodingTrust [1] evaluates LLM trustworthiness across eight perspectives; the
+    Adversarial Robustness perspective ships AdvGLUE++ [1], a set of word-level
+    adversarial perturbations of GLUE [2] / AdvGLUE [3] inputs. The perturbations
+    are generated with five attack strategies (``bertattack``, ``semattack``,
+    ``sememepso``, ``textbugger``, ``textfooler``) against three surrogate models
+    (Alpaca-7B, Vicuna-13B, StableVicuna-13B) and are studied for transfer to
+    GPT-3.5 and GPT-4.
+
+    The published data lives in three files under
+    ``AI-secure/DecodingTrust/data/adv-glue-plus-plus/data/`` — ``alpaca.json``,
+    ``vicuna.json`` and ``stable-vicuna.json``. Each file is a JSON object keyed
+    by the six GLUE tasks (``sst2``, ``qqp``, ``mnli``, ``mnli-mm``, ``qnli``,
+    ``rte``). Records come in two shapes depending on the attack that produced
+    them: some carry a pre-composed adversarial ``sentence`` while others store
+    the perturbed parts separately (e.g. ``premise``/``hypothesis`` for NLI,
+    ``question1``/``question2`` for QQP). The loader builds the prompt from the
+    pre-composed ``sentence`` when present and otherwise joins the component
+    fields using the same ``"premise: ... hypothesis: ..."`` layout DecodingTrust
+    uses, so no records are dropped. Each record's gold ``label``, attack
+    ``method``, ``data_construction`` flag and clean ``original_*`` counterparts
+    are preserved in metadata. The loader fetches the source files at runtime
+    from ``raw.githubusercontent.com`` (no redistribution) at a pinned commit SHA.
+
+    References:
+        [1] [@wang2023decodingtrust] https://github.com/AI-secure/DecodingTrust
+        [2] GLUE (Wang et al., 2019)
+        [3] AdvGLUE (Wang et al., 2021)
+
+    License:
+        DecodingTrust is distributed under CC BY-SA 4.0. PyRIT fetches the
+        prompts at runtime and does not redistribute them. Attribution to the
+        DecodingTrust authors is recorded on every ``SeedPrompt`` produced.
+
+    Note:
+        AdvGLUE++ inputs are perturbed but otherwise benign natural-language
+        understanding sentences — they probe model robustness, not harmful
+        content — so no ``harm_categories`` are assigned.
+    """
+
+    # Class-level metadata picked up by _RemoteDatasetLoader._parse_metadata_async.
+    # See pyrit/datasets/seed_datasets/seed_metadata.py for the schema. No
+    # harm_categories: these are robustness probes, not harmful prompts. "synthetic"
+    # reflects that the perturbations are algorithmically generated.
+    modalities: list[str] = ["text"]
+    size: str = "huge"  # ~11k (alpaca) up to ~40k (source_model=ALL)
+    tags: set[str] = {"safety", "synthetic"}
+
+    _AUTHORS: tuple[str, ...] = (
+        "Boxin Wang",
+        "Weixin Chen",
+        "Hengzhi Pei",
+        "Chulin Xie",
+        "Mintong Kang",
+        "Chenhui Zhang",
+        "Chejian Xu",
+        "Zidi Xiong",
+        "Ritik Dutta",
+        "Rylan Schaeffer",
+        "Sang T. Truong",
+        "Simran Arora",
+        "Mantas Mazeika",
+        "Dan Hendrycks",
+        "Zinan Lin",
+        "Yu Cheng",
+        "Sanmi Koyejo",
+        "Dawn Song",
+        "Bo Li",
+    )
+
+    _GROUPS: tuple[str, ...] = (
+        "University of Illinois Urbana-Champaign",
+        "Stanford University",
+        "University of California, Berkeley",
+        "Center for AI Safety",
+        "Microsoft Research",
+    )
+
+    _DESCRIPTION = (
+        "Adversarial Robustness (AdvGLUE++) perspective of the DecodingTrust benchmark "
+        "(Wang et al., 2023). Word-level adversarial perturbations of GLUE/AdvGLUE inputs "
+        "generated with five attack strategies against three surrogate models "
+        "(Alpaca-7B, Vicuna-13B, StableVicuna-13B). Each prompt is the perturbed "
+        "adversarial sentence; the clean original, gold label, attack method and task are "
+        "preserved in metadata."
+    )
+
+    def __init__(
+        self,
+        *,
+        source_model: DecodingTrustAdvGLUEModel = DecodingTrustAdvGLUEModel.ALPACA,
+        tasks: Sequence[DecodingTrustAdvGLUETask] | None = None,
+    ) -> None:
+        """
+        Initialize the DecodingTrust AdvGLUE++ dataset loader.
+
+        Args:
+            source_model: Which surrogate model's adversarial set to load.
+                Defaults to ``DecodingTrustAdvGLUEModel.ALPACA`` (one file);
+                ``ALL`` concatenates all three surrogate files.
+            tasks: Restrict to these GLUE tasks. ``None`` (default) keeps all six.
+
+        Raises:
+            ValueError: If ``source_model`` is not a ``DecodingTrustAdvGLUEModel``,
+                or if ``tasks`` contains a value that is not a
+                ``DecodingTrustAdvGLUETask``.
+        """
+        self._validate_enum(source_model, DecodingTrustAdvGLUEModel, "source_model")
+        if tasks is not None:
+            self._validate_enums(tasks, DecodingTrustAdvGLUETask, "tasks")
+        self.source_model = source_model
+        # Store the selected task keys as a set of source-JSON keys; None => all.
+        self.task_keys: set[str] = {t.value for t in tasks} if tasks else set(_TASK_KEYS)
+
+    @property
+    def dataset_name(self) -> str:
+        """The dataset name."""
+        return "decoding_trust_adv_glue_plus_plus"
+
+    def _model_urls(self) -> list[str]:
+        """Return the source file URLs implied by ``self.source_model``."""
+        if self.source_model is DecodingTrustAdvGLUEModel.ALL:
+            models = [m for m in DecodingTrustAdvGLUEModel if m is not DecodingTrustAdvGLUEModel.ALL]
+        else:
+            models = [self.source_model]
+        return [f"{_BASE_URL}{model.value}.json" for model in models]
+
+    async def fetch_dataset_async(self, *, cache: bool = True) -> SeedDataset:
+        """
+        Fetch the DecodingTrust AdvGLUE++ prompts and return them as a SeedDataset.
+
+        Args:
+            cache: Whether to cache the fetched JSON files locally. Defaults to True.
+
+        Returns:
+            SeedDataset: A SeedDataset whose seeds are the selected adversarial prompts.
+
+        Raises:
+            ValueError: If a source file is not a JSON object keyed by task, or if
+                the chosen filter combination leaves zero seeds.
+        """
+        logger.info(f"Loading DecodingTrust AdvGLUE++ source_model={self.source_model.value!r} from {_BASE_URL}")
+
+        seed_prompts: list[SeedUnion] = []
+        for url in self._model_urls():
+            raw = self._fetch_from_url(source=url, source_type="public_url", cache=cache)
+            # AdvGLUE++ files are a JSON object {task: [record, ...]}, unlike the
+            # list-shaped JSONL the base type hints assume.
+            by_task = cast("dict[str, Any]", raw)
+            if not isinstance(by_task, dict):
+                raise ValueError(
+                    f"Expected AdvGLUE++ file {url!r} to be a JSON object keyed by task, got {type(by_task).__name__}"
+                )
+            model_name = url.rsplit("/", 1)[-1].removesuffix(".json")
+            seed_prompts.extend(self._records_to_seed_prompts(by_task=by_task, source_url=url, model_name=model_name))
+
+        if not seed_prompts:
+            raise ValueError("SeedDataset cannot be empty. Check your filter criteria.")
+        logger.info(f"Loaded {len(seed_prompts)} prompts from DecodingTrust AdvGLUE++")
+        return SeedDataset(seeds=seed_prompts, dataset_name=self.dataset_name)
+
+    def _records_to_seed_prompts(
+        self,
+        *,
+        by_task: dict[str, Any],
+        source_url: str,
+        model_name: str,
+    ) -> list[SeedUnion]:
+        """
+        Convert one surrogate file's task->records mapping into SeedPrompt instances.
+
+        Args:
+            by_task: The parsed ``{task: [record, ...]}`` object from a source file.
+            source_url: The file URL; becomes each prompt's ``source``.
+            model_name: The surrogate model name (e.g. ``"alpaca"``) for metadata.
+
+        Returns:
+            List of SeedPrompt objects, one per record that passes the task filter
+            and yields non-empty adversarial text.
+
+        Raises:
+            ValueError: If a task's value is not a list of records.
+        """
+        seed_prompts: list[SeedUnion] = []
+        for task_key, records in by_task.items():
+            if task_key not in self.task_keys:
+                continue
+            if not isinstance(records, list):
+                raise ValueError(
+                    f"Expected task {task_key!r} in {source_url!r} to map to a list, got {type(records).__name__}"
+                )
+            for item in records:
+                if not isinstance(item, dict):
+                    logger.warning(f"Skipping non-dict record in task {task_key!r} (type={type(item).__name__})")
+                    continue
+
+                text = self._compose_text(task_key=task_key, item=item)
+                if not text:
+                    logger.warning(f"Skipping record with no usable adversarial text in task {task_key!r}")
+                    continue
+
+                seed_prompts.append(
+                    SeedPrompt(
+                        value=text,
+                        data_type="text",
+                        dataset_name=self.dataset_name,
+                        harm_categories=[],
+                        description=self._DESCRIPTION,
+                        source=source_url,
+                        authors=list(self._AUTHORS),
+                        groups=list(self._GROUPS),
+                        metadata=self._build_metadata(item=item, task_key=task_key, model_name=model_name),
+                    )
+                )
+        return seed_prompts
+
+    def _compose_text(self, *, task_key: str, item: dict[str, Any]) -> str | None:
+        """
+        Build the adversarial input text for one record.
+
+        Records ship in two shapes: some carry a pre-composed ``sentence``, others
+        store the perturbed parts separately (see ``_COMPONENT_TEMPLATES``). When a
+        record is in component form its parts are joined as
+        ``"label1: value1 label2: value2"`` — the layout DecodingTrust uses for its
+        own pre-composed ``sentence`` — so both shapes yield equivalent prompts.
+
+        Args:
+            task_key: The GLUE task the record belongs to.
+            item: A single AdvGLUE++ record.
+
+        Returns:
+            The composed adversarial text, or None if the record has neither a
+            usable ``sentence`` nor a complete set of component fields.
+        """
+        template = _COMPONENT_TEMPLATES.get(task_key)
+        if template is not None:
+            trigger_field, parts = template
+            if trigger_field in item:
+                segments: list[str] = []
+                for label, source_field in parts:
+                    value = item.get(source_field)
+                    if not isinstance(value, str) or not value:
+                        return None  # incomplete component record — skip
+                    segments.append(f"{label}: {value}")
+                return " ".join(segments)
+
+        # Pre-composed shape (always the case for sst2, and for the pre-joined
+        # records of the other tasks): the `sentence` field is the full input.
+        sentence = item.get("sentence")
+        if isinstance(sentence, str) and sentence:
+            return sentence
+        return None
+
+    def _build_metadata(self, *, item: dict[str, Any], task_key: str, model_name: str) -> dict[str, str]:
+        """
+        Assemble per-seed metadata (provenance) for one AdvGLUE++ record.
+
+        Args:
+            item: A single AdvGLUE++ record.
+            task_key: The GLUE task the record belongs to.
+            model_name: The surrogate model the adversarial example was crafted on.
+
+        Returns:
+            A flat ``dict[str, str]`` of provenance fields. Optional source fields
+            are included only when present.
+        """
+        metadata: dict[str, str] = {"task": task_key, "source_model": model_name}
+
+        label = item.get("label")
+        if isinstance(label, int):
+            metadata["label"] = str(label)
+            label_name = _LABEL_NAMES.get(task_key, {}).get(label)
+            if label_name is not None:
+                metadata["label_name"] = label_name
+
+        for key in ("method", "data_construction"):
+            value = item.get(key)
+            if isinstance(value, str) and value:
+                metadata[key] = value
+
+        # Preserve every clean counterpart the source provides. Which `original_*`
+        # fields exist depends on the task and record shape (e.g. original_sentence,
+        # original_premise/hypothesis, original_sentence1/2, original_question1/2).
+        metadata.update(
+            {
+                key: value
+                for key, value in item.items()
+                if key.startswith("original_") and isinstance(value, str) and value
+            }
+        )
+
+        idx = item.get("idx")
+        if isinstance(idx, int):
+            metadata["idx"] = str(idx)
+
+        return metadata

--- a/tests/unit/datasets/test_decoding_trust_adv_glue_dataset.py
+++ b/tests/unit/datasets/test_decoding_trust_adv_glue_dataset.py
@@ -1,0 +1,309 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from unittest.mock import patch
+
+import pytest
+
+from pyrit.datasets.seed_datasets.remote.decoding_trust_adv_glue_dataset import (
+    _BASE_URL,
+    _DECODING_TRUST_COMMIT,
+    DecodingTrustAdvGLUEModel,
+    DecodingTrustAdvGLUETask,
+    _DecodingTrustAdvGLUEDataset,
+)
+from pyrit.datasets.seed_datasets.seed_metadata import RECOMMENDED_TAGS
+from pyrit.models import SeedDataset, SeedPrompt
+
+
+def _record(
+    *,
+    sentence: str,
+    original_sentence: str = "clean version",
+    label: int = 1,
+    method: str = "textfooler",
+    data_construction: str = "word",
+    idx: int = 0,
+) -> dict:
+    """Build one AdvGLUE++-shaped record."""
+    return {
+        "idx": idx,
+        "sentence": sentence,
+        "original_sentence": original_sentence,
+        "label": label,
+        "method": method,
+        "data_construction": data_construction,
+    }
+
+
+def _file(**tasks) -> dict:
+    """Build a source-file object {task: [records]} from keyword task lists."""
+    return dict(tasks)
+
+
+@pytest.fixture
+def alpaca_file():
+    return _file(
+        sst2=[_record(sentence="adv sst2 one", label=1), _record(sentence="adv sst2 two", label=0)],
+        mnli=[_record(sentence="adv mnli one", label=2)],
+    )
+
+
+class TestDecodingTrustAdvGLUEDataset:
+    """Test the DecodingTrust AdvGLUE++ (adversarial robustness) dataset loader."""
+
+    async def test_default_source_model_is_alpaca(self, alpaca_file):
+        """Default constructor fetches only alpaca.json (a single file)."""
+        loader = _DecodingTrustAdvGLUEDataset()
+
+        assert loader.source_model is DecodingTrustAdvGLUEModel.ALPACA
+
+        with patch.object(loader, "_fetch_from_url", return_value=alpaca_file) as mock_fetch:
+            dataset = await loader.fetch_dataset_async()
+
+        mock_fetch.assert_called_once_with(source=f"{_BASE_URL}alpaca.json", source_type="public_url", cache=True)
+        assert isinstance(dataset, SeedDataset)
+        assert len(dataset.seeds) == 3
+
+    async def test_source_model_all_fetches_three_files(self, alpaca_file):
+        """source_model=ALL fetches alpaca, vicuna and stable-vicuna and concatenates."""
+        loader = _DecodingTrustAdvGLUEDataset(source_model=DecodingTrustAdvGLUEModel.ALL)
+
+        with patch.object(loader, "_fetch_from_url", side_effect=[alpaca_file, alpaca_file, alpaca_file]) as mock_fetch:
+            dataset = await loader.fetch_dataset_async()
+
+        assert mock_fetch.call_count == 3
+        fetched = {call.kwargs["source"] for call in mock_fetch.call_args_list}
+        assert fetched == {
+            f"{_BASE_URL}alpaca.json",
+            f"{_BASE_URL}vicuna.json",
+            f"{_BASE_URL}stable-vicuna.json",
+        }
+        assert len(dataset.seeds) == 9  # 3 records x 3 files
+
+    async def test_task_filter_restricts_tasks(self, alpaca_file):
+        """A tasks filter keeps only records from the selected GLUE tasks."""
+        loader = _DecodingTrustAdvGLUEDataset(tasks=[DecodingTrustAdvGLUETask.MNLI])
+
+        with patch.object(loader, "_fetch_from_url", return_value=alpaca_file):
+            dataset = await loader.fetch_dataset_async()
+
+        assert [seed.value for seed in dataset.seeds] == ["adv mnli one"]
+
+    def test_invalid_source_model_raises(self):
+        """A raw string for source_model is rejected by _validate_enum."""
+        with pytest.raises(ValueError, match="DecodingTrustAdvGLUEModel"):
+            _DecodingTrustAdvGLUEDataset(source_model="alpaca")  # type: ignore[arg-type]
+
+    def test_invalid_task_raises(self):
+        """A raw string inside tasks is rejected by _validate_enums."""
+        with pytest.raises(ValueError, match="DecodingTrustAdvGLUETask"):
+            _DecodingTrustAdvGLUEDataset(tasks=["sst2"])  # type: ignore[list-item]
+
+    async def test_prompt_value_is_adversarial_sentence(self, alpaca_file):
+        """The SeedPrompt value is the perturbed adversarial `sentence`."""
+        loader = _DecodingTrustAdvGLUEDataset()
+
+        with patch.object(loader, "_fetch_from_url", return_value=alpaca_file):
+            dataset = await loader.fetch_dataset_async()
+
+        first = dataset.seeds[0]
+        assert isinstance(first, SeedPrompt)
+        assert first.value == "adv sst2 one"
+        # Robustness probes carry no harm categories.
+        assert first.harm_categories == []
+
+    async def test_per_seed_metadata(self, alpaca_file):
+        """Provenance fields land in metadata, including the human-readable label name."""
+        loader = _DecodingTrustAdvGLUEDataset()
+
+        with patch.object(loader, "_fetch_from_url", return_value=alpaca_file):
+            dataset = await loader.fetch_dataset_async()
+
+        seed = dataset.seeds[0]
+        assert seed.dataset_name == "decoding_trust_adv_glue_plus_plus"
+        assert seed.source == f"{_BASE_URL}alpaca.json"
+        assert seed.authors is not None and "Boxin Wang" in seed.authors
+        meta = seed.metadata
+        assert meta is not None
+        assert meta["task"] == "sst2"
+        assert meta["source_model"] == "alpaca"
+        assert meta["label"] == "1"
+        assert meta["label_name"] == "positive"  # sst2 label 1
+        assert meta["method"] == "textfooler"
+        assert meta["data_construction"] == "word"
+        assert meta["original_sentence"] == "clean version"
+        assert meta["idx"] == "0"
+
+    async def test_mnli_label_name_mapping(self, alpaca_file):
+        """MNLI label 2 maps to 'contradiction'."""
+        loader = _DecodingTrustAdvGLUEDataset(tasks=[DecodingTrustAdvGLUETask.MNLI])
+
+        with patch.object(loader, "_fetch_from_url", return_value=alpaca_file):
+            dataset = await loader.fetch_dataset_async()
+
+        assert dataset.seeds[0].metadata["label_name"] == "contradiction"
+
+    async def test_unknown_label_omits_label_name(self):
+        """A label with no mapping stores label but not label_name."""
+        file = _file(sst2=[_record(sentence="x", label=7)])
+        loader = _DecodingTrustAdvGLUEDataset()
+
+        with patch.object(loader, "_fetch_from_url", return_value=file):
+            dataset = await loader.fetch_dataset_async()
+
+        meta = dataset.seeds[0].metadata
+        assert meta["label"] == "7"
+        assert "label_name" not in meta
+
+    async def test_component_form_mnli_composed(self):
+        """MNLI records that store premise/hypothesis separately are composed, not dropped."""
+        file = _file(
+            mnli=[
+                {
+                    "idx": 5,
+                    "premise": "the cat sat",
+                    "hypothesis": "a feline rested",
+                    "original_hypothesis": "a cat rested",
+                    "label": 1,
+                    "method": "bertattack",
+                    "data_construction": "word",
+                }
+            ]
+        )
+        loader = _DecodingTrustAdvGLUEDataset(tasks=[DecodingTrustAdvGLUETask.MNLI])
+
+        with patch.object(loader, "_fetch_from_url", return_value=file):
+            dataset = await loader.fetch_dataset_async()
+
+        seed = dataset.seeds[0]
+        assert seed.value == "premise: the cat sat hypothesis: a feline rested"
+        assert seed.metadata["label_name"] == "neutral"
+        # Clean counterpart preserved even though there's no `original_sentence`.
+        assert seed.metadata["original_hypothesis"] == "a cat rested"
+
+    async def test_component_form_rte_maps_to_premise_hypothesis(self):
+        """RTE sentence1/sentence2 map to premise/hypothesis in the composed text."""
+        file = _file(rte=[{"idx": 9, "sentence1": "A big storm hit", "sentence2": "It was calm", "label": 1}])
+        loader = _DecodingTrustAdvGLUEDataset(tasks=[DecodingTrustAdvGLUETask.RTE])
+
+        with patch.object(loader, "_fetch_from_url", return_value=file):
+            dataset = await loader.fetch_dataset_async()
+
+        assert dataset.seeds[0].value == "premise: A big storm hit hypothesis: It was calm"
+
+    async def test_component_form_qqp_composed(self):
+        """QQP question1/question2 records are composed."""
+        file = _file(qqp=[{"idx": 2, "question1": "How to X?", "question2": "how do i x?", "label": 1}])
+        loader = _DecodingTrustAdvGLUEDataset(tasks=[DecodingTrustAdvGLUETask.QQP])
+
+        with patch.object(loader, "_fetch_from_url", return_value=file):
+            dataset = await loader.fetch_dataset_async()
+
+        assert dataset.seeds[0].value == "question1: How to X? question2: how do i x?"
+
+    async def test_qnli_component_vs_precomposed(self):
+        """QNLI: a record with `question` is composed; one without is used as-is.
+
+        The `sentence` field is overloaded for QNLI — it is the passage in
+        component form but the full pre-joined input otherwise — so presence of
+        `question` is what disambiguates.
+        """
+        file = _file(
+            qnli=[
+                {"idx": 1, "question": "Who?", "sentence": "Alice went home.", "label": 0},
+                {"idx": 2, "sentence": "question: Who? sentence: Bob went home.", "label": 1},
+            ]
+        )
+        loader = _DecodingTrustAdvGLUEDataset(tasks=[DecodingTrustAdvGLUETask.QNLI])
+
+        with patch.object(loader, "_fetch_from_url", return_value=file):
+            dataset = await loader.fetch_dataset_async()
+
+        values = [seed.value for seed in dataset.seeds]
+        assert values == [
+            "question: Who? sentence: Alice went home.",
+            "question: Who? sentence: Bob went home.",
+        ]
+
+    async def test_incomplete_component_record_skipped(self):
+        """A component-form record missing its second field is skipped, not half-composed."""
+        file = _file(mnli=[{"idx": 1, "premise": "only premise", "label": 0}])
+        loader = _DecodingTrustAdvGLUEDataset(tasks=[DecodingTrustAdvGLUETask.MNLI])
+
+        with patch.object(loader, "_fetch_from_url", return_value=file):
+            with pytest.raises(ValueError, match="SeedDataset cannot be empty"):
+                await loader.fetch_dataset_async()
+
+    async def test_skips_records_missing_sentence(self):
+        """Records with missing/empty sentence or non-dict shape are skipped, not fatal."""
+        file = _file(
+            sst2=[
+                _record(sentence="keep"),
+                {"label": 1},  # missing sentence
+                {"sentence": ""},  # empty sentence
+                "not a dict",  # malformed record
+            ]
+        )
+        loader = _DecodingTrustAdvGLUEDataset()
+
+        with patch.object(loader, "_fetch_from_url", return_value=file):
+            dataset = await loader.fetch_dataset_async()
+
+        assert [seed.value for seed in dataset.seeds] == ["keep"]
+
+    async def test_raises_when_task_value_not_list(self):
+        """A task mapping to a non-list is a hard error."""
+        file = {"sst2": {"not": "a list"}}
+        loader = _DecodingTrustAdvGLUEDataset()
+
+        with patch.object(loader, "_fetch_from_url", return_value=file):
+            with pytest.raises(ValueError, match="to map to a list"):
+                await loader.fetch_dataset_async()
+
+    async def test_raises_when_file_not_object(self):
+        """A source file that is not a JSON object is a hard error."""
+        loader = _DecodingTrustAdvGLUEDataset()
+
+        with patch.object(loader, "_fetch_from_url", return_value=["not", "an", "object"]):
+            with pytest.raises(ValueError, match="JSON object keyed by task"):
+                await loader.fetch_dataset_async()
+
+    async def test_raises_when_filters_leave_zero_seeds(self):
+        """A task filter that matches nothing in the file yields an empty result and raises."""
+        file = _file(mnli=[_record(sentence="only mnli")])
+        loader = _DecodingTrustAdvGLUEDataset(tasks=[DecodingTrustAdvGLUETask.RTE])
+
+        with patch.object(loader, "_fetch_from_url", return_value=file):
+            with pytest.raises(ValueError, match="SeedDataset cannot be empty"):
+                await loader.fetch_dataset_async()
+
+    def test_dataset_name(self):
+        """dataset_name returns the canonical id."""
+        assert _DecodingTrustAdvGLUEDataset().dataset_name == "decoding_trust_adv_glue_plus_plus"
+
+    def test_source_urls_are_pinned_commit(self):
+        """Source URLs must reference the pinned commit SHA and the AdvGLUE++ path."""
+        loader = _DecodingTrustAdvGLUEDataset(source_model=DecodingTrustAdvGLUEModel.ALL)
+        urls = loader._model_urls()
+
+        assert len(urls) == 3
+        for url in urls:
+            assert _DECODING_TRUST_COMMIT in url
+            assert "/data/adv-glue-plus-plus/data/" in url
+            assert url.endswith(".json")
+
+    def test_single_model_url(self):
+        """A single source_model resolves to exactly one file URL."""
+        loader = _DecodingTrustAdvGLUEDataset(source_model=DecodingTrustAdvGLUEModel.VICUNA)
+        assert loader._model_urls() == [f"{_BASE_URL}vicuna.json"]
+
+    def test_class_level_metadata(self):
+        """Class metadata drives dataset discovery and must use the canonical vocab."""
+        assert _DecodingTrustAdvGLUEDataset.modalities == ["text"]
+        assert _DecodingTrustAdvGLUEDataset.size == "huge"
+        assert _DecodingTrustAdvGLUEDataset.tags == {"safety", "synthetic"}
+        # Tags must be drawn from the recommended vocabulary (soft contract).
+        assert _DecodingTrustAdvGLUEDataset.tags <= RECOMMENDED_TAGS
+        # Adversarial robustness prompts are benign NLU sentences: no harm categories.
+        assert not hasattr(_DecodingTrustAdvGLUEDataset, "harm_categories")


### PR DESCRIPTION
Adds a remote seed-dataset loader for the Adversarial Robustness perspective of the DecodingTrust benchmark (AdvGLUE++), one of the open DecodingTrust sub-tasks tracked in microsoft/PyRIT#291.

The loader fetches the three AdvGLUE++ surrogate files (alpaca, vicuna, stable-vicuna) at a pinned commit SHA and exposes each perturbed GLUE input as a SeedPrompt. Records ship in two shapes: some carry a pre-composed `sentence`, others store the perturbed parts separately (premise/hypothesis, sentence1/sentence2, question1/question2). The loader composes the prompt from component fields when needed using the same layout DecodingTrust uses, so no records are dropped, and preserves gold label, attack method and the clean `original_*` counterparts in metadata.

- New loader `_DecodingTrustAdvGLUEDataset` with `DecodingTrustAdvGLUEModel` and `DecodingTrustAdvGLUETask` filters, registered in the remote package.
- 22 unit tests covering both record shapes, per-task composition (including the QNLI `sentence` overload), filters, metadata and error paths.


Claude-Session: https://claude.ai/code/session_01LZPdM9LfD7nVRJRkyu2Ld9

<!--- Please add one of the following as a prefix to the pull request title: -->
<!--- DOC for documentation changes -->
<!--- MAINT for maintenance changes, e.g., build pipeline fixes -->
<!--- FIX for bug fixes -->
<!--- TEST for adding tests -->
<!--- FEAT for new features and enhancements (which implies that tests + doc changes are included) -->
<!--- Additionally, if your PR is not yet ready for review, create it as a "Draft" PR and prefix [DRAFT] -->

<!--- Note on BREAKING changes: If your PR includes a change that will require users to make a corresponding
change (e.g. naming changes), please list [BREAKING] in front of the above prefix in the PR title.
For example, [BREAKING] FEAT or [BREAKING] MAINT -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

<!--- If you are considering making a contribution please open an issue first. -->
<!--- This can help in identifying if the contribution fits into the plans for PyRIT. -->
<!--- Maintainers may be aware of obstacles that aren't obvious, or clarify requirements, and thereby save you time. -->

<!--- If your change is BREAKING please include reasoning for why below. -->


## Tests and Documentation

<!--- Contributions require tests and documentation (if applicable). -->
<!--- Include a description of tests and documentation updated (if applicable) -->

<!--- JupyText helps us see regressions in APIs or in our documentation by executing all code samples -->
<!--- Include how you/if ran JupyText here -->
<!--- This is described at: https://github.com/microsoft/PyRIT/tree/main/doc  -->
