### PR TITLE
FIX Select GPT-5 response piece by data type instead of position

### DIFF
--- a/doc/code/targets/2_openai_responses_target.ipynb
+++ b/doc/code/targets/2_openai_responses_target.ipynb
@@ -395,7 +395,10 @@
     "response = await target.send_prompt_async(message=message)  # type: ignore\n",
     "\n",
     "# Validate and print the response\n",
-    "response_json = json.loads(response[0].message_pieces[1].converted_value)\n",
+    "# Reasoning models return an extra \"reasoning\" piece, so select the text piece explicitly\n",
+    "# instead of relying on the position of the pieces.\n",
+    "text_piece = response[0].get_piece_by_type(data_type=\"text\")\n",
+    "response_json = json.loads(text_piece.converted_value)\n",
     "print(json.dumps(response_json, indent=2))\n",
     "jsonschema.validate(instance=response_json, schema=person_schema)"
    ]

--- a/doc/code/targets/2_openai_responses_target.py
+++ b/doc/code/targets/2_openai_responses_target.py
@@ -135,7 +135,10 @@ target = OpenAIResponseTarget(
 response = await target.send_prompt_async(message=message)  # type: ignore
 
 # Validate and print the response
-response_json = json.loads(response[0].message_pieces[1].converted_value)
+# Reasoning models return an extra "reasoning" piece, so select the text piece explicitly
+# instead of relying on the position of the pieces.
+text_piece = response[0].get_piece_by_type(data_type="text")
+response_json = json.loads(text_piece.converted_value)
 print(json.dumps(response_json, indent=2))
 jsonschema.validate(instance=response_json, schema=person_schema)
 

--- a/tests/integration/targets/test_openai_responses_gpt5.py
+++ b/tests/integration/targets/test_openai_responses_gpt5.py
@@ -60,10 +60,12 @@ async def test_openai_responses_gpt5(sqlite_instance, gpt5_args):
     assert result is not None
     assert len(result) == 1
     assert len(result[0].message_pieces) == 2
-    assert result[0].message_pieces[0].api_role == "assistant"
-    assert result[0].message_pieces[1].api_role == "assistant"
+    assert all(piece.api_role == "assistant" for piece in result[0].message_pieces)
+    assert result[0].get_piece_by_type(data_type="reasoning") is not None
+    text_piece = result[0].get_piece_by_type(data_type="text")
+    assert text_piece is not None
     # Hope that the model manages to give the correct answer somewhere (GPT-5 really should)
-    assert "Paris" in result[0].message_pieces[1].converted_value
+    assert "Paris" in text_piece.converted_value
 
 
 async def test_openai_responses_gpt5_json_schema(sqlite_instance, gpt5_args):
@@ -110,7 +112,9 @@ async def test_openai_responses_gpt5_json_schema(sqlite_instance, gpt5_args):
 
     assert len(response) == 1
     assert len(response[0].message_pieces) == 2
-    response_piece = response[0].message_pieces[1]
+    assert response[0].get_piece_by_type(data_type="reasoning") is not None
+    response_piece = response[0].get_piece_by_type(data_type="text")
+    assert response_piece is not None
     assert response_piece.api_role == "assistant"
     response_json = json.loads(response_piece.converted_value)
     jsonschema.validate(instance=response_json, schema=cat_schema)
@@ -144,7 +148,9 @@ async def test_openai_responses_gpt5_json_object(sqlite_instance, gpt5_args):
 
     assert len(response) == 1
     assert len(response[0].message_pieces) == 2
-    response_piece = response[0].message_pieces[1]
+    assert response[0].get_piece_by_type(data_type="reasoning") is not None
+    response_piece = response[0].get_piece_by_type(data_type="text")
+    assert response_piece is not None
     assert response_piece.api_role == "assistant"
     _ = json.loads(response_piece.converted_value)
     # Can't assert more, since the failure could be due to a bad generation by the model


### PR DESCRIPTION
## Description

#2283 made `OpenAIResponseTarget` sort `reasoning` pieces *after* the actionable response pieces, so that `Message.get_piece()` (which defaults to `n=0`) hands scorers and scenarios the actual answer rather than the reasoning blob. For reasoning models such as GPT-5 that flipped the piece order from `[reasoning, text]` to `[text, reasoning]`.

The GPT-5 Responses integration tests and the paired Responses doc notebook still hard-coded `message_pieces[1]` as the answer, so they were validating the reasoning piece. Because these tests need live Azure GPT-5 + Entra auth they don't run in PR CI, which is why they went stale unnoticed. A remote integration run on `main` surfaced them:

- `test_execute_notebooks[2_openai_responses_target.ipynb]`
- `test_openai_responses_gpt5[entra]`
- `test_openai_responses_gpt5_json_schema[entra]`

`test_openai_responses_gpt5_json_object` did not fail but was silently broken — it only asserts `json.loads(...)` succeeds, and the serialized reasoning piece is itself valid JSON, so it passed vacuously against the wrong piece. It's fixed here too.

The product behavior is correct and unchanged — this PR only fixes the stale assumptions in the tests and docs. Assertions now select the piece via `Message.get_piece_by_type(data_type="text")` so they no longer depend on ordering, while still asserting that both pieces are present and that a `reasoning` piece exists.

## Tests and Documentation

`doc/code/targets/2_openai_responses_target.py` and its `.ipynb` were updated inline and verified in sync by round-tripping the notebook through `jupytext --to py:percent` and diffing against the committed `.py` (identical). Notebook outputs are preserved.

Test runs (live Azure GPT-5, Entra auth):

- `tests/integration/targets/test_openai_responses_gpt5.py` — 5 passed, 5 skipped (all `[entra]` params pass; `[api-key]` params remain skipped since key auth is disabled in our tenant)
- `test_notebooks_targets.py::test_execute_notebooks[2_openai_responses_target.ipynb]` — passed
- `tests/unit/prompt_target/target/test_openai_response_target.py` — 75 passed, confirming the ordering contract added by #2283 is untouched