### PR TITLE
FIX: `pyrit_shell run` fails for every scenario with a flag-collision error

### DIFF
--- a/pyrit/cli/_cli_args.py
+++ b/pyrit/cli/_cli_args.py
@@ -611,7 +611,7 @@ def parse_run_arguments(*, args_string: str, declared_params: list[Parameter] | 
         always populated from the first positional token.
 
     Raises:
-        ValueError: Empty input, scenario-flag collision, or shell parser failure.
+        ValueError: Empty input or shell parser failure.
     """
     parts = shlex.split(args_string)
 
@@ -709,40 +709,31 @@ def _arg_spec_from_parameter(*, param: Parameter) -> _ArgSpec:
 
 def _resolve_scenario_flag_collisions(*, scenario_specs: list[_ArgSpec], base_specs: list[_ArgSpec]) -> list[_ArgSpec]:
     """
-    Drop scenario specs that collide with a built-in flag; reject scenario-vs-scenario collisions.
+    Drop scenario specs whose flag is already taken; first declaration wins.
 
     A scenario's ``supported_parameters`` (fetched from the API) include the framework's common
     parameters — e.g. ``memory_labels``, ``max_concurrency``, ``max_retries`` — which normalize to
-    flags already provided as built-ins. Those built-ins own the flag, so the scenario copy is
-    silently dropped, mirroring ``pyrit_scan._add_scenario_params_from_api``. A genuine
-    scenario-vs-scenario collision (two declared params normalizing to the same flag) is still a
-    scenario bug, so it raises.
+    flags already provided as built-ins. A scenario could also declare two params that normalize to
+    the same flag. In both cases the colliding spec is silently dropped and the earlier owner (the
+    built-in, or the first-declared scenario param) keeps the flag. This mirrors
+    ``pyrit_scan._add_scenario_params_from_api``, which skips any flag already registered on the
+    parser, so the two entry points accept the same inputs.
 
     Args:
         scenario_specs: Specs built from scenario-declared parameters.
         base_specs: Built-in run argument specs.
 
     Returns:
-        list[_ArgSpec]: The scenario specs whose flags do not collide with a built-in flag.
-
-    Raises:
-        ValueError: If two scenario parameters normalize to the same CLI flag.
+        list[_ArgSpec]: The scenario specs whose flags do not collide with a built-in flag or an
+            earlier scenario spec.
     """
-    base_flags = {flag for spec in base_specs for flag in spec.flags}
+    seen: set[str] = {flag for spec in base_specs for flag in spec.flags}
     resolved: list[_ArgSpec] = []
-    seen: set[str] = set()
     for spec in scenario_specs:
-        # Scenario specs carry a single flag, but guard defensively in case that changes.
-        if any(flag in base_flags for flag in spec.flags):
-            # Common framework parameter already handled by the matching built-in flag.
+        if any(flag in seen for flag in spec.flags):
+            # Flag already owned by a built-in or an earlier scenario param; first wins.
             continue
-        for flag in spec.flags:
-            if flag in seen:
-                raise ValueError(
-                    f"Scenario declares two parameters that normalize to the same CLI flag {flag!r}. "
-                    f"Rename one of them."
-                )
-            seen.add(flag)
+        seen.update(spec.flags)
         resolved.append(spec)
     return resolved
 

--- a/pyrit/cli/_cli_args.py
+++ b/pyrit/cli/_cli_args.py
@@ -621,7 +621,7 @@ def parse_run_arguments(*, args_string: str, declared_params: list[Parameter] | 
     augmented_specs: list[_ArgSpec] = list(_RUN_ARG_SPECS)
     if declared_params:
         scenario_specs = [_arg_spec_from_parameter(param=p) for p in declared_params]
-        _validate_scenario_flag_collisions(scenario_specs=scenario_specs, base_specs=_RUN_ARG_SPECS)
+        scenario_specs = _resolve_scenario_flag_collisions(scenario_specs=scenario_specs, base_specs=_RUN_ARG_SPECS)
         augmented_specs.extend(scenario_specs)
 
     result = _parse_shell_arguments(parts=parts[1:], arg_specs=augmented_specs)
@@ -707,29 +707,44 @@ def _arg_spec_from_parameter(*, param: Parameter) -> _ArgSpec:
     )
 
 
-def _validate_scenario_flag_collisions(*, scenario_specs: list[_ArgSpec], base_specs: list[_ArgSpec]) -> None:
+def _resolve_scenario_flag_collisions(*, scenario_specs: list[_ArgSpec], base_specs: list[_ArgSpec]) -> list[_ArgSpec]:
     """
-    Reject scenario-vs-built-in and scenario-vs-scenario flag collisions.
+    Drop scenario specs that collide with a built-in flag; reject scenario-vs-scenario collisions.
+
+    A scenario's ``supported_parameters`` (fetched from the API) include the framework's common
+    parameters — e.g. ``memory_labels``, ``max_concurrency``, ``max_retries`` — which normalize to
+    flags already provided as built-ins. Those built-ins own the flag, so the scenario copy is
+    silently dropped, mirroring ``pyrit_scan._add_scenario_params_from_api``. A genuine
+    scenario-vs-scenario collision (two declared params normalizing to the same flag) is still a
+    scenario bug, so it raises.
+
+    Args:
+        scenario_specs: Specs built from scenario-declared parameters.
+        base_specs: Built-in run argument specs.
+
+    Returns:
+        list[_ArgSpec]: The scenario specs whose flags do not collide with a built-in flag.
 
     Raises:
-        ValueError: If a scenario flag duplicates a built-in flag, or two
-            scenario parameters normalize to the same CLI flag.
+        ValueError: If two scenario parameters normalize to the same CLI flag.
     """
     base_flags = {flag for spec in base_specs for flag in spec.flags}
+    resolved: list[_ArgSpec] = []
     seen: set[str] = set()
     for spec in scenario_specs:
+        # Scenario specs carry a single flag, but guard defensively in case that changes.
+        if any(flag in base_flags for flag in spec.flags):
+            # Common framework parameter already handled by the matching built-in flag.
+            continue
         for flag in spec.flags:
-            if flag in base_flags:
-                raise ValueError(
-                    f"Scenario parameter flag {flag!r} collides with a built-in flag. "
-                    f"Rename the parameter to avoid the collision."
-                )
             if flag in seen:
                 raise ValueError(
                     f"Scenario declares two parameters that normalize to the same CLI flag {flag!r}. "
                     f"Rename one of them."
                 )
             seen.add(flag)
+        resolved.append(spec)
+    return resolved
 
 
 def extract_scenario_args(*, parsed: dict[str, Any]) -> dict[str, Any]:

--- a/tests/unit/cli/test_cli_args.py
+++ b/tests/unit/cli/test_cli_args.py
@@ -3,7 +3,22 @@
 
 import pytest
 
-from pyrit.cli._cli_args import _argparse_validator
+from pyrit.cli._cli_args import _argparse_validator, parse_run_arguments
+from pyrit.models import Parameter
+
+
+def _sp(*, name: str, description: str = "", param_type: str = "str") -> Parameter:
+    """Build a real Parameter from Summary-style kwargs (param_type as a string)."""
+    return Parameter.model_validate(
+        {
+            "name": name,
+            "description": description,
+            "default": None,
+            "type_name": param_type,
+            "choices": None,
+            "is_list": False,
+        }
+    )
 
 
 def test_argparse_validator_no_params_raises():
@@ -23,3 +38,38 @@ def test_argparse_validator_wraps_keyword_only():
 
     wrapped = _argparse_validator(validate_name)
     assert wrapped("hello") == "HELLO"
+
+
+def test_parse_run_arguments_skips_scenario_params_colliding_with_builtins():
+    """
+    Scenario ``supported_parameters`` include framework common params (e.g. memory_labels)
+    whose flags match built-ins. Those must be silently dropped, not raise, so ``run`` works.
+    """
+    declared_params = [
+        _sp(name="memory_labels", description="Common framework param."),
+        _sp(name="max_concurrency", description="Common framework param.", param_type="int"),
+        _sp(name="max_turns", description="Scenario custom param.", param_type="int"),
+    ]
+
+    result = parse_run_arguments(
+        args_string="airt.scam --target openai_chat --max-turns 3",
+        declared_params=declared_params,
+    )
+
+    assert result["scenario_name"] == "airt.scam"
+    assert result["target"] == "openai_chat"
+    # The dropped common params keep their built-in result keys (not scenario__-prefixed).
+    assert result["scenario__max_turns"] == 3
+    assert "scenario__memory_labels" not in result
+    assert "scenario__max_concurrency" not in result
+
+
+def test_parse_run_arguments_raises_on_scenario_vs_scenario_collision():
+    """Two scenario params normalizing to the same CLI flag remain a scenario bug and raise."""
+    declared_params = [
+        _sp(name="max_turns", description="First."),
+        _sp(name="max-turns", description="Normalizes to the same flag."),
+    ]
+
+    with pytest.raises(ValueError, match="normalize to the same CLI flag"):
+        parse_run_arguments(args_string="airt.scam", declared_params=declared_params)

--- a/tests/unit/cli/test_cli_args.py
+++ b/tests/unit/cli/test_cli_args.py
@@ -64,12 +64,18 @@ def test_parse_run_arguments_skips_scenario_params_colliding_with_builtins():
     assert "scenario__max_concurrency" not in result
 
 
-def test_parse_run_arguments_raises_on_scenario_vs_scenario_collision():
-    """Two scenario params normalizing to the same CLI flag remain a scenario bug and raise."""
+def test_parse_run_arguments_first_wins_on_scenario_vs_scenario_collision():
+    """Two scenario params normalizing to the same CLI flag: first wins, second is dropped (parity with pyrit_scan)."""
     declared_params = [
         _sp(name="max_turns", description="First."),
         _sp(name="max-turns", description="Normalizes to the same flag."),
     ]
 
-    with pytest.raises(ValueError, match="normalize to the same CLI flag"):
-        parse_run_arguments(args_string="airt.scam", declared_params=declared_params)
+    result = parse_run_arguments(
+        args_string="airt.scam --max-turns 4",
+        declared_params=declared_params,
+    )
+
+    # The first declaration owns the flag; only one scenario__ key is produced.
+    assert result["scenario__max_turns"] == "4"
+    assert "scenario__max-turns" not in result


### PR DESCRIPTION
## Bug Description

Running any scenario from `pyrit_shell` failed before argument parsing with:

```
Error: Scenario parameter flag '--memory-labels' collides with a built-in flag. Rename the parameter to avoid the collision.
```

**Root cause:** The shell registers each of a scenario's parameters as a CLI flag, using the full list from the API (`scenario_meta.supported_parameters`). That list combines the scenario's *custom* parameters with the framework's *common* parameters (`memory_labels`, `max_concurrency`, `max_retries`), which normalize to flags that already exist as built-in shell flags. The collision guard `_validate_scenario_flag_collisions` **raised** on the first such clash (`memory_labels`) instead of skipping it. Since every scenario carries the common parameters, `run` was broken universally.

`pyrit_scan` was unaffected: its `_add_scenario_params_from_api` **silently skips** any scenario flag that already exists as a built-in. The inconsistency between the two entry points was the bug.

## Fix

Make the shell mirror `pyrit_scan`. Replaced `_validate_scenario_flag_collisions` with `_resolve_scenario_flag_collisions` in `pyrit/cli/_cli_args.py`, which **silently drops** any scenario spec whose flag is already taken — by a built-in flag *or* an earlier scenario param — so the earlier owner keeps the flag (**first wins**). This matches `pyrit_scan._add_scenario_params_from_api`, which skips any flag already registered on the parser, so both entry points now accept the same inputs.

`parse_run_arguments` now uses the returned filtered specs rather than relying on a validator side effect.

## Testing

- Added `tests/unit/cli/test_cli_args.py::test_parse_run_arguments_skips_scenario_params_colliding_with_builtins` — reproduces the `airt.scam` case (common params present) and asserts `run` parses successfully while the scenario's custom `--max-turns` flag still works.
- Added `tests/unit/cli/test_cli_args.py::test_parse_run_arguments_first_wins_on_scenario_vs_scenario_collision` — confirms two scenario params normalizing to the same flag resolve first-wins (parity with `pyrit_scan`), not an error.
- New tests pass. Full `test_cli_args.py` + `test_pyrit_shell.py` suites pass (86/86), no regressions.

