### PR TITLE
TEST: fix flaky CreateTargetDialog accessibility test

### DIFF
--- a/frontend/src/components/Config/CreateTargetDialog.test.tsx
+++ b/frontend/src/components/Config/CreateTargetDialog.test.tsx
@@ -88,9 +88,9 @@ const TestWrapper: React.FC<{ children: React.ReactNode }> = ({
 // Fluent's Dropdown renders its listbox in a portal guarded by a focus
 // modalizer. Under jsdom the popover only toggles via a direct click event,
 // and the `aria-hidden` the modalizer puts on the dialog while the listbox is
-// open is never restored once it closes, which would hide the rest of the form
-// from role-based queries. Both behaviors are jsdom artifacts — real pointer
-// and keyboard interaction is covered by e2e/config.spec.ts.
+// open is not reliably restored once it closes, which would hide the rest of
+// the form from role-based queries. Both behaviors are jsdom artifacts — real
+// pointer and keyboard interaction is covered by e2e/config.spec.ts.
 async function openTargetTypePicker(): Promise<HTMLElement> {
   const picker = screen.getByRole("combobox", { name: /target type/i });
   await waitFor(() => {
@@ -101,15 +101,34 @@ async function openTargetTypePicker(): Promise<HTMLElement> {
   return picker;
 }
 
+// Drops the leftover `aria-hidden` from the dialog and everything above it.
+// It is a no-op while a listbox is open, so the modalizer keeps its real
+// behavior and only the missing restore is compensated for.
 function restoreDialogAccessibility(): void {
   const dialog = document.querySelector('[role="dialog"]');
   if (!dialog) return;
+  if (document.querySelector('[role="listbox"]')) return;
   const hiddenAncestors = document.querySelectorAll('[aria-hidden="true"]');
   for (const element of Array.from(hiddenAncestors)) {
     if (element === dialog || element.contains(dialog)) {
       element.removeAttribute("aria-hidden");
     }
   }
+}
+
+// The modalizer can re-apply `aria-hidden` well after the listbox closed —
+// on an unrelated focus change, for instance — so a one-shot cleanup leaves
+// every later `*ByRole` query racing against it. Re-run the cleanup whenever
+// the attribute reappears instead.
+function watchDialogAccessibility(): MutationObserver {
+  const observer = new MutationObserver(restoreDialogAccessibility);
+  observer.observe(document.documentElement, {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    attributeFilter: ["aria-hidden"],
+  });
+  return observer;
 }
 
 async function selectTargetType(value: string): Promise<void> {
@@ -198,13 +217,20 @@ describe("CreateTargetDialog", () => {
     onCreated: jest.fn(),
   };
 
+  let dialogAccessibilityObserver: MutationObserver;
+
   beforeEach(() => {
+    dialogAccessibilityObserver = watchDialogAccessibility();
     jest.clearAllMocks();
     mockedTargetsApi.listTargetCatalog.mockResolvedValue(TARGET_CATALOG);
     mockedTargetsApi.listTargets.mockResolvedValue({
       items: [],
       pagination: { limit: 200, has_more: false, next_cursor: null, prev_cursor: null },
     } as unknown as Awaited<ReturnType<typeof mockedTargetsApi.listTargets>>);
+  });
+
+  afterEach(() => {
+    dialogAccessibilityObserver.disconnect();
   });
 
   it("should render dialog when open", () => {


### PR DESCRIPTION
## Description

`CreateTargetDialog > should keep full long registry names accessible after selecting RoundRobin targets` fails intermittently in CI with:

```
Unable to find an accessible element with the role "button" and name "Remove openai-production-eastus2-red-team-evaluation-primary-deployment"
```

Seen on PR #2325 (a uv.lock-only dependabot bump, so unrelated to any product change); a plain re-run of the same commit passed.

**Root cause.** Fluent's Dropdown focus modalizer (tabster) sets `aria-hidden="true"` on the dialog's ancestors while the listbox popover is open. In a real browser it removes that on close; under jsdom it is not reliably restored. Because `getByRole` searches the accessibility tree and defaults to `hidden: false`, anything under an `aria-hidden` ancestor becomes invisible to it.

The test file already had a `restoreDialogAccessibility()` workaround, but it was a one-shot snapshot called once at the end of `selectTargetType()`. If tabster re-applied the attribute afterwards (for example on a later focus change from a subsequent click), nothing stripped it again, and every later `*ByRole` query in that test went blind. Under CI load the timing shifted just enough for that to happen.

The failure signature matches exactly: the `getByLabelText("Selected target: ...")` assertion immediately above passed (label queries do no accessibility filtering) while the `getByRole("button", { name: "Remove ..." })` assertion failed, even though both elements render from the same JSX block in `CreateTargetDialog.tsx` and always appear together.

**Fix.** Replace the point-in-time cleanup with a `MutationObserver` (`watchDialogAccessibility()`) that re-runs the cleanup whenever `aria-hidden` reappears above the dialog, installed in `beforeEach` and disconnected in `afterEach`. This is centralized, so future `*ByRole` assertions in this file do not need to remember a workaround.

The helper is now a no-op while a listbox is actually open, so tabster keeps its real behavior and only the restore that jsdom skips is compensated for.

Notably, the assertions are unchanged. No swap to `getByLabelText` and no `{ hidden: true }` escape hatch, since the point of the assertion is that the Remove button is genuinely reachable in the accessibility tree.

Scope check: this is the only test file that opens a Fluent listbox popover inside a modal Dialog, so no other file has the same latent race. ChatWindow's converter Combobox is not inside a dialog and therefore has no modalizer.

## Tests and Documentation

Test-only change; no product code and no documentation affected, so JupyText was not applicable.

Verification:

- Deterministic repro: re-adding `aria-hidden="true"` to a dialog ancestor from a `setTimeout` right before the failing assertion reproduces the exact CI error with the observer disabled, and passes with it enabled. The temporary sabotage was reverted before committing.
- Ran the suite 15 consecutive times: 51/51 tests passing on every run, 0 failures.
- `npm run lint` and `npm run type-check` both clean.