### PR TITLE
FIX: Correct invalid target initializer guidance

### DIFF
--- a/frontend/src/components/Config/CreateTargetDialog.test.tsx
+++ b/frontend/src/components/Config/CreateTargetDialog.test.tsx
@@ -398,16 +398,20 @@ describe("CreateTargetDialog", () => {
     });
   });
 
-  it("should display pyrit_conf hint text", () => {
+  it("should display supported target initializer guidance", () => {
     render(
       <TestWrapper>
         <CreateTargetDialog {...defaultProps} />
       </TestWrapper>
     );
 
+    expect(screen.getByText("target", { selector: "code" })).toBeInTheDocument();
     expect(
-      screen.getByText(/auto-populated by adding an initializer/)
+      screen.getByText(/registers available prompt targets from endpoints/i)
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText("airt", { selector: "code" })
+    ).not.toBeInTheDocument();
   });
 
   it("should render .pyrit_conf_example as an accessible link", () => {

--- a/frontend/src/components/Config/CreateTargetDialog.test.tsx
+++ b/frontend/src/components/Config/CreateTargetDialog.test.tsx
@@ -427,6 +427,7 @@ describe("CreateTargetDialog", () => {
       "href",
       "https://github.com/microsoft/PyRIT/blob/main/.pyrit_conf_example"
     );
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });
 
   it("should show field validation errors when submitting form without endpoint", async () => {

--- a/frontend/src/components/Config/CreateTargetDialog.tsx
+++ b/frontend/src/components/Config/CreateTargetDialog.tsx
@@ -712,9 +712,9 @@ export default function CreateTargetDialog({ open, onClose, onCreated, existingT
 
               {!isRoundRobin && (
               <Label size="small" style={{ color: tokens.colorNeutralForeground3 }}>
-                Targets can also be auto-populated by adding an initializer (e.g. <code>airt</code>) to your{' '}
-                <code>~/.pyrit/.pyrit_conf</code> file, which reads endpoints from your <code>.env</code> and{' '}
-                <code>.env.local</code> files. See{' '}
+                Targets can also be auto-populated by adding the <code>target</code> initializer to your{' '}
+                <code>~/.pyrit/.pyrit_conf</code> file, which registers available prompt targets from endpoints in{' '}
+                your <code>.env</code> and <code>.env.local</code> files. See{' '}
                 <Link href="https://github.com/microsoft/PyRIT/blob/main/.pyrit_conf_example" target="_blank" inline>
                   .pyrit_conf_example
                 </Link>.

--- a/frontend/src/components/Config/CreateTargetDialog.tsx
+++ b/frontend/src/components/Config/CreateTargetDialog.tsx
@@ -715,7 +715,12 @@ export default function CreateTargetDialog({ open, onClose, onCreated, existingT
                 Targets can also be auto-populated by adding the <code>target</code> initializer to your{' '}
                 <code>~/.pyrit/.pyrit_conf</code> file, which registers available prompt targets from endpoints in{' '}
                 your <code>.env</code> and <code>.env.local</code> files. See{' '}
-                <Link href="https://github.com/microsoft/PyRIT/blob/main/.pyrit_conf_example" target="_blank" inline>
+                <Link
+                  href="https://github.com/microsoft/PyRIT/blob/main/.pyrit_conf_example"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  inline
+                >
                   .pyrit_conf_example
                 </Link>.
               </Label>

--- a/frontend/src/components/Config/TargetConfig.test.tsx
+++ b/frontend/src/components/Config/TargetConfig.test.tsx
@@ -118,6 +118,13 @@ describe("TargetConfig", () => {
     await waitFor(() => {
       expect(screen.getByText("No Targets Configured")).toBeInTheDocument();
     });
+    expect(screen.getByText("target", { selector: "code" })).toBeInTheDocument();
+    expect(
+      screen.getByText(/register available prompt targets automatically/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("airt", { selector: "code" })
+    ).not.toBeInTheDocument();
   });
 
   it(

--- a/frontend/src/components/Config/TargetConfig.test.tsx
+++ b/frontend/src/components/Config/TargetConfig.test.tsx
@@ -125,6 +125,9 @@ describe("TargetConfig", () => {
     expect(
       screen.queryByText("airt", { selector: "code" })
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: ".pyrit_conf_example" })
+    ).toHaveAttribute("rel", "noopener noreferrer");
   });
 
   it(

--- a/frontend/src/components/Config/TargetConfig.tsx
+++ b/frontend/src/components/Config/TargetConfig.tsx
@@ -122,7 +122,12 @@ export default function TargetConfig({ activeTarget, onSetActiveTarget }: Target
             to auto-populate targets from your <code>.env</code> and <code>.env.local</code> files.
             For example, add <code>target</code> to the <code>initializers</code> list to register
             available prompt targets automatically. See the{' '}
-            <Link href="https://github.com/microsoft/PyRIT/blob/main/.pyrit_conf_example" target="_blank" inline>
+            <Link
+              href="https://github.com/microsoft/PyRIT/blob/main/.pyrit_conf_example"
+              target="_blank"
+              rel="noopener noreferrer"
+              inline
+            >
               .pyrit_conf_example
             </Link>{' '}
             for details.

--- a/frontend/src/components/Config/TargetConfig.tsx
+++ b/frontend/src/components/Config/TargetConfig.tsx
@@ -120,8 +120,8 @@ export default function TargetConfig({ activeTarget, onSetActiveTarget }: Target
           <Text size={300} style={{ color: tokens.colorNeutralForeground3 }}>
             Add a target manually, or configure an initializer in your <code>~/.pyrit/.pyrit_conf</code> file
             to auto-populate targets from your <code>.env</code> and <code>.env.local</code> files.
-            For example, add <code>airt</code> to the <code>initializers</code> list to register
-            Azure OpenAI targets automatically. See the{' '}
+            For example, add <code>target</code> to the <code>initializers</code> list to register
+            available prompt targets automatically. See the{' '}
             <Link href="https://github.com/microsoft/PyRIT/blob/main/.pyrit_conf_example" target="_blank" inline>
               .pyrit_conf_example
             </Link>{' '}


### PR DESCRIPTION
## Summary
- replace removed `airt` initializer guidance in CoPyRIT target configuration with supported `target`
- clarify that `target` registers available prompt targets from configured environment endpoints
- add focused regression assertions for both guidance surfaces

## Validation
- `npm test -- --runInBand --runTestsByPath src\components\Config\TargetConfig.test.tsx src\components\Config\CreateTargetDialog.test.tsx` (60 passed)
- targeted ESLint on the four changed frontend files
- `npm run build`