### PR TITLE
MAINT: Bump brace-expansion, js-yaml, postcss, and setuptools for Dependabot alerts

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5345,16 +5345,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/brace-expansion/node_modules/balanced-match": {
@@ -6723,9 +6723,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10987,9 +10987,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8191,9 +8191,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -9680,9 +9680,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -10126,9 +10126,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -10146,7 +10146,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,8 +67,8 @@
     "rollup": "4.59.0",
     "@tootallnate/once": "3.0.1",
     "follow-redirects": "1.16.0",
-    "js-yaml": "4.2.0",
-    "postcss": "8.5.13",
+    "js-yaml": "4.3.0",
+    "postcss": "8.5.23",
     "ws": "8.21.0"
   }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -6387,11 +6387,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "80.9.0"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Resolves six open Dependabot alerts by bumping locked dependency versions. All six are transitive; only lockfiles and the existing `overrides` block in `frontend/package.json` change, so there are no source or API changes.

| Package | Change | Advisory |
| --- | --- | --- |
| brace-expansion | 5.0.6 -> 5.0.8, 2.1.1 -> 2.1.2, 1.1.15 -> 1.1.16 | GHSA-3jxr-9vmj-r5cp (DoS via exponential-time expansion) |
| js-yaml | 4.2.0 -> 4.3.0 | quadratic CPU via YAML merge-key chains |
| postcss | 8.5.13 -> 8.5.23 (nanoid moves with it) | path traversal via sourceMappingURL |
| setuptools | 80.9.0 -> 83.0.0 | sdist MANIFEST.in exclusion bypass on macOS APFS/HFS+ |

### brace-expansion

The tree had three separate copies, each pinned by a different `minimatch` major (v1 under `test-exclude`, v2 under `glob`, v5 top level). The usual fear here is that collapsing them onto one version breaks things, since the v1/v2/v5 APIs differ. That is not needed: each patched release lives inside its own major line, so a plain `npm update brace-expansion` bumped all three with no new `overrides` entry and no major upgrades.

### js-yaml and postcss

Both were already pinned in the `overrides` block for earlier advisories, so this only widens the existing pins.

### setuptools

Transitive via jupyterlab, spacy, thinc, and torch. Only the locked version moves; the `setuptools>=64.0.0` build-system pin in `pyproject.toml` is untouched.

One thing to flag for reviewers: the setuptools entry in `uv.lock` loses its `upload-time` field. The package index used to resolve this bump does not publish that field, so `uv lock` omits it. The URLs, sha256 hashes, and byte sizes are all correct and point at `files.pythonhosted.org` as before; `upload-time` will come back on the next relock. The `uv.lock` diff is deliberately scoped to just the 3 lines of the setuptools block.

### Not included

Dependabot also flags react-router (alert #216, GHSA-qwww-vcr4-c8h2, RSC mode CSRF bypass). That one is intentionally left out of this PR because it is a genuine breaking upgrade rather than a version bump: v8 removes the `react-router-dom` package entirely, is ESM-only, and declares `engines: node >=22.22.0` while `frontend_tests.yml` pins `NODE_VERSION: "20"`. The advisory itself notes it "only affects your application if you are using the unstable RSC APIs", and this frontend is a plain client-side SPA with no RSC, so the vulnerability is not reachable. It has been done separately and will come as its own PR.

## Tests and Documentation

No documentation changes; this is a dependency-only PR, so JupyText was not run.

Validation performed locally:

- Frontend: `npm ci` (lockfile integrity verified), `npm test` (984/984 passing across 50 suites), `npm run build`, `npm run lint` all clean.
- Python: `uv lock --check` passes with no drift, and `uv run pytest tests/unit -k "converter or memory"` gives 2191 passed, 49 skipped.

Note on a pre-existing flake: `InitializerParametersDialog > submits toggled boolean and selected multiselect values`, and occasionally other tests such as `CreateTargetDialog > should hide the Authentication field until a target type is selected`, fail intermittently. This reproduces on unmodified `main`, so it is not a regression from these bumps. It shows up most often under `npm run test:coverage` but has also been observed on a plain `npm test` run. The affected tests pass reliably when run in isolation. Worth fixing separately.
