### PR TITLE
FIX GCG: forward hf_token as None instead of an empty string

### DIFF
--- a/pyrit/executor/promptgen/gcg/attack/base/attack_manager.py
+++ b/pyrit/executor/promptgen/gcg/attack/base/attack_manager.py
@@ -1819,7 +1819,7 @@ class ModelWorker:
     def __init__(
         self,
         model_path: str,
-        token: str,
+        token: str | None,
         model_kwargs: dict[str, Any],
         tokenizer: Any,
         device: str,

--- a/pyrit/executor/promptgen/gcg/generator.py
+++ b/pyrit/executor/promptgen/gcg/generator.py
@@ -410,7 +410,10 @@ class GCGGenerator(
 
         all_models = self._models + self._test_models
         return SimpleNamespace(
-            token=self._hf_token or "",
+            # None means anonymous access. An empty string makes huggingface_hub send
+            # "Authorization: Bearer " with no credential, which httpx rejects as an
+            # illegal header value, so public models would fail to load.
+            token=self._hf_token,
             tokenizer_paths=[m.name for m in all_models],
             tokenizer_kwargs=[m.tokenizer_kwargs for m in all_models],
             model_paths=[m.name for m in all_models],

--- a/tests/unit/executor/promptgen/gcg/test_generator.py
+++ b/tests/unit/executor/promptgen/gcg/test_generator.py
@@ -158,6 +158,27 @@ class TestValidateContext:
             )
 
 
+class TestToAttackParamsToken:
+    """The HuggingFace token forwarded to model loading."""
+
+    def test_token_is_none_when_not_supplied(self) -> None:
+        # An empty string makes huggingface_hub send "Authorization: Bearer " with no
+        # credential, which httpx rejects as an illegal header value. None means anonymous,
+        # which is what loading a public model needs.
+        gen = GCGGenerator(models=[GCGModelConfig(name=_LLAMA_2)])
+
+        params = gen._to_attack_params(context=GCGContext(goals=["g"], targets=["t"]))
+
+        assert params.token is None
+
+    def test_token_is_forwarded_when_supplied(self) -> None:
+        gen = GCGGenerator(models=[GCGModelConfig(name=_LLAMA_2)], hf_token="hf_example")
+
+        params = gen._to_attack_params(context=GCGContext(goals=["g"], targets=["t"]))
+
+        assert params.token == "hf_example"
+
+
 @pytest.fixture
 def patched_get_workers():
     """Patch the heavy worker spawn so lifecycle tests don't try to load real models."""


### PR DESCRIPTION
Fixes #2274.

`GCGGenerator._to_attack_params` built the attack params with `token=self._hf_token or ""`. Since `hf_token` defaults to `None` (correct for a public model), the `or ""` turned it into an empty string, which `huggingface_hub` sends as `Authorization: Bearer ` with no credential. httpx rejects that as an illegal header, so GCG could not load any ungated model:

```
_StrategyRuntimeError: Strategy execution failed for GCGGenerator: Illegal header value b'Bearer '
```

`None` is HuggingFace's value for anonymous access, so it is forwarded unchanged now.

## Changes

- `generator.py`: forward `self._hf_token` as-is instead of coercing `None` to `""`.
- `attack_manager.py`: widen `ModelWorker.__init__`'s `token` parameter to `str | None`, matching what is now passed.
- `test_generator.py`: new `TestToAttackParamsToken` covering both the absent-token and supplied-token cases.

The absent-token test fails on the current code with `assert '' is None` and passes with the fix, so it pins the regression.

## Verification

```
pytest tests/unit/executor/promptgen/gcg
=> 199 passed

pre-commit run
=> all hooks passed, including ruff and ty
```

I am separately setting up a run against `TinyLlama/TinyLlama-1.1B-Chat-v1.0` on a free GPU to confirm the full load path end to end, and will post that here once it completes. The unit coverage above pins the specific defect regardless.
