### PR TITLE
[BREAKING] MAINT: Remove expired single-turn system prompt

### DIFF
--- a/pyrit/executor/attack/core/attack_strategy.py
+++ b/pyrit/executor/attack/core/attack_strategy.py
@@ -648,7 +648,7 @@ class AttackStrategy(Strategy[AttackStrategyContextT, AttackStrategyResultT], Id
             next_message (Message | None): Message to send to the target.
             prepended_conversation (list[Message] | None): Conversation to prepend.
             memory_labels (dict[str, str] | None): Memory labels for the attack context.
-            **kwargs: Additional context-specific parameters (conversation_id, system_prompt, etc.).
+            **kwargs: Additional context-specific parameters (conversation_id, metadata, etc.).
 
         Returns:
             AttackStrategyResultT: The result of the attack execution.

--- a/pyrit/executor/attack/single_turn/single_turn_attack_strategy.py
+++ b/pyrit/executor/attack/single_turn/single_turn_attack_strategy.py
@@ -9,7 +9,6 @@ from abc import ABC
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from pyrit.common.deprecation import print_deprecation_message
 from pyrit.common.logger import logger
 from pyrit.executor.attack.core.attack_parameters import AttackParameters, AttackParamsT
 from pyrit.executor.attack.core.attack_strategy import AttackContext, AttackStrategy
@@ -32,21 +31,8 @@ class SingleTurnAttackContext(AttackContext[AttackParamsT]):
     # Unique identifier of the main conversation between the attacker and model
     conversation_id: str = field(default_factory=lambda: str(uuid.uuid4()))
 
-    # Deprecated, non-functional no-op; removed in 0.17.0. Set the objective
-    # target's system prompt via ``prepended_conversation`` instead.
-    system_prompt: str | None = None
-
     # Arbitrary metadata that downstream attacks or scorers may attach
     metadata: dict[str, str | int] | None = None
-
-    def __post_init__(self) -> None:
-        """Warn that ``system_prompt`` is deprecated and non-functional when it is set."""
-        if self.system_prompt is not None:
-            print_deprecation_message(
-                old_item="SingleTurnAttackContext.system_prompt",
-                new_item="prepended_conversation=[Message.from_system_prompt(...)]",
-                removed_in="0.17.0",
-            )
 
 
 class SingleTurnAttackStrategy(AttackStrategy[SingleTurnAttackContext[Any], AttackResult], ABC):

--- a/tests/unit/executor/attack/single_turn/test_prompt_sending.py
+++ b/tests/unit/executor/attack/single_turn/test_prompt_sending.py
@@ -207,16 +207,14 @@ class TestContextValidation:
 
     def test_validate_context_with_additional_optional_fields(self, mock_target):
         attack = PromptSendingAttack(objective_target=mock_target)
-        with pytest.warns(DeprecationWarning, match="system_prompt"):
-            context = SingleTurnAttackContext(
-                params=AttackParameters(
-                    objective="Test objective",
-                    next_message=Message.from_prompt(prompt="test", role="user"),
-                ),
-                conversation_id=str(uuid.uuid4()),
-                system_prompt="System prompt",
-                metadata={"key": "value"},
-            )
+        context = SingleTurnAttackContext(
+            params=AttackParameters(
+                objective="Test objective",
+                next_message=Message.from_prompt(prompt="test", role="user"),
+            ),
+            conversation_id=str(uuid.uuid4()),
+            metadata={"key": "value"},
+        )
 
         attack._validate_context(context=context)  # Should not raise
 
@@ -1050,26 +1048,12 @@ class TestAttackLifecycle:
         assert context.memory_labels == {"test": "label"}
         assert context.next_message is not None
 
-    async def test_execute_async_with_deprecated_system_prompt_warns(self, mock_target, sample_response):
-        """Passing the deprecated system_prompt= still routes to the context field but warns."""
+    async def test_execute_async_with_system_prompt_raises_error(self, mock_target):
+        """Passing the removed system_prompt parameter is rejected."""
         attack = PromptSendingAttack(objective_target=mock_target)
-        attack._validate_context = MagicMock()
-        attack._setup_async = AsyncMock()
-        attack._perform_async = AsyncMock(
-            return_value=AttackResult(
-                conversation_id="test-id",
-                objective="Test objective",
-                outcome=AttackOutcome.SUCCESS,
-                last_response=sample_response.get_piece(),
-            )
-        )
-        attack._teardown_async = AsyncMock()
 
-        with pytest.warns(DeprecationWarning, match="system_prompt"):
+        with pytest.raises(ValueError, match="does not accept parameters.*system_prompt"):
             await attack.execute_async(objective="Test objective", system_prompt="System prompt")
-
-        context = attack._validate_context.call_args.kwargs["context"]
-        assert context.system_prompt == "System prompt"
 
     async def test_execute_async_with_invalid_params_raises_error(self, mock_target):
         """Test execute_async raises error when invalid parameters are passed"""


### PR DESCRIPTION
## Description

Remove the expired `SingleTurnAttackContext.system_prompt` compatibility field before the v1.0.0 release. The field was non-functional and scheduled for removal in v0.17.0; callers must use `prepended_conversation` instead.

This also removes the stale kwargs example and verifies that `system_prompt` is now rejected as unsupported.

## Tests and Documentation

- `uv run pytest tests\unit\executor\attack\single_turn\test_prompt_sending.py -q` (59 passed)
- Ruff check and format check on changed files
- `ty check` on changed files
- `pre-commit run --files ...` on changed files
- No documentation update is needed because the removed field was already documented as non-functional and its replacement remains unchanged.