### PR TITLE
FEAT: `scenario-results` command and `--view` flag for past scenario results

### DIFF
--- a/pyrit/cli/_banner.py
+++ b/pyrit/cli/_banner.py
@@ -258,7 +258,7 @@ def _build_static_banner() -> StaticBannerData:
         "  • list-converters       - See all registered converter instances",
         "  • run <scenario> [opts] - Execute a security scenario",
         "  • scenario-history      - View your session history",
-        "  • print-scenario [N]    - Display detailed results",
+        "  • scenario-results [id] - Inspect a run's attack results",
         "  • help [command]        - Get help on any command",
         "  • clear                 - Clear the screen",
         "  • exit                  - Quit the shell",

--- a/pyrit/cli/_cli_args.py
+++ b/pyrit/cli/_cli_args.py
@@ -19,6 +19,7 @@ import inspect
 import json
 import logging
 import shlex
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, get_args, get_origin
 
@@ -39,6 +40,51 @@ if TYPE_CHECKING:
 IN_MEMORY = "InMemory"
 SQLITE = "SQLite"
 AZURE_SQL = "AzureSQL"
+
+
+# ---------------------------------------------------------------------------
+# Scenario-results views
+# ---------------------------------------------------------------------------
+
+
+class ScenarioResultView(str, Enum):
+    """
+    Granularity of a ``scenario-results`` render.
+
+    Defined here (a lightweight, parse-time-safe module) rather than alongside
+    the Pydantic payload models in ``pyrit.cli._results`` so the argument parsers
+    can reference it without importing ``pydantic`` on the ``--help`` path.
+    Inherits from ``str`` so the value round-trips cleanly through argparse.
+    """
+
+    #: Scenario-level aggregate (totals + per-group success rates).
+    OVERVIEW = "overview"
+    #: One row per individual attack result.
+    ATTACKS = "attacks"
+
+
+def parse_scenario_result_view(raw: str) -> ScenarioResultView:
+    """
+    Parse a ``--view`` token into a ``ScenarioResultView``.
+
+    Used as an argparse ``type=`` so an invalid value produces an error that
+    lists the valid view names (``ScenarioResultView(raw)`` alone would raise a
+    bare ``ValueError`` argparse renders without the choices).
+
+    Args:
+        raw (str): The raw ``--view`` token.
+
+    Returns:
+        ScenarioResultView: The matching view.
+
+    Raises:
+        argparse.ArgumentTypeError: If *raw* is not a valid view name.
+    """
+    try:
+        return ScenarioResultView(raw)
+    except ValueError:
+        valid = ", ".join(view.value for view in ScenarioResultView)
+        raise argparse.ArgumentTypeError(f"invalid view '{raw}' (choose from {valid})") from None
 
 
 # ---------------------------------------------------------------------------
@@ -372,6 +418,72 @@ ARG_HELP = {
     "Targets are registered by initializers (e.g., 'target' initializer). "
     "Use --list-targets to see available target names after initializers have run",
 }
+
+
+def add_results_arguments(*, parser: argparse.ArgumentParser, include_id_flag: bool = False) -> None:
+    """
+    Add the shared ``scenario-results`` selection flags to *parser*.
+
+    Registers ``--view``, ``--attack-result-ids``, and ``--limit`` in a
+    ``scenario results`` group so that ``pyrit_scan`` and ``pyrit_shell`` expose
+    an identical results interface. The scenario-result id differs by surface —
+    a ``--scenario-results`` value in scan versus a positional in the shell — so
+    it is only added here when *include_id_flag* is set (the scan case).
+
+    ``--view`` defaults to ``None`` (not ``OVERVIEW``) so callers can tell an
+    explicit ``--view`` apart from an omitted one; resolve it with
+    ``pyrit.cli._results.resolve_view``.
+
+    Args:
+        parser (argparse.ArgumentParser): The parser to extend.
+        include_id_flag (bool): When True, also register ``--scenario-results``
+            (scan's mode flag). Defaults to False.
+    """
+    group = parser.add_argument_group("scenario results")
+    if include_id_flag:
+        group.add_argument(
+            "--scenario-results",
+            dest="scenario_results",
+            metavar="SCENARIO_RESULT_ID",
+            help="Print results for a completed scenario run and exit",
+        )
+    group.add_argument(
+        "--view",
+        type=parse_scenario_result_view,
+        default=None,
+        metavar="{" + ",".join(view.value for view in ScenarioResultView) + "}",
+        help="Result granularity: 'overview' (aggregate, default) or 'attacks' (per-attack table)",
+    )
+    group.add_argument(
+        "--attack-result-ids",
+        nargs="+",
+        metavar="ID",
+        help="Restrict the view to these attack result ids (default: all attacks in the run)",
+    )
+    group.add_argument(
+        "--limit",
+        type=positive_int,
+        metavar="N",
+        help="Show at most N attack rows (ignored for --view overview)",
+    )
+
+
+def build_scenario_results_parser() -> argparse.ArgumentParser:
+    """
+    Build the ``pyrit_shell`` parser for ``scenario-results <id> [flags]``.
+
+    The shell takes the scenario-result id positionally (scan takes it as the
+    ``--scenario-results`` value), then shares the remaining selection flags via
+    ``add_results_arguments``. ``add_help`` is disabled so a bad line raises
+    ``SystemExit`` for the caller to catch instead of printing argparse's help.
+
+    Returns:
+        argparse.ArgumentParser: The configured parser.
+    """
+    parser = argparse.ArgumentParser(prog="scenario-results", add_help=False)
+    parser.add_argument("scenario_result_id", help="Scenario result id to inspect")
+    add_results_arguments(parser=parser)
+    return parser
 
 
 # ---------------------------------------------------------------------------

--- a/pyrit/cli/_output.py
+++ b/pyrit/cli/_output.py
@@ -16,6 +16,7 @@ import sys
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from pyrit.cli._results import AttacksTablePayload
     from pyrit.models import ScenarioResult
     from pyrit.models.catalog import (
         RegisteredInitializer,
@@ -403,7 +404,7 @@ def print_scenario_run_summary(*, run: ScenarioRunSummary) -> None:
 
 async def print_scenario_result_async(*, result: ScenarioResult) -> None:
     """
-    Print detailed scenario results using the output module.
+    Print scenario overview using the output module.
 
     Args:
         result: Deserialized ``ScenarioResult`` from the REST API.
@@ -412,6 +413,47 @@ async def print_scenario_result_async(*, result: ScenarioResult) -> None:
 
     printer = PrettyScenarioResultMemoryPrinter()
     await printer.write_async(result)
+
+
+# Outcome -> color, mirroring the pretty printer's inverted palette (a
+# successful attack is a failure for the defender, so it is shown in red).
+_OUTCOME_COLORS = {
+    "success": "red",
+    "failure": "green",
+    "error": "yellow",
+    "undetermined": None,
+}
+
+
+def print_attacks_table(*, payload: AttacksTablePayload) -> None:
+    """
+    Print the per-attack table for a scenario run.
+
+    Args:
+        payload (AttacksTablePayload): The rows to render plus the pre-limit total.
+    """
+    if not payload.rows:
+        print(f"\nNo attack results found for scenario {payload.scenario_result_id}.")
+        return
+
+    _header(f"Attack Results — scenario {payload.scenario_result_id}")
+    for index, row in enumerate(payload.rows, start=1):
+        outcome = row.outcome.upper()
+        score = row.score_value if row.score_value is not None else "—"
+        _cprint(
+            f"  {index}. [{outcome}] turns={row.executed_turns}  score={score}",
+            color=_OUTCOME_COLORS.get(row.outcome),
+            bold=True,
+        )
+        print(f"       id:        {row.attack_result_id}")
+        print(f"       technique: {row.atomic_attack_name}")
+        print(f"       objective: {row.objective}")
+
+    shown = len(payload.rows)
+    if shown < payload.total:
+        print(f"\nShowing {shown} of {payload.total} attacks (use --limit to change).")
+    else:
+        print(f"\nTotal attacks: {payload.total}")
 
 
 # ---------------------------------------------------------------------------

--- a/pyrit/cli/_results.py
+++ b/pyrit/cli/_results.py
@@ -1,0 +1,136 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""
+Typed payloads and builders for the ``scenario-results`` command.
+
+A *view* selects the data (one of these payloads); a *format* serializes it.
+Keeping the payload a Pydantic model makes it the single source of truth: the
+console renderer reads it today, and ``--output json`` will serialize the same
+object in a later phase, so every format stays consistent.
+
+This module imports ``pydantic`` and is therefore loaded only from deferred
+(post-parse) call sites, never on the CLI ``--help`` path. The lightweight
+``ScenarioResultView`` enum lives in ``pyrit.cli._cli_args`` for that reason.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from pyrit.cli._cli_args import ScenarioResultView
+
+if TYPE_CHECKING:
+    from pyrit.models import ScenarioResult
+
+
+class AttackRow(BaseModel):
+    """A single attack result rendered as one row of the attacks table."""
+
+    attack_result_id: str
+    atomic_attack_name: str
+    objective: str
+    outcome: str
+    executed_turns: int
+    score_value: str | None = None
+
+
+class AttacksTablePayload(BaseModel):
+    """
+    The ``attacks`` view: one row per attack result in a scenario run.
+
+    ``total`` is the number of attacks that matched the selection before
+    ``--limit`` was applied; ``len(rows)`` is how many are actually included.
+    Exposing both lets any renderer show a "showing N of M" note.
+    """
+
+    scenario_result_id: str
+    rows: list[AttackRow] = Field(default_factory=list)
+    total: int = 0
+
+
+def resolve_view(*, view: ScenarioResultView | None) -> ScenarioResultView:
+    """
+    Resolve an optional ``--view`` value to a concrete view.
+
+    Args:
+        view (ScenarioResultView | None): The parsed view, or ``None`` when the
+            flag was omitted.
+
+    Returns:
+        ScenarioResultView: The explicit view, defaulting to ``OVERVIEW``.
+    """
+    return view if view is not None else ScenarioResultView.OVERVIEW
+
+
+def apply_view_limit_policy(*, view: ScenarioResultView, limit: int | None) -> int | None:
+    """
+    Apply the ``--limit`` policy for the chosen *view*.
+
+    ``--limit`` caps a per-attack row list, which the aggregate ``overview`` view
+    does not have. Rather than silently accept a no-op flag, warn the user and
+    drop it so the behavior is explicit.
+
+    Args:
+        view (ScenarioResultView): The resolved view.
+        limit (int | None): The requested row cap, if any.
+
+    Returns:
+        int | None: The effective limit (``None`` for ``overview``).
+    """
+    if view is ScenarioResultView.OVERVIEW and limit is not None:
+        print("Note: --limit has no effect with --view overview; ignoring it.")
+        return None
+    return limit
+
+
+def build_attacks_table_payload(
+    *,
+    result: ScenarioResult,
+    scenario_result_id: str,
+    attack_result_ids: list[str] | None = None,
+    limit: int | None = None,
+) -> AttacksTablePayload:
+    """
+    Build the ``attacks`` payload from an already-fetched scenario result.
+
+    Every ``AttackResult`` is already embedded in *result* (grouped by atomic
+    attack name), so no extra server calls are needed. ``--limit`` is applied
+    here, on the payload, rather than in a renderer, so that all output formats
+    honor it identically.
+
+    Args:
+        result (ScenarioResult): The full scenario result to read attacks from.
+        scenario_result_id (str): The run id, echoed back on the payload.
+        attack_result_ids (list[str] | None): When provided, keep only attacks
+            whose id is in this set. Defaults to None (all attacks).
+        limit (int | None): Maximum number of rows to include. Defaults to None.
+
+    Returns:
+        AttacksTablePayload: The rows plus the pre-limit total.
+    """
+    id_filter = set(attack_result_ids) if attack_result_ids else None
+
+    rows: list[AttackRow] = []
+    for atomic_attack_name, attack_results in result.attack_results.items():
+        for attack_result in attack_results:
+            if id_filter is not None and attack_result.attack_result_id not in id_filter:
+                continue
+            score = attack_result.last_score
+            rows.append(
+                AttackRow(
+                    attack_result_id=attack_result.attack_result_id,
+                    atomic_attack_name=atomic_attack_name,
+                    objective=attack_result.objective,
+                    outcome=attack_result.outcome.value,
+                    executed_turns=attack_result.executed_turns,
+                    score_value=str(score.score_value) if score is not None else None,
+                )
+            )
+
+    total = len(rows)
+    if limit is not None:
+        rows = rows[:limit]
+    return AttacksTablePayload(scenario_result_id=scenario_result_id, rows=rows, total=total)

--- a/pyrit/cli/pyrit_scan.py
+++ b/pyrit/cli/pyrit_scan.py
@@ -23,6 +23,7 @@ from urllib.parse import urlparse
 from pyrit.cli._cli_args import (
     ARG_HELP,
     _parse_initializer_arg,
+    add_results_arguments,
     build_parameters_from_api,
     collapse_dataset_filters,
     non_negative_int,
@@ -278,6 +279,9 @@ def _build_base_parser(*, add_help: bool = True) -> ArgumentParser:
         help=ARG_HELP["dataset_filters"],
     )
 
+    # -- Scenario results (inspect a completed run and exit) --
+    add_results_arguments(parser=parser, include_id_flag=True)
+
     return parser
 
 
@@ -491,6 +495,7 @@ def _is_command_specified(*, parsed_args: Namespace) -> bool:
         or parsed_args.list_converters
         or parsed_args.list_datasets
         or parsed_args.add_initializer
+        or parsed_args.scenario_results
         or parsed_args.scenario_name
     )
 
@@ -586,6 +591,70 @@ async def _handle_add_initializer_async(*, client: Any, parsed_args: Namespace) 
         except ServerNotAvailableError as exc:
             print(f"Error: {exc}")
             return 1
+    return 0
+
+
+def _validate_results_flags(*, parsed_args: Namespace) -> str | None:
+    """
+    Ensure the ``scenario-results`` sub-flags are only used with ``--scenario-results``.
+
+    ``--view`` / ``--attack-result-ids`` / ``--limit`` only mean something when a
+    run is being inspected. Because the flat parser accepts them regardless, this
+    check gives a clear error instead of the generic "no scenario specified"
+    fallthrough.
+
+    Args:
+        parsed_args (Namespace): The parsed CLI arguments.
+
+    Returns:
+        str | None: An error message when a sub-flag is misused, else None.
+    """
+    if parsed_args.scenario_results:
+        return None
+    misused: list[str] = []
+    if parsed_args.view is not None:
+        misused.append("--view")
+    if parsed_args.attack_result_ids:
+        misused.append("--attack-result-ids")
+    if parsed_args.limit is not None:
+        misused.append("--limit")
+    if not misused:
+        return None
+    return f"Error: {', '.join(misused)} require --scenario-results <id>."
+
+
+async def _handle_results_async(*, client: Any, parsed_args: Namespace) -> int:
+    """
+    Handle ``--scenario-results``: fetch a run and render the requested view.
+
+    Returns:
+        int: Exit code (``0`` on success, ``1`` on error).
+    """
+    from pyrit.cli import _output
+    from pyrit.cli._cli_args import ScenarioResultView
+    from pyrit.cli._results import apply_view_limit_policy, build_attacks_table_payload, resolve_view
+
+    scenario_result_id = parsed_args.scenario_results
+    view = resolve_view(view=parsed_args.view)
+    limit = apply_view_limit_policy(view=view, limit=parsed_args.limit)
+
+    try:
+        result = await client.get_scenario_run_results_async(scenario_result_id=scenario_result_id)
+    except Exception as exc:
+        _print_cli_exception(exc=exc)
+        return 1
+
+    if view is ScenarioResultView.OVERVIEW:
+        await _output.print_scenario_result_async(result=result)
+        return 0
+
+    payload = build_attacks_table_payload(
+        result=result,
+        scenario_result_id=scenario_result_id,
+        attack_result_ids=parsed_args.attack_result_ids,
+        limit=limit,
+    )
+    _output.print_attacks_table(payload=payload)
     return 0
 
 
@@ -777,6 +846,9 @@ async def _dispatch_with_client_async(*, client: Any, parsed_args: Namespace) ->
     if parsed_args.add_initializer:
         return await _handle_add_initializer_async(client=client, parsed_args=parsed_args)
 
+    if parsed_args.scenario_results:
+        return await _handle_results_async(client=client, parsed_args=parsed_args)
+
     scenario_name = parsed_args.scenario_name
     if not scenario_name:
         print("Error: No scenario specified. Provide one positionally or use --list-scenarios.")
@@ -814,6 +886,11 @@ async def _run_async(*, parsed_args: Namespace) -> int:
 
     if parsed_args.stop_server:
         return await _handle_stop_server_async(parsed_args=parsed_args)
+
+    results_flag_error = _validate_results_flags(parsed_args=parsed_args)
+    if results_flag_error is not None:
+        print(results_flag_error, file=sys.stderr)
+        return 1
 
     if not (parsed_args.start_server or _is_command_specified(parsed_args=parsed_args)):
         _build_base_parser().print_help()

--- a/pyrit/cli/pyrit_shell.py
+++ b/pyrit/cli/pyrit_shell.py
@@ -73,7 +73,8 @@ class PyRITShell(cmd.Cmd):
         list-converters            - List all registered converter instances
         run <scenario> [opts]      - Run a scenario with optional parameters
         scenario-history [N]       - List the last N (default 10) scenario runs
-        print-scenario [id]        - Print detailed results for a scenario run
+        scenario-results [id]      - Inspect a run: --view overview|attacks
+        print-scenario [id]        - Deprecated alias for 'scenario-results'
         start-server               - Start a local backend server
         stop-server                - Stop the owned backend server
         help [command]             - Show help for a command
@@ -536,28 +537,91 @@ class PyRITShell(cmd.Cmd):
         except Exception as e:
             print(f"Error: {e}")
 
+    def do_scenario_results(self, arg: str) -> None:
+        """
+        Inspect the results of a completed scenario run.
+
+        Usage:
+            scenario-results <scenario_result_id> [--view overview|attacks]
+                [--attack-result-ids <id> ...] [--limit N]
+
+        Views:
+            overview   Scenario-level aggregate: totals and per-group success
+                       rates (the default).
+            attacks    One row per attack result (id, objective, outcome,
+                       turns, score).
+        """
+        if not self._ensure_client():
+            return
+
+        import shlex
+
+        from pyrit.cli._cli_args import ScenarioResultView, build_scenario_results_parser
+        from pyrit.cli._output import print_attacks_table, print_scenario_result_async
+        from pyrit.cli._results import apply_view_limit_policy, build_attacks_table_payload, resolve_view
+
+        try:
+            tokens = shlex.split(arg)
+        except ValueError as exc:
+            print(f"Error parsing arguments: {exc}")
+            return
+        if not tokens:
+            print(
+                "Usage: scenario-results <scenario_result_id> "
+                "[--view overview|attacks] [--attack-result-ids <id> ...] [--limit N]"
+            )
+            print("Use 'scenario-history' to see available run IDs.")
+            return
+
+        parser = build_scenario_results_parser()
+        try:
+            parsed = parser.parse_args(tokens)
+        except SystemExit:
+            return
+
+        view = resolve_view(view=parsed.view)
+        limit = apply_view_limit_policy(view=view, limit=parsed.limit)
+
+        try:
+            result = self._run_async(
+                self._api_client.get_scenario_run_results_async(scenario_result_id=parsed.scenario_result_id)
+            )
+        except Exception as exc:
+            print(f"Error: {exc}")
+            return
+
+        if view is ScenarioResultView.OVERVIEW:
+            self._run_async(print_scenario_result_async(result=result))
+            return
+
+        payload = build_attacks_table_payload(
+            result=result,
+            scenario_result_id=parsed.scenario_result_id,
+            attack_result_ids=parsed.attack_result_ids,
+            limit=limit,
+        )
+        print_attacks_table(payload=payload)
+
     def do_print_scenario(self, arg: str) -> None:
         """
-        Print detailed results for a scenario run.
+        Print a scenario run's overview (deprecated alias for ``scenario-results``).
+
+        Equivalent to ``scenario-results <id>``, whose default ``overview`` view
+        produces the same output.
 
         Usage:
             print-scenario <scenario_result_id>
         """
-        if not self._ensure_client():
-            return
-        from pyrit.cli._output import print_scenario_result_async
+        from pyrit.common.deprecation import print_deprecation_message
 
-        arg = arg.strip()
-        if not arg:
-            print("Usage: print-scenario <scenario_result_id>")
-            print("Use 'scenario-history' to see available run IDs.")
-            return
-
-        try:
-            detail = self._run_async(self._api_client.get_scenario_run_results_async(scenario_result_id=arg))
-            self._run_async(print_scenario_result_async(result=detail))
-        except Exception as e:
-            print(f"Error: {e}")
+        print_deprecation_message(
+            old_item="print-scenario",
+            new_item="scenario-results",
+            removed_in="1.3.0",
+        )
+        # DeprecationWarning is suppressed by default in the REPL, so also print a visible note.
+        print("Note: 'print-scenario' is deprecated; use 'scenario-results <id>' instead.")
+        self.do_scenario_results(arg.strip())
 
     # ------------------------------------------------------------------
     # Server management

--- a/tests/unit/cli/test_output.py
+++ b/tests/unit/cli/test_output.py
@@ -667,6 +667,67 @@ async def test_print_scenario_result_async_accepts_real_scenario_result():
 
 
 # ---------------------------------------------------------------------------
+# print_attacks_table
+# ---------------------------------------------------------------------------
+
+
+def _attacks_payload(*, rows, total):
+    from pyrit.cli._results import AttackRow, AttacksTablePayload
+
+    return AttacksTablePayload(
+        scenario_result_id="SID",
+        rows=[AttackRow(**row) for row in rows],
+        total=total,
+    )
+
+
+def test_print_attacks_table_empty(capsys):
+    _output.print_attacks_table(payload=_attacks_payload(rows=[], total=0))
+    out = capsys.readouterr().out
+    assert "No attack results found" in out
+    assert "SID" in out
+
+
+def test_print_attacks_table_renders_rows(capsys):
+    rows = [
+        {
+            "attack_result_id": "aid-1",
+            "atomic_attack_name": "tech_a",
+            "objective": "extract secrets",
+            "outcome": "success",
+            "executed_turns": 3,
+            "score_value": "0.9",
+        }
+    ]
+    _output.print_attacks_table(payload=_attacks_payload(rows=rows, total=1))
+    out = capsys.readouterr().out
+    assert "aid-1" in out
+    assert "tech_a" in out
+    assert "extract secrets" in out
+    assert "SUCCESS" in out
+    assert "0.9" in out
+    assert "Total attacks: 1" in out
+
+
+def test_print_attacks_table_shows_truncation_note(capsys):
+    rows = [
+        {
+            "attack_result_id": "aid-1",
+            "atomic_attack_name": "tech_a",
+            "objective": "obj",
+            "outcome": "failure",
+            "executed_turns": 1,
+            "score_value": None,
+        }
+    ]
+    # total (5) exceeds shown rows (1) -> "showing N of M" note.
+    _output.print_attacks_table(payload=_attacks_payload(rows=rows, total=5))
+    out = capsys.readouterr().out
+    assert "Showing 1 of 5" in out
+    assert "—" in out  # missing score placeholder
+
+
+# ---------------------------------------------------------------------------
 # print_scenario_runs_list
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/cli/test_pyrit_scan.py
+++ b/tests/unit/cli/test_pyrit_scan.py
@@ -1123,6 +1123,70 @@ class TestMainExtraPaths:
         assert "disabled" in capsys.readouterr().out
 
 
+class TestScenarioResultsFlag:
+    """Tests for the ``--scenario-results`` mode flag, validation, and dispatch."""
+
+    def test_parse_args_recognizes_scenario_results(self):
+        args = pyrit_scan.parse_args(
+            ["--scenario-results", "SID", "--view", "attacks", "--attack-result-ids", "a", "b", "--limit", "2"]
+        )
+        assert args.scenario_results == "SID"
+        assert args.view.value == "attacks"
+        assert args.attack_result_ids == ["a", "b"]
+        assert args.limit == 2
+
+    def test_scenario_results_is_a_specified_command(self):
+        args = pyrit_scan.parse_args(["--scenario-results", "SID"])
+        assert pyrit_scan._is_command_specified(parsed_args=args) is True
+
+    def test_validate_results_flags_allows_bare_scenario_results(self):
+        args = pyrit_scan.parse_args(["--scenario-results", "SID"])
+        assert pyrit_scan._validate_results_flags(parsed_args=args) is None
+
+    def test_validate_results_flags_rejects_subflags_without_id(self):
+        args = pyrit_scan.parse_args(["test_scenario", "--view", "attacks", "--limit", "3"])
+        error = pyrit_scan._validate_results_flags(parsed_args=args)
+        assert error is not None
+        assert "--view" in error and "--limit" in error
+        assert "--scenario-results" in error
+
+    def test_validate_results_flags_ignores_when_no_subflags(self):
+        args = pyrit_scan.parse_args(["test_scenario"])
+        assert pyrit_scan._validate_results_flags(parsed_args=args) is None
+
+    def test_handle_results_overview_delegates_to_printer(self):
+        import asyncio
+
+        client = AsyncMock()
+        client.get_scenario_run_results_async.return_value = _make_scenario_result()
+        parsed = pyrit_scan.parse_args(["--scenario-results", "SID"])
+        with patch("pyrit.cli._output.print_scenario_result_async", new_callable=AsyncMock) as mock_print:
+            rc = asyncio.run(pyrit_scan._handle_results_async(client=client, parsed_args=parsed))
+        assert rc == 0
+        client.get_scenario_run_results_async.assert_awaited_once_with(scenario_result_id="SID")
+        mock_print.assert_awaited_once()
+
+    def test_handle_results_attacks_prints_table(self, capsys):
+        import asyncio
+
+        client = AsyncMock()
+        client.get_scenario_run_results_async.return_value = _make_scenario_result()
+        parsed = pyrit_scan.parse_args(["--scenario-results", "SID", "--view", "attacks"])
+        rc = asyncio.run(pyrit_scan._handle_results_async(client=client, parsed_args=parsed))
+        assert rc == 0
+        assert "extract data" in capsys.readouterr().out
+
+    def test_handle_results_reports_fetch_error(self, capsys):
+        import asyncio
+
+        client = AsyncMock()
+        client.get_scenario_run_results_async.side_effect = RuntimeError("boom")
+        parsed = pyrit_scan.parse_args(["--scenario-results", "SID"])
+        rc = asyncio.run(pyrit_scan._handle_results_async(client=client, parsed_args=parsed))
+        assert rc == 1
+        assert "boom" in capsys.readouterr().out
+
+
 class TestScenarioParamFlow:
     """Regression tests for scenario-declared parameters flowing through the CLI."""
 

--- a/tests/unit/cli/test_pyrit_shell.py
+++ b/tests/unit/cli/test_pyrit_shell.py
@@ -823,6 +823,76 @@ class TestServerManagement:
         mock_stop.assert_not_called()
         assert "not stopping" in capsys.readouterr().out
 
+
+def _attacks_scenario_result():
+    """Build a ScenarioResult carrying two attacks for the 'attacks' view tests."""
+    import uuid
+
+    from pyrit.models import AttackOutcome, AttackResult, ScenarioRunState
+
+    def _attack(objective, outcome):
+        return AttackResult(conversation_id=str(uuid.uuid4()), objective=objective, outcome=outcome)
+
+    return make_scenario_result(
+        scenario_name="foo",
+        objective_target_identifier=None,
+        objective_scorer_identifier=None,
+        attack_results={
+            "tech_a": [_attack("obj-alpha", AttackOutcome.SUCCESS)],
+            "tech_b": [_attack("obj-beta", AttackOutcome.FAILURE)],
+        },
+        scenario_run_state=ScenarioRunState.COMPLETED,
+    )
+
+
+class TestDoScenarioResults:
+    """Tests for the ``scenario-results`` command and its ``print-scenario`` alias."""
+
+    def test_no_args_prints_usage(self, shell, capsys):
+        s, _ = shell
+        s.do_scenario_results("")
+        assert "Usage: scenario-results" in capsys.readouterr().out
+
+    def test_overview_delegates_to_scenario_printer(self, shell):
+        s, client = shell
+        client.get_scenario_run_results_async = AsyncMock(return_value=_attacks_scenario_result())
+        with patch("pyrit.cli._output.print_scenario_result_async", new_callable=AsyncMock) as mock_print:
+            s.do_scenario_results("rid-1")
+        client.get_scenario_run_results_async.assert_awaited_once_with(scenario_result_id="rid-1")
+        mock_print.assert_awaited_once()
+
+    def test_attacks_view_prints_table(self, shell, capsys):
+        s, client = shell
+        client.get_scenario_run_results_async = AsyncMock(return_value=_attacks_scenario_result())
+        s.do_scenario_results("rid-1 --view attacks")
+        out = capsys.readouterr().out
+        assert "obj-alpha" in out
+        assert "obj-beta" in out
+        assert "tech_a" in out
+
+    def test_attacks_view_respects_limit(self, shell, capsys):
+        s, client = shell
+        client.get_scenario_run_results_async = AsyncMock(return_value=_attacks_scenario_result())
+        s.do_scenario_results("rid-1 --view attacks --limit 1")
+        assert "Showing 1 of 2" in capsys.readouterr().out
+
+    def test_fetch_error_is_reported(self, shell, capsys):
+        s, client = shell
+        client.get_scenario_run_results_async = AsyncMock(side_effect=RuntimeError("nope"))
+        s.do_scenario_results("rid-1")
+        assert "Error: nope" in capsys.readouterr().out
+
+    def test_print_scenario_alias_warns_and_delegates(self, shell, capsys):
+        s, client = shell
+        client.get_scenario_run_results_async = AsyncMock(return_value=_attacks_scenario_result())
+        with (
+            patch("pyrit.cli._output.print_scenario_result_async", new_callable=AsyncMock) as mock_print,
+            pytest.warns(DeprecationWarning, match="print-scenario is deprecated.*Use scenario-results"),
+        ):
+            s.do_print_scenario("rid-1")
+        assert "deprecated" in capsys.readouterr().out.lower()
+        mock_print.assert_awaited_once()
+
     def test_stop_server_close_client_swallows_errors(self, shell):
         s, client = shell
         launcher = MagicMock()

--- a/tests/unit/cli/test_results.py
+++ b/tests/unit/cli/test_results.py
@@ -1,0 +1,217 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""
+Unit tests for the ``scenario-results`` payload builders, view policies, and
+shared argument parser (``pyrit.cli._results`` and ``pyrit.cli._cli_args``).
+"""
+
+import uuid
+
+import pytest
+
+from pyrit.cli._cli_args import (
+    ScenarioResultView,
+    add_results_arguments,
+    build_scenario_results_parser,
+)
+from pyrit.cli._results import (
+    apply_view_limit_policy,
+    build_attacks_table_payload,
+    resolve_view,
+)
+from pyrit.models import AttackOutcome, AttackResult, Score
+from unit.mocks import make_scenario_result
+
+
+def _attack(*, outcome=AttackOutcome.SUCCESS, objective="obj", turns=1, with_score=False):
+    attack = AttackResult(
+        conversation_id=str(uuid.uuid4()),
+        objective=objective,
+        outcome=outcome,
+        executed_turns=turns,
+    )
+    if with_score:
+        attack.last_score = Score(
+            score_value="0.9",
+            score_type="float_scale",
+            message_piece_id=str(uuid.uuid4()),
+        )
+    return attack
+
+
+def _result(attack_results):
+    return make_scenario_result(attack_results=attack_results)
+
+
+# ---------------------------------------------------------------------------
+# ScenarioResultView
+# ---------------------------------------------------------------------------
+
+
+def test_scenario_result_view_values():
+    assert ScenarioResultView.OVERVIEW.value == "overview"
+    assert ScenarioResultView.ATTACKS.value == "attacks"
+
+
+# ---------------------------------------------------------------------------
+# resolve_view
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_view_defaults_to_overview_when_omitted():
+    assert resolve_view(view=None) is ScenarioResultView.OVERVIEW
+
+
+def test_resolve_view_passes_through_explicit_value():
+    assert resolve_view(view=ScenarioResultView.ATTACKS) is ScenarioResultView.ATTACKS
+
+
+# ---------------------------------------------------------------------------
+# apply_view_limit_policy
+# ---------------------------------------------------------------------------
+
+
+def test_limit_policy_drops_and_warns_for_overview(capsys):
+    effective = apply_view_limit_policy(view=ScenarioResultView.OVERVIEW, limit=5)
+    assert effective is None
+    assert "no effect" in capsys.readouterr().out
+
+
+def test_limit_policy_keeps_limit_for_attacks(capsys):
+    effective = apply_view_limit_policy(view=ScenarioResultView.ATTACKS, limit=5)
+    assert effective == 5
+    assert capsys.readouterr().out == ""
+
+
+def test_limit_policy_noop_when_no_limit(capsys):
+    assert apply_view_limit_policy(view=ScenarioResultView.OVERVIEW, limit=None) is None
+    assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# build_attacks_table_payload
+# ---------------------------------------------------------------------------
+
+
+def test_builder_includes_all_attacks_grouped_by_atomic_name():
+    result = _result(
+        {
+            "tech_a": [_attack(objective="a1"), _attack(objective="a2")],
+            "tech_b": [_attack(objective="b1")],
+        }
+    )
+    payload = build_attacks_table_payload(result=result, scenario_result_id="SID")
+    assert payload.scenario_result_id == "SID"
+    assert payload.total == 3
+    assert len(payload.rows) == 3
+    assert {row.atomic_attack_name for row in payload.rows} == {"tech_a", "tech_b"}
+
+
+def test_builder_maps_outcome_and_score():
+    result = _result(
+        {
+            "tech_a": [
+                _attack(outcome=AttackOutcome.SUCCESS, turns=4, with_score=True),
+                _attack(outcome=AttackOutcome.FAILURE, with_score=False),
+            ]
+        }
+    )
+    payload = build_attacks_table_payload(result=result, scenario_result_id="SID")
+    scored, unscored = payload.rows[0], payload.rows[1]
+    assert scored.outcome == "success"
+    assert scored.executed_turns == 4
+    assert scored.score_value == "0.9"
+    assert unscored.outcome == "failure"
+    assert unscored.score_value is None
+
+
+def test_builder_filters_by_attack_result_ids():
+    keep = _attack(objective="keep")
+    drop = _attack(objective="drop")
+    result = _result({"tech_a": [keep, drop]})
+    payload = build_attacks_table_payload(
+        result=result,
+        scenario_result_id="SID",
+        attack_result_ids=[keep.attack_result_id],
+    )
+    assert payload.total == 1
+    assert payload.rows[0].attack_result_id == keep.attack_result_id
+
+
+def test_builder_limit_caps_rows_but_total_is_pre_limit():
+    result = _result({"tech_a": [_attack() for _ in range(5)]})
+    payload = build_attacks_table_payload(result=result, scenario_result_id="SID", limit=2)
+    assert payload.total == 5
+    assert len(payload.rows) == 2
+
+
+def test_builder_handles_no_attacks():
+    payload = build_attacks_table_payload(result=_result({}), scenario_result_id="SID")
+    assert payload.total == 0
+    assert payload.rows == []
+
+
+# ---------------------------------------------------------------------------
+# Shared argument parser
+# ---------------------------------------------------------------------------
+
+
+def test_shell_parser_parses_id_and_flags():
+    parser = build_scenario_results_parser()
+    parsed = parser.parse_args(["SID", "--view", "attacks", "--attack-result-ids", "x", "y", "--limit", "3"])
+    assert parsed.scenario_result_id == "SID"
+    assert parsed.view is ScenarioResultView.ATTACKS
+    assert parsed.attack_result_ids == ["x", "y"]
+    assert parsed.limit == 3
+
+
+def test_shell_parser_view_defaults_to_none_when_omitted():
+    parser = build_scenario_results_parser()
+    parsed = parser.parse_args(["SID"])
+    assert parsed.view is None
+    assert parsed.attack_result_ids is None
+    assert parsed.limit is None
+
+
+def test_shell_parser_rejects_unknown_view(capsys):
+    parser = build_scenario_results_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["SID", "--view", "bogus"])
+    err = capsys.readouterr().err
+    assert "choose from overview, attacks" in err
+
+
+def test_parse_scenario_result_view_valid_and_invalid():
+    import argparse
+
+    from pyrit.cli._cli_args import parse_scenario_result_view
+
+    assert parse_scenario_result_view("attacks") is ScenarioResultView.ATTACKS
+    with pytest.raises(argparse.ArgumentTypeError, match="choose from overview, attacks"):
+        parse_scenario_result_view("nope")
+
+
+def test_shell_parser_rejects_non_positive_limit():
+    parser = build_scenario_results_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["SID", "--limit", "0"])
+
+
+def test_add_results_arguments_registers_id_flag_when_requested():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    add_results_arguments(parser=parser, include_id_flag=True)
+    parsed = parser.parse_args(["--scenario-results", "SID", "--view", "overview"])
+    assert parsed.scenario_results == "SID"
+    assert parsed.view is ScenarioResultView.OVERVIEW
+
+
+def test_add_results_arguments_omits_id_flag_by_default():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    add_results_arguments(parser=parser)
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--scenario-results", "SID"])


### PR DESCRIPTION
## Description
This is phase 2 of the goal of letting users dig into individual attack results after running scenarios in pyrit_scan or pyrit_shell. See gist [here](https://gist.github.com/jsong468/778aeac56ce5043c6764b225530f9c0f). This PR allows users to run a `scenario-results` command and specify a `--view` and `--limit` flag when displaying individual attack results `--attack-result-ids`

Example of "attacks" view
<img width="1638" height="727" alt="image" src="https://github.com/user-attachments/assets/de4e6f76-3a17-4290-9178-c5b95249ef01" />



## Tests and Documentation
Unit tests added and ran.