### PR TITLE
MAINT post-1.0.0 release update to 1.1.0.dev0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyrit-frontend",
-  "version": "0.15.0-dev.0",
+  "version": "1.1.0-dev.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyrit"
-version = "0.15.0.dev0"
+version = "1.1.0.dev0"
 description = "The Python Risk Identification Tool for LLMs (PyRIT) is a library used to assess the robustness of LLMs"
 authors = [
     { name = "Microsoft AI Red Team", email = "airedteam@microsoft.com" },

--- a/pyrit/__init__.py
+++ b/pyrit/__init__.py
@@ -6,7 +6,7 @@ __name__ = "pyrit"
 # NOTE: __version__ must be set before imports below to avoid circular import issues.
 # Submodules (e.g., component_identifier, memory_models) reference pyrit.__version__
 # and get imported transitively during the .common import chain.
-__version__ = "0.15.0.dev0"
+__version__ = "1.1.0.dev0"
 
 from .common import turn_off_transformers_warning  # noqa: F401
 from .show_versions import show_versions  # noqa: F401

--- a/uv.lock
+++ b/uv.lock
@@ -5236,7 +5236,7 @@ wheels = [
 
 [[package]]
 name = "pyrit"
-version = "0.15.0.dev0"
+version = "1.1.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Set the Python development version to `1.1.0.dev0` in `pyrit/__init__.py` and `pyproject.toml`.
- Set the frontend development version to `1.1.0-dev.0` in `frontend/package.json`.
- Update only the editable PyRIT project version in `uv.lock`, as required by `uv lock --check`; `frontend/package-lock.json` remains unchanged because the existing npm lock-consistency path accepts the package metadata without regeneration.
- Search `main` for `0.14.0` references. No remaining references semantically represent the current/latest stable release, so historical release-process examples, migration tests, evaluation fixtures, dependency metadata, and archived documentation references remain unchanged.

## Validation
- Exact metadata assertions: Python package, project, and lock versions are `1.1.0.dev0`; frontend package version is `1.1.0-dev.0`.
- `uv lock --check`
- `uv run ruff check pyrit/__init__.py`
- `uv run pytest -q tests/unit/test_show_versions.py tests/unit/models/identifiers/test_component_identifier.py -k "get_deps_info_contains_pyrit or pyrit_version_set or to_dict_basic"` (`3 passed`)
- `npm ci --dry-run --ignore-scripts --no-audit --no-fund --offline`
- Commit-time pre-commit hooks, including Ruff and `ty`

A full local `npm ci` was also attempted, but the npm registry returned a TLS handshake failure while fetching `react-joyride`; the lock-consistency dry run above completed successfully.

## Documentation versions
`.github/docs-versions.yml` is intentionally untouched. Documentation-version configuration is handled separately by #2257.