### PR TITLE
FIX: improve frontend accessibility and mobile responsiveness

### DIFF
--- a/frontend/e2e/accessibility.spec.ts
+++ b/frontend/e2e/accessibility.spec.ts
@@ -25,7 +25,9 @@ async function expectTourContained(page: Page, dialog: Locator, checkTouchTarget
       const box = await dialog.boundingBox();
       const viewport = page.viewportSize();
       const dimensions = await page.evaluate(() => ({
+        clientHeight: document.documentElement.clientHeight,
         clientWidth: document.documentElement.clientWidth,
+        scrollHeight: document.documentElement.scrollHeight,
         scrollWidth: document.documentElement.scrollWidth,
       }));
 
@@ -34,6 +36,9 @@ async function expectTourContained(page: Page, dialog: Locator, checkTouchTarget
         viewport !== null &&
         box.x >= 0 &&
         box.x + box.width <= viewport.width + 1 &&
+        box.y >= 0 &&
+        box.y + box.height <= viewport.height + 1 &&
+        dimensions.scrollHeight <= dimensions.clientHeight + 1 &&
         dimensions.scrollWidth <= dimensions.clientWidth + 1
       );
     })

--- a/frontend/e2e/accessibility.spec.ts
+++ b/frontend/e2e/accessibility.spec.ts
@@ -1,5 +1,58 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Locator, type Page } from "@playwright/test";
 import { makeTarget } from "./_targets";
+
+async function expectMinimumTouchTarget(locator: Locator, minimum = 44): Promise<void> {
+  await expect(locator).toBeVisible();
+
+  const box = await locator.boundingBox();
+
+  expect(box).not.toBeNull();
+  expect(box!.width).toBeGreaterThanOrEqual(minimum);
+  expect(box!.height).toBeGreaterThanOrEqual(minimum);
+}
+
+async function expectTourContained(page: Page, dialog: Locator, checkTouchTargets: boolean): Promise<void> {
+  await expect(dialog).toBeVisible();
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      })
+  );
+
+  await expect
+    .poll(async () => {
+      const box = await dialog.boundingBox();
+      const viewport = page.viewportSize();
+      const dimensions = await page.evaluate(() => ({
+        clientWidth: document.documentElement.clientWidth,
+        scrollWidth: document.documentElement.scrollWidth,
+      }));
+
+      return (
+        box !== null &&
+        viewport !== null &&
+        box.x >= 0 &&
+        box.x + box.width <= viewport.width + 1 &&
+        dimensions.scrollWidth <= dimensions.clientWidth + 1
+      );
+    })
+    .toBe(true);
+
+  const actions = dialog.getByRole("button");
+  const actionCount = await actions.count();
+
+  expect(actionCount).toBeGreaterThan(0);
+
+  for (let index = 0; index < actionCount; index += 1) {
+    const action = actions.nth(index);
+    await expect(action).toBeVisible();
+
+    if (checkTouchTargets) {
+      await expectMinimumTouchTarget(action);
+    }
+  }
+}
 
 test.describe("Accessibility", () => {
   test.beforeEach(async ({ page }) => {
@@ -159,6 +212,12 @@ test.describe("Accessibility", () => {
               endpoint: "https://test.com",
               model_name: "gpt-4o",
             }),
+            makeTarget({
+              target_registry_name: "a11y-second-target",
+              target_type: "TextTarget",
+              endpoint: "https://test.com/text",
+              model_name: "text-model",
+            }),
           ],
           pagination: { limit: 200, has_more: false, next_cursor: null, prev_cursor: null },
         }),
@@ -172,7 +231,107 @@ test.describe("Accessibility", () => {
     // Table should exist
     const table = page.getByRole("table");
     await expect(table).toBeVisible();
+    await expect(page.getByRole("combobox", { name: "Filter by type:" })).toBeVisible();
   });
+
+  test("major views expose page headings and one primary navigation landmark", async ({ page }) => {
+    const navigation = page.getByRole("navigation", { name: "Primary" });
+
+    await expect(navigation).toHaveCount(1);
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Welcome to Co-PyRIT" })
+    ).toBeVisible();
+    await expect(navigation.getByRole("button", { name: "Home" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+
+    const views = [
+      { button: "Attack History", heading: "Attack History" },
+      { button: "Configuration", heading: "Target Configuration" },
+      { button: "Chat", heading: "Chat" },
+    ];
+
+    for (const view of views) {
+      await navigation.getByRole("button", { name: view.button }).click();
+      await expect(
+        page.getByRole("heading", { level: 1, name: view.heading })
+      ).toBeAttached();
+      await expect(page.locator("main h1")).toHaveCount(1);
+      await expect(navigation.getByRole("button", { name: view.button })).toHaveAttribute(
+        "aria-current",
+        "page"
+      );
+    }
+  });
+
+  test("mobile audit controls provide 44px touch targets", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+
+    await expectMinimumTouchTarget(page.getByRole("button", { name: "Labels" }));
+    await expectMinimumTouchTarget(page.getByRole("button", { name: "Configure a target" }));
+    await expectMinimumTouchTarget(page.getByRole("button", { name: "Take a tour" }));
+
+    await page.route(/\/api\/targets/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [
+            makeTarget({
+              target_registry_name: "mobile-touch-target",
+              target_type: "OpenAIChatTarget",
+              endpoint: "https://test.com",
+              model_name: "gpt-4o",
+            }),
+          ],
+          pagination: { limit: 200, has_more: false, next_cursor: null, prev_cursor: null },
+        }),
+      });
+    });
+
+    await page.getByRole("button", { name: "Configuration" }).click();
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Target Configuration" })
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Refresh" })).toBeEnabled();
+    await expectMinimumTouchTarget(page.getByRole("button", { name: "Refresh" }));
+    await expectMinimumTouchTarget(page.getByRole("button", { name: "New Target" }));
+  });
+
+  for (const viewport of [
+    { name: "mobile", width: 390, height: 844 },
+    { name: "desktop", width: 1280, height: 800 },
+  ]) {
+    test(`tour remains contained and actionable on ${viewport.name}`, async ({ page }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await page.getByRole("button", { name: "Take a tour" }).click();
+
+      const dialog = page.getByRole("alertdialog");
+
+      for (let step = 0; step < 5; step += 1) {
+        await expect(dialog).toContainText(`${step + 1} of 5`);
+        await expectTourContained(page, dialog, viewport.name === "mobile");
+
+        if (viewport.name === "desktop" && step === 0) {
+          const targetBox = await page.locator('[data-tour="sidebar-nav"]').boundingBox();
+          const dialogBox = await dialog.boundingBox();
+
+          expect(targetBox).not.toBeNull();
+          expect(dialogBox).not.toBeNull();
+          expect(dialogBox!.x).toBeGreaterThanOrEqual(targetBox!.x + targetBox!.width);
+        }
+
+        if (step < 4) {
+          await dialog.getByRole("button", { name: "Next", exact: true }).click();
+        }
+      }
+
+      await dialog.getByRole("button", { name: "Anchors Away!", exact: true }).click();
+      await expect(dialog).toBeHidden();
+      await expect(page).toHaveURL(/\/$/);
+    });
+  }
 });
 
 test.describe("Visual Consistency", () => {

--- a/frontend/src/components/Chat/ChatWindow.styles.ts
+++ b/frontend/src/components/Chat/ChatWindow.styles.ts
@@ -7,6 +7,17 @@ export const useChatWindowStyles = makeStyles({
     width: '100%',
     overflow: 'hidden',
   },
+  pageHeading: {
+    position: 'absolute',
+    width: '1px',
+    height: '1px',
+    padding: 0,
+    margin: '-1px',
+    overflow: 'hidden',
+    clip: 'rect(0, 0, 0, 0)',
+    whiteSpace: 'nowrap',
+    border: 0,
+  },
   chatArea: {
     display: 'flex',
     flexDirection: 'column',

--- a/frontend/src/components/Chat/ChatWindow.test.tsx
+++ b/frontend/src/components/Chat/ChatWindow.test.tsx
@@ -305,6 +305,7 @@ describe("ChatWindow Integration", () => {
 
     // The ribbon no longer shows the "PyRIT Attack" prefix; the target
     // badge stands on its own as the leftmost element.
+    expect(screen.getByRole("heading", { level: 1, name: "Chat" })).toBeInTheDocument();
     expect(screen.queryByText("PyRIT Attack")).not.toBeInTheDocument();
     expect(screen.getByTestId("target-badge")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /new attack/i })).toBeInTheDocument();

--- a/frontend/src/components/Chat/ChatWindow.tsx
+++ b/frontend/src/components/Chat/ChatWindow.tsx
@@ -616,6 +616,7 @@ export default function ChatWindow({
 
   return (
     <div className={styles.root}>
+      <h1 className={styles.pageHeading}>Chat</h1>
       {isConverterPanelOpen && (
         <ConverterPanel
           onClose={() => setIsConverterPanelOpen(false)}

--- a/frontend/src/components/Config/TargetConfig.styles.ts
+++ b/frontend/src/components/Config/TargetConfig.styles.ts
@@ -47,6 +47,7 @@ export const useTargetConfigStyles = makeStyles({
   headerAction: {
     '@media (max-width: 600px)': {
       flex: '1 1 8rem',
+      minHeight: '44px',
     },
   },
   emptyState: {

--- a/frontend/src/components/Config/TargetConfig.test.tsx
+++ b/frontend/src/components/Config/TargetConfig.test.tsx
@@ -82,6 +82,9 @@ describe("TargetConfig", () => {
       </TestWrapper>
     );
 
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Target Configuration" })
+    ).toBeInTheDocument();
     expect(screen.getByText("Loading targets...")).toBeInTheDocument();
   });
 

--- a/frontend/src/components/Config/TargetConfig.tsx
+++ b/frontend/src/components/Config/TargetConfig.tsx
@@ -76,7 +76,7 @@ export default function TargetConfig({ activeTarget, onSetActiveTarget }: Target
     <div className={styles.root} data-testid="target-config">
       <div className={styles.header}>
         <div className={styles.headerLeft}>
-          <Text size={600} weight="semibold">Target Configuration</Text>
+          <Text as="h1" size={600} weight="semibold">Target Configuration</Text>
           <Text size={300} style={{ color: tokens.colorNeutralForeground3 }}>
             Manage targets for attack sessions. Select a target to use in the chat view.
           </Text>

--- a/frontend/src/components/Config/TargetTable.test.tsx
+++ b/frontend/src/components/Config/TargetTable.test.tsx
@@ -312,7 +312,7 @@ describe('TargetTable', () => {
     expect(screen.getByText('dall-e-3')).toBeInTheDocument()
 
     // Filter to OpenAIChatTarget
-    const select = screen.getByRole('combobox')
+    const select = screen.getByRole('combobox', { name: 'Filter by type:' })
     fireEvent.change(select, { target: { value: 'OpenAIChatTarget' } })
 
     expect(screen.getByText('gpt-4')).toBeInTheDocument()

--- a/frontend/src/components/Config/TargetTable.tsx
+++ b/frontend/src/components/Config/TargetTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, forwardRef } from 'react'
+import React, { useState, useMemo, forwardRef, useId } from 'react'
 import {
   Table,
   TableHeader,
@@ -242,6 +242,7 @@ function InnerTargetRows({ parentKey, innerTargets, weights }: {
 
 export default function TargetTable({ targets, activeTarget, onSetActiveTarget }: TargetTableProps) {
   const styles = useTargetTableStyles()
+  const typeFilterId = useId()
   const [typeFilter, setTypeFilter] = useState('')
   // Tracks which RoundRobinTarget rows are expanded to show inner targets.
   // We use a Set of target_registry_name strings — when a name is in the set,
@@ -334,8 +335,11 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
 
       {targetTypes.length > 1 && (
         <div className={styles.filterRow}>
-          <Text size={200}>Filter by type:</Text>
+          <label htmlFor={typeFilterId}>
+            <Text size={200}>Filter by type:</Text>
+          </label>
           <Select
+            id={typeFilterId}
             className={styles.filterSelect}
             value={typeFilter}
             onChange={(_, data) => setTypeFilter(data.value)}

--- a/frontend/src/components/History/AttackHistory.test.tsx
+++ b/frontend/src/components/History/AttackHistory.test.tsx
@@ -81,7 +81,7 @@ describe('AttackHistory', () => {
       </TestWrapper>
     )
 
-    expect(screen.getByText('Attack History')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 1, name: 'Attack History' })).toBeInTheDocument()
     expect(screen.getByTestId('refresh-btn')).toBeInTheDocument()
     expect(screen.getByTestId('attack-type-filter')).toBeInTheDocument()
     expect(screen.getByTestId('outcome-filter')).toBeInTheDocument()

--- a/frontend/src/components/History/AttackHistory.tsx
+++ b/frontend/src/components/History/AttackHistory.tsx
@@ -180,7 +180,7 @@ export default function AttackHistory({ onOpenAttack, filters, onFiltersChange }
     <div className={styles.root}>
       <div className={styles.header} data-tour="history-filters">
         <div className={styles.headerRow}>
-          <Text size={500} weight="semibold">Attack History</Text>
+          <Text as="h1" size={500} weight="semibold">Attack History</Text>
           <Button
             appearance="subtle"
             icon={<ArrowSyncRegular />}

--- a/frontend/src/components/Home/Home.styles.ts
+++ b/frontend/src/components/Home/Home.styles.ts
@@ -13,6 +13,9 @@ export const useHomeStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
     gap: tokens.spacingVerticalXXL,
+    '@media (max-width: 600px)': {
+      padding: `${tokens.spacingVerticalL} ${tokens.spacingHorizontalM}`,
+    },
   },
   hero: {
     display: 'flex',
@@ -29,6 +32,9 @@ export const useHomeStyles = makeStyles({
     display: 'grid',
     gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
     gap: tokens.spacingHorizontalL,
+    '@media (max-width: 600px)': {
+      gridTemplateColumns: 'minmax(0, 1fr)',
+    },
   },
   card: {
     backgroundColor: tokens.colorNeutralBackground1,
@@ -65,6 +71,11 @@ export const useHomeStyles = makeStyles({
     justifyContent: 'flex-end',
     gap: tokens.spacingHorizontalS,
   },
+  mobilePrimaryAction: {
+    '@media (max-width: 600px)': {
+      minHeight: '44px',
+    },
+  },
   targetSummary: {
     display: 'flex',
     flexDirection: 'column',
@@ -90,6 +101,9 @@ export const useHomeStyles = makeStyles({
     display: 'grid',
     gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
     gap: tokens.spacingHorizontalL,
+    '@media (max-width: 600px)': {
+      gridTemplateColumns: 'minmax(0, 1fr)',
+    },
   },
   operationCard: {
     backgroundColor: tokens.colorNeutralBackground1,

--- a/frontend/src/components/Home/Home.test.tsx
+++ b/frontend/src/components/Home/Home.test.tsx
@@ -64,7 +64,14 @@ describe("Home", () => {
 
   it("renders the welcome hero", async () => {
     render(<TestWrapper><Home {...defaultProps} /></TestWrapper>);
-    expect(screen.getByText(/welcome to co-pyrit/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 1, name: /welcome to co-pyrit/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: "Labels" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: "Target" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Recent operations" })
+    ).toBeInTheDocument();
     await waitFor(() => expect(mockListAttacks).toHaveBeenCalled());
   });
 

--- a/frontend/src/components/Home/Home.tsx
+++ b/frontend/src/components/Home/Home.tsx
@@ -140,7 +140,7 @@ export default function Home({
     <div className={styles.root} data-testid="home-view">
       <div className={styles.container}>
         <div className={styles.hero}>
-          <Text size={700} weight="semibold" className={styles.heroTitle}>
+          <Text as="h1" size={700} weight="semibold" className={styles.heroTitle}>
             Welcome to Co-PyRIT
           </Text>
           <Text size={300} className={styles.heroSubtitle}>
@@ -152,7 +152,7 @@ export default function Home({
           <section className={styles.card} data-testid="home-labels-card" data-tour="labels-card">
             <div className={styles.cardHeader}>
               <span className={styles.cardIcon}><TagMultipleRegular /></span>
-              <Text size={500} weight="semibold">Labels</Text>
+              <Text as="h2" size={500} weight="semibold">Labels</Text>
             </div>
             <div className={styles.cardBody}>
               <Text size={200} className={styles.heroSubtitle}>
@@ -168,7 +168,7 @@ export default function Home({
           <section className={styles.card} data-testid="home-target-card" data-tour="target-card">
             <div className={styles.cardHeader}>
               <span className={styles.cardIcon}><TargetRegular /></span>
-              <Text size={500} weight="semibold">Target</Text>
+              <Text as="h2" size={500} weight="semibold">Target</Text>
             </div>
             <div className={styles.cardBody}>
               {activeTarget ? (
@@ -192,6 +192,7 @@ export default function Home({
                 iconPosition="after"
                 onClick={() => onNavigate('config')}
                 data-testid="home-configure-target-btn"
+                className={styles.mobilePrimaryAction}
               >
                 {activeTarget ? 'Manage targets' : 'Configure a target'}
               </Button>
@@ -201,7 +202,7 @@ export default function Home({
 
         <section data-testid="home-recent-operations">
           <div className={styles.sectionHeader}>
-            <Text size={500} weight="semibold">Recent operations</Text>
+            <Text as="h2" size={500} weight="semibold">Recent operations</Text>
             <Button
               appearance="subtle"
               icon={<ArrowRightRegular />}
@@ -248,7 +249,7 @@ export default function Home({
                     data-testid={`home-operation-${op.isUnlabeled ? 'unlabeled' : op.name}`}
                   >
                     <div className={styles.operationHeader}>
-                      <Text size={400} className={styles.operationName} title={op.name}>
+                      <Text as="h3" size={400} className={styles.operationName} title={op.name}>
                         {op.name}
                       </Text>
                       <Badge appearance="tint" size="small">

--- a/frontend/src/components/Labels/LabelsBar.styles.ts
+++ b/frontend/src/components/Labels/LabelsBar.styles.ts
@@ -16,6 +16,9 @@ export const useLabelsBarStyles = makeStyles({
   },
   iconButton: {
     flexShrink: 0,
+    '@media (max-width: 600px)': {
+      minHeight: '44px',
+    },
   },
   iconTooltipBody: {
     whiteSpace: 'nowrap',

--- a/frontend/src/components/Layout/MainLayout.styles.ts
+++ b/frontend/src/components/Layout/MainLayout.styles.ts
@@ -35,6 +35,11 @@ export const useMainLayoutStyles = makeStyles({
   spacer: {
     flex: 1,
   },
+  tourButton: {
+    '@media (max-width: 600px)': {
+      minHeight: '44px',
+    },
+  },
   contentArea: {
     display: 'flex',
     flex: 1,

--- a/frontend/src/components/Layout/MainLayout.tsx
+++ b/frontend/src/components/Layout/MainLayout.tsx
@@ -57,6 +57,7 @@ export default function MainLayout({
             icon={<QuestionCircleRegular />}
             onClick={onStartTour}
             data-testid="start-tour"
+            className={styles.tourButton}
           >
             Take a tour
           </Button>

--- a/frontend/src/components/Sidebar/Navigation.styles.ts
+++ b/frontend/src/components/Sidebar/Navigation.styles.ts
@@ -9,6 +9,12 @@ export const useNavigationStyles = makeStyles({
     alignItems: 'center',
     gap: tokens.spacingVerticalM,
   },
+  primaryNavigation: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: tokens.spacingVerticalM,
+  },
   navButton: {
     width: '44px',
     height: '44px',

--- a/frontend/src/components/Sidebar/Navigation.test.tsx
+++ b/frontend/src/components/Sidebar/Navigation.test.tsx
@@ -32,6 +32,19 @@ describe("Navigation", () => {
     expect(screen.getByRole("button", { name: "Home" })).toBeInTheDocument();
   });
 
+  it("exposes one primary navigation landmark and marks the current view", () => {
+    renderWithProvider(<Navigation {...defaultProps} />);
+
+    expect(screen.getByRole("navigation", { name: "Primary" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Chat" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+    expect(screen.getByRole("button", { name: "Home" })).not.toHaveAttribute(
+      "aria-current"
+    );
+  });
+
   it("calls onNavigate with 'home' when home button is clicked", async () => {
     const user = userEvent.setup();
     const onNavigate = jest.fn();

--- a/frontend/src/components/Sidebar/Navigation.tsx
+++ b/frontend/src/components/Sidebar/Navigation.tsx
@@ -58,45 +58,51 @@ export default function Navigation({ currentView, onNavigate, onOpenFeedback }: 
 
   return (
     <div className={styles.root} data-tour="sidebar-nav">
-      <Button
-        className={styles.navButton}
-        data-active={currentView === 'home'}
-        appearance="subtle"
-        icon={<HomeRegular />}
-        title="Home"
-        aria-label="Home"
-        onClick={() => onNavigate('home')}
-      />
+      <nav aria-label="Primary" className={styles.primaryNavigation}>
+        <Button
+          className={styles.navButton}
+          data-active={currentView === 'home'}
+          appearance="subtle"
+          icon={<HomeRegular />}
+          title="Home"
+          aria-label="Home"
+          aria-current={currentView === 'home' ? 'page' : undefined}
+          onClick={() => onNavigate('home')}
+        />
 
-      <Button
-        className={styles.navButton}
-        data-active={currentView === 'chat'}
-        appearance="subtle"
-        icon={<ChatRegular />}
-        title="Chat"
-        aria-label="Chat"
-        onClick={() => onNavigate('chat')}
-      />
+        <Button
+          className={styles.navButton}
+          data-active={currentView === 'chat'}
+          appearance="subtle"
+          icon={<ChatRegular />}
+          title="Chat"
+          aria-label="Chat"
+          aria-current={currentView === 'chat' ? 'page' : undefined}
+          onClick={() => onNavigate('chat')}
+        />
 
-      <Button
-        className={styles.navButton}
-        data-active={currentView === 'history'}
-        appearance="subtle"
-        icon={<HistoryRegular />}
-        title="Attack History"
-        aria-label="Attack History"
-        onClick={() => onNavigate('history')}
-      />
+        <Button
+          className={styles.navButton}
+          data-active={currentView === 'history'}
+          appearance="subtle"
+          icon={<HistoryRegular />}
+          title="Attack History"
+          aria-label="Attack History"
+          aria-current={currentView === 'history' ? 'page' : undefined}
+          onClick={() => onNavigate('history')}
+        />
 
-      <Button
-        className={styles.navButton}
-        data-active={currentView === 'config'}
-        appearance="subtle"
-        icon={<SettingsRegular />}
-        title="Configuration"
-        aria-label="Configuration"
-        onClick={() => onNavigate('config')}
-      />
+        <Button
+          className={styles.navButton}
+          data-active={currentView === 'config'}
+          appearance="subtle"
+          icon={<SettingsRegular />}
+          title="Configuration"
+          aria-label="Configuration"
+          aria-current={currentView === 'config' ? 'page' : undefined}
+          onClick={() => onNavigate('config')}
+        />
+      </nav>
 
       <div className={styles.spacer} />
 

--- a/frontend/src/components/Tour/TourTooltip.styles.ts
+++ b/frontend/src/components/Tour/TourTooltip.styles.ts
@@ -5,7 +5,8 @@ export const useTourTooltipStyles = makeStyles({
   wrapper: {
     display: 'flex',
     flexDirection: 'column',
-    maxWidth: '420px',
+    width: '420px',
+    maxWidth: `calc(100vw - ${tokens.spacingHorizontalM} - ${tokens.spacingHorizontalM})`,
     position: 'relative',
   },
   container: {
@@ -30,16 +31,34 @@ export const useTourTooltipStyles = makeStyles({
     objectFit: 'contain',
     pointerEvents: 'none',
     zIndex: 1,
+    '@media (max-width: 600px)': {
+      left: 0,
+    },
+  },
+  closeRow: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    marginBottom: '-8px',
+    marginTop: '-4px',
+  },
+  closeButton: {
+    '@media (max-width: 600px)': {
+      minWidth: '44px',
+      minHeight: '44px',
+    },
   },
   content: {
     color: tokens.colorNeutralForeground1,
     lineHeight: tokens.lineHeightBase300,
+    overflowWrap: 'anywhere',
   },
   footer: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
     gap: tokens.spacingHorizontalS,
+    flexWrap: 'wrap',
+    paddingLeft: '72px',
   },
   stepCounter: {
     color: tokens.colorNeutralForeground3,
@@ -49,5 +68,13 @@ export const useTourTooltipStyles = makeStyles({
     display: 'flex',
     gap: tokens.spacingHorizontalS,
     marginLeft: 'auto',
+    flexWrap: 'wrap',
+    justifyContent: 'flex-end',
+  },
+  actionButton: {
+    '@media (max-width: 600px)': {
+      minWidth: '44px',
+      minHeight: '44px',
+    },
   },
 })

--- a/frontend/src/components/Tour/TourTooltip.tsx
+++ b/frontend/src/components/Tour/TourTooltip.tsx
@@ -34,16 +34,17 @@ export default function TourTooltip({
   return (
     <div {...tooltipProps}>
       <FluentProvider theme={isDarkMode ? webDarkTheme : webLightTheme}>
-        <div className={styles.wrapper}>
+        <div className={styles.wrapper} data-testid="tour-tooltip-card">
           <div className={styles.container}>
             {/* Close (X) button — top-right, hidden on last step */}
-            <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: '-8px', marginTop: '-4px' }}>
+            <div className={styles.closeRow}>
               {!isLastStep && (
                 <Button
                   {...closeProps}
                   appearance="subtle"
                   icon={<DismissRegular />}
                   size="small"
+                  className={styles.closeButton}
                 />
               )}
             </div>
@@ -54,26 +55,26 @@ export default function TourTooltip({
             </Text>
 
             {/* Footer: step counter + buttons, offset right to leave room for mascot */}
-            <div className={styles.footer} style={{ paddingLeft: '72px' }}>
+            <div className={styles.footer}>
               <Text className={styles.stepCounter} size={200}>
                 {index + 1} of {size}
               </Text>
 
               <div className={styles.actions}>
                 {!isLastStep && (
-                  <Button {...skipProps} appearance="subtle" size="small">
+                  <Button {...skipProps} appearance="subtle" size="small" className={styles.actionButton}>
                     Skip tour
                   </Button>
                 )}
 
                 {index > 0 && (
-                  <Button {...backProps} appearance="outline" size="small">
+                  <Button {...backProps} appearance="outline" size="small" className={styles.actionButton}>
                     Back
                   </Button>
                 )}
 
                 {continuous && (
-                  <Button {...primaryProps} appearance="primary" size="small">
+                  <Button {...primaryProps} appearance="primary" size="small" className={styles.actionButton}>
                     {isLastStep ? "Anchors Away!" : 'Next'}
                   </Button>
                 )}

--- a/frontend/src/hooks/useTour.test.ts
+++ b/frontend/src/hooks/useTour.test.ts
@@ -50,6 +50,13 @@ describe('useTour', () => {
 
     expect(result.current.tourProps.run).toBe(true)
     expect(result.current.tourProps.stepIndex).toBe(0)
+    expect(result.current.tourProps.floatingOptions).toEqual({
+      hideArrow: true,
+      shiftOptions: {
+        crossAxis: true,
+        padding: 12,
+      },
+    })
   })
 
   it('startTour navigates to home and defers step when on a different view', () => {

--- a/frontend/src/hooks/useTour.ts
+++ b/frontend/src/hooks/useTour.ts
@@ -10,7 +10,14 @@ import type { ViewName } from '../components/Sidebar/Navigation'
 // Static Joyride config — hoisted to module scope so they're created once,
 // not on every render. Joyride compares these by reference internally.
 const JOYRIDE_STEPS = [...TOUR_STEPS]
-const JOYRIDE_FLOATING_OPTIONS = { hideArrow: true } as const
+const TOUR_VIEWPORT_PADDING_PX = 12
+const JOYRIDE_FLOATING_OPTIONS = {
+  hideArrow: true,
+  shiftOptions: {
+    crossAxis: true,
+    padding: TOUR_VIEWPORT_PADDING_PX,
+  },
+} as const
 const JOYRIDE_OPTIONS = {
   closeButtonAction: 'skip' as const,
   overlayClickAction: false as const,


### PR DESCRIPTION
## Description

The July 21 exploratory audit found that the onboarding tour became unusable on a 390px viewport, several major views lacked heading and navigation semantics, the target-type filter had no accessible name, and key mobile controls fell below a 44px touch target. This change resolves those findings while preserving the existing Fluent UI design, desktop density, dark mode, and tour navigation behavior.

- Keeps every tour step inside the viewport by combining Floating UI cross-axis shifting with a viewport-bounded tooltip, wrapping actions, and a contained mascot treatment.
- Adds one page-level heading to Home, Attack History, Target Configuration, and Chat, plus a labeled primary navigation landmark and current-page semantics.
- Associates `Filter by type:` with its native select through stable semantic label wiring.
- Applies mobile-only 44px minimum hit areas to the audited Home, Configuration, and tour controls without expanding their desktop layout.
- Adds focused unit and Playwright coverage for semantics, accessible naming, settled tour geometry, horizontal overflow, action visibility, and measured touch-target dimensions.

### Visual comparison (390x844)

#### Onboarding tour

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/468e9844-22b2-47bc-a8b0-f7e0e0a2a954" alt="Before: onboarding tour clipped beyond the mobile viewport" width="320"> | <img src="https://github.com/user-attachments/assets/f7c8542f-3d82-4fed-9594-7f7d5546eeb2" alt="After: onboarding tour contained within the mobile viewport" width="320"> |

#### Home controls and responsive containment

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/ac399338-09e4-46a2-af4d-81ffc2332f14" alt="Before: Home controls at the mobile edge" width="320"> | <img src="https://github.com/user-attachments/assets/760d1db4-214a-4cf0-ba0a-71fd2890e04a" alt="After: Home content and controls contained on mobile" width="320"> |

#### Configuration actions

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/19758134-a7e3-49a1-8a07-485f1d36f9dd" alt="Before: compact Configuration mobile actions" width="320"> | <img src="https://github.com/user-attachments/assets/98d234f2-0fdd-456c-9f47-c31047c117d9" alt="After: Configuration actions with 44px mobile hit areas" width="320"> |

The heading, navigation landmark, current-page, and filter-label changes are intentionally not visually apparent.

## Tests and Documentation

- Targeted Jest: 7 suites, 186 tests passed for Home, Attack History, Target Configuration, TargetTable, ChatWindow, Navigation, and `useTour`.
- TourTooltip Jest: 1 suite, 12 tests passed.
- Playwright mock project: 12 tests passed in `e2e/accessibility.spec.ts`, including every tour step at 390x844 and 1280x800 after positioning settles.
- `npm run type-check` passed.
- ESLint passed with zero warnings across all changed frontend files.
- `npm run build` passed (`tsc && vite build`).
- Documentation changes: N/A. JupyText: N/A.