### PR TITLE
MAINT Simplify Foundry technique mapping

### DIFF
--- a/pyrit/scenario/scenarios/foundry/red_team_agent.py
+++ b/pyrit/scenario/scenarios/foundry/red_team_agent.py
@@ -42,9 +42,14 @@ from pyrit.converter import (
 from pyrit.converter.binary_converter import BinaryConverter
 from pyrit.converter.token_smuggling.ascii_smuggler_converter import AsciiSmugglerConverter
 from pyrit.datasets import TextJailBreak
-from pyrit.executor.attack import CrescendoAttack, PromptSendingAttack, RedTeamingAttack, TreeOfAttacksWithPruningAttack
+from pyrit.executor.attack import (
+    AttackStrategy,
+    CrescendoAttack,
+    PromptSendingAttack,
+    RedTeamingAttack,
+    TreeOfAttacksWithPruningAttack,
+)
 from pyrit.executor.attack.core.attack_config import AttackAdversarialConfig, AttackConverterConfig, AttackScoringConfig
-from pyrit.executor.attack.core.attack_strategy import AttackStrategy
 from pyrit.models import AttackSeedGroup
 from pyrit.prompt_normalizer.converter_configuration import ConverterConfiguration
 from pyrit.prompt_target import PromptTarget

--- a/pyrit/scenario/scenarios/foundry/red_team_agent.py
+++ b/pyrit/scenario/scenarios/foundry/red_team_agent.py
@@ -10,9 +10,11 @@ available attacks against specified datasets.
 """
 
 import logging
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from inspect import signature
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, cast
 
 from pyrit.common import apply_defaults
 from pyrit.converter import (
@@ -42,6 +44,7 @@ from pyrit.converter.token_smuggling.ascii_smuggler_converter import AsciiSmuggl
 from pyrit.datasets import TextJailBreak
 from pyrit.executor.attack import CrescendoAttack, PromptSendingAttack, RedTeamingAttack, TreeOfAttacksWithPruningAttack
 from pyrit.executor.attack.core.attack_config import AttackAdversarialConfig, AttackConverterConfig, AttackScoringConfig
+from pyrit.executor.attack.core.attack_strategy import AttackStrategy
 from pyrit.models import AttackSeedGroup
 from pyrit.prompt_normalizer.converter_configuration import ConverterConfiguration
 from pyrit.prompt_target import PromptTarget
@@ -56,8 +59,6 @@ from pyrit.scenario.core.scenario_technique import ScenarioTechnique
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-
-    from pyrit.executor.attack.core.attack_strategy import AttackStrategy
 
 AttackStrategyT = TypeVar("AttackStrategyT", bound="AttackStrategy[Any, Any]")
 logger = logging.getLogger(__name__)
@@ -193,6 +194,40 @@ class FoundryTechnique(ScenarioTechnique):
         return cls.EASY
 
 
+@dataclass(frozen=True)
+class _AttackSpecification:
+    """Declarative construction details for a Foundry attack technique."""
+
+    attack_type: type[AttackStrategy[Any, Any]]
+    kwargs: tuple[tuple[str, Any], ...] = ()
+
+
+@dataclass(frozen=True)
+class _ConverterSpecification:
+    """Declarative construction details for a Foundry converter technique."""
+
+    factory: Callable[..., Converter]
+    kwargs: tuple[tuple[str, Any], ...] = ()
+    deferred_kwargs: tuple[tuple[str, Callable[[], Any]], ...] = ()
+    target_kwarg: str | None = None
+
+    def create(self, *, converter_target: PromptTarget) -> Converter:
+        """
+        Create a fresh converter from this specification.
+
+        Args:
+            converter_target (PromptTarget): Target supplied to converters that require one.
+
+        Returns:
+            Converter: The configured converter instance.
+        """
+        kwargs = dict(self.kwargs)
+        kwargs.update((name, factory()) for name, factory in self.deferred_kwargs)
+        if self.target_kwarg:
+            kwargs[self.target_kwarg] = converter_target
+        return self.factory(**kwargs)
+
+
 class RedTeamAgent(Scenario):
     """
     RedTeamAgent is a preconfigured scenario that automatically generates multiple
@@ -208,6 +243,56 @@ class RedTeamAgent(Scenario):
     """
 
     VERSION: int = 1
+    _DEFAULT_ATTACK_SPECIFICATION: ClassVar[_AttackSpecification] = _AttackSpecification(PromptSendingAttack)
+    _ATTACK_SPECIFICATIONS: ClassVar[Mapping[FoundryTechnique, _AttackSpecification]] = MappingProxyType(
+        {
+            FoundryTechnique.Crescendo: _AttackSpecification(CrescendoAttack),
+            FoundryTechnique.MultiTurn: _AttackSpecification(RedTeamingAttack),
+            FoundryTechnique.Pair: _AttackSpecification(
+                TreeOfAttacksWithPruningAttack,
+                kwargs=(("tree_width", 1),),
+            ),
+            FoundryTechnique.Tap: _AttackSpecification(TreeOfAttacksWithPruningAttack),
+        }
+    )
+    _CONVERTER_SPECIFICATIONS: ClassVar[Mapping[FoundryTechnique, _ConverterSpecification]] = MappingProxyType(
+        {
+            FoundryTechnique.AnsiAttack: _ConverterSpecification(AnsiAttackConverter),
+            FoundryTechnique.AsciiArt: _ConverterSpecification(AsciiArtConverter),
+            FoundryTechnique.AsciiSmuggler: _ConverterSpecification(AsciiSmugglerConverter),
+            FoundryTechnique.Atbash: _ConverterSpecification(AtbashConverter),
+            FoundryTechnique.Base64: _ConverterSpecification(Base64Converter),
+            FoundryTechnique.Binary: _ConverterSpecification(BinaryConverter),
+            FoundryTechnique.Caesar: _ConverterSpecification(
+                CaesarConverter,
+                kwargs=(("caesar_offset", 3),),
+            ),
+            FoundryTechnique.CharacterSpace: _ConverterSpecification(CharacterSpaceConverter),
+            FoundryTechnique.CharSwap: _ConverterSpecification(CharSwapConverter),
+            FoundryTechnique.Diacritic: _ConverterSpecification(DiacriticConverter),
+            FoundryTechnique.Flip: _ConverterSpecification(FlipConverter),
+            FoundryTechnique.Leetspeak: _ConverterSpecification(LeetspeakConverter),
+            FoundryTechnique.Morse: _ConverterSpecification(MorseConverter),
+            FoundryTechnique.ROT13: _ConverterSpecification(ROT13Converter),
+            FoundryTechnique.SuffixAppend: _ConverterSpecification(
+                SuffixAppendConverter,
+                kwargs=(("suffix", "!!!"),),
+            ),
+            FoundryTechnique.StringJoin: _ConverterSpecification(StringJoinConverter),
+            FoundryTechnique.Tense: _ConverterSpecification(
+                TenseConverter,
+                kwargs=(("tense", "past"),),
+                target_kwarg="converter_target",
+            ),
+            FoundryTechnique.UnicodeConfusable: _ConverterSpecification(UnicodeConfusableConverter),
+            FoundryTechnique.UnicodeSubstitution: _ConverterSpecification(UnicodeSubstitutionConverter),
+            FoundryTechnique.Url: _ConverterSpecification(UrlConverter),
+            FoundryTechnique.Jailbreak: _ConverterSpecification(
+                TextJailbreakConverter,
+                deferred_kwargs=(("jailbreak_template", lambda: TextJailBreak(random_template=True)),),
+            ),
+        }
+    )
 
     @apply_defaults
     def __init__(
@@ -386,70 +471,22 @@ class RedTeamAgent(Scenario):
         Raises:
             ValueError: If a converter technique in the composite is not recognized.
         """
-        attack: AttackStrategy[Any, Any]
-
-        attack_type: type[AttackStrategy[Any, Any]] = PromptSendingAttack
-        attack_kwargs: dict[str, Any] = {}
-        if composite.attack is not None:
-            if composite.attack == FoundryTechnique.Crescendo:
-                attack_type = CrescendoAttack
-            elif composite.attack == FoundryTechnique.MultiTurn:
-                attack_type = RedTeamingAttack
-            elif composite.attack == FoundryTechnique.Pair:
-                attack_type = TreeOfAttacksWithPruningAttack
-                attack_kwargs = {"tree_width": 1}
-            elif composite.attack == FoundryTechnique.Tap:
-                attack_type = TreeOfAttacksWithPruningAttack
-
+        attack_specification = self._ATTACK_SPECIFICATIONS.get(
+            composite.attack,
+            self._DEFAULT_ATTACK_SPECIFICATION,
+        )
         converters: list[Converter] = []
         for technique in composite.converters:
-            if technique == FoundryTechnique.AnsiAttack:
-                converters.append(AnsiAttackConverter())
-            elif technique == FoundryTechnique.AsciiArt:
-                converters.append(AsciiArtConverter())
-            elif technique == FoundryTechnique.AsciiSmuggler:
-                converters.append(AsciiSmugglerConverter())
-            elif technique == FoundryTechnique.Atbash:
-                converters.append(AtbashConverter())
-            elif technique == FoundryTechnique.Base64:
-                converters.append(Base64Converter())
-            elif technique == FoundryTechnique.Binary:
-                converters.append(BinaryConverter())
-            elif technique == FoundryTechnique.Caesar:
-                converters.append(CaesarConverter(caesar_offset=3))
-            elif technique == FoundryTechnique.CharacterSpace:
-                converters.append(CharacterSpaceConverter())
-            elif technique == FoundryTechnique.CharSwap:
-                converters.append(CharSwapConverter())
-            elif technique == FoundryTechnique.Diacritic:
-                converters.append(DiacriticConverter())
-            elif technique == FoundryTechnique.Flip:
-                converters.append(FlipConverter())
-            elif technique == FoundryTechnique.Leetspeak:
-                converters.append(LeetspeakConverter())
-            elif technique == FoundryTechnique.Morse:
-                converters.append(MorseConverter())
-            elif technique == FoundryTechnique.ROT13:
-                converters.append(ROT13Converter())
-            elif technique == FoundryTechnique.SuffixAppend:
-                converters.append(SuffixAppendConverter(suffix="!!!"))
-            elif technique == FoundryTechnique.StringJoin:
-                converters.append(StringJoinConverter())
-            elif technique == FoundryTechnique.Tense:
-                converters.append(TenseConverter(tense="past", converter_target=self._adversarial_chat))
-            elif technique == FoundryTechnique.UnicodeConfusable:
-                converters.append(UnicodeConfusableConverter())
-            elif technique == FoundryTechnique.UnicodeSubstitution:
-                converters.append(UnicodeSubstitutionConverter())
-            elif technique == FoundryTechnique.Url:
-                converters.append(UrlConverter())
-            elif technique == FoundryTechnique.Jailbreak:
-                jailbreak_template = TextJailBreak(random_template=True)
-                converters.append(TextJailbreakConverter(jailbreak_template=jailbreak_template))
-            else:
+            converter_specification = self._CONVERTER_SPECIFICATIONS.get(technique)
+            if converter_specification is None:
                 raise ValueError(f"Unknown technique: {technique}")
+            converters.append(converter_specification.create(converter_target=self._adversarial_chat))
 
-        attack = self._get_attack(attack_type=attack_type, converters=converters, attack_kwargs=attack_kwargs)
+        attack = self._get_attack(
+            attack_type=attack_specification.attack_type,
+            converters=converters,
+            attack_kwargs=dict(attack_specification.kwargs),
+        )
 
         return AtomicAttack(
             atomic_attack_name=composite.name,

--- a/tests/unit/scenario/foundry/test_red_team_agent.py
+++ b/tests/unit/scenario/foundry/test_red_team_agent.py
@@ -3,14 +3,43 @@
 
 """Tests for the RedTeamAgent class."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
-from pyrit.converter import Base64Converter
+from pyrit.converter import (
+    AnsiAttackConverter,
+    AsciiArtConverter,
+    AtbashConverter,
+    Base64Converter,
+    CaesarConverter,
+    CharacterSpaceConverter,
+    CharSwapConverter,
+    Converter,
+    DiacriticConverter,
+    FlipConverter,
+    LeetspeakConverter,
+    MorseConverter,
+    ROT13Converter,
+    StringJoinConverter,
+    SuffixAppendConverter,
+    TenseConverter,
+    TextJailbreakConverter,
+    UnicodeConfusableConverter,
+    UnicodeSubstitutionConverter,
+    UrlConverter,
+)
+from pyrit.converter.binary_converter import BinaryConverter
+from pyrit.converter.token_smuggling.ascii_smuggler_converter import AsciiSmugglerConverter
+from pyrit.executor.attack import (
+    CrescendoAttack,
+    PromptSendingAttack,
+    RedTeamingAttack,
+    TreeOfAttacksWithPruningAttack,
+)
 from pyrit.executor.attack.core.attack_config import AttackScoringConfig
-from pyrit.executor.attack.multi_turn.crescendo import CrescendoAttack
-from pyrit.executor.attack.single_turn.prompt_sending import PromptSendingAttack
+from pyrit.executor.attack.core.attack_strategy import AttackStrategy
 from pyrit.models import AttackSeedGroup, ComponentIdentifier, SeedObjective
 from pyrit.prompt_target import PromptTarget
 from pyrit.scenario import AtomicAttack, DatasetAttackConfiguration
@@ -36,6 +65,53 @@ def _mock_target_id(name: str = "MockTarget") -> ComponentIdentifier:
         class_name=name,
         class_module="test",
     )
+
+
+def _converter_technique_cases() -> list[tuple[FoundryTechnique, type[Converter]]]:
+    """Return every supported Foundry converter mapping."""
+    return [
+        (FoundryTechnique.AnsiAttack, AnsiAttackConverter),
+        (FoundryTechnique.AsciiArt, AsciiArtConverter),
+        (FoundryTechnique.AsciiSmuggler, AsciiSmugglerConverter),
+        (FoundryTechnique.Atbash, AtbashConverter),
+        (FoundryTechnique.Base64, Base64Converter),
+        (FoundryTechnique.Binary, BinaryConverter),
+        (FoundryTechnique.Caesar, CaesarConverter),
+        (FoundryTechnique.CharacterSpace, CharacterSpaceConverter),
+        (FoundryTechnique.CharSwap, CharSwapConverter),
+        (FoundryTechnique.Diacritic, DiacriticConverter),
+        (FoundryTechnique.Flip, FlipConverter),
+        (FoundryTechnique.Leetspeak, LeetspeakConverter),
+        (FoundryTechnique.Morse, MorseConverter),
+        (FoundryTechnique.ROT13, ROT13Converter),
+        (FoundryTechnique.SuffixAppend, SuffixAppendConverter),
+        (FoundryTechnique.StringJoin, StringJoinConverter),
+        (FoundryTechnique.Tense, TenseConverter),
+        (FoundryTechnique.UnicodeConfusable, UnicodeConfusableConverter),
+        (FoundryTechnique.UnicodeSubstitution, UnicodeSubstitutionConverter),
+        (FoundryTechnique.Url, UrlConverter),
+        (FoundryTechnique.Jailbreak, TextJailbreakConverter),
+    ]
+
+
+def _attack_technique_cases() -> list[tuple[FoundryTechnique | None, type[AttackStrategy[Any, Any]], int | None]]:
+    """Return every supported Foundry attack mapping plus the baseline."""
+    return [
+        (None, PromptSendingAttack, None),
+        (FoundryTechnique.Crescendo, CrescendoAttack, None),
+        (FoundryTechnique.MultiTurn, RedTeamingAttack, None),
+        (FoundryTechnique.Pair, TreeOfAttacksWithPruningAttack, 1),
+        (FoundryTechnique.Tap, TreeOfAttacksWithPruningAttack, 3),
+    ]
+
+
+def _get_request_converters(atomic_attack: AtomicAttack) -> list[Converter]:
+    """Return request converters from an atomic attack in execution order."""
+    return [
+        converter
+        for configuration in atomic_attack.attack_technique.attack.get_request_converters()
+        for converter in configuration.converters
+    ]
 
 
 @pytest.fixture
@@ -90,6 +166,21 @@ def mock_float_threshold_scorer():
     mock.get_identifier.return_value = _mock_scorer_id("MockFloatScaleThresholdScorer")
     mock.threshold = 0.7
     return mock
+
+
+@pytest.fixture
+def configured_scenario(
+    mock_objective_target: PromptTarget,
+    mock_adversarial_target: PromptTarget,
+    mock_float_threshold_scorer: FloatScaleThresholdScorer,
+) -> RedTeamAgent:
+    """Create a scenario ready for direct technique materialization."""
+    scenario = RedTeamAgent(
+        adversarial_chat=mock_adversarial_target,
+        attack_scoring_config=AttackScoringConfig(objective_scorer=mock_float_threshold_scorer),
+    )
+    scenario._objective_target = mock_objective_target
+    return scenario
 
 
 @pytest.fixture
@@ -543,107 +634,177 @@ class TestFoundryGetAttack:
 
 @pytest.mark.usefixtures(*FIXTURES)
 class TestFoundryAllTechniques:
-    """Tests that all techniques can be instantiated."""
+    """Tests for the complete declarative Foundry technique mapping."""
 
-    @pytest.mark.parametrize(
-        "technique",
-        [
-            FoundryTechnique.AnsiAttack,
-            FoundryTechnique.AsciiArt,
-            FoundryTechnique.AsciiSmuggler,
-            FoundryTechnique.Atbash,
-            FoundryTechnique.Base64,
-            FoundryTechnique.Binary,
-            FoundryTechnique.Caesar,
-            FoundryTechnique.CharacterSpace,
-            FoundryTechnique.CharSwap,
-            FoundryTechnique.Diacritic,
-            FoundryTechnique.Flip,
-            FoundryTechnique.Leetspeak,
-            FoundryTechnique.Morse,
-            FoundryTechnique.ROT13,
-            FoundryTechnique.SuffixAppend,
-            FoundryTechnique.StringJoin,
-            FoundryTechnique.Tense,
-            FoundryTechnique.UnicodeConfusable,
-            FoundryTechnique.UnicodeSubstitution,
-            FoundryTechnique.Url,
-            FoundryTechnique.Jailbreak,
-        ],
-    )
-    async def test_all_single_turn_techniques_create_attack_runs(
-        self, mock_objective_target, mock_objective_scorer, mock_memory_seed_groups, mock_dataset_config, technique
-    ):
-        """Test that all single-turn techniques can create attack runs."""
-        with patch.object(
-            RedTeamAgent,
-            "_resolve_seed_groups_by_dataset_async",
-            new_callable=AsyncMock,
-            return_value={"memory": mock_memory_seed_groups},
-        ):
-            scenario = RedTeamAgent(
-                attack_scoring_config=AttackScoringConfig(objective_scorer=mock_objective_scorer),
-            )
-
-            scenario.set_params_from_args(
-                args={
-                    "objective_target": mock_objective_target,
-                    "scenario_techniques": [technique],
-                    "dataset_config": mock_dataset_config,
-                }
-            )
-            await scenario.initialize_async()
-
-            # Get the composite technique that was created during initialization
-            composite_technique = scenario._scenario_composites[0]
-            atomic_attack = scenario._get_attack_from_technique(
-                composite=composite_technique, seed_groups=mock_memory_seed_groups
-            )
-            assert isinstance(atomic_attack, AtomicAttack)
-
-    @pytest.mark.parametrize(
-        "technique",
-        [
-            FoundryTechnique.MultiTurn,
-            FoundryTechnique.Crescendo,
-        ],
-    )
-    async def test_all_multi_turn_techniques_create_attack_runs(
+    @pytest.mark.parametrize(("technique", "expected_converter_type"), _converter_technique_cases())
+    def test_converter_technique_maps_to_expected_type(
         self,
-        mock_objective_target,
-        mock_adversarial_target,
-        mock_objective_scorer,
-        mock_memory_seed_groups,
-        mock_dataset_config,
-        technique,
-    ):
-        """Test that all multi-turn techniques can create attack runs."""
-        with patch.object(
-            RedTeamAgent,
-            "_resolve_seed_groups_by_dataset_async",
-            new_callable=AsyncMock,
-            return_value={"memory": mock_memory_seed_groups},
-        ):
-            scenario = RedTeamAgent(
-                adversarial_chat=mock_adversarial_target,
-                attack_scoring_config=AttackScoringConfig(objective_scorer=mock_objective_scorer),
+        configured_scenario: RedTeamAgent,
+        mock_memory_seed_groups: list[AttackSeedGroup],
+        technique: FoundryTechnique,
+        expected_converter_type: type[Converter],
+    ) -> None:
+        """Each converter technique creates its declared concrete converter."""
+        atomic_attack = configured_scenario._get_attack_from_technique(
+            composite=FoundryComposite(attack=None, converters=[technique]),
+            seed_groups=mock_memory_seed_groups,
+        )
+
+        converters = _get_request_converters(atomic_attack)
+        assert len(converters) == 1
+        assert type(converters[0]) is expected_converter_type
+
+    @pytest.mark.parametrize(("technique", "expected_attack_type", "expected_tree_width"), _attack_technique_cases())
+    def test_attack_technique_maps_to_expected_type_and_configuration(
+        self,
+        configured_scenario: RedTeamAgent,
+        mock_memory_seed_groups: list[AttackSeedGroup],
+        mock_float_threshold_scorer: FloatScaleThresholdScorer,
+        technique: FoundryTechnique | None,
+        expected_attack_type: type[AttackStrategy[Any, Any]],
+        expected_tree_width: int | None,
+    ) -> None:
+        """Each attack technique keeps its class, tree width, and supplied scorer."""
+        atomic_attack = configured_scenario._get_attack_from_technique(
+            composite=FoundryComposite(attack=technique),
+            seed_groups=mock_memory_seed_groups,
+        )
+
+        attack = atomic_attack.attack_technique.attack
+        assert type(attack) is expected_attack_type
+        if expected_tree_width is not None:
+            assert attack._tree_width == expected_tree_width
+            assert attack._objective_scorer is mock_float_threshold_scorer
+
+    def test_mapping_cases_cover_all_concrete_foundry_techniques(self) -> None:
+        """The mapping cases stay exhaustive as the Foundry enum evolves."""
+        converter_techniques = {technique for technique, _ in _converter_technique_cases()}
+        attack_techniques = {technique for technique, _, _ in _attack_technique_cases() if technique is not None}
+
+        assert converter_techniques == set(FoundryTechnique.get_techniques_by_tag("converter"))
+        assert attack_techniques == set(FoundryTechnique.get_techniques_by_tag("attack"))
+
+    @pytest.mark.parametrize(
+        ("technique", "attribute", "expected_value"),
+        [
+            (FoundryTechnique.Caesar, "caesar_offset", 3),
+            (FoundryTechnique.SuffixAppend, "_suffix", "!!!"),
+        ],
+    )
+    def test_converter_technique_preserves_special_arguments(
+        self,
+        configured_scenario: RedTeamAgent,
+        mock_memory_seed_groups: list[AttackSeedGroup],
+        technique: FoundryTechnique,
+        attribute: str,
+        expected_value: object,
+    ) -> None:
+        """Converters with fixed Foundry arguments retain those exact values."""
+        atomic_attack = configured_scenario._get_attack_from_technique(
+            composite=FoundryComposite(attack=None, converters=[technique]),
+            seed_groups=mock_memory_seed_groups,
+        )
+
+        converter = _get_request_converters(atomic_attack)[0]
+        assert getattr(converter, attribute) == expected_value
+
+    def test_tense_converter_preserves_tense_and_adversarial_target(
+        self,
+        configured_scenario: RedTeamAgent,
+        mock_memory_seed_groups: list[AttackSeedGroup],
+        mock_adversarial_target: PromptTarget,
+    ) -> None:
+        """Tense keeps the past-tense setting and exact adversarial target."""
+        atomic_attack = configured_scenario._get_attack_from_technique(
+            composite=FoundryComposite(attack=None, converters=[FoundryTechnique.Tense]),
+            seed_groups=mock_memory_seed_groups,
+        )
+
+        converter = _get_request_converters(atomic_attack)[0]
+        assert isinstance(converter, TenseConverter)
+        assert converter._tense == "past"
+        assert converter._converter_target is mock_adversarial_target
+
+    def test_jailbreak_converter_builds_fresh_random_template(
+        self,
+        configured_scenario: RedTeamAgent,
+        mock_memory_seed_groups: list[AttackSeedGroup],
+    ) -> None:
+        """Every Jailbreak materialization gets a newly selected random template."""
+        templates = [MagicMock(), MagicMock()]
+        with patch(
+            "pyrit.scenario.scenarios.foundry.red_team_agent.TextJailBreak",
+            side_effect=templates,
+        ) as template_constructor:
+            atomic_attacks = [
+                configured_scenario._get_attack_from_technique(
+                    composite=FoundryComposite(attack=None, converters=[FoundryTechnique.Jailbreak]),
+                    seed_groups=mock_memory_seed_groups,
+                )
+                for _ in range(2)
+            ]
+
+        converters = [_get_request_converters(atomic_attack)[0] for atomic_attack in atomic_attacks]
+        assert template_constructor.call_args_list == [call(random_template=True), call(random_template=True)]
+        assert isinstance(converters[0], TextJailbreakConverter)
+        assert isinstance(converters[1], TextJailbreakConverter)
+        assert converters[0].jail_break_template is templates[0]
+        assert converters[1].jail_break_template is templates[1]
+
+    def test_composite_preserves_converter_order(
+        self,
+        configured_scenario: RedTeamAgent,
+        mock_memory_seed_groups: list[AttackSeedGroup],
+    ) -> None:
+        """Composite converters remain in caller-specified execution order."""
+        atomic_attack = configured_scenario._get_attack_from_technique(
+            composite=FoundryComposite(
+                attack=None,
+                converters=[
+                    FoundryTechnique.Url,
+                    FoundryTechnique.Base64,
+                    FoundryTechnique.ROT13,
+                ],
+            ),
+            seed_groups=mock_memory_seed_groups,
+        )
+
+        converters = _get_request_converters(atomic_attack)
+        assert [type(converter) for converter in converters] == [UrlConverter, Base64Converter, ROT13Converter]
+
+    def test_unknown_converter_technique_raises_existing_error(
+        self,
+        configured_scenario: RedTeamAgent,
+        mock_memory_seed_groups: list[AttackSeedGroup],
+    ) -> None:
+        """Unsupported converter names retain the existing ValueError."""
+        composite = FoundryComposite(attack=None)
+        composite.converters.append(cast("FoundryTechnique", "unsupported"))
+
+        with pytest.raises(ValueError) as exc_info:
+            configured_scenario._get_attack_from_technique(
+                composite=composite,
+                seed_groups=mock_memory_seed_groups,
             )
 
-            scenario.set_params_from_args(
-                args={
-                    "objective_target": mock_objective_target,
-                    "scenario_techniques": [technique],
-                    "dataset_config": mock_dataset_config,
-                }
-            )
-            await scenario.initialize_async()
+        assert str(exc_info.value) == "Unknown technique: unsupported"
 
-            # Get the composite technique that was created during initialization
-            composite_technique = scenario._scenario_composites[0]
-            atomic_attack = scenario._get_attack_from_technique(
-                composite=composite_technique, seed_groups=mock_memory_seed_groups
-            )
-            assert isinstance(atomic_attack, AtomicAttack)
+    def test_unknown_attack_technique_retains_baseline_fallback(
+        self,
+        configured_scenario: RedTeamAgent,
+        mock_memory_seed_groups: list[AttackSeedGroup],
+    ) -> None:
+        """An unknown attack-tagged value still falls back to PromptSendingAttack."""
+        unknown_attack = MagicMock()
+        unknown_attack.tags = {"attack"}
+        unknown_attack.value = "unsupported"
+
+        atomic_attack = configured_scenario._get_attack_from_technique(
+            composite=FoundryComposite(attack=cast("FoundryTechnique", unknown_attack)),
+            seed_groups=mock_memory_seed_groups,
+        )
+
+        assert type(atomic_attack.attack_technique.attack) is PromptSendingAttack
 
 
 @pytest.mark.usefixtures(*FIXTURES)


### PR DESCRIPTION
## Description

`RedTeamAgent._get_attack_from_technique` encoded the Foundry attack and converter catalog in a long conditional chain, making supported mappings and constructor exceptions difficult to audit. This replaces those branches with immutable, Foundry-local attack and converter specifications while retaining direct attack construction rather than adopting the mutable global registry.

The refactor preserves all existing behavior: baseline and four attack mappings, all 21 converter mappings, converter order, fresh instances, Caesar/suffix/Tense/Jailbreak defaults, exact unsupported-converter errors, unknown-attack fallback, and PAIR/TAP scoring semantics. The mapping portion of `_get_attack_from_technique` is reduced from 70 lines to 22.

## Tests and Documentation

Added exhaustive parameterized coverage for every attack and converter mapping, enum completeness, special constructor arguments, fresh Jailbreak templates, converter ordering, unsupported values, baseline fallback, and PAIR/TAP scorer behavior.

Validated with:
- `tests/unit/scenario/foundry/test_red_team_agent.py` (56 passed)
- focused mapping tests (34 passed)
- `tests/partner_integration/azure_ai_evaluation/test_foundry_scenario_contract.py` (7 passed)
- Ruff format and lint checks
- targeted `ty` checks

Documentation is unchanged because the public Foundry API and behavior are unchanged. JupyText was not applicable.