### PR TITLE
FEAT: Add conversation export button to the GUI chat view

### DIFF
--- a/doc/gui/0_gui.md
+++ b/doc/gui/0_gui.md
@@ -72,6 +72,17 @@ Each assistant message has four action buttons:
 
 Click the panel toggle in the ribbon to open the conversations sidebar. This panel shows all conversations within the current attack, including message counts and last-message previews. You can switch between conversations, create new ones, and promote a conversation to be the "main" conversation.
 
+#### Exporting a Conversation
+
+Click the **Export** button in the ribbon to download the conversation that is currently displayed. Two formats are offered from the button's menu:
+
+- **Markdown (`.md`):** A human-readable transcript with each message labeled by role. Best for reading, sharing, or pasting into reports.
+- **JSON (`.json`):** A structured record of the conversation for tooling and further processing.
+
+The export runs entirely in your browser and captures exactly what is shown in the chat, including the system prompt shown in the banner — no data is sent to the server. Export stays available for read-only historical conversations, and is disabled while a conversation is empty, still loading, or sending. The button is disabled until there is at least one message to export.
+
+> **Note:** Exported files can contain adversarial prompts, model responses, and other sensitive material. Store and share them responsibly.
+
 #### Labels
 
 The labels bar in the ribbon displays the current attack's labels (e.g., `operator`, `operation`). Labels are key-value pairs that help organize and filter attacks. You can add, edit, and remove labels inline. The `operator` and `operation` labels are required and cannot be removed.

--- a/doc/gui/0_gui.md
+++ b/doc/gui/0_gui.md
@@ -79,7 +79,7 @@ Click the **Export** button in the ribbon to download the conversation that is c
 - **Markdown (`.md`):** A human-readable transcript with each message labeled by role. Best for reading, sharing, or pasting into reports.
 - **JSON (`.json`):** A structured record of the conversation for tooling and further processing.
 
-The export runs entirely in your browser and captures exactly what is shown in the chat, including the system prompt shown in the banner — no data is sent to the server. Export stays available for read-only historical conversations, and is disabled while a conversation is empty, still loading, or sending. The button is disabled until there is at least one message to export.
+The export runs entirely in your browser and captures exactly what is shown in the chat, including the system prompt shown in the banner — no data is sent to the server. Export stays available for read-only historical conversations, and is disabled while a conversation is empty, still loading, or sending. The button is disabled until there is at least one user or model message to export.
 
 > **Note:** Exported files can contain adversarial prompts, model responses, and other sensitive material. Store and share them responsibly.
 

--- a/frontend/e2e/chat.spec.ts
+++ b/frontend/e2e/chat.spec.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { test, expect, type Page } from "@playwright/test";
 import { makeTarget } from "./_targets";
 
@@ -892,5 +893,67 @@ test.describe("Target type scenarios", () => {
     await expect(badge).toBeVisible();
     await expect(badge).toContainText("OpenAIImageTarget");
     await expect(badge).toContainText(/dall-e-3/);
+  });
+});
+
+test.describe("Conversation export", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockBackendAPIs(page);
+    await page.goto("/");
+    await activateMockTarget(page);
+
+    // A viewable conversation must be on screen before export is enabled.
+    await page.getByRole("textbox").fill("Export me please");
+    await page.getByRole("button", { name: /send/i }).click();
+    await expect(
+      page.getByText("Mock response for: Export me please"),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  // Trigger the export menu, pick a format, and return the real downloaded file.
+  // Exercises the browser download path (Blob -> object URL -> anchor click)
+  // that jsdom mocks out in the unit tests.
+  async function triggerExport(
+    page: Page,
+    itemTestId: string,
+  ): Promise<{ filename: string; content: string }> {
+    const exportButton = page.getByTestId("export-conversation-btn");
+    await expect(exportButton).toBeEnabled();
+
+    const downloadPromise = page.waitForEvent("download");
+    await exportButton.click();
+    await page.getByTestId(itemTestId).click();
+
+    const download = await downloadPromise;
+    const filePath = await download.path();
+    expect(filePath).not.toBeNull();
+    return {
+      filename: download.suggestedFilename(),
+      content: readFileSync(filePath, "utf-8"),
+    };
+  }
+
+  test("downloads the displayed conversation as Markdown", async ({ page }) => {
+    const { filename, content } = await triggerExport(page, "export-markdown-item");
+
+    expect(filename).toMatch(/^copyrit-conversation-e2e-conv-001-.*\.md$/);
+    expect(content).toContain("# CoPyRIT conversation export");
+    expect(content).toContain("Export me please");
+    expect(content).toContain("Mock response for: Export me please");
+  });
+
+  test("downloads the displayed conversation as JSON", async ({ page }) => {
+    const { filename, content } = await triggerExport(page, "export-json-item");
+
+    expect(filename).toMatch(/^copyrit-conversation-e2e-conv-001-.*\.json$/);
+
+    const parsed = JSON.parse(content) as {
+      conversation_id: string;
+      messages: unknown[];
+    };
+    expect(parsed.conversation_id).toBe("e2e-conv-001");
+    expect(parsed.messages.length).toBeGreaterThanOrEqual(2);
+    expect(content).toContain("Export me please");
+    expect(content).toContain("Mock response for: Export me please");
   });
 });

--- a/frontend/e2e/touch-targets.spec.ts
+++ b/frontend/e2e/touch-targets.spec.ts
@@ -413,6 +413,7 @@ test.describe("Mobile touch targets", () => {
       page.locator(
         [
           '[data-testid="labels-icon-btn"]',
+          '[data-testid="export-conversation-btn"]',
           '[data-testid="toggle-panel-btn"]',
           '[data-testid="new-attack-btn"]',
           '[aria-label="Attach files"]',

--- a/frontend/src/components/Chat/ChatWindow.test.tsx
+++ b/frontend/src/components/Chat/ChatWindow.test.tsx
@@ -3276,6 +3276,28 @@ describe("ChatWindow Integration", () => {
       expect(screen.getByRole("button", { name: /export conversation/i })).toBeDisabled();
     });
 
+    it("keeps export disabled when the only loaded message is a system prompt", async () => {
+      mockedAttacksApi.getMessages.mockResolvedValue({ messages: [] });
+      mockedMapper.backendMessagesToFrontend.mockReturnValue([
+        { role: "system", content: "You are a pirate.", timestamp: "2026-07-22T02:30:07.000Z" },
+      ]);
+      render(
+        <TestWrapper>
+          <ChatWindow
+            {...defaultProps}
+            attackResultId="ar-1"
+            conversationId="conv-1"
+            activeConversationId="conv-1"
+          />
+        </TestWrapper>
+      );
+      await waitFor(() => {
+        expect(mockedMapper.backendMessagesToFrontend).toHaveBeenCalled();
+      });
+      // A lone system prompt renders only in the banner, so export stays disabled.
+      expect(screen.getByRole("button", { name: /export conversation/i })).toBeDisabled();
+    });
+
     it("opens a menu with Markdown and JSON options", async () => {
       const user = userEvent.setup();
       await renderWithLoadedConversation();

--- a/frontend/src/components/Chat/ChatWindow.test.tsx
+++ b/frontend/src/components/Chat/ChatWindow.test.tsx
@@ -3185,4 +3185,184 @@ describe("ChatWindow Integration", () => {
       expect(screen.queryByTestId("converted-value-input")).not.toBeInTheDocument();
     });
   });
+
+  // -----------------------------------------------------------------------
+  // Conversation export
+  // -----------------------------------------------------------------------
+
+  describe("conversation export", () => {
+    function spyOnDownloadAnchor(): { clickSpy: jest.Mock; getDownloadAnchor: () => HTMLAnchorElement } {
+      const anchors: HTMLAnchorElement[] = [];
+      const clickSpy = jest.fn();
+      const origCreateElement = document.createElement.bind(document);
+      jest.spyOn(document, "createElement").mockImplementation((tag: string) => {
+        const el = origCreateElement(tag);
+        if (tag === "a") {
+          anchors.push(el as HTMLAnchorElement);
+          jest.spyOn(el as HTMLAnchorElement, "click").mockImplementation(clickSpy);
+        }
+        return el;
+      });
+      return { clickSpy, getDownloadAnchor: () => anchors.find((a) => a.download) as HTMLAnchorElement };
+    }
+
+    async function renderWithLoadedConversation(
+      props: Record<string, unknown> = {}
+    ): Promise<void> {
+      mockedAttacksApi.getMessages.mockResolvedValue({ messages: [] });
+      mockedMapper.backendMessagesToFrontend.mockReturnValue(mockMessages);
+      render(
+        <TestWrapper>
+          <ChatWindow
+            {...defaultProps}
+            attackResultId="ar-1"
+            conversationId="conv-1"
+            activeConversationId="conv-1"
+            {...props}
+          />
+        </TestWrapper>
+      );
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: /export conversation/i })).toBeEnabled()
+      );
+    }
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it("shows an export button in the ribbon", () => {
+      render(
+        <TestWrapper>
+          <ChatWindow {...defaultProps} />
+        </TestWrapper>
+      );
+      expect(screen.getByRole("button", { name: /export conversation/i })).toBeInTheDocument();
+    });
+
+    it("disables export when the conversation is empty", () => {
+      render(
+        <TestWrapper>
+          <ChatWindow {...defaultProps} />
+        </TestWrapper>
+      );
+      expect(screen.getByRole("button", { name: /export conversation/i })).toBeDisabled();
+    });
+
+    it("enables export once a conversation with messages loads", async () => {
+      await renderWithLoadedConversation();
+      expect(screen.getByRole("button", { name: /export conversation/i })).toBeEnabled();
+    });
+
+    it("keeps export disabled when every loaded message is a loading placeholder", async () => {
+      mockedAttacksApi.getMessages.mockResolvedValue({ messages: [] });
+      mockedMapper.backendMessagesToFrontend.mockReturnValue([
+        { role: "assistant", content: "", timestamp: "2026-07-22T02:30:07.000Z", isLoading: true },
+      ]);
+      render(
+        <TestWrapper>
+          <ChatWindow
+            {...defaultProps}
+            attackResultId="ar-1"
+            conversationId="conv-1"
+            activeConversationId="conv-1"
+          />
+        </TestWrapper>
+      );
+      await waitFor(() => {
+        expect(mockedMapper.backendMessagesToFrontend).toHaveBeenCalled();
+      });
+      // length > 0 but no non-loading message => export must stay disabled.
+      expect(screen.getByRole("button", { name: /export conversation/i })).toBeDisabled();
+    });
+
+    it("opens a menu with Markdown and JSON options", async () => {
+      const user = userEvent.setup();
+      await renderWithLoadedConversation();
+
+      await user.click(screen.getByRole("button", { name: /export conversation/i }));
+
+      expect(screen.getByRole("menuitem", { name: /export as markdown/i })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: /export as json/i })).toBeInTheDocument();
+    });
+
+    it("downloads Markdown when the Markdown option is clicked", async () => {
+      const user = userEvent.setup();
+      await renderWithLoadedConversation();
+      const { clickSpy, getDownloadAnchor } = spyOnDownloadAnchor();
+
+      await user.click(screen.getByRole("button", { name: /export conversation/i }));
+      await user.click(screen.getByRole("menuitem", { name: /export as markdown/i }));
+
+      const blob = (URL.createObjectURL as jest.Mock).mock.calls[0][0] as Blob;
+      expect(blob.type).toBe("text/markdown;charset=utf-8");
+      expect(getDownloadAnchor().download).toMatch(/^copyrit-conversation-conv-1-.*\.md$/);
+      expect(clickSpy).toHaveBeenCalled();
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+    });
+
+    it("downloads JSON without re-fetching the conversation", async () => {
+      const user = userEvent.setup();
+      await renderWithLoadedConversation();
+      const callsBefore = mockedAttacksApi.getMessages.mock.calls.length;
+      const { getDownloadAnchor } = spyOnDownloadAnchor();
+
+      await user.click(screen.getByRole("button", { name: /export conversation/i }));
+      await user.click(screen.getByRole("menuitem", { name: /export as json/i }));
+
+      const blob = (URL.createObjectURL as jest.Mock).mock.calls[0][0] as Blob;
+      expect(blob.type).toBe("application/json;charset=utf-8");
+      expect(getDownloadAnchor().download).toMatch(/^copyrit-conversation-conv-1-.*\.json$/);
+      // WYSIWYG: export serializes in-state messages and makes no extra API call.
+      expect(mockedAttacksApi.getMessages.mock.calls.length).toBe(callsBefore);
+    });
+
+    it("exports the displayed conversation id when it differs from the attack's main conversation", async () => {
+      const user = userEvent.setup();
+      // Viewing a branch: activeConversationId (displayed) differs from the
+      // attack's main conversationId. handleExport uses activeConversationId.
+      await renderWithLoadedConversation({
+        conversationId: "conv-main",
+        activeConversationId: "conv-branch",
+      });
+      const { getDownloadAnchor } = spyOnDownloadAnchor();
+
+      await user.click(screen.getByRole("button", { name: /export conversation/i }));
+      await user.click(screen.getByRole("menuitem", { name: /export as markdown/i }));
+
+      expect(getDownloadAnchor().download).toMatch(/^copyrit-conversation-conv-branch-.*\.md$/);
+    });
+
+    it("allows exporting a read-only historical conversation", async () => {
+      const user = userEvent.setup();
+      // Operator lock: the loaded attack belongs to a different operator.
+      await renderWithLoadedConversation({ attackLabels: { operator: "someone-else" } });
+      const { clickSpy } = spyOnDownloadAnchor();
+
+      const exportButton = screen.getByRole("button", { name: /export conversation/i });
+      expect(exportButton).toBeEnabled();
+
+      await user.click(exportButton);
+      await user.click(screen.getByRole("menuitem", { name: /export as markdown/i }));
+
+      expect(clickSpy).toHaveBeenCalled();
+    });
+
+    it("disables export while a message is being sent", async () => {
+      const user = userEvent.setup();
+      mockedMapper.buildMessagePieces.mockResolvedValue([
+        { data_type: "text", original_value: "hi" },
+      ]);
+      // addMessage never resolves, so the conversation stays in the sending state.
+      mockedAttacksApi.addMessage.mockImplementation(() => new Promise(() => {}));
+      await renderWithLoadedConversation();
+
+      await user.type(screen.getByRole("textbox"), "hi");
+      await user.click(screen.getByRole("button", { name: /send/i }));
+
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: /export conversation/i })).toBeDisabled()
+      );
+    });
+  });
 });

--- a/frontend/src/components/Chat/ChatWindow.tsx
+++ b/frontend/src/components/Chat/ChatWindow.tsx
@@ -2,6 +2,11 @@ import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import {
   Button,
   Drawer,
+  Menu,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
   mergeClasses,
   Switch,
   Text,
@@ -9,7 +14,7 @@ import {
   useRestoreFocusSource,
   useRestoreFocusTarget,
 } from '@fluentui/react-components'
-import { AddRegular, PanelRightRegular } from '@fluentui/react-icons'
+import { AddRegular, ArrowDownloadRegular, PanelRightRegular } from '@fluentui/react-icons'
 import MessageList from './MessageList'
 import SystemPromptBanner from './SystemPromptBanner'
 import ChatInputArea from './ChatInputArea'
@@ -23,6 +28,8 @@ import type { ChatInputAreaHandle } from './ChatInputArea'
 import { attacksApi } from '../../services/api'
 import { toApiError } from '../../services/errors'
 import { buildMessagePieces, backendMessagesToFrontend } from '../../utils/messageMapper'
+import { exportConversation } from '../../utils/conversationExport'
+import type { ExportFormat } from '../../utils/conversationExport'
 import type { Message, MessageAttachment, TargetInstance, TargetInfo } from '../../types'
 import { targetInfoMatchesTarget } from '../../utils/targetIdentity'
 import type { ViewName } from '../Sidebar/Navigation'
@@ -617,6 +624,20 @@ export default function ChatWindow({
 
   const systemMessage = messages.find(message => message.role === 'system')
 
+  // Export is available whenever there is a stable, viewable conversation:
+  // not while empty, loading, or mid-send. Read-only / operator-lock /
+  // cross-target states do not block export.
+  const canExportConversation =
+    messages.some((message) => !message.isLoading) &&
+    !isSending &&
+    !isLoadingAttack &&
+    !isLoadingMessages &&
+    !awaitingConversationLoad
+
+  const handleExport = (format: ExportFormat) => {
+    exportConversation({ messages, conversationId: activeConversationId ?? conversationId, format })
+  }
+
   return (
     <div className={styles.root}>
       <h1 className={styles.pageHeading}>Chat</h1>
@@ -654,6 +675,30 @@ export default function ChatWindow({
                 data-testid="global-markdown-toggle"
               />
             </Tooltip>
+            <Menu>
+              <MenuTrigger disableButtonEnhancement>
+                <Tooltip content="Export conversation" relationship="label">
+                  <Button
+                    appearance="subtle"
+                    className={styles.ribbonAction}
+                    icon={<ArrowDownloadRegular />}
+                    disabled={!canExportConversation}
+                    aria-label="Export conversation"
+                    data-testid="export-conversation-btn"
+                  />
+                </Tooltip>
+              </MenuTrigger>
+              <MenuPopover>
+                <MenuList>
+                  <MenuItem onClick={() => handleExport('markdown')} data-testid="export-markdown-item">
+                    Export as Markdown (.md)
+                  </MenuItem>
+                  <MenuItem onClick={() => handleExport('json')} data-testid="export-json-item">
+                    Export as JSON (.json)
+                  </MenuItem>
+                </MenuList>
+              </MenuPopover>
+            </Menu>
             <Tooltip content="Toggle conversations panel" relationship="label">
               <Button
                 {...restoreFocusTargetAttributes}

--- a/frontend/src/components/Chat/ChatWindow.tsx
+++ b/frontend/src/components/Chat/ChatWindow.tsx
@@ -625,10 +625,11 @@ export default function ChatWindow({
   const systemMessage = messages.find(message => message.role === 'system')
 
   // Export is available whenever there is a stable, viewable conversation:
-  // not while empty, loading, or mid-send. Read-only / operator-lock /
-  // cross-target states do not block export.
+  // not while empty, loading, or mid-send. A lone system prompt (rendered only
+  // in the banner, not the chat body) does not count as an exportable message.
+  // Read-only / operator-lock / cross-target states do not block export.
   const canExportConversation =
-    messages.some((message) => !message.isLoading) &&
+    messages.some((message) => !message.isLoading && message.role !== 'system') &&
     !isSending &&
     !isLoadingAttack &&
     !isLoadingMessages &&

--- a/frontend/src/utils/conversationExport.test.ts
+++ b/frontend/src/utils/conversationExport.test.ts
@@ -1,0 +1,444 @@
+import {
+  exportConversation,
+  conversationToMarkdown,
+  conversationToJson,
+  buildExportFilename,
+  downloadTextFile,
+  EXPORT_MIME_TYPES,
+} from "./conversationExport";
+import type { Message } from "../types";
+
+const FIXED_NOW = new Date("2026-07-22T02:34:01.059Z");
+
+function message(overrides: Partial<Message> = {}): Message {
+  return {
+    role: "assistant",
+    content: "Hello there",
+    timestamp: "2026-07-22T02:30:07.000Z",
+    ...overrides,
+  };
+}
+
+function blobToText(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(blob);
+  });
+}
+
+function installAnchorSpy(): { clickSpy: jest.Mock; getAnchor: () => HTMLAnchorElement } {
+  const clickSpy = jest.fn();
+  let anchor: HTMLAnchorElement | null = null;
+  const origCreateElement = document.createElement.bind(document);
+  jest.spyOn(document, "createElement").mockImplementation((tag: string) => {
+    const el = origCreateElement(tag);
+    if (tag === "a") {
+      anchor = el as HTMLAnchorElement;
+      jest.spyOn(el, "click").mockImplementation(clickSpy);
+    }
+    return el;
+  });
+  return { clickSpy, getAnchor: () => anchor as HTMLAnchorElement };
+}
+
+describe("conversationExport", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("conversationToMarkdown", () => {
+    it("renders a header with the conversation id, exported time, and message count", () => {
+      const md = conversationToMarkdown([message()], "conv-1", FIXED_NOW);
+      expect(md).toContain("# CoPyRIT conversation export");
+      expect(md).toContain("- Conversation: conv-1");
+      expect(md).toContain("- Exported: 2026-07-22T02:34:01.059Z");
+      expect(md).toContain("- Messages: 1");
+    });
+
+    it("renders one section per message with a role label and timestamp", () => {
+      const md = conversationToMarkdown(
+        [
+          message({ role: "user", content: "hi", timestamp: "2026-07-22T02:30:05.000Z" }),
+          message({ role: "assistant", content: "hello", timestamp: "2026-07-22T02:30:07.000Z" }),
+        ],
+        "conv-1",
+        FIXED_NOW
+      );
+      expect(md).toContain("## User — 2026-07-22T02:30:05.000Z");
+      expect(md).toContain("## Assistant — 2026-07-22T02:30:07.000Z");
+    });
+
+    it("includes the system message (hidden in the chat view)", () => {
+      const md = conversationToMarkdown(
+        [message({ role: "system", content: "You are helpful" })],
+        "conv-1",
+        FIXED_NOW
+      );
+      expect(md).toContain("## System — ");
+      expect(md).toContain("You are helpful");
+    });
+
+    it("skips the loading placeholder", () => {
+      const md = conversationToMarkdown(
+        [message({ content: "real" }), message({ role: "assistant", content: "", isLoading: true })],
+        "conv-1",
+        FIXED_NOW
+      );
+      expect(md).toContain("- Messages: 1");
+      expect(md).toContain("real");
+    });
+
+    it("wraps content in a code fence and grows the fence when content contains backticks", () => {
+      const md = conversationToMarkdown([message({ content: "plain" })], "conv-1", FIXED_NOW);
+      expect(md).toContain("```\nplain\n```");
+
+      const withFence = conversationToMarkdown(
+        [message({ content: "```js\ncode\n```" })],
+        "conv-1",
+        FIXED_NOW
+      );
+      // Longest run in content is 3 backticks, so the wrapper must use 4.
+      expect(withFence).toContain("````\n```js\ncode\n```\n````");
+    });
+
+    it("does not overflow the stack when content has a huge number of separate backtick runs", () => {
+      // Adversarial content: many isolated backticks produce one regex match per
+      // run. A spread-based Math.max(...runs) would throw RangeError here.
+      const content = Array(200000).fill("`").join(" ");
+      let md = "";
+      expect(() => {
+        md = conversationToMarkdown([message({ content })], "conv-1", FIXED_NOW);
+      }).not.toThrow();
+      // The longest run is a single backtick, so the fence stays at three.
+      expect(md).toContain("```\n" + content + "\n```");
+    });
+
+    it("includes the Original block only when the original content differs", () => {
+      const differs = conversationToMarkdown(
+        [message({ content: "converted", originalContent: "original" })],
+        "conv-1",
+        FIXED_NOW
+      );
+      expect(differs).toContain("**Original (before conversion):**");
+      expect(differs).toContain("original");
+
+      const same = conversationToMarkdown(
+        [message({ content: "converted", originalContent: "converted" })],
+        "conv-1",
+        FIXED_NOW
+      );
+      expect(same).not.toContain("**Original (before conversion):**");
+    });
+
+    it("includes a Reasoning block when reasoning summaries are present", () => {
+      const md = conversationToMarkdown(
+        [message({ reasoningSummaries: ["thought one", "thought two"] })],
+        "conv-1",
+        FIXED_NOW
+      );
+      expect(md).toContain("**Reasoning:**");
+      expect(md).toContain("thought one");
+      expect(md).toContain("thought two");
+    });
+
+    it("includes an error line with the type, and the description when present", () => {
+      const withDescription = conversationToMarkdown(
+        [message({ error: { type: "blocked", description: "content was filtered" } })],
+        "conv-1",
+        FIXED_NOW
+      );
+      expect(withDescription).toContain("**Error (blocked)**: content was filtered");
+
+      const typeOnly = conversationToMarkdown(
+        [message({ error: { type: "processing" } })],
+        "conv-1",
+        FIXED_NOW
+      );
+      expect(typeOnly).toContain("**Error (processing)**");
+      expect(typeOnly).not.toContain("**Error (processing)**:");
+    });
+
+    it("lists attachments by type, name, and mime type without inlining data", () => {
+      const md = conversationToMarkdown(
+        [
+          message({
+            attachments: [
+              { type: "image", name: "result.png", url: "data:image/png;base64,AAAA", mimeType: "image/png" },
+            ],
+          }),
+        ],
+        "conv-1",
+        FIXED_NOW
+      );
+      expect(md).toContain("**Attachments:**");
+      expect(md).toContain("- image: result.png (image/png)");
+      expect(md).not.toContain("base64,AAAA");
+    });
+
+    it("lists original attachments shown in the UI before conversion", () => {
+      const md = conversationToMarkdown(
+        [
+          message({
+            content: "converted.png",
+            originalAttachments: [
+              { type: "image", name: "original.png", url: "blob:orig", mimeType: "image/png" },
+            ],
+          }),
+        ],
+        "conv-1",
+        FIXED_NOW
+      );
+      expect(md).toContain("**Original attachments (before conversion):**");
+      expect(md).toContain("- image: original.png (image/png)");
+    });
+
+    it("collapses newlines in attachment names and error text so they cannot inject structure", () => {
+      const md = conversationToMarkdown(
+        [
+          message({
+            error: { type: "blocked", description: "filtered\n## Injected heading" },
+            attachments: [
+              { type: "file", name: "safe.txt\n## Injected heading", url: "u", mimeType: "text/plain" },
+            ],
+          }),
+        ],
+        "conv-1",
+        FIXED_NOW
+      );
+      // No line may begin a new markdown heading from untrusted inline text.
+      expect(md).not.toContain("\n## Injected heading");
+    });
+
+    it("neutralizes newlines in system-provided header fields (conversation id, timestamp)", () => {
+      const md = conversationToMarkdown(
+        [message({ timestamp: "2026-07-22T02:30:07.000Z\n## Injected heading" })],
+        "conv-1\n## Injected heading",
+        FIXED_NOW
+      );
+      expect(md).not.toContain("\n## Injected heading");
+    });
+
+    it("handles an empty conversation with a header and zero messages", () => {
+      const md = conversationToMarkdown([], "conv-1", FIXED_NOW);
+      expect(md).toContain("- Messages: 0");
+      expect(md).not.toContain("## ");
+    });
+
+    it("labels an unsaved conversation when the id is null", () => {
+      const md = conversationToMarkdown([message()], null, FIXED_NOW);
+      expect(md).toContain("- Conversation: (unsaved)");
+    });
+
+    it("defaults the exported time to now when omitted", () => {
+      const md = conversationToMarkdown([message()], "conv-1");
+      expect(md).toContain("# CoPyRIT conversation export");
+      expect(md).toContain("- Exported: ");
+    });
+  });
+
+  describe("conversationToJson", () => {
+    it("returns pretty-printed JSON with a conversation_id and messages envelope", () => {
+      const json = conversationToJson([message({ content: "hi" })], "conv-1");
+      const parsed = JSON.parse(json);
+      expect(parsed.conversation_id).toBe("conv-1");
+      expect(parsed.messages).toHaveLength(1);
+      expect(parsed.messages[0].content).toBe("hi");
+      expect(json).toContain("\n  "); // two-space indentation
+    });
+
+    it("drops the loading placeholder", () => {
+      const json = conversationToJson(
+        [message({ content: "real" }), message({ role: "assistant", content: "", isLoading: true })],
+        "conv-1"
+      );
+      expect(JSON.parse(json).messages).toHaveLength(1);
+    });
+
+    it("omits the in-memory File handle but keeps the other attachment fields", () => {
+      const file = new File(["x"], "local.png", { type: "image/png" });
+      const json = conversationToJson(
+        [
+          message({
+            attachments: [
+              {
+                type: "image",
+                name: "local.png",
+                url: "blob:local",
+                mimeType: "image/png",
+                pieceId: "piece-9",
+                file,
+              },
+            ],
+          }),
+        ],
+        "conv-1"
+      );
+      const attachment = JSON.parse(json).messages[0].attachments[0];
+      expect(attachment.file).toBeUndefined();
+      expect(attachment.name).toBe("local.png");
+      expect(attachment.pieceId).toBe("piece-9");
+    });
+
+    it("keeps a serializable metadata field named 'file' (only the attachment File handle is stripped)", () => {
+      const file = new File(["x"], "local.png", { type: "image/png" });
+      const json = conversationToJson(
+        [
+          message({
+            attachments: [
+              {
+                type: "image",
+                name: "local.png",
+                url: "blob:local",
+                mimeType: "image/png",
+                metadata: { file: "source/path.txt", video_id: "v1" },
+                file,
+              },
+            ],
+          }),
+        ],
+        "conv-1"
+      );
+      const attachment = JSON.parse(json).messages[0].attachments[0];
+      expect(attachment.file).toBeUndefined();
+      expect(attachment.metadata.file).toBe("source/path.txt");
+      expect(attachment.metadata.video_id).toBe("v1");
+    });
+
+    it("strips the File handle from original attachments too", () => {
+      const file = new File(["x"], "orig.png", { type: "image/png" });
+      const json = conversationToJson(
+        [
+          message({
+            originalAttachments: [
+              { type: "image", name: "orig.png", url: "blob:orig", mimeType: "image/png", file },
+            ],
+          }),
+        ],
+        "conv-1"
+      );
+      const attachment = JSON.parse(json).messages[0].originalAttachments[0];
+      expect(attachment.file).toBeUndefined();
+      expect(attachment.name).toBe("orig.png");
+    });
+
+    it("passes through a null conversation id", () => {
+      const json = conversationToJson([message()], null);
+      expect(JSON.parse(json).conversation_id).toBeNull();
+    });
+
+    it("does not mutate the input messages", () => {
+      const input = [message({ content: "hi", isLoading: false })];
+      const snapshot = JSON.stringify(input);
+      conversationToJson(input, "conv-1");
+      expect(JSON.stringify(input)).toBe(snapshot);
+    });
+  });
+
+  describe("buildExportFilename", () => {
+    it("builds a markdown filename with a sanitized id and timestamp", () => {
+      expect(buildExportFilename("3fa85f64-b3fc", "markdown", FIXED_NOW)).toBe(
+        "copyrit-conversation-3fa85f64-b3fc-2026-07-22T02-34-01-059.md"
+      );
+    });
+
+    it("builds a json filename", () => {
+      expect(buildExportFilename("conv-1", "json", FIXED_NOW)).toBe(
+        "copyrit-conversation-conv-1-2026-07-22T02-34-01-059.json"
+      );
+    });
+
+    it("sanitizes unsafe characters in the conversation id", () => {
+      expect(buildExportFilename("a/b c:d", "markdown", FIXED_NOW)).toBe(
+        "copyrit-conversation-a_b_c_d-2026-07-22T02-34-01-059.md"
+      );
+    });
+
+    it("omits the id segment when the conversation id is null", () => {
+      expect(buildExportFilename(null, "json", FIXED_NOW)).toBe(
+        "copyrit-conversation-2026-07-22T02-34-01-059.json"
+      );
+    });
+
+    it("includes millisecond precision so exports in the same second do not collide", () => {
+      const a = buildExportFilename("conv-1", "json", new Date("2026-07-22T02:34:01.001Z"));
+      const b = buildExportFilename("conv-1", "json", new Date("2026-07-22T02:34:01.002Z"));
+      expect(a).not.toBe(b);
+    });
+
+    it("produces a filesystem-safe name with no colons", () => {
+      expect(buildExportFilename("conv-1", "markdown", FIXED_NOW)).not.toContain(":");
+    });
+
+    it("defaults to the current time when now is omitted", () => {
+      expect(buildExportFilename("conv-1", "markdown")).toMatch(/^copyrit-conversation-conv-1-.*\.md$/);
+    });
+  });
+
+  describe("downloadTextFile", () => {
+    it("creates a blob download, sets the filename, clicks the anchor, and revokes the url", () => {
+      const { clickSpy, getAnchor } = installAnchorSpy();
+      downloadTextFile("body", "file.md", "text/markdown;charset=utf-8");
+
+      const createObjectUrl = URL.createObjectURL as jest.Mock;
+      const blob = createObjectUrl.mock.calls[0][0] as Blob;
+      expect(blob.type).toBe("text/markdown;charset=utf-8");
+      expect(getAnchor().download).toBe("file.md");
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+    });
+
+    it("removes the anchor and revokes the object url even when the click throws", () => {
+      let anchor: HTMLAnchorElement | null = null;
+      const origCreateElement = document.createElement.bind(document);
+      jest.spyOn(document, "createElement").mockImplementation((tag: string) => {
+        const el = origCreateElement(tag);
+        if (tag === "a") {
+          anchor = el as HTMLAnchorElement;
+          jest.spyOn(el, "click").mockImplementation(() => {
+            throw new Error("click failed");
+          });
+        }
+        return el;
+      });
+
+      expect(() => downloadTextFile("body", "file.md", "text/markdown")).toThrow("click failed");
+      expect(anchor).not.toBeNull();
+      expect(document.body.contains(anchor)).toBe(false);
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+    });
+  });
+
+  describe("exportConversation", () => {
+    it("exports Markdown with the markdown mime type and rendered transcript", async () => {
+      const { getAnchor } = installAnchorSpy();
+      exportConversation({ messages: [message({ content: "hi" })], conversationId: "conv-1", format: "markdown", now: FIXED_NOW });
+
+      const blob = (URL.createObjectURL as jest.Mock).mock.calls[0][0] as Blob;
+      expect(blob.type).toBe(EXPORT_MIME_TYPES.markdown);
+      expect(getAnchor().download).toMatch(/^copyrit-conversation-conv-1-.*\.md$/);
+      expect(await blobToText(blob)).toContain("# CoPyRIT conversation export");
+    });
+
+    it("exports JSON with the json mime type and a parseable envelope", async () => {
+      const { getAnchor } = installAnchorSpy();
+      exportConversation({ messages: [message({ content: "hi" })], conversationId: "conv-1", format: "json", now: FIXED_NOW });
+
+      const blob = (URL.createObjectURL as jest.Mock).mock.calls[0][0] as Blob;
+      expect(blob.type).toBe(EXPORT_MIME_TYPES.json);
+      expect(getAnchor().download).toMatch(/^copyrit-conversation-conv-1-.*\.json$/);
+      expect(JSON.parse(await blobToText(blob)).conversation_id).toBe("conv-1");
+    });
+
+    it("defaults the timestamp when now is omitted", () => {
+      const { getAnchor } = installAnchorSpy();
+      exportConversation({ messages: [message()], conversationId: "conv-1", format: "markdown" });
+      expect(getAnchor().download).toMatch(/^copyrit-conversation-conv-1-.*\.md$/);
+    });
+  });
+});

--- a/frontend/src/utils/conversationExport.test.ts
+++ b/frontend/src/utils/conversationExport.test.ts
@@ -252,6 +252,16 @@ describe("conversationExport", () => {
       expect(json).toContain("\n  "); // two-space indentation
     });
 
+    it("records the export timestamp in the envelope", () => {
+      const json = conversationToJson([message({ content: "hi" })], "conv-1", FIXED_NOW);
+      expect(JSON.parse(json).exported_at).toBe(FIXED_NOW.toISOString());
+    });
+
+    it("defaults the export timestamp to a valid ISO string when omitted", () => {
+      const exportedAt = JSON.parse(conversationToJson([message()], "conv-1")).exported_at;
+      expect(Number.isNaN(Date.parse(exportedAt))).toBe(false);
+    });
+
     it("drops the loading placeholder", () => {
       const json = conversationToJson(
         [message({ content: "real" }), message({ role: "assistant", content: "", isLoading: true })],
@@ -439,6 +449,15 @@ describe("conversationExport", () => {
       const { getAnchor } = installAnchorSpy();
       exportConversation({ messages: [message()], conversationId: "conv-1", format: "markdown" });
       expect(getAnchor().download).toMatch(/^copyrit-conversation-conv-1-.*\.md$/);
+    });
+
+    it("uses one timestamp for both the JSON body and the filename", async () => {
+      const { getAnchor } = installAnchorSpy();
+      exportConversation({ messages: [message({ content: "hi" })], conversationId: "conv-1", format: "json", now: FIXED_NOW });
+
+      const blob = (URL.createObjectURL as jest.Mock).mock.calls[0][0] as Blob;
+      expect(JSON.parse(await blobToText(blob)).exported_at).toBe(FIXED_NOW.toISOString());
+      expect(getAnchor().download).toContain("2026-07-22T02-34-01-059");
     });
   });
 });

--- a/frontend/src/utils/conversationExport.ts
+++ b/frontend/src/utils/conversationExport.ts
@@ -1,0 +1,201 @@
+import type { Message, MessageAttachment } from '../types'
+
+export type ExportFormat = 'markdown' | 'json'
+
+const FILE_EXTENSIONS: Record<ExportFormat, string> = {
+  markdown: 'md',
+  json: 'json',
+}
+
+export const EXPORT_MIME_TYPES: Record<ExportFormat, string> = {
+  markdown: 'text/markdown;charset=utf-8',
+  json: 'application/json;charset=utf-8',
+}
+
+const ROLE_LABELS: Record<Message['role'], string> = {
+  user: 'User',
+  assistant: 'Assistant',
+  simulated_assistant: 'Simulated Assistant',
+  system: 'System',
+}
+
+/**
+ * Serialize, name, and download the currently viewed conversation in one call.
+ * Markdown and JSON share a single timestamp so the filename and the document
+ * body agree.
+ */
+export function exportConversation({
+  messages,
+  conversationId,
+  format,
+  now = new Date(),
+}: {
+  messages: Message[]
+  conversationId: string | null
+  format: ExportFormat
+  now?: Date
+}): void {
+  const content =
+    format === 'markdown'
+      ? conversationToMarkdown(messages, conversationId, now)
+      : conversationToJson(messages, conversationId)
+  downloadTextFile(content, buildExportFilename(conversationId, format, now), EXPORT_MIME_TYPES[format])
+}
+
+/**
+ * Render the conversation as a human-readable Markdown transcript. Includes the
+ * system message (hidden in the chat view) and drops the "typing" placeholder.
+ * Free text is wrapped in dynamically sized code fences, and inline metadata
+ * (attachment names, error text) has its newlines collapsed, so untrusted
+ * content cannot corrupt the document structure.
+ */
+export function conversationToMarkdown(
+  messages: Message[],
+  conversationId: string | null,
+  exportedAt: Date = new Date(),
+): string {
+  const exported = withoutLoadingPlaceholders(messages)
+  const lines: string[] = [
+    '# CoPyRIT conversation export',
+    '',
+    `- Conversation: ${inlineText(conversationId ?? '(unsaved)')}`,
+    `- Exported: ${exportedAt.toISOString()}`,
+    `- Messages: ${exported.length}`,
+  ]
+
+  for (const message of exported) {
+    lines.push('', `## ${ROLE_LABELS[message.role]} — ${inlineText(message.timestamp)}`, '', fencedBlock(message.content))
+
+    if (message.originalContent != null && message.originalContent !== message.content) {
+      lines.push('', '**Original (before conversion):**', '', fencedBlock(message.originalContent))
+    }
+    appendAttachmentList(lines, 'Original attachments (before conversion):', message.originalAttachments)
+    if (message.reasoningSummaries && message.reasoningSummaries.length > 0) {
+      lines.push('', '**Reasoning:**', '', fencedBlock(message.reasoningSummaries.join('\n\n')))
+    }
+    if (message.error) {
+      const description = message.error.description ? `: ${inlineText(message.error.description)}` : ''
+      lines.push('', `**Error (${inlineText(message.error.type)})**${description}`)
+    }
+    appendAttachmentList(lines, 'Attachments:', message.attachments)
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+/**
+ * Serialize the in-state conversation to pretty-printed JSON, exporting exactly
+ * what the GUI holds (WYSIWYG). Loading placeholders are dropped and the
+ * non-serializable `File` handle is removed from each attachment; every other
+ * field (including attachment metadata) is preserved as-is.
+ */
+export function conversationToJson(messages: Message[], conversationId: string | null): string {
+  const envelope = {
+    conversation_id: conversationId,
+    messages: withoutLoadingPlaceholders(messages).map(messageForExport),
+  }
+  return JSON.stringify(envelope, null, 2)
+}
+
+/**
+ * Build a filesystem-safe filename for an exported conversation, e.g.
+ * `copyrit-conversation-<id>-<timestamp>.md`. Falls back to a name without the
+ * id when the conversation has none.
+ */
+export function buildExportFilename(
+  conversationId: string | null,
+  format: ExportFormat,
+  now: Date = new Date(),
+): string {
+  const timestamp = now.toISOString().slice(0, 23).replace(/[:.]/g, '-')
+  const extension = FILE_EXTENSIONS[format]
+  const sanitizedId = conversationId ? conversationId.replace(/[^A-Za-z0-9._-]/g, '_') : ''
+  return sanitizedId
+    ? `copyrit-conversation-${sanitizedId}-${timestamp}.${extension}`
+    : `copyrit-conversation-${timestamp}.${extension}`
+}
+
+/**
+ * Trigger a browser download of `content` as `filename`. Uses the Blob → object
+ * URL → anchor-click idiom and always revokes the object URL, even if the click
+ * throws.
+ */
+export function downloadTextFile(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType })
+  const objectUrl = URL.createObjectURL(blob)
+  try {
+    const link = document.createElement('a')
+    link.href = objectUrl
+    link.download = filename
+    document.body.appendChild(link)
+    try {
+      link.click()
+    } finally {
+      link.remove()
+    }
+  } finally {
+    URL.revokeObjectURL(objectUrl)
+  }
+}
+
+function withoutLoadingPlaceholders(messages: Message[]): Message[] {
+  return messages.filter((message) => !message.isLoading)
+}
+
+function messageForExport(message: Message): Message {
+  if (!message.attachments && !message.originalAttachments) {
+    return message
+  }
+  const next: Message = { ...message }
+  if (message.attachments) {
+    next.attachments = message.attachments.map(attachmentWithoutFile)
+  }
+  if (message.originalAttachments) {
+    next.originalAttachments = message.originalAttachments.map(attachmentWithoutFile)
+  }
+  return next
+}
+
+function attachmentWithoutFile(attachment: MessageAttachment): MessageAttachment {
+  const next = { ...attachment }
+  delete next.file
+  return next
+}
+
+function appendAttachmentList(
+  lines: string[],
+  heading: string,
+  attachments: MessageAttachment[] | undefined,
+): void {
+  if (!attachments || attachments.length === 0) {
+    return
+  }
+  lines.push('', `**${heading}**`, '')
+  for (const attachment of attachments) {
+    lines.push(`- ${inlineText(attachment.type)}: ${inlineText(attachment.name)} (${inlineText(attachment.mimeType)})`)
+  }
+}
+
+function inlineText(value: string): string {
+  return value.replace(/[\r\n]+/g, ' ')
+}
+
+function fencedBlock(content: string): string {
+  const longestRun = longestBacktickRun(content)
+  const fence = '`'.repeat(Math.max(3, longestRun + 1))
+  return `${fence}\n${content}\n${fence}`
+}
+
+function longestBacktickRun(content: string): number {
+  const runs = content.match(/`+/g)
+  if (!runs) {
+    return 0
+  }
+  let longest = 0
+  for (const run of runs) {
+    if (run.length > longest) {
+      longest = run.length
+    }
+  }
+  return longest
+}

--- a/frontend/src/utils/conversationExport.ts
+++ b/frontend/src/utils/conversationExport.ts
@@ -38,7 +38,7 @@ export function exportConversation({
   const content =
     format === 'markdown'
       ? conversationToMarkdown(messages, conversationId, now)
-      : conversationToJson(messages, conversationId)
+      : conversationToJson(messages, conversationId, now)
   downloadTextFile(content, buildExportFilename(conversationId, format, now), EXPORT_MIME_TYPES[format])
 }
 
@@ -85,13 +85,19 @@ export function conversationToMarkdown(
 
 /**
  * Serialize the in-state conversation to pretty-printed JSON, exporting exactly
- * what the GUI holds (WYSIWYG). Loading placeholders are dropped and the
+ * what the GUI holds (WYSIWYG). The envelope records the conversation id, the
+ * export timestamp, and the messages. Loading placeholders are dropped and the
  * non-serializable `File` handle is removed from each attachment; every other
  * field (including attachment metadata) is preserved as-is.
  */
-export function conversationToJson(messages: Message[], conversationId: string | null): string {
+export function conversationToJson(
+  messages: Message[],
+  conversationId: string | null,
+  exportedAt: Date = new Date(),
+): string {
   const envelope = {
     conversation_id: conversationId,
+    exported_at: exportedAt.toISOString(),
     messages: withoutLoadingPlaceholders(messages).map(messageForExport),
   }
   return JSON.stringify(envelope, null, 2)
@@ -187,14 +193,16 @@ function fencedBlock(content: string): string {
 }
 
 function longestBacktickRun(content: string): number {
-  const runs = content.match(/`+/g)
-  if (!runs) {
-    return 0
-  }
   let longest = 0
-  for (const run of runs) {
-    if (run.length > longest) {
-      longest = run.length
+  let current = 0
+  for (let i = 0; i < content.length; i++) {
+    if (content[i] === '`') {
+      current += 1
+      if (current > longest) {
+        longest = current
+      }
+    } else {
+      current = 0
     }
   }
   return longest


### PR DESCRIPTION
## Description

Adds an **Export** control to the CoPyRIT chat ribbon that downloads the currently
displayed conversation as **Markdown** or **JSON**. Serialization is fully
client-side (from the in-view messages) — no backend changes and no
conversation data leaves the browser.

- **`conversationExport.ts`** (new): pure Markdown/JSON serializers, timestamped
  filename builder, and a Blob-based download helper. Hardened for safety —
  dynamically-sized code fences, sanitized filenames, strips non-serializable
  `File` handles and in-flight loading placeholders, and revokes the object URL.
- **`ChatWindow.tsx`**: Export menu button (Markdown / JSON) enabled only when a
  viewable, settled conversation is shown; exports the displayed branch. Uses a
  Fluent `Tooltip` label to match the sibling ribbon buttons.

Frontend-only; no Python/API changes.

## Tests and Documentation

**Tests**
- 35 unit tests for the serializers, filename builder, and download helper
  (`conversationExport.test.ts`).
- 10 unit tests for the `ChatWindow` export menu (gating, format selection,
  Markdown/JSON output).
- 2 real-browser Playwright E2E tests that trigger the download and assert the
  actual downloaded Markdown/JSON bytes (`chat.spec.ts`).

**Documentation**
- Updated `doc/gui/0_gui.md` to document the export button and its
  behavior (including the system prompt shown in the banner).
- No notebooks / JupyText-paired docs changed, so no JupyText execution was
  needed.