### PR TITLE
MAINT Simplify OpenAI Responses input serialization

### DIFF
--- a/pyrit/prompt_target/openai/openai_response_target.py
+++ b/pyrit/prompt_target/openai/openai_response_target.py
@@ -4,6 +4,7 @@
 import json
 import logging
 from collections.abc import Awaitable, Callable, MutableSequence
+from dataclasses import dataclass
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -41,13 +42,20 @@ from pyrit.prompt_target.openai.openai_error_handling import _is_content_filter_
 from pyrit.prompt_target.openai.openai_target import OpenAITarget
 
 if TYPE_CHECKING:
-    from openai.types.responses import ResponseInputImageParam
+    from openai.types.responses import ResponseFunctionToolCallParam, ResponseInputImageParam
+    from openai.types.responses.response_input_item_param import FunctionCallOutput
 
 logger = logging.getLogger(__name__)
 
 
 # Tool function registry (agentic extension)
 ToolExecutor = Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]
+
+
+@dataclass(frozen=True)
+class _SerializedPiece:
+    item: dict[str, Any]
+    placement: Literal["inline", "top_level"]
 
 
 class MessagePieceType(str, Enum):
@@ -264,6 +272,57 @@ class OpenAIResponseTarget(OpenAITarget):
             return dict(image_item)
         raise ValueError(f"Unsupported piece type for inline content: {piece.converted_value_data_type}")
 
+    def _serialize_system_message(self, pieces: list[MessagePiece]) -> dict[str, Any]:
+        content = [{"type": "input_text", "text": piece.converted_value} for piece in pieces]
+        return {"role": "developer", "content": content}
+
+    def _serialize_function_call(self, piece: MessagePiece) -> "ResponseFunctionToolCallParam":
+        stored = json.loads(piece.original_value)
+        return {
+            "type": stored["type"],
+            "call_id": stored["call_id"],
+            "name": stored["name"],
+            "arguments": stored["arguments"],
+        }
+
+    def _serialize_tool_call(self, piece: MessagePiece) -> dict[str, Any]:
+        stored = json.loads(piece.original_value)
+        if stored.get("type") == "web_search_call":
+            return {
+                "type": stored["type"],
+                "call_id": stored.get("call_id"),
+                "query": stored.get("query"),
+            }
+        filtered = {"type": stored["type"]}
+        filtered.update({key: stored[key] for key in ("call_id", "query", "name", "arguments") if key in stored})
+        return filtered
+
+    def _serialize_function_call_output(self, piece: MessagePiece) -> "FunctionCallOutput":
+        payload = json.loads(piece.original_value)
+        output = payload.get("output")
+        if not isinstance(output, str):
+            output = json.dumps(output, separators=(",", ":"))
+        return {
+            "type": "function_call_output",
+            "call_id": payload["call_id"],
+            "output": output,
+        }
+
+    async def _serialize_piece_async(self, *, piece: MessagePiece, message_index: int) -> _SerializedPiece | None:
+        data_type = piece.converted_value_data_type
+        if data_type == "reasoning":
+            return None
+        if data_type in {"text", "image_path"} or piece.structured_refusal is not None:
+            item = await self._construct_input_item_from_piece_async(piece)
+            return _SerializedPiece(item=item, placement="inline")
+        if data_type == "function_call":
+            return _SerializedPiece(item=dict(self._serialize_function_call(piece)), placement="top_level")
+        if data_type == "tool_call":
+            return _SerializedPiece(item=self._serialize_tool_call(piece), placement="top_level")
+        if data_type == "function_call_output":
+            return _SerializedPiece(item=dict(self._serialize_function_call_output(piece)), placement="top_level")
+        raise ValueError(f"Unsupported data type '{data_type}' in message index {message_index}")
+
     async def _build_input_for_multi_modal_async(self, conversation: MutableSequence[Message]) -> list[dict[str, Any]]:
         """
         Build the Responses API `input` array.
@@ -282,7 +341,7 @@ class OpenAIResponseTarget(OpenAITarget):
             A list of input items ready for the Responses API.
 
         Raises:
-            ValueError: If the conversation is empty or a system message has >1 piece.
+            ValueError: If the conversation is empty or a message has no pieces.
         """
         if not conversation:
             raise ValueError("Conversation cannot be empty")
@@ -296,85 +355,20 @@ class OpenAIResponseTarget(OpenAITarget):
                     f"Failed to process conversation message at index {msg_idx}: Message contains no message pieces"
                 )
 
-            # System message (remapped to developer)
             if pieces[0].api_role == "system":
-                system_content = [{"type": "input_text", "text": piece.converted_value} for piece in pieces]
-                input_items.append({"role": "developer", "content": system_content})
+                input_items.append(self._serialize_system_message(pieces))
                 continue
 
-            # All pieces in a Message share the same role
             role = pieces[0].api_role
             content: list[dict[str, Any]] = []
-
             for piece in pieces:
-                dtype = piece.converted_value_data_type
-
-                # Skip reasoning - it's stored in memory but not sent back to API
-                if dtype == "reasoning":
+                serialized = await self._serialize_piece_async(piece=piece, message_index=msg_idx)
+                if serialized is None:
                     continue
-
-                # Inline content (text/images/structured refusals) - accumulate in content list
-                if dtype in {"text", "image_path"} or piece.structured_refusal is not None:
-                    content.append(await self._construct_input_item_from_piece_async(piece))
-                    continue
-
-                # Top-level artifacts - emit as standalone items
-                if dtype not in {"function_call", "function_call_output", "tool_call"}:
-                    raise ValueError(f"Unsupported data type '{dtype}' in message index {msg_idx}")
-
-                if dtype in {"function_call", "tool_call"}:
-                    # Parse the stored JSON and filter to only API-expected fields
-                    stored = json.loads(piece.original_value)
-                    if dtype == "function_call":
-                        # Only include fields the API expects for function_call
-                        input_items.append(
-                            {
-                                "type": stored["type"],
-                                "call_id": stored["call_id"],
-                                "name": stored["name"],
-                                "arguments": stored["arguments"],
-                            }
-                        )
-                    elif dtype == "tool_call":
-                        # Filter tool_call fields based on type
-                        tool_type = stored.get("type")
-                        if tool_type == "web_search_call":
-                            # Web search call structure
-                            input_items.append(
-                                {
-                                    "type": stored["type"],
-                                    "call_id": stored.get("call_id"),
-                                    "query": stored.get("query"),
-                                }
-                            )
-                        else:
-                            # For unknown tool types, try to include only known fields
-                            filtered = {"type": stored["type"]}
-                            if "call_id" in stored:
-                                filtered["call_id"] = stored["call_id"]
-                            if "query" in stored:
-                                filtered["query"] = stored["query"]
-                            if "name" in stored:
-                                filtered["name"] = stored["name"]
-                            if "arguments" in stored:
-                                filtered["arguments"] = stored["arguments"]
-                            input_items.append(filtered)
-
-                if dtype == "function_call_output":
-                    payload = json.loads(piece.original_value)
-                    output = payload.get("output")
-                    if not isinstance(output, str):
-                        # Responses API requires string output; serialize if needed
-                        output = json.dumps(output, separators=(",", ":"))
-                    input_items.append(
-                        {
-                            "type": "function_call_output",
-                            "call_id": payload["call_id"],
-                            "output": output,
-                        }
-                    )
-
-            # Append accumulated inline content for this message
+                if serialized.placement == "inline":
+                    content.append(serialized.item)
+                else:
+                    input_items.append(serialized.item)
             if content:
                 input_items.append({"role": role, "content": content})
 

--- a/tests/unit/prompt_target/target/test_openai_response_target.py
+++ b/tests/unit/prompt_target/target/test_openai_response_target.py
@@ -26,7 +26,14 @@ from pyrit.exceptions.exception_classes import (
 )
 from pyrit.executor.attack import AttackExecutor, AttackScoringConfig, PromptSendingAttack
 from pyrit.memory.memory_interface import MemoryInterface
-from pyrit.models import AttackOutcome, JsonResponseConfig, Message, MessagePiece, flatten_to_message_pieces
+from pyrit.models import (
+    AttackOutcome,
+    JsonResponseConfig,
+    Message,
+    MessagePiece,
+    PromptDataType,
+    flatten_to_message_pieces,
+)
 from pyrit.prompt_target import OpenAIResponseTarget, PromptTarget
 from pyrit.score import SelfAskRefusalScorer, TrueFalseInverterScorer
 
@@ -212,6 +219,23 @@ async def test_build_input_for_multi_modal_with_unsupported_data_types(target: O
     with pytest.raises(ValueError) as excinfo:
         await target._build_input_for_multi_modal_async([Message(message_pieces=[entry])])
     assert "Unsupported data type 'audio_path' in message index 0" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("data_type", ["audio_path", "binary_path", "video_path", "url"])
+async def test_build_input_for_multi_modal_preserves_unsupported_modalities(
+    target: OpenAIResponseTarget, data_type: PromptDataType
+):
+    piece = MessagePiece(
+        role="user",
+        original_value="unsupported-value",
+        original_value_data_type=data_type,
+        converted_value_data_type=data_type,
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        await target._build_input_for_multi_modal_async([Message(message_pieces=[piece])])
+
+    assert str(exc_info.value) == f"Unsupported data type '{data_type}' in message index 0"
 
 
 async def test_construct_request_body_includes_extra_body_params(
@@ -883,6 +907,184 @@ async def test_build_input_for_multi_modal_async_function_call_output_stringifie
     # The Output must be a string for Responses API
     assert isinstance(items[0]["output"], str)
     assert json.loads(items[0]["output"]) == {"ok": True, "value": 5}
+
+
+async def test_build_input_for_multi_modal_async_preserves_mixed_payload_contract(target: OpenAIResponseTarget):
+    refusal_piece = MessagePiece(
+        role="assistant",
+        original_value="stored refusal",
+        original_value_data_type="error",
+        response_error="blocked",
+    )
+    refusal_piece.mark_as_structured_refusal(refusal="refused")
+
+    conversation = [
+        Message(
+            message_pieces=[
+                MessagePiece(role="system", original_value="system-a"),
+                MessagePiece(role="system", original_value="system-b"),
+            ]
+        ),
+        Message(
+            message_pieces=[
+                MessagePiece(role="user", original_value="user text"),
+                MessagePiece(role="user", original_value="image.png", original_value_data_type="image_path"),
+            ]
+        ),
+        Message(
+            message_pieces=[
+                MessagePiece(role="assistant", original_value="assistant text"),
+                MessagePiece(
+                    role="assistant",
+                    original_value='{"type":"reasoning"}',
+                    original_value_data_type="reasoning",
+                ),
+                MessagePiece(
+                    role="assistant",
+                    original_value=json.dumps(
+                        {
+                            "type": "function_call",
+                            "call_id": "function-1",
+                            "name": "lookup",
+                            "arguments": '{"value":1}',
+                            "id": "drop-id",
+                            "status": "completed",
+                        }
+                    ),
+                    original_value_data_type="function_call",
+                ),
+                MessagePiece(
+                    role="assistant",
+                    original_value=json.dumps({"type": "web_search_call", "call_id": "web-1", "id": "drop-id"}),
+                    original_value_data_type="tool_call",
+                ),
+                MessagePiece(
+                    role="assistant",
+                    original_value=json.dumps(
+                        {
+                            "type": "provider_tool_call",
+                            "call_id": "tool-1",
+                            "query": "query",
+                            "name": "provider-tool",
+                            "arguments": "{}",
+                            "id": "drop-id",
+                            "status": "completed",
+                        }
+                    ),
+                    original_value_data_type="tool_call",
+                ),
+                MessagePiece(
+                    role="assistant",
+                    original_value=json.dumps(
+                        {
+                            "type": "function_call_output",
+                            "call_id": "function-1",
+                            "output": {"ok": True},
+                            "id": "drop-id",
+                        }
+                    ),
+                    original_value_data_type="function_call_output",
+                ),
+                refusal_piece,
+            ]
+        ),
+    ]
+
+    with patch(
+        "pyrit.prompt_target.openai.openai_response_target.convert_local_image_to_data_url_async",
+        return_value="data:image/png;base64,image-data",
+    ):
+        result = await target._build_input_for_multi_modal_async(conversation)
+
+    assert result == [
+        {
+            "role": "developer",
+            "content": [
+                {"type": "input_text", "text": "system-a"},
+                {"type": "input_text", "text": "system-b"},
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "user text"},
+                {
+                    "detail": "auto",
+                    "type": "input_image",
+                    "image_url": "data:image/png;base64,image-data",
+                },
+            ],
+        },
+        {
+            "type": "function_call",
+            "call_id": "function-1",
+            "name": "lookup",
+            "arguments": '{"value":1}',
+        },
+        {"type": "web_search_call", "call_id": "web-1", "query": None},
+        {
+            "type": "provider_tool_call",
+            "call_id": "tool-1",
+            "query": "query",
+            "name": "provider-tool",
+            "arguments": "{}",
+        },
+        {"type": "function_call_output", "call_id": "function-1", "output": '{"ok":true}'},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "output_text", "text": "assistant text"},
+                {"type": "output_text", "text": "refused"},
+            ],
+        },
+    ]
+
+
+@pytest.mark.parametrize("data_type", ["function_call", "tool_call", "function_call_output"])
+async def test_build_input_for_multi_modal_async_preserves_malformed_artifact_error(
+    target: OpenAIResponseTarget, data_type: PromptDataType
+):
+    piece = MessagePiece(
+        role="assistant",
+        original_value="{",
+        original_value_data_type=data_type,
+    )
+
+    with pytest.raises(json.JSONDecodeError, match="Expecting property name enclosed in double quotes"):
+        await target._build_input_for_multi_modal_async([Message(message_pieces=[piece])])
+
+
+@pytest.mark.parametrize(
+    ("data_type", "payload", "missing_field"),
+    [
+        ("function_call", {"call_id": "call-1", "name": "lookup", "arguments": "{}"}, "type"),
+        ("tool_call", {"call_id": "call-1"}, "type"),
+        ("function_call_output", {"type": "function_call_output", "output": "done"}, "call_id"),
+    ],
+)
+async def test_build_input_for_multi_modal_async_preserves_missing_artifact_field_error(
+    target: OpenAIResponseTarget,
+    data_type: PromptDataType,
+    payload: dict[str, Any],
+    missing_field: str,
+):
+    piece = MessagePiece(
+        role="assistant",
+        original_value=json.dumps(payload),
+        original_value_data_type=data_type,
+    )
+
+    with pytest.raises(KeyError) as exc_info:
+        await target._build_input_for_multi_modal_async([Message(message_pieces=[piece])])
+
+    assert exc_info.value.args == (missing_field,)
+
+
+async def test_build_input_for_multi_modal_async_preserves_empty_conversation_error(target: OpenAIResponseTarget):
+    with pytest.raises(ValueError) as exc_info:
+        await target._build_input_for_multi_modal_async([])
+
+    assert str(exc_info.value) == "Conversation cannot be empty"
 
 
 def test_make_tool_piece_serializes_output_and_sets_call_id(target: OpenAIResponseTarget):


### PR DESCRIPTION
## Description

The OpenAI Responses input builder had accumulated validation, artifact parsing, field filtering, placement, and ordering logic in one branch-heavy method. This refactor separates those wire-format concerns so future payload changes are easier to review without changing target behavior.

Private serializers now handle system messages, function calls, provider tool calls, and function-call outputs. A single placement-aware dispatcher classifies each piece as inline content, a top-level artifact, or omitted reasoning, leaving the main builder responsible only for validation and ordered assembly.

The payload contract remains unchanged, including text roles, image data URLs, system-to-developer mapping, structured refusals, reasoning omission, tool field filtering, compact JSON outputs, unsupported modalities, exception behavior, and artifact-before-inline ordering. The core method is reduced from 115 to 50 lines and measured complexity from 21 to 9.

## Tests and Documentation

- Added exact mixed-payload contract coverage for text, image, refusal, reasoning, function calls, function outputs, and provider tool calls.
- Added error contracts for malformed artifacts, missing required fields, empty input, and unsupported audio, binary, video, and URL modalities.
- Ran both focused OpenAI Response target modules: 92 tests passed.
- Ran Ruff format/check and targeted `ty` checks for the implementation and test modules.
- Differentially compared against `origin/main`: the complete mixed payload and 13 error contracts were identical.
- Documentation and JupyText: N/A; this is an internal behavior-preserving refactor.