### PR TITLE
MAINT Deduplicate pretty output color formatting

### DIFF
--- a/pyrit/output/_formatting.py
+++ b/pyrit/output/_formatting.py
@@ -1,0 +1,26 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from colorama import Style
+
+
+class _PrettyPrinterMixin:
+    """Shared ANSI line formatting for pretty printers."""
+
+    _enable_colors: bool
+
+    def _format_colored(self, text: str, *colors: str) -> str:
+        """
+        Format text with color codes if colors are enabled.
+
+        Args:
+            text (str): The text to format.
+            *colors: Variable number of colorama color constants to apply.
+
+        Returns:
+            str: The formatted line with trailing newline.
+        """
+        if self._enable_colors and colors:
+            color_prefix = "".join(colors)
+            return f"{color_prefix}{text}{Style.RESET_ALL}\n"
+        return f"{text}\n"

--- a/pyrit/output/attack_result/pretty.py
+++ b/pyrit/output/attack_result/pretty.py
@@ -7,13 +7,14 @@ from typing import Any
 from colorama import Back, Fore, Style
 
 from pyrit.models import AttackOutcome, AttackResult, ConversationType, Message, Score
+from pyrit.output._formatting import _PrettyPrinterMixin
 from pyrit.output.attack_result.base import AttackResultPrinterBase
 from pyrit.output.conversation.pretty import PrettyConversationPrinter
 from pyrit.output.score.pretty import PrettyScorePrinter
 from pyrit.output.sink import Sink
 
 
-class PrettyAttackResultPrinter(AttackResultPrinterBase):
+class PrettyAttackResultPrinter(_PrettyPrinterMixin, AttackResultPrinterBase):
     """
     Pretty printer for attack results with ANSI-colored formatting.
 
@@ -67,22 +68,6 @@ class PrettyAttackResultPrinter(AttackResultPrinterBase):
             blur_images=blur_images,
             blur_radius=blur_radius,
         )
-
-    def _format_colored(self, text: str, *colors: str) -> str:
-        """
-        Format text with color codes if colors are enabled.
-
-        Args:
-            text (str): The text to format.
-            *colors: Variable number of colorama color constants to apply.
-
-        Returns:
-            str: The formatted line with trailing newline.
-        """
-        if self._enable_colors and colors:
-            color_prefix = "".join(colors)
-            return f"{color_prefix}{text}{Style.RESET_ALL}\n"
-        return f"{text}\n"
 
     async def render_async(
         self,

--- a/pyrit/output/conversation/pretty.py
+++ b/pyrit/output/conversation/pretty.py
@@ -7,6 +7,7 @@ import textwrap
 from colorama import Fore, Style
 
 from pyrit.models import Message, MessagePiece, Score
+from pyrit.output._formatting import _PrettyPrinterMixin
 from pyrit.output.conversation.base import ConversationPrinterBase
 from pyrit.output.score.pretty import PrettyScorePrinter
 from pyrit.output.sink import Sink
@@ -14,7 +15,7 @@ from pyrit.output.sink import Sink
 logger = logging.getLogger(__name__)
 
 
-class PrettyConversationPrinter(ConversationPrinterBase):
+class PrettyConversationPrinter(_PrettyPrinterMixin, ConversationPrinterBase):
     """
     Pretty printer for conversation message histories with ANSI-colored formatting.
 
@@ -173,22 +174,6 @@ class PrettyConversationPrinter(ConversationPrinterBase):
             await self._display_image_async(piece)
 
         return "".join(lines)
-
-    def _format_colored(self, text: str, *colors: str) -> str:
-        """
-        Format text with color codes if colors are enabled.
-
-        Args:
-            text (str): The text to format.
-            *colors: Variable number of colorama color constants to apply.
-
-        Returns:
-            str: The formatted line with trailing newline.
-        """
-        if self._enable_colors and colors:
-            color_prefix = "".join(colors)
-            return f"{color_prefix}{text}{Style.RESET_ALL}\n"
-        return f"{text}\n"
 
     def _render_wrapped_text(self, text: str, color: str) -> str:
         """

--- a/pyrit/output/scenario_result/pretty.py
+++ b/pyrit/output/scenario_result/pretty.py
@@ -6,12 +6,13 @@ import textwrap
 from colorama import Fore, Style
 
 from pyrit.models import AttackOutcome, ScenarioResult
+from pyrit.output._formatting import _PrettyPrinterMixin
 from pyrit.output.scenario_result.base import ScenarioResultPrinterBase
 from pyrit.output.scorer.base import ScorerPrinterBase
 from pyrit.output.sink import Sink
 
 
-class PrettyScenarioResultPrinter(ScenarioResultPrinterBase):
+class PrettyScenarioResultPrinter(_PrettyPrinterMixin, ScenarioResultPrinterBase):
     """
     Pretty printer for scenario results with ANSI-colored formatting.
 
@@ -50,22 +51,6 @@ class PrettyScenarioResultPrinter(ScenarioResultPrinterBase):
         self._enable_colors = enable_colors
         self._scorer_printer = scorer_printer
         self._sort_groups_by_success_rate = sort_groups_by_success_rate
-
-    def _format_colored(self, text: str, *colors: str) -> str:
-        """
-        Format text with color codes if colors are enabled.
-
-        Args:
-            text (str): The text to format.
-            *colors: Variable number of colorama color constants to apply.
-
-        Returns:
-            str: The formatted line with trailing newline.
-        """
-        if self._enable_colors and colors:
-            color_prefix = "".join(colors)
-            return f"{color_prefix}{text}{Style.RESET_ALL}\n"
-        return f"{text}\n"
 
     def _render_section_header(self, title: str) -> str:
         """

--- a/pyrit/output/score/pretty.py
+++ b/pyrit/output/score/pretty.py
@@ -3,14 +3,15 @@
 
 import textwrap
 
-from colorama import Fore, Style
+from colorama import Fore
 
 from pyrit.models import Score
+from pyrit.output._formatting import _PrettyPrinterMixin
 from pyrit.output.base import PrinterBase
 from pyrit.output.sink import Sink
 
 
-class PrettyScorePrinter(PrinterBase):
+class PrettyScorePrinter(_PrettyPrinterMixin, PrinterBase):
     """
     Pretty printer for individual Score objects with ANSI-colored formatting.
 
@@ -35,22 +36,6 @@ class PrettyScorePrinter(PrinterBase):
         self._width = width
         self._indent = " " * indent_size
         self._enable_colors = enable_colors
-
-    def _format_colored(self, text: str, *colors: str) -> str:
-        """
-        Format text with color codes if colors are enabled.
-
-        Args:
-            text (str): The text to format.
-            *colors: Variable number of colorama color constants to apply.
-
-        Returns:
-            str: The formatted line with trailing newline.
-        """
-        if self._enable_colors and colors:
-            color_prefix = "".join(colors)
-            return f"{color_prefix}{text}{Style.RESET_ALL}\n"
-        return f"{text}\n"
 
     def _render_score(self, score: Score, indent_level: int = 3) -> str:
         """

--- a/pyrit/output/scorer/pretty.py
+++ b/pyrit/output/scorer/pretty.py
@@ -6,11 +6,12 @@ from typing import Any
 from colorama import Fore, Style
 
 from pyrit.models import ComponentIdentifier
+from pyrit.output._formatting import _PrettyPrinterMixin
 from pyrit.output.scorer.base import ScorerPrinterBase
 from pyrit.output.sink import Sink
 
 
-class PrettyScorerPrinter(ScorerPrinterBase):
+class PrettyScorerPrinter(_PrettyPrinterMixin, ScorerPrinterBase):
     """
     Pretty printer for scorer information with ANSI-colored formatting.
 
@@ -38,22 +39,6 @@ class PrettyScorerPrinter(ScorerPrinterBase):
             raise ValueError("indent_size must be non-negative")
         self._indent = " " * indent_size
         self._enable_colors = enable_colors
-
-    def _format_colored(self, text: str, *colors: str) -> str:
-        """
-        Format text with color codes if colors are enabled.
-
-        Args:
-            text (str): The text to format.
-            *colors: Variable number of colorama color constants to apply.
-
-        Returns:
-            str: The formatted line with trailing newline.
-        """
-        if self._enable_colors and colors:
-            color_prefix = "".join(colors)
-            return f"{color_prefix}{text}{Style.RESET_ALL}\n"
-        return f"{text}\n"
 
     def _get_quality_color(
         self, value: float, *, higher_is_better: bool, good_threshold: float, bad_threshold: float

--- a/tests/unit/output/test_formatting.py
+++ b/tests/unit/output/test_formatting.py
@@ -1,0 +1,30 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import pytest
+from colorama import Fore, Style
+
+from pyrit.output._formatting import _PrettyPrinterMixin
+
+
+class _TestPrettyPrinter(_PrettyPrinterMixin):
+    def __init__(self, *, enable_colors: bool) -> None:
+        self._enable_colors = enable_colors
+
+
+@pytest.mark.parametrize(
+    "enable_colors,colors,expected",
+    [
+        (True, (Style.BRIGHT, Fore.RED), f"{Style.BRIGHT}{Fore.RED}text{Style.RESET_ALL}\n"),
+        (False, (Style.BRIGHT, Fore.RED), "text\n"),
+        (True, (), "text\n"),
+    ],
+)
+def test_format_colored_preserves_line_output(
+    enable_colors: bool,
+    colors: tuple[str, ...],
+    expected: str,
+) -> None:
+    printer = _TestPrettyPrinter(enable_colors=enable_colors)
+
+    assert printer._format_colored("text", *colors) == expected


### PR DESCRIPTION
## Description

Five pretty output printers carried identical ANSI line-formatting implementations, increasing maintenance cost and making behavior easier to drift. This change extracts that behavior into a narrow internal `_PrettyPrinterMixin` while keeping each domain printer's public API, inheritance contract, and rendered output unchanged.

All five pretty printers inherit the shared helper, leaving generic and domain-specific printer bases untouched. Focused coverage verifies exact colored output, disabled-color output, and the no-color argument path.

## Tests and Documentation

- `uv run pytest tests\unit\output -q` (188 passed)
- `uv run ruff check` on changed files
- `uv run ruff format --check` on changed files
- `uv run ty check` on changed files
- `git diff --check`
- Pre-commit hooks passed during commit

Documentation was not updated because this is an internal refactor with no public API or behavior change. JupyText was not applicable.