### PR TITLE
FEAT: print full scenario result ID in pyrit_scan and pyrit_shell

### DIFF
--- a/pyrit/cli/_output.py
+++ b/pyrit/cli/_output.py
@@ -433,10 +433,9 @@ def print_scenario_runs_list(*, runs: list[ScenarioRunSummary]) -> None:
     print("\nScenario Run History:")
     print("=" * 80)
     for idx, run in enumerate(runs, start=1):
-        rid = run.scenario_result_id[:8]
         created = run.created_at.isoformat() if run.created_at else "?"
         print(
-            f"  {idx}) [{run.status.value}] {run.scenario_name} (id: {rid}…) — "
+            f"  {idx}) [{run.status.value}] {run.scenario_name} (id: {run.scenario_result_id}) — "
             f"{run.total_attacks} attacks, {run.objective_achieved_rate}% success — {created}"
         )
     print("=" * 80)

--- a/pyrit/output/scenario_result/pretty.py
+++ b/pyrit/output/scenario_result/pretty.py
@@ -139,6 +139,7 @@ class PrettyScenarioResultPrinter(_PrettyPrinterMixin, ScenarioResultPrinterBase
         lines.append(self._render_section_header("Scenario Information"))
         lines.append(self._format_colored(f"{self._indent}📋 Scenario Details", Style.BRIGHT))
         lines.append(self._format_colored(f"{self._indent * 2}• Name: {result.scenario_name}", Fore.CYAN))
+        lines.append(self._format_colored(f"{self._indent * 2}• Result ID: {result.id}", Fore.CYAN))
         lines.append(
             self._format_colored(f"{self._indent * 2}• Scenario Version: {result.scenario_version}", Fore.CYAN)
         )

--- a/tests/unit/cli/test_output.py
+++ b/tests/unit/cli/test_output.py
@@ -700,7 +700,9 @@ def test_print_scenario_runs_list_populated(capsys):
     captured = capsys.readouterr()
     assert "scen-a" in captured.out
     assert "scen-b" in captured.out
-    assert "abcdefgh" in captured.out
+    assert "abcdefgh1234" in captured.out
+    assert "ijklmnop5678" in captured.out
+    assert "…" not in captured.out
     assert "Total runs: 2" in captured.out
 
 

--- a/tests/unit/output/scenario_result/test_pretty.py
+++ b/tests/unit/output/scenario_result/test_pretty.py
@@ -69,6 +69,7 @@ async def test_write_async_renders_full_summary(printer, capsys):
     assert "SCENARIO RESULTS" in out
     assert "TestScenario" in out
     assert "Scenario Information" in out
+    assert f"Result ID: {result.id}" in out
     assert "Description" in out
     assert "Target Type: MockTarget" in out
     assert "gpt-test" in out


### PR DESCRIPTION
## Description
This PR (phase 1) ensures that the full scenario ID gets printed in pyrit_scan and pyrit_shell so that it can used to dig into specific attack results/conversations later on. See gist [here](https://gist.github.com/jsong468/778aeac56ce5043c6764b225530f9c0f) for full implementation plan. 


## Tests and Documentation

Unit tests modified and re-ran