### PR TITLE
FIX Prevent stale server PID records on cancellation

### DIFF
--- a/pyrit/cli/_server_launcher.py
+++ b/pyrit/cli/_server_launcher.py
@@ -415,11 +415,16 @@ async def _write_pid_record_async(*, host: str, port: int, pid: int) -> None:
             pid=pid,
         )
     )
-    try:
-        await asyncio.shield(write_task)
-    except asyncio.CancelledError:
-        await write_task
-        raise
+    cancellation: asyncio.CancelledError | None = None
+    while not write_task.done():
+        try:
+            await asyncio.shield(write_task)
+        except asyncio.CancelledError as exc:
+            cancellation = exc
+
+    write_task.result()
+    if cancellation is not None:
+        raise cancellation
 
 
 class ServerLauncher:

--- a/pyrit/cli/_server_launcher.py
+++ b/pyrit/cli/_server_launcher.py
@@ -400,6 +400,28 @@ async def _spawn_backend_process_async(
         raise
 
 
+async def _write_pid_record_async(*, host: str, port: int, pid: int) -> None:
+    """
+    Persist process state before allowing cancellation to unwind startup.
+
+    Raises:
+        asyncio.CancelledError: After the in-flight record write completes.
+    """
+    write_task = asyncio.create_task(
+        asyncio.to_thread(
+            _write_pid_record,
+            host=host,
+            port=port,
+            pid=pid,
+        )
+    )
+    try:
+        await asyncio.shield(write_task)
+    except asyncio.CancelledError:
+        await write_task
+        raise
+
+
 class ServerLauncher:
     """
     Launch and manage a local ``pyrit_backend`` server.
@@ -530,7 +552,7 @@ class ServerLauncher:
         startup_succeeded = False
         cleanup_attempted = False
         try:
-            await asyncio.to_thread(_write_pid_record, host=host, port=port, pid=launcher_pid)
+            await _write_pid_record_async(host=host, port=port, pid=launcher_pid)
             _logger.info("Backend launcher PID: %d (logs: %s)", launcher_pid, self._log_path)
             deadline = time.monotonic() + startup_timeout
             while True:
@@ -557,7 +579,7 @@ class ServerLauncher:
                     listener_pid = await asyncio.to_thread(_find_pid_on_port, port=port)
                     if listener_pid is not None:
                         self._listener_pid = listener_pid
-                        await asyncio.to_thread(_write_pid_record, host=host, port=port, pid=listener_pid)
+                        await _write_pid_record_async(host=host, port=port, pid=listener_pid)
                     print(f"Server ready (PID {self._listener_pid}). Logs: {self._log_path}")
                     startup_succeeded = True
                     return base_url

--- a/tests/unit/cli/test_server_launcher.py
+++ b/tests/unit/cli/test_server_launcher.py
@@ -312,7 +312,7 @@ async def test_start_async_cancellation_cleans_up_spawned_process():
     assert not _server_launcher._pid_file_path(port=8000).exists()
 
 
-async def test_start_async_cancellation_waits_for_pid_write_before_cleanup():
+async def test_start_async_repeated_cancellation_waits_for_pid_write_before_cleanup():
     launcher = ServerLauncher()
     fake_proc = MagicMock()
     fake_proc.pid = 99
@@ -339,6 +339,9 @@ async def test_start_async_cancellation_waits_for_pid_write_before_cleanup():
     ):
         startup_task = asyncio.create_task(launcher.start_async(host="localhost", port=8000, startup_timeout=60))
         assert await asyncio.to_thread(write_started.wait, 5)
+        startup_task.cancel()
+        await asyncio.sleep(0)
+        assert not startup_task.done()
         startup_task.cancel()
         await asyncio.sleep(0)
         assert not startup_task.done()

--- a/tests/unit/cli/test_server_launcher.py
+++ b/tests/unit/cli/test_server_launcher.py
@@ -312,6 +312,46 @@ async def test_start_async_cancellation_cleans_up_spawned_process():
     assert not _server_launcher._pid_file_path(port=8000).exists()
 
 
+async def test_start_async_cancellation_waits_for_pid_write_before_cleanup():
+    launcher = ServerLauncher()
+    fake_proc = MagicMock()
+    fake_proc.pid = 99
+    fake_proc.poll.return_value = None
+    write_started = threading.Event()
+    release_write = threading.Event()
+    write_finished = threading.Event()
+
+    def delayed_write(*, host: str, port: int, pid: int) -> None:
+        write_started.set()
+        release_write.wait(timeout=5)
+        _server_launcher._pid_file_path(port=port).parent.mkdir(parents=True, exist_ok=True)
+        _server_launcher._pid_file_path(port=port).write_text(
+            json.dumps({"host": host, "port": port, "pid": pid}),
+            encoding="utf-8",
+        )
+        write_finished.set()
+
+    with (
+        patch.object(ServerLauncher, "probe_health_async", new=AsyncMock(return_value=False)),
+        patch("subprocess.Popen", return_value=fake_proc),
+        patch.object(_server_launcher, "_write_pid_record", side_effect=delayed_write),
+        patch.object(_server_launcher, "_terminate_process_tree", return_value=True) as stop_tree_mock,
+    ):
+        startup_task = asyncio.create_task(launcher.start_async(host="localhost", port=8000, startup_timeout=60))
+        assert await asyncio.to_thread(write_started.wait, 5)
+        startup_task.cancel()
+        await asyncio.sleep(0)
+        assert not startup_task.done()
+        release_write.set()
+        with pytest.raises(asyncio.CancelledError):
+            await startup_task
+
+    assert write_finished.is_set()
+    stop_tree_mock.assert_called_once_with(process=fake_proc)
+    assert launcher.pid is None
+    assert not _server_launcher._pid_file_path(port=8000).exists()
+
+
 async def test_start_async_timeout_caps_hanging_health_probe():
     launcher = ServerLauncher()
     fake_proc = MagicMock()


### PR DESCRIPTION
## Description

Cancelling scanner server startup while a PID record is being written in a worker thread can let cleanup finish first, after which the worker recreates a stale PID file.

This change shields each in-flight PID write and waits for it to finish before propagating cancellation. Existing startup cleanup then reliably removes the completed record. The behavior applies to both the launcher PID and the resolved listener PID.

## Tests and Documentation

Added a deterministic cancellation test that blocks PID persistence, cancels startup, verifies cleanup waits for the write, and asserts process termination, cleared state, and no remaining PID record.

Validated with the full CLI unit suite, focused server launcher tests, Ruff, formatting, type checks, and repository pre-commit hooks. Documentation changes are not applicable.