### PR TITLE
TEST: Restore renamed notebook exclusion

### DIFF
--- a/doc/generate_docs/pct_to_ipynb.py
+++ b/doc/generate_docs/pct_to_ipynb.py
@@ -7,30 +7,26 @@ import subprocess
 from pathlib import Path
 
 skip_files = {
-    "conf.py",
     # executor / gcg
     "1_gcg_azure_ml.py",  # missing required env variables
     # converters
     "2_audio_converters.py",  # requires Azure Speech API key
-    "6_human_converter.py",  # requires human input
     # datasets
     "2_seed_programming.py",  # requires OpenAI API credentials
     # memory
-    "6_azure_sql_memory.py",  # requires Azure SQL setup, remove following completion of #4001
-    "7_azure_sql_memory_attacks.py",  # remove following completion of #4001
+    "6_azure_sql_memory.py",  # requires Azure SQL setup
+    "7_azure_sql_memory_attacks.py",  # requires Azure SQL setup
     "embeddings.py",  # requires OpenAI embedding API key
-    # scoring
-    "prompt_shield_scorer.py",  # requires Azure Content Safety API key
     # targets
-    "4_non_llm_targets.py",  # requires Azure SQL Storage IO for Azure Storage Account (see #4001)
+    "8_non_llm_targets.py",  # requires Azure Blob Storage data-plane credentials
     "4_openai_video_target.py",  # requires OpenAI video API key
+    "10_1_playwright_target.py",  # Playwright installation takes too long
+    "10_2_playwright_target_copilot.py",  # Playwright installation takes too long, plus requires M365 account
     "10_3_websocket_copilot_target.py",  # requires manual token pasting
-    "playwright_target.py",  # Playwright installation takes too long
-    "playwright_target_copilot.py",  # Playwright installation takes too long, plus requires M365 account
     "app.py",  # Flask app for playwright demo, not a notebook
     # executor
-    "1_xpia_website.py",  # requires publicly accessible Azure Storage Account
-    "2_xpia_ai_recruiter.py",  # requires AI recruiter service running locally
+    # requires a publicly accessible Azure Storage Account and the AI recruiter service running locally
+    "5_workflow.py",
 }
 
 # Get the doc directory (parent of generate_docs where this script is located)

--- a/tests/integration/memory/test_notebooks_memory.py
+++ b/tests/integration/memory/test_notebooks_memory.py
@@ -13,8 +13,8 @@ from pyrit.common import path
 nb_directory_path = pathlib.Path(path.DOCS_CODE_PATH, "memory").resolve()
 
 skipped_files = [
-    "6_azure_sql_memory.ipynb",  # todo: requires Azure SQL setup, remove following completion of #4001
-    "7_azure_sql_memory_attacks.ipynb",  # todo: remove following completion of #4001
+    "6_azure_sql_memory.ipynb",  # requires Azure SQL setup
+    "7_azure_sql_memory_attacks.ipynb",  # requires Azure SQL setup
     "embeddings.ipynb",  # requires OpenAI embedding API key
 ]
 

--- a/tests/integration/score/test_scorer_notebooks.py
+++ b/tests/integration/score/test_scorer_notebooks.py
@@ -12,9 +12,7 @@ from pyrit.common import path
 
 nb_directory_path = pathlib.Path(path.DOCS_CODE_PATH, "scoring").resolve()
 
-skipped_files = [
-    "prompt_shield_scorer.ipynb",  # requires Azure Content Safety API key
-]
+skipped_files: list[str] = []
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/targets/test_notebooks_targets.py
+++ b/tests/integration/targets/test_notebooks_targets.py
@@ -14,7 +14,7 @@ nb_directory_path = pathlib.Path(path.DOCS_CODE_PATH, "targets").resolve()
 
 skipped_files = [
     "4_openai_video_target.ipynb",  # requires OpenAI video API key
-    "8_non_llm_targets.ipynb",  # requires Azure SQL Storage IO for Azure Storage Account (see #4001)
+    "8_non_llm_targets.ipynb",  # requires Azure Blob Storage data-plane credentials
     "10_1_playwright_target.ipynb",  # Playwright installation takes too long
     "10_2_playwright_target_copilot.ipynb",  # Playwright installation takes too long, plus requires M365 account
     "10_3_websocket_copilot_target.ipynb",  # WebSocket Copilot target requires manual pasting tokens

--- a/tests/integration/targets/test_notebooks_targets.py
+++ b/tests/integration/targets/test_notebooks_targets.py
@@ -14,6 +14,7 @@ nb_directory_path = pathlib.Path(path.DOCS_CODE_PATH, "targets").resolve()
 
 skipped_files = [
     "4_openai_video_target.ipynb",  # requires OpenAI video API key
+    "8_non_llm_targets.ipynb",  # requires Azure SQL Storage IO for Azure Storage Account (see #4001)
     "10_1_playwright_target.ipynb",  # Playwright installation takes too long
     "10_2_playwright_target_copilot.ipynb",  # Playwright installation takes too long, plus requires M365 account
     "10_3_websocket_copilot_target.ipynb",  # WebSocket Copilot target requires manual pasting tokens


### PR DESCRIPTION
## Summary

- restore the non-LLM target notebook exclusion under its current `8_non_llm_targets` name in integration tests and docs generation
- update other renamed generator exclusions for Playwright and the consolidated XPIA workflow
- remove exclusions for deleted notebooks and replace orphaned `#4001` references with self-contained requirements

## Testing

- `uv run pytest tests\integration\targets\test_entra_auth_targets.py::test_video_target_entra_auth tests\integration\targets\test_entra_auth_targets.py::test_video_target_remix_entra_auth -q`
- `uv run pytest tests\integration\targets\test_notebooks_targets.py tests\integration\memory\test_notebooks_memory.py tests\integration\score\test_scorer_notebooks.py --collect-only -q`
- `uv run ruff check doc\generate_docs\pct_to_ipynb.py tests\integration\memory\test_notebooks_memory.py tests\integration\score\test_scorer_notebooks.py tests\integration\targets\test_notebooks_targets.py`