### PR TITLE
FIX Restore targets for deep-linked conversations

### DIFF
--- a/frontend/e2e/routing.spec.ts
+++ b/frontend/e2e/routing.spec.ts
@@ -12,6 +12,26 @@ const KNOWN_ATTACKS: Record<string, { outcome: "success" | "failure" }> = {
   "atk-success": { outcome: "success" },
   "atk-failure": { outcome: "failure" },
 };
+const ROUTING_TARGET_HASH = "routing-target-full-hash";
+const ROUTING_TARGET = {
+  target_registry_name: "routing-target",
+  identifier: {
+    class_name: "OpenAIChatTarget",
+    hash: ROUTING_TARGET_HASH,
+    endpoint: null,
+    model_name: "gpt-4o",
+  },
+  capabilities: {
+    supports_multi_turn: true,
+    supports_json_schema: false,
+    supports_json_output: false,
+    supports_system_prompt: false,
+    supported_input_modalities: ["text"],
+    supported_output_modalities: ["text"],
+  },
+  target_specific_params: null,
+  inner_targets: null,
+};
 
 /** Build an attack summary for the single-attack (getAttack) endpoint. */
 function makeAttackSummary(attackResultId: string, outcome: "success" | "failure") {
@@ -19,13 +39,17 @@ function makeAttackSummary(attackResultId: string, outcome: "success" | "failure
     attack_result_id: attackResultId,
     conversation_id: `conv-${attackResultId}`,
     attack_type: "SingleTurnAttack",
-    target: { target_type: "OpenAIChatTarget", model_name: "gpt-4o" },
+    target: {
+      target_type: "OpenAIChatTarget",
+      model_name: "gpt-4o",
+      identifier_hash: ROUTING_TARGET_HASH,
+    },
     converters: [],
     outcome,
     last_message_preview: null,
     message_count: 1,
     related_conversation_ids: [],
-    labels: { operator: "alice" },
+    labels: {},
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
   };
@@ -78,12 +102,14 @@ const MARKDOWN_PREFERENCE_STORAGE_KEY = "pyrit.chatMarkdownMode";
 
 /** Register every API mock the routing tests rely on. */
 async function mockRoutingAPIs(page: Page) {
-  // No active target configured – the chat ribbon shows "No target selected".
   await page.route(/\/api\/targets/, async (route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ items: [] }),
+      body: JSON.stringify({
+        items: [ROUTING_TARGET],
+        pagination: { limit: 200, has_more: false, next_cursor: null, prev_cursor: null },
+      }),
     });
   });
 
@@ -214,13 +240,21 @@ test.describe("URL-driven routing", () => {
     await expect(page.getByTestId("attack-row-atk-failure")).not.toBeVisible();
   });
 
-  test("deep-links into an attack and hydrates its conversation", async ({ page }) => {
+  test("deep-links into an attack and restores its target after reload", async ({ page }) => {
     await page.goto("/attacks/atk-1");
 
     // The router keeps the deep link, and the attack named by the URL – not
     // some default/empty conversation – drives the chat window.
     await expect(page).toHaveURL(/\/attacks\/atk-1$/);
     await expect(page.getByText("Loaded from atk-1")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("chat-input")).toBeEnabled();
+    await expect(page.getByTestId("no-target-banner")).not.toBeVisible();
+
+    await page.reload();
+
+    await expect(page.getByText("Loaded from atk-1")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("chat-input")).toBeEnabled();
+    await expect(page.getByTestId("no-target-banner")).not.toBeVisible();
   });
 
   test("shows the not-found screen for an unknown attack id", async ({ page }) => {

--- a/frontend/e2e/routing.spec.ts
+++ b/frontend/e2e/routing.spec.ts
@@ -41,6 +41,7 @@ function makeAttackSummary(attackResultId: string, outcome: "success" | "failure
     attack_type: "SingleTurnAttack",
     target: {
       target_type: "OpenAIChatTarget",
+      target_registry_name: ROUTING_TARGET.target_registry_name,
       model_name: "gpt-4o",
       identifier_hash: ROUTING_TARGET_HASH,
     },
@@ -103,13 +104,17 @@ const MARKDOWN_PREFERENCE_STORAGE_KEY = "pyrit.chatMarkdownMode";
 /** Register every API mock the routing tests rely on. */
 async function mockRoutingAPIs(page: Page) {
   await page.route(/\/api\/targets/, async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    const body = pathname.endsWith(`/${ROUTING_TARGET.target_registry_name}`)
+      ? ROUTING_TARGET
+      : {
+          items: [ROUTING_TARGET],
+          pagination: { limit: 200, has_more: false, next_cursor: null, prev_cursor: null },
+        };
     await route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({
-        items: [ROUTING_TARGET],
-        pagination: { limit: 200, has_more: false, next_cursor: null, prev_cursor: null },
-      }),
+      body: JSON.stringify(body),
     });
   });
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -426,7 +426,7 @@ describe("App", () => {
     expect(screen.getByTestId("conversation-id")).toHaveTextContent("conv-123");
   });
 
-  it("retains the active target identifier when creating an attack", () => {
+  it("retains and trusts the active target when creating an attack", () => {
     renderApp();
 
     fireEvent.click(screen.getByTestId("nav-config"));
@@ -435,6 +435,40 @@ describe("App", () => {
     fireEvent.click(screen.getByTestId("set-conversation"));
 
     expect(screen.getByTestId("attack-target-hash")).toHaveTextContent("test-target-hash");
+    expect(screen.getByTestId("target-resolution-status")).toHaveTextContent("resolved");
+    expect(mockListTargets).not.toHaveBeenCalled();
+  });
+
+  it("retains a route-resolved target when branching to a new attack", async () => {
+    const resolvedTarget = makeTarget({
+      target_registry_name: "branch-target",
+      identifier_hash: "branch-target-hash",
+    });
+    mockGetAttack.mockResolvedValue({
+      attack_result_id: "ar-source",
+      conversation_id: "conv-source",
+      labels: {},
+      related_conversation_ids: [],
+      target: {
+        target_type: "TextTarget",
+        identifier_hash: "branch-target-hash",
+      },
+    });
+    mockListTargets.mockResolvedValue({
+      items: [resolvedTarget],
+      pagination: { limit: 200, has_more: false, next_cursor: null },
+    });
+
+    renderApp("/attacks/ar-source");
+    await waitFor(() =>
+      expect(screen.getByTestId("active-target-name")).toHaveTextContent("branch-target")
+    );
+
+    fireEvent.click(screen.getByTestId("set-conversation"));
+
+    expect(screen.getByTestId("active-target-name")).toHaveTextContent("branch-target");
+    expect(screen.getByTestId("target-resolution-status")).toHaveTextContent("resolved");
+    expect(mockListTargets).toHaveBeenCalledTimes(1);
   });
 
   it("clears conversationId on new attack", () => {
@@ -846,6 +880,35 @@ describe("App", () => {
     expect(mockListTargets).toHaveBeenNthCalledWith(2, 200, "page-2");
   });
 
+  it("fails closed when registry pagination does not advance", async () => {
+    mockGetAttack.mockResolvedValue({
+      attack_result_id: "ar-stalled-pagination",
+      conversation_id: "conv-stalled-pagination",
+      labels: {},
+      related_conversation_ids: [],
+      target: {
+        target_type: "TextTarget",
+        identifier_hash: "pagination-hash",
+      },
+    });
+    mockListTargets
+      .mockResolvedValueOnce({
+        items: [],
+        pagination: { limit: 200, has_more: true, next_cursor: "same-cursor" },
+      })
+      .mockResolvedValueOnce({
+        items: [],
+        pagination: { limit: 200, has_more: true, next_cursor: "same-cursor" },
+      });
+
+    renderApp("/attacks/ar-stalled-pagination");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("target-resolution-status")).toHaveTextContent("error")
+    );
+    expect(screen.getByTestId("active-target-name")).toHaveTextContent("none");
+  });
+
   it("restores the target again after an app remount", async () => {
     const exactTarget = makeTarget({
       target_registry_name: "remounted-target",
@@ -877,6 +940,44 @@ describe("App", () => {
       expect(screen.getByTestId("active-target-name")).toHaveTextContent("remounted-target")
     );
     expect(mockListTargets).toHaveBeenCalledTimes(2);
+  });
+
+  it("revokes a restored target when it is removed before remount", async () => {
+    const exactTarget = makeTarget({
+      target_registry_name: "removed-target",
+      identifier_hash: "removed-hash",
+    });
+    mockGetAttack.mockResolvedValue({
+      attack_result_id: "ar-removed",
+      conversation_id: "conv-removed",
+      labels: {},
+      related_conversation_ids: [],
+      target: {
+        target_type: "TextTarget",
+        identifier_hash: "removed-hash",
+      },
+    });
+    mockListTargets
+      .mockResolvedValueOnce({
+        items: [exactTarget],
+        pagination: { limit: 200, has_more: false, next_cursor: null },
+      })
+      .mockResolvedValueOnce({
+        items: [],
+        pagination: { limit: 200, has_more: false, next_cursor: null },
+      });
+
+    const firstRender = renderApp("/attacks/ar-removed");
+    await waitFor(() =>
+      expect(screen.getByTestId("active-target-name")).toHaveTextContent("removed-target")
+    );
+    firstRender.unmount();
+
+    renderApp("/attacks/ar-removed");
+    await waitFor(() =>
+      expect(screen.getByTestId("target-resolution-status")).toHaveTextContent("unavailable")
+    );
+    expect(screen.getByTestId("active-target-name")).toHaveTextContent("none");
   });
 
   it("revalidates a previously resolved target when revisiting the same attack", async () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -60,6 +60,7 @@ jest.mock("./services/api", () => ({
   },
   targetsApi: {
     listTargets: jest.fn(),
+    getTarget: jest.fn(),
   },
   versionApi: {
     getVersion: jest.fn().mockResolvedValue({ version: "1.0.0" }),
@@ -71,6 +72,7 @@ const mockedVersionApi = jest.requireMock("./services/api").versionApi;
 
 const mockGetAttack = attacksApi.getAttack as jest.Mock;
 const mockListTargets = targetsApi.listTargets as jest.Mock;
+const mockGetTarget = targetsApi.getTarget as jest.Mock;
 
 // Mock the child components to isolate App logic
 jest.mock("./components/Labels/LabelsBar", () => {
@@ -333,6 +335,7 @@ describe("App", () => {
       items: [],
       pagination: { limit: 200, has_more: false, next_cursor: null },
     });
+    mockGetTarget.mockRejectedValue({ isAxiosError: true, response: { status: 404 } });
     window.localStorage.clear();
   });
 
@@ -880,6 +883,168 @@ describe("App", () => {
     expect(mockListTargets).toHaveBeenNthCalledWith(2, 200, "page-2");
   });
 
+  it("restores a named target directly after validating its full hash", async () => {
+    const exactTarget = makeTarget({
+      target_registry_name: "persisted-alias",
+      identifier_hash: "persisted-alias-hash",
+    });
+    mockGetAttack.mockResolvedValue({
+      attack_result_id: "ar-named",
+      conversation_id: "conv-named",
+      labels: {},
+      related_conversation_ids: [],
+      target: {
+        target_type: "TextTarget",
+        target_registry_name: "persisted-alias",
+        identifier_hash: "persisted-alias-hash",
+      },
+    });
+    mockGetTarget.mockResolvedValue(exactTarget);
+
+    renderApp("/attacks/ar-named");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("active-target-name")).toHaveTextContent("persisted-alias")
+    );
+    expect(screen.getByTestId("target-resolution-status")).toHaveTextContent("resolved");
+    expect(mockGetTarget).toHaveBeenCalledWith("persisted-alias");
+    expect(mockListTargets).not.toHaveBeenCalled();
+  });
+
+  it("falls back to full-hash resolution when a persisted alias points to a different target", async () => {
+    const staleAliasTarget = makeTarget({
+      target_registry_name: "reused-alias",
+      identifier_hash: "different-hash",
+    });
+    const renamedTarget = makeTarget({
+      target_registry_name: "renamed-target",
+      identifier_hash: "original-hash",
+    });
+    mockGetAttack.mockResolvedValue({
+      attack_result_id: "ar-reused-alias",
+      conversation_id: "conv-reused-alias",
+      labels: {},
+      related_conversation_ids: [],
+      target: {
+        target_type: "TextTarget",
+        target_registry_name: "reused-alias",
+        identifier_hash: "original-hash",
+      },
+    });
+    mockGetTarget.mockResolvedValue(staleAliasTarget);
+    mockListTargets.mockResolvedValue({
+      items: [staleAliasTarget, renamedTarget],
+      pagination: { limit: 200, has_more: false, next_cursor: null },
+    });
+
+    renderApp("/attacks/ar-reused-alias");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("active-target-name")).toHaveTextContent("renamed-target")
+    );
+    expect(mockGetTarget).toHaveBeenCalledWith("reused-alias");
+    expect(mockListTargets).toHaveBeenCalledWith(200, undefined);
+  });
+
+  it("falls back to full-hash resolution when a persisted alias was removed", async () => {
+    const renamedTarget = makeTarget({
+      target_registry_name: "renamed-target",
+      identifier_hash: "original-hash",
+    });
+    mockGetAttack.mockResolvedValue({
+      attack_result_id: "ar-removed-alias",
+      conversation_id: "conv-removed-alias",
+      labels: {},
+      related_conversation_ids: [],
+      target: {
+        target_type: "TextTarget",
+        target_registry_name: "removed-alias",
+        identifier_hash: "original-hash",
+      },
+    });
+    mockListTargets.mockResolvedValue({
+      items: [renamedTarget],
+      pagination: { limit: 200, has_more: false, next_cursor: null },
+    });
+
+    renderApp("/attacks/ar-removed-alias");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("active-target-name")).toHaveTextContent("renamed-target")
+    );
+    expect(mockGetTarget).toHaveBeenCalledWith("removed-alias");
+    expect(mockListTargets).toHaveBeenCalledWith(200, undefined);
+  });
+
+  it("falls back when a reserved alias returns a non-target response", async () => {
+    const exactTarget = makeTarget({
+      target_registry_name: "catalog",
+      identifier_hash: "catalog-target-hash",
+    });
+    mockGetAttack.mockResolvedValue({
+      attack_result_id: "ar-catalog-alias",
+      conversation_id: "conv-catalog-alias",
+      labels: {},
+      related_conversation_ids: [],
+      target: {
+        target_type: "TextTarget",
+        target_registry_name: "catalog",
+        identifier_hash: "catalog-target-hash",
+      },
+    });
+    mockGetTarget.mockResolvedValue({ items: [] });
+    mockListTargets.mockResolvedValue({
+      items: [exactTarget],
+      pagination: { limit: 200, has_more: false, next_cursor: null },
+    });
+
+    renderApp("/attacks/ar-catalog-alias");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("active-target-name")).toHaveTextContent("catalog")
+    );
+    expect(mockGetTarget).toHaveBeenCalledWith("catalog");
+    expect(mockListTargets).toHaveBeenCalledWith(200, undefined);
+  });
+
+  it("retries named-target registry failures without masking them with a list fallback", async () => {
+    const exactTarget = makeTarget({
+      target_registry_name: "persisted-alias",
+      identifier_hash: "persisted-alias-hash",
+    });
+    mockGetAttack.mockResolvedValue({
+      attack_result_id: "ar-named-error",
+      conversation_id: "conv-named-error",
+      labels: {},
+      related_conversation_ids: [],
+      target: {
+        target_type: "TextTarget",
+        target_registry_name: "persisted-alias",
+        identifier_hash: "persisted-alias-hash",
+      },
+    });
+    mockGetTarget
+      .mockRejectedValueOnce({ isAxiosError: true, response: { status: 500 } })
+      .mockResolvedValueOnce(exactTarget);
+    const user = userEvent.setup();
+
+    renderApp("/attacks/ar-named-error");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("target-resolution-status")).toHaveTextContent("error")
+    );
+    expect(screen.getByTestId("active-target-name")).toHaveTextContent("none");
+    expect(mockListTargets).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTestId("retry-target-resolution"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("active-target-name")).toHaveTextContent("persisted-alias")
+    );
+    expect(mockGetTarget).toHaveBeenCalledTimes(2);
+    expect(mockListTargets).not.toHaveBeenCalled();
+  });
+
   it("fails closed when registry pagination does not advance", async () => {
     mockGetAttack.mockResolvedValue({
       attack_result_id: "ar-stalled-pagination",
@@ -1169,6 +1334,40 @@ describe("App", () => {
     );
     expect(screen.getByTestId("active-target-name")).toHaveTextContent("test_target");
     expect(mockListTargets).toHaveBeenCalledWith(200, undefined);
+  });
+
+  it("preserves an explicitly selected alias with the same canonical hash", async () => {
+    const persistedAliasTarget = makeTarget({
+      target_registry_name: "persisted-alias",
+      target_type: "OpenAIChatTarget",
+      identifier_hash: "test-target-hash",
+    });
+    mockGetAttack.mockResolvedValue({
+      attack_result_id: "ar-same-identity",
+      conversation_id: "conv-same-identity",
+      labels: {},
+      related_conversation_ids: [],
+      target: {
+        target_type: "OpenAIChatTarget",
+        target_registry_name: "persisted-alias",
+        identifier_hash: "test-target-hash",
+      },
+    });
+    mockGetTarget.mockResolvedValue(persistedAliasTarget);
+    const user = userEvent.setup();
+    renderApp();
+
+    await user.click(screen.getByTestId("nav-config"));
+    await user.click(screen.getByTestId("set-target"));
+    await user.click(screen.getByTestId("nav-history"));
+    await user.click(screen.getByTestId("open-attack"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("target-resolution-status")).toHaveTextContent("resolved")
+    );
+    expect(screen.getByTestId("active-target-name")).toHaveTextContent("test_target");
+    expect(mockGetTarget).toHaveBeenCalledWith("persisted-alias");
+    expect(mockListTargets).not.toHaveBeenCalled();
   });
 
   it.each([401, 500])(

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -4,11 +4,13 @@
  */
 
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 import App from "./App";
 import { ThemeProvider } from "./hooks/useTheme";
 
-import { attacksApi } from "./services/api";
+import { attacksApi, targetsApi } from "./services/api";
+import { makeTarget } from "./test-utils/targetFixtures";
 
 const mockGetActiveAccount = jest.fn();
 
@@ -56,6 +58,9 @@ jest.mock("./services/api", () => ({
     createAttack: jest.fn(),
     deleteAttack: jest.fn(),
   },
+  targetsApi: {
+    listTargets: jest.fn(),
+  },
   versionApi: {
     getVersion: jest.fn().mockResolvedValue({ version: "1.0.0" }),
   },
@@ -65,6 +70,7 @@ jest.mock("./services/api", () => ({
 const mockedVersionApi = jest.requireMock("./services/api").versionApi;
 
 const mockGetAttack = attacksApi.getAttack as jest.Mock;
+const mockListTargets = targetsApi.listTargets as jest.Mock;
 
 // Mock the child components to isolate App logic
 jest.mock("./components/Labels/LabelsBar", () => {
@@ -120,6 +126,8 @@ jest.mock("./components/Chat/ChatWindow", () => {
     conversationId,
     activeConversationId,
     attackTarget,
+    targetResolutionStatus,
+    onRetryTargetResolution,
     onConversationCreated,
     onSelectConversation,
     labels,
@@ -130,6 +138,8 @@ jest.mock("./components/Chat/ChatWindow", () => {
     conversationId: string | null;
     activeConversationId: string | null;
     attackTarget?: { identifier_hash?: string | null } | null;
+    targetResolutionStatus?: string;
+    onRetryTargetResolution?: () => void;
     onConversationCreated: (attackResultId: string, conversationId: string) => void;
     onSelectConversation: (convId: string) => void;
     labels: Record<string, string>;
@@ -140,7 +150,11 @@ jest.mock("./components/Chat/ChatWindow", () => {
         <span data-testid="conversation-id">{conversationId ?? "none"}</span>
         <span data-testid="active-conversation-id">{activeConversationId ?? "none"}</span>
         <span data-testid="has-target">{activeTarget ? "yes" : "no"}</span>
+        <span data-testid="active-target-name">
+          {(activeTarget as { target_registry_name?: string } | null)?.target_registry_name ?? "none"}
+        </span>
         <span data-testid="attack-target-hash">{attackTarget?.identifier_hash ?? "none"}</span>
+        <span data-testid="target-resolution-status">{targetResolutionStatus ?? "none"}</span>
         <span data-testid="labels-operator">{labels.operator ?? ""}</span>
         <span data-testid="labels-json">{JSON.stringify(labels)}</span>
         <button onClick={onNewAttack} data-testid="new-attack">
@@ -158,6 +172,11 @@ jest.mock("./components/Chat/ChatWindow", () => {
         >
           Select Conv
         </button>
+        {onRetryTargetResolution && (
+          <button onClick={onRetryTargetResolution} data-testid="retry-target-resolution">
+            Retry target resolution
+          </button>
+        )}
       </div>
     );
   };
@@ -310,6 +329,10 @@ describe("App", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetActiveAccount.mockReturnValue(null);
+    mockListTargets.mockResolvedValue({
+      items: [],
+      pagination: { limit: 200, has_more: false, next_cursor: null },
+    });
     window.localStorage.clear();
   });
 
@@ -774,5 +797,389 @@ describe("App", () => {
     expect(
       JSON.parse(screen.getByTestId("history-filters").textContent ?? "{}").outcome
     ).toBe("success");
+  });
+
+  it("restores the exact registered target from a direct attack URL across registry pages", async () => {
+    const nearDuplicate = makeTarget({
+      target_registry_name: "near-duplicate",
+      target_type: "OpenAIChatTarget",
+      endpoint: "https://example.test",
+      model_name: "gpt-test",
+      identifier_hash: "persisted-full-hash-near",
+    });
+    const exactTarget = makeTarget({
+      target_registry_name: "exact-target",
+      target_type: "OpenAIChatTarget",
+      endpoint: "https://example.test",
+      model_name: "gpt-test",
+      identifier_hash: "persisted-full-hash",
+    });
+    mockGetAttack.mockResolvedValue({
+      attack_result_id: "ar-direct",
+      conversation_id: "conv-direct",
+      labels: {},
+      related_conversation_ids: [],
+      target: {
+        target_type: "OpenAIChatTarget",
+        endpoint: "https://example.test",
+        model_name: "gpt-test",
+        identifier_hash: "persisted-full-hash",
+      },
+    });
+    mockListTargets
+      .mockResolvedValueOnce({
+        items: [nearDuplicate],
+        pagination: { limit: 200, has_more: true, next_cursor: "page-2" },
+      })
+      .mockResolvedValueOnce({
+        items: [exactTarget],
+        pagination: { limit: 200, has_more: false, next_cursor: null },
+      });
+
+    renderApp("/attacks/ar-direct");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("active-target-name")).toHaveTextContent("exact-target")
+    );
+    expect(screen.getByTestId("target-resolution-status")).toHaveTextContent("resolved");
+    expect(mockListTargets).toHaveBeenNthCalledWith(1, 200, undefined);
+    expect(mockListTargets).toHaveBeenNthCalledWith(2, 200, "page-2");
+  });
+
+  it("restores the target again after an app remount", async () => {
+    const exactTarget = makeTarget({
+      target_registry_name: "remounted-target",
+      identifier_hash: "remount-hash",
+    });
+    mockGetAttack.mockResolvedValue({
+      attack_result_id: "ar-remount",
+      conversation_id: "conv-remount",
+      labels: {},
+      related_conversation_ids: [],
+      target: {
+        target_type: "TextTarget",
+        identifier_hash: "remount-hash",
+      },
+    });
+    mockListTargets.mockResolvedValue({
+      items: [exactTarget],
+      pagination: { limit: 200, has_more: false, next_cursor: null },
+    });
+
+    const firstRender = renderApp("/attacks/ar-remount");
+    await waitFor(() =>
+      expect(screen.getByTestId("active-target-name")).toHaveTextContent("remounted-target")
+    );
+    firstRender.unmount();
+
+    renderApp("/attacks/ar-remount");
+    await waitFor(() =>
+      expect(screen.getByTestId("active-target-name")).toHaveTextContent("remounted-target")
+    );
+    expect(mockListTargets).toHaveBeenCalledTimes(2);
+  });
+
+  it("revalidates a previously resolved target when revisiting the same attack", async () => {
+    const exactTarget = makeTarget({
+      target_registry_name: "revisited-target",
+      identifier_hash: "revisited-hash",
+    });
+    let resolveRevisitAttack: (value: unknown) => void = () => {};
+    let resolveRevisit: (value: unknown) => void = () => {};
+    const attack = {
+      attack_result_id: "ar-attack-1",
+      conversation_id: "conv-revisited",
+      labels: {},
+      related_conversation_ids: [],
+      target: {
+        target_type: "TextTarget",
+        identifier_hash: "revisited-hash",
+      },
+    };
+    mockGetAttack
+      .mockResolvedValueOnce(attack)
+      .mockImplementationOnce(
+        () => new Promise((resolve) => {
+          resolveRevisitAttack = resolve;
+        })
+      );
+    mockListTargets
+      .mockResolvedValueOnce({
+        items: [exactTarget],
+        pagination: { limit: 200, has_more: false, next_cursor: null },
+      })
+      .mockImplementationOnce(
+        () => new Promise((resolve) => {
+          resolveRevisit = resolve;
+        })
+      );
+    const user = userEvent.setup();
+    renderApp("/attacks/ar-attack-1");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("active-target-name")).toHaveTextContent("revisited-target")
+    );
+    await user.click(screen.getByTestId("nav-history"));
+    await user.click(screen.getByTestId("open-attack"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("attack-result-id")).toHaveTextContent("none")
+    );
+    expect(screen.getByTestId("active-target-name")).toHaveTextContent("none");
+
+    resolveRevisitAttack(attack);
+    await waitFor(() =>
+      expect(screen.getByTestId("target-resolution-status")).toHaveTextContent("loading")
+    );
+    expect(screen.getByTestId("active-target-name")).toHaveTextContent("none");
+
+    resolveRevisit({
+      items: [exactTarget],
+      pagination: { limit: 200, has_more: false, next_cursor: null },
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("active-target-name")).toHaveTextContent("revisited-target")
+    );
+  });
+
+  it("keeps a near-duplicate target read-only when its full hash differs", async () => {
+    mockGetAttack.mockResolvedValue({
+      attack_result_id: "ar-near",
+      conversation_id: "conv-near",
+      labels: {},
+      related_conversation_ids: [],
+      target: {
+        target_type: "OpenAIChatTarget",
+        endpoint: "https://example.test",
+        model_name: "gpt-test",
+        identifier_hash: "required-full-hash",
+      },
+    });
+    mockListTargets.mockResolvedValue({
+      items: [
+        makeTarget({
+          target_registry_name: "near-target",
+          target_type: "OpenAIChatTarget",
+          endpoint: "https://example.test",
+          model_name: "gpt-test",
+          identifier_hash: "different-full-hash",
+        }),
+      ],
+      pagination: { limit: 200, has_more: false, next_cursor: null },
+    });
+
+    renderApp("/attacks/ar-near");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("target-resolution-status")).toHaveTextContent("unavailable")
+    );
+    expect(screen.getByTestId("active-target-name")).toHaveTextContent("none");
+  });
+
+  it("keeps duplicate exact target identities read-only as ambiguous", async () => {
+    mockGetAttack.mockResolvedValue({
+      attack_result_id: "ar-ambiguous",
+      conversation_id: "conv-ambiguous",
+      labels: {},
+      related_conversation_ids: [],
+      target: {
+        target_type: "TextTarget",
+        identifier_hash: "duplicate-hash",
+      },
+    });
+    mockListTargets.mockResolvedValue({
+      items: [
+        makeTarget({
+          target_registry_name: "duplicate-a",
+          identifier_hash: "duplicate-hash",
+        }),
+        makeTarget({
+          target_registry_name: "duplicate-b",
+          identifier_hash: "duplicate-hash",
+        }),
+      ],
+      pagination: { limit: 200, has_more: false, next_cursor: null },
+    });
+
+    renderApp("/attacks/ar-ambiguous");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("target-resolution-status")).toHaveTextContent("ambiguous")
+    );
+    expect(screen.getByTestId("active-target-name")).toHaveTextContent("none");
+  });
+
+  it("preserves an explicitly selected different target and reports a cross-target state", async () => {
+    mockGetAttack.mockResolvedValue({
+      attack_result_id: "ar-other-target",
+      conversation_id: "conv-other-target",
+      labels: {},
+      related_conversation_ids: [],
+      target: {
+        target_type: "TextTarget",
+        identifier_hash: "other-target-hash",
+      },
+    });
+    const user = userEvent.setup();
+    renderApp();
+
+    await user.click(screen.getByTestId("nav-config"));
+    await user.click(screen.getByTestId("set-target"));
+    await user.click(screen.getByTestId("nav-history"));
+    await user.click(screen.getByTestId("open-attack"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("target-resolution-status")).toHaveTextContent("explicit-mismatch")
+    );
+    expect(screen.getByTestId("active-target-name")).toHaveTextContent("test_target");
+    expect(mockListTargets).not.toHaveBeenCalled();
+  });
+
+  it("hash-validates an explicitly selected matching target against the registry", async () => {
+    const selectedTarget = makeTarget({
+      target_registry_name: "test_target",
+      target_type: "OpenAIChatTarget",
+      identifier_hash: "test-target-hash",
+    });
+    mockGetAttack.mockResolvedValue({
+      attack_result_id: "ar-same-target",
+      conversation_id: "conv-same-target",
+      labels: {},
+      related_conversation_ids: [],
+      target: {
+        target_type: "OpenAIChatTarget",
+        identifier_hash: "test-target-hash",
+      },
+    });
+    mockListTargets.mockResolvedValue({
+      items: [selectedTarget],
+      pagination: { limit: 200, has_more: false, next_cursor: null },
+    });
+    const user = userEvent.setup();
+    renderApp();
+
+    await user.click(screen.getByTestId("nav-config"));
+    await user.click(screen.getByTestId("set-target"));
+    await user.click(screen.getByTestId("nav-history"));
+    await user.click(screen.getByTestId("open-attack"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("target-resolution-status")).toHaveTextContent("resolved")
+    );
+    expect(screen.getByTestId("active-target-name")).toHaveTextContent("test_target");
+    expect(mockListTargets).toHaveBeenCalledWith(200, undefined);
+  });
+
+  it.each([401, 500])(
+    "keeps the attack read-only after a registry %s and resolves it on retry",
+    async (status: number) => {
+      const exactTarget = makeTarget({
+        target_registry_name: "retry-target",
+        identifier_hash: "retry-hash",
+      });
+      mockGetAttack.mockResolvedValue({
+        attack_result_id: "ar-retry",
+        conversation_id: "conv-retry",
+        labels: {},
+        related_conversation_ids: [],
+        target: {
+          target_type: "TextTarget",
+          identifier_hash: "retry-hash",
+        },
+      });
+      mockListTargets
+        .mockRejectedValueOnce({ isAxiosError: true, response: { status } })
+        .mockResolvedValueOnce({
+          items: [exactTarget],
+          pagination: { limit: 200, has_more: false, next_cursor: null },
+        });
+      const user = userEvent.setup();
+      renderApp("/attacks/ar-retry");
+
+      await waitFor(() =>
+        expect(screen.getByTestId("target-resolution-status")).toHaveTextContent("error")
+      );
+      expect(screen.getByTestId("active-target-name")).toHaveTextContent("none");
+
+      await user.click(screen.getByTestId("retry-target-resolution"));
+
+      await waitFor(() =>
+        expect(screen.getByTestId("active-target-name")).toHaveTextContent("retry-target")
+      );
+      expect(screen.getByTestId("target-resolution-status")).toHaveTextContent("resolved");
+    }
+  );
+
+  it("ignores a stale target registry response after navigating to another attack", async () => {
+    let resolveFirstRegistryPage: (value: unknown) => void = () => {};
+    mockGetAttack.mockImplementation(async (attackId: string) => ({
+      attack_result_id: attackId,
+      conversation_id: `conv-${attackId}`,
+      labels: {},
+      related_conversation_ids: [],
+      target: {
+        target_type: "TextTarget",
+        identifier_hash: `${attackId}-hash`,
+      },
+    }));
+    mockListTargets
+      .mockImplementationOnce(
+        () => new Promise((resolve) => {
+          resolveFirstRegistryPage = resolve;
+        })
+      )
+      .mockResolvedValueOnce({
+        items: [
+          makeTarget({
+            target_registry_name: "attack-2-target",
+            identifier_hash: "ar-attack-2-hash",
+          }),
+        ],
+        pagination: { limit: 200, has_more: false, next_cursor: null },
+      });
+    const user = userEvent.setup();
+    renderApp("/history");
+
+    await user.click(screen.getByTestId("open-attack"));
+    await waitFor(() =>
+      expect(screen.getByTestId("target-resolution-status")).toHaveTextContent("loading")
+    );
+    await user.click(screen.getByTestId("nav-history"));
+    await user.click(screen.getByTestId("open-attack-2"));
+    await waitFor(() =>
+      expect(screen.getByTestId("active-target-name")).toHaveTextContent("attack-2-target")
+    );
+
+    resolveFirstRegistryPage({
+      items: [
+        makeTarget({
+          target_registry_name: "stale-attack-1-target",
+          identifier_hash: "ar-attack-1-hash",
+        }),
+      ],
+      pagination: { limit: 200, has_more: false, next_cursor: null },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("active-target-name")).toHaveTextContent("attack-2-target")
+    );
+  });
+
+  it("keeps legacy attacks without complete target metadata read-only", async () => {
+    mockGetAttack.mockResolvedValue({
+      attack_result_id: "ar-legacy",
+      conversation_id: "conv-legacy",
+      labels: {},
+      related_conversation_ids: [],
+      target: null,
+    });
+
+    renderApp("/attacks/ar-legacy");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("target-resolution-status")).toHaveTextContent("legacy")
+    );
+    expect(screen.getByTestId("active-target-name")).toHaveTextContent("none");
+    expect(mockListTargets).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,11 +14,12 @@ import FeedbackDialog from './components/Feedback/FeedbackDialog'
 import type { HistoryFilters } from './components/History/historyFilters'
 import { ConnectionBanner } from './components/ConnectionBanner'
 import { ErrorBoundary } from './components/ErrorBoundary'
+import { useAttackTargetResolution } from './hooks/useAttackTargetResolution'
 import { ConnectionHealthProvider, useConnectionHealth } from './hooks/useConnectionHealth'
 import { DEFAULT_GLOBAL_LABELS } from './components/Labels/labelDefaults'
 import { filtersFromSearchParams, filtersToSearchParams } from './components/History/historyFilters'
 import type { ViewName } from './components/Sidebar/Navigation'
-import type { TargetInstance, TargetInfo } from './types'
+import type { TargetInfo } from './types'
 import {
   targetEndpoint,
   targetIdentifierHash,
@@ -54,6 +55,7 @@ type AttackLoadStatus = 'loading' | 'success' | 'not-found' | 'error'
 /** Attack data named by the URL; `id` marks which attack the data belongs to. */
 interface LoadedAttack {
   id: string
+  loadSequence: number
   mainConversationId: string | null
   labels: Record<string, string> | null
   target: TargetInfo | null
@@ -102,7 +104,6 @@ function App() {
   const routeConversationId = conversationMatch?.params.conversationId ?? null
   const currentView: ViewName = routeAttackId !== null ? 'chat' : viewFromPath(location.pathname)
 
-  const [activeTarget, setActiveTarget] = useState<TargetInstance | null>(null)
   const [globalLabels, setGlobalLabels] = useState<Record<string, string>>({ ...DEFAULT_GLOBAL_LABELS })
 
   // History filters live in the URL query string so they are shareable and
@@ -131,6 +132,7 @@ function App() {
   // When set, the loader skips exactly one fetch for this id — used after
   // first-message/branch creation seeds the data, avoiding a redundant getAttack.
   const skipNextLoadForAttackId = useRef<string | null>(null)
+  const attackLoadSequence = useRef(0)
   // The attack whose deep-linked conversation id we have already validated.
   const validatedConversationForAttack = useRef<string | null>(null)
 
@@ -170,22 +172,6 @@ function App() {
     return () => { ignore = true }
   }, [instance])
 
-  const handleSetActiveTarget = useCallback((target: TargetInstance) => {
-    setActiveTarget(prev => {
-      const isSame = prev &&
-        prev.target_registry_name === target.target_registry_name &&
-        targetType(prev) === targetType(target) &&
-        (targetEndpoint(prev) ?? '') === (targetEndpoint(target) ?? '') &&
-        (targetModelName(prev) ?? '') === (targetModelName(target) ?? '')
-      if (isSame) return prev
-      // Switching targets no longer clears the loaded attack.  The cross-target
-      // guard in ChatWindow prevents sending to a mismatched target, and the
-      // backend enforces this server-side as well.  Clearing state here was
-      // confusing because navigating to config to pick the *correct* target
-      // would wipe the conversation the user was trying to continue.
-      return target
-    })
-  }, [])
   // Hydrate loadedAttack from the routed attack id. Depends on routeAttackId
   // ONLY, so switching conversations within an attack never refetches.
   useEffect(() => {
@@ -201,8 +187,11 @@ function App() {
       return
     }
     let cancelled = false
+    const loadSequence = attackLoadSequence.current + 1
+    attackLoadSequence.current = loadSequence
     setLoadedAttack({
       id: routeAttackId,
+      loadSequence,
       status: 'loading',
       mainConversationId: null,
       labels: null,
@@ -215,6 +204,7 @@ function App() {
         if (cancelled) return
         setLoadedAttack({
           id: routeAttackId,
+          loadSequence,
           mainConversationId: attack.conversation_id,
           labels: attack.labels ?? {},
           target: attack.target ?? null,
@@ -230,6 +220,7 @@ function App() {
         const isMissing = toApiError(err).status === 404
         setLoadedAttack({
           id: routeAttackId,
+          loadSequence,
           status: isMissing ? 'not-found' : 'error',
           mainConversationId: null,
           labels: null,
@@ -249,6 +240,16 @@ function App() {
   const isAttackNotFound = attackForRoute?.status === 'not-found'
   const isAttackError = attackForRoute?.status === 'error'
   const isLoadingAttack = routeAttackId !== null && !readyAttack && !isAttackNotFound && !isAttackError
+  const {
+    activeTarget,
+    setExplicitTarget: handleSetActiveTarget,
+    resolutionStatus: targetResolutionStatus,
+    retryResolution: retryTargetResolution,
+  } = useAttackTargetResolution({
+    attackId: readyAttack?.id ?? null,
+    attackLoadSequence: readyAttack?.loadSequence ?? 0,
+    attackTarget: readyAttack?.target ?? null,
+  })
   const activeConversationId = readyAttack
     ? routeConversationId ?? readyAttack.mainConversationId
     : null
@@ -295,8 +296,11 @@ function App() {
         }
       : null
     skipNextLoadForAttackId.current = arId
+    const loadSequence = attackLoadSequence.current + 1
+    attackLoadSequence.current = loadSequence
     setLoadedAttack({
       id: arId,
+      loadSequence,
       mainConversationId: convId,
       // New attack uses the current user's labels, so it is never operator-locked.
       labels: null,
@@ -339,6 +343,8 @@ function App() {
       onNavigate={handleNavigate}
       attackLabels={readyAttack ? readyAttack.labels : null}
       attackTarget={readyAttack ? readyAttack.target : null}
+      targetResolutionStatus={targetResolutionStatus}
+      onRetryTargetResolution={retryTargetResolution}
       isLoadingAttack={isLoadingAttack}
       relatedConversationCount={readyAttack ? readyAttack.relatedConversationIds.length : 0}
     />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -300,6 +300,7 @@ function App() {
     const target: TargetInfo | null = activeTarget
       ? {
           target_type: targetType(activeTarget),
+          target_registry_name: activeTarget.target_registry_name,
           endpoint: targetEndpoint(activeTarget),
           model_name: targetModelName(activeTarget),
           identifier_hash: targetIdentifierHash(activeTarget),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,6 +56,7 @@ type AttackLoadStatus = 'loading' | 'success' | 'not-found' | 'error'
 interface LoadedAttack {
   id: string
   loadSequence: number
+  targetSource: 'persisted' | 'active-selection'
   mainConversationId: string | null
   labels: Record<string, string> | null
   target: TargetInfo | null
@@ -192,6 +193,7 @@ function App() {
     setLoadedAttack({
       id: routeAttackId,
       loadSequence,
+      targetSource: 'persisted',
       status: 'loading',
       mainConversationId: null,
       labels: null,
@@ -205,6 +207,7 @@ function App() {
         setLoadedAttack({
           id: routeAttackId,
           loadSequence,
+          targetSource: 'persisted',
           mainConversationId: attack.conversation_id,
           labels: attack.labels ?? {},
           target: attack.target ?? null,
@@ -221,6 +224,7 @@ function App() {
         setLoadedAttack({
           id: routeAttackId,
           loadSequence,
+          targetSource: 'persisted',
           status: isMissing ? 'not-found' : 'error',
           mainConversationId: null,
           labels: null,
@@ -249,6 +253,7 @@ function App() {
     attackId: readyAttack?.id ?? null,
     attackLoadSequence: readyAttack?.loadSequence ?? 0,
     attackTarget: readyAttack?.target ?? null,
+    attackTargetSource: readyAttack?.targetSource ?? 'persisted',
   })
   const activeConversationId = readyAttack
     ? routeConversationId ?? readyAttack.mainConversationId
@@ -287,6 +292,11 @@ function App() {
   const handleConversationCreated = useCallback((arId: string, convId: string) => {
     // Seed the freshly-created attack synchronously and tell the loader to skip
     // its next fetch for this id, so the attack opens without a redundant load.
+    if (activeTarget) {
+      // The target that created or branched this attack is now an explicit
+      // selection for the new attack; a later reload will revalidate it.
+      handleSetActiveTarget(activeTarget)
+    }
     const target: TargetInfo | null = activeTarget
       ? {
           target_type: targetType(activeTarget),
@@ -301,6 +311,7 @@ function App() {
     setLoadedAttack({
       id: arId,
       loadSequence,
+      targetSource: 'active-selection',
       mainConversationId: convId,
       // New attack uses the current user's labels, so it is never operator-locked.
       labels: null,
@@ -311,7 +322,7 @@ function App() {
     // Replace when promoting an empty /chat to its attack url (first message);
     // push when branching from an existing attack so Back returns to the source.
     navigate(attackPath(arId), { replace: routeAttackId === null })
-  }, [activeTarget, routeAttackId, navigate])
+  }, [activeTarget, handleSetActiveTarget, routeAttackId, navigate])
 
   const handleSelectConversation = useCallback((convId: string) => {
     if (!routeAttackId) return

--- a/frontend/src/components/Chat/ChatInputArea.test.tsx
+++ b/frontend/src/components/Chat/ChatInputArea.test.tsx
@@ -98,6 +98,65 @@ describe("ChatInputArea", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("should show a retry action when target verification fails", async () => {
+    const user = userEvent.setup();
+    const onRetryTargetResolution = jest.fn();
+
+    render(
+      <TestWrapper>
+        <ChatInputArea
+          {...defaultProps}
+          targetResolutionStatus="error"
+          onRetryTargetResolution={onRetryTargetResolution}
+        />
+      </TestWrapper>
+    );
+
+    expect(screen.getByTestId("target-resolution-error-banner")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onRetryTargetResolution).toHaveBeenCalledTimes(1);
+  });
+
+  it("should direct ambiguous target identities to remove duplicates and retry", async () => {
+    const user = userEvent.setup();
+    const onRetryTargetResolution = jest.fn();
+
+    render(
+      <TestWrapper>
+        <ChatInputArea
+          {...defaultProps}
+          targetResolutionStatus="ambiguous"
+          onRetryTargetResolution={onRetryTargetResolution}
+        />
+      </TestWrapper>
+    );
+
+    expect(screen.getByTestId("target-resolution-ambiguous-banner")).toBeInTheDocument();
+    expect(screen.getByText(/remove duplicate registrations/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onRetryTargetResolution).toHaveBeenCalledTimes(1);
+  });
+
+  it("should keep legacy attacks read-only while allowing a new-attack template", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TestWrapper>
+        <ChatInputArea
+          {...defaultProps}
+          activeTarget={makeTarget({ target_registry_name: "explicit-target" })}
+          targetResolutionStatus="legacy"
+        />
+      </TestWrapper>
+    );
+
+    expect(screen.getByTestId("target-resolution-legacy-banner")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /continue with your target/i }));
+    expect(defaultProps.onUseAsTemplate).toHaveBeenCalledTimes(1);
+  });
+
   it("should call onSend with input value when send button clicked", async () => {
     const user = userEvent.setup();
     const onSend = jest.fn();

--- a/frontend/src/components/Chat/ChatInputArea.tsx
+++ b/frontend/src/components/Chat/ChatInputArea.tsx
@@ -9,6 +9,7 @@ import {
 } from '@fluentui/react-components'
 import { SendRegular, AttachRegular, DismissRegular, InfoRegular, AddRegular, CopyRegular, WarningRegular, SettingsRegular, ArrowShuffleRegular, OpenRegular, ArrowSyncRegular } from '@fluentui/react-icons'
 import type { AttackTargetResolutionStatus, MessageAttachment, TargetInstance } from '../../types'
+import { isTargetResolutionBlocking } from '../../utils/targetIdentity'
 import { useChatInputAreaStyles } from './ChatInputArea.styles'
 import SystemPromptSetup from './SystemPromptSetup'
 import { PIECE_TYPE_TO_DATA_TYPE } from './converterTypes'
@@ -594,7 +595,7 @@ const ChatInputArea = forwardRef<ChatInputAreaHandle, ChatInputAreaProps>(functi
   return (
     <div className={styles.root}>
       <div className={styles.inputContainer}>
-        {['loading', 'unavailable', 'ambiguous', 'error', 'legacy'].includes(targetResolutionStatus) ? (
+        {isTargetResolutionBlocking(targetResolutionStatus) ? (
           <TargetResolutionBanner
             status={targetResolutionStatus}
             activeTarget={activeTarget}

--- a/frontend/src/components/Chat/ChatInputArea.tsx
+++ b/frontend/src/components/Chat/ChatInputArea.tsx
@@ -7,8 +7,8 @@ import {
   tokens,
   mergeClasses,
 } from '@fluentui/react-components'
-import { SendRegular, AttachRegular, DismissRegular, InfoRegular, AddRegular, CopyRegular, WarningRegular, SettingsRegular, ArrowShuffleRegular, OpenRegular } from '@fluentui/react-icons'
-import { MessageAttachment, TargetInstance } from '../../types'
+import { SendRegular, AttachRegular, DismissRegular, InfoRegular, AddRegular, CopyRegular, WarningRegular, SettingsRegular, ArrowShuffleRegular, OpenRegular, ArrowSyncRegular } from '@fluentui/react-icons'
+import type { AttackTargetResolutionStatus, MessageAttachment, TargetInstance } from '../../types'
 import { useChatInputAreaStyles } from './ChatInputArea.styles'
 import SystemPromptSetup from './SystemPromptSetup'
 import { PIECE_TYPE_TO_DATA_TYPE } from './converterTypes'
@@ -57,6 +57,102 @@ function StatusBanner({ icon, text, buttonText, buttonIcon, onButtonClick, testI
       )}
     </div>
   )
+}
+
+interface TargetResolutionBannerProps {
+  status: AttackTargetResolutionStatus
+  activeTarget?: TargetInstance | null
+  onRetry?: () => void
+  onConfigureTarget: () => void
+  onUseAsTemplate: () => void
+  styles: ReturnType<typeof useChatInputAreaStyles>
+}
+
+function TargetResolutionBanner({
+  status,
+  activeTarget,
+  onRetry,
+  onConfigureTarget,
+  onUseAsTemplate,
+  styles,
+}: TargetResolutionBannerProps) {
+  if (status === 'loading') {
+    return (
+      <StatusBanner
+        className={styles.statusBanner}
+        textClassName={styles.statusBannerText}
+        icon={<ArrowSyncRegular fontSize={18} />}
+        text="Verifying this attack's target before enabling changes..."
+        testId="target-resolution-loading-banner"
+      />
+    )
+  }
+  if (status === 'error') {
+    return (
+      <StatusBanner
+        className={styles.statusBanner}
+        textClassName={styles.statusBannerText}
+        icon={<WarningRegular fontSize={18} />}
+        text="Target verification failed. This conversation remains read-only."
+        buttonText="Retry"
+        buttonIcon={<ArrowSyncRegular />}
+        onButtonClick={onRetry}
+        testId="target-resolution-error-banner"
+        buttonTestId="retry-target-resolution-btn"
+        buttonClassName={styles.touchTarget}
+      />
+    )
+  }
+  if (status === 'unavailable') {
+    return (
+      <StatusBanner
+        className={styles.statusBanner}
+        textClassName={styles.statusBannerText}
+        icon={<WarningRegular fontSize={18} />}
+        text="The target used by this attack is not currently registered. This conversation is read-only."
+        buttonText="Retry"
+        buttonIcon={<ArrowSyncRegular />}
+        onButtonClick={onRetry}
+        testId="target-resolution-unavailable-banner"
+        buttonTestId="retry-target-resolution-btn"
+        buttonClassName={styles.touchTarget}
+      />
+    )
+  }
+  if (status === 'ambiguous') {
+    return (
+      <StatusBanner
+        className={styles.statusBanner}
+        textClassName={styles.statusBannerText}
+        icon={<WarningRegular fontSize={18} />}
+        text="Multiple registered targets have this attack's identity. Remove duplicate registrations, then retry."
+        buttonText="Retry"
+        buttonIcon={<ArrowSyncRegular />}
+        onButtonClick={onRetry}
+        testId="target-resolution-ambiguous-banner"
+        buttonTestId="retry-target-resolution-btn"
+        buttonClassName={styles.touchTarget}
+      />
+    )
+  }
+  if (status === 'legacy') {
+    const canUseAsTemplate = Boolean(activeTarget)
+    return (
+      <StatusBanner
+        className={styles.statusBanner}
+        textClassName={styles.statusBannerText}
+        icon={<WarningRegular fontSize={18} />}
+        text="This attack does not contain a complete target identity. The original conversation is read-only."
+        buttonText={canUseAsTemplate ? 'Continue with your target' : 'Configure Target'}
+        buttonIcon={canUseAsTemplate ? <CopyRegular /> : <SettingsRegular />}
+        onButtonClick={canUseAsTemplate ? onUseAsTemplate : onConfigureTarget}
+        testId="target-resolution-legacy-banner"
+        buttonTestId={canUseAsTemplate ? 'use-as-template-btn' : 'configure-target-input-btn'}
+        buttonClassName={styles.touchTarget}
+      />
+    )
+  }
+  return null
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +411,8 @@ interface ChatInputAreaProps {
   onNewConversation: () => void
   operatorLocked?: boolean
   crossTargetLocked?: boolean
+  targetResolutionStatus?: AttackTargetResolutionStatus
+  onRetryTargetResolution?: () => void
   onUseAsTemplate: () => void
   attackOperator?: string
   noTargetSelected?: boolean
@@ -341,7 +439,7 @@ interface ChatInputAreaProps {
   onSystemPromptChange?: (value: string) => void
 }
 
-const ChatInputArea = forwardRef<ChatInputAreaHandle, ChatInputAreaProps>(function ChatInputArea({ onSend, disabled = false, activeTarget, singleTurnLimitReached = false, onNewConversation, operatorLocked = false, crossTargetLocked = false, onUseAsTemplate, attackOperator, noTargetSelected = false, onConfigureTarget, onToggleConverterPanel, isConverterPanelOpen = false, onInputChange, onAttachmentsChange, convertedValue, originalValue: _originalValue, onClearConversion, onConvertedValueChange, converterOutputDataTypes = [], mediaConversions = [], onClearMediaConversion, convertedFileChip, onClearConvertedFileChip, showSystemPrompt = false, supportsSystemPrompt = false, systemPrompt = '', onSystemPromptChange }, ref) {
+const ChatInputArea = forwardRef<ChatInputAreaHandle, ChatInputAreaProps>(function ChatInputArea({ onSend, disabled = false, activeTarget, singleTurnLimitReached = false, onNewConversation, operatorLocked = false, crossTargetLocked = false, targetResolutionStatus = 'idle', onRetryTargetResolution, onUseAsTemplate, attackOperator, noTargetSelected = false, onConfigureTarget, onToggleConverterPanel, isConverterPanelOpen = false, onInputChange, onAttachmentsChange, convertedValue, originalValue: _originalValue, onClearConversion, onConvertedValueChange, converterOutputDataTypes = [], mediaConversions = [], onClearMediaConversion, convertedFileChip, onClearConvertedFileChip, showSystemPrompt = false, supportsSystemPrompt = false, systemPrompt = '', onSystemPromptChange }, ref) {
   const styles = useChatInputAreaStyles()
   const [input, setInput] = useState('')
   const [attachments, setAttachments] = useState<MessageAttachment[]>([])
@@ -496,7 +594,16 @@ const ChatInputArea = forwardRef<ChatInputAreaHandle, ChatInputAreaProps>(functi
   return (
     <div className={styles.root}>
       <div className={styles.inputContainer}>
-        {noTargetSelected ? (
+        {['loading', 'unavailable', 'ambiguous', 'error', 'legacy'].includes(targetResolutionStatus) ? (
+          <TargetResolutionBanner
+            status={targetResolutionStatus}
+            activeTarget={activeTarget}
+            onRetry={onRetryTargetResolution}
+            onConfigureTarget={onConfigureTarget}
+            onUseAsTemplate={onUseAsTemplate}
+            styles={styles}
+          />
+        ) : noTargetSelected ? (
           <StatusBanner
             className={styles.noTargetBanner}
             textClassName={styles.noTargetText}

--- a/frontend/src/components/Chat/ChatWindow.test.tsx
+++ b/frontend/src/components/Chat/ChatWindow.test.tsx
@@ -507,6 +507,79 @@ describe("ChatWindow Integration", () => {
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
   });
 
+  it("should disable sending while routed attack metadata is loading", () => {
+    render(
+      <TestWrapper>
+        <ChatWindow
+          {...defaultProps}
+          activeTarget={mockTarget}
+          isLoadingAttack
+        />
+      </TestWrapper>
+    );
+
+    expect(screen.getByTestId("chat-input")).toBeDisabled();
+  });
+
+  it("should keep an unverifiable historical target read-only and retryable", async () => {
+    const user = userEvent.setup();
+    const onRetryTargetResolution = jest.fn();
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: "Historical response",
+        timestamp: "2026-01-01T00:00:00Z",
+      },
+    ];
+    mockedAttacksApi.getMessages.mockResolvedValue({ messages: [] });
+    mockedAttacksApi.getConversations.mockResolvedValue({
+      attack_result_id: "ar-unverifiable",
+      main_conversation_id: "conv-unverifiable",
+      conversations: [
+        {
+          conversation_id: "conv-unverifiable",
+          message_count: 1,
+        },
+        {
+          conversation_id: "conv-related",
+          message_count: 1,
+        },
+      ],
+    });
+    mockedMapper.backendMessagesToFrontend.mockReturnValue(messages);
+
+    render(
+      <TestWrapper>
+        <ChatWindow
+          {...defaultProps}
+          activeTarget={null}
+          attackResultId="ar-unverifiable"
+          conversationId="conv-unverifiable"
+          activeConversationId="conv-unverifiable"
+          attackTarget={{
+            target_type: "TextTarget",
+            identifier_hash: "unverifiable-hash",
+          }}
+          targetResolutionStatus="error"
+          onRetryTargetResolution={onRetryTargetResolution}
+          relatedConversationCount={1}
+        />
+      </TestWrapper>
+    );
+
+    expect(await screen.findByTestId("target-resolution-error-banner")).toBeInTheDocument();
+    expect(await screen.findByText("Historical response")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(screen.getByTestId("copy-to-input-btn-0")).toBeDisabled();
+    expect(screen.getByTestId("branch-conv-btn-0")).toBeDisabled();
+    expect(screen.getByTestId("branch-attack-btn-0")).toBeDisabled();
+    expect(await screen.findByTestId("star-btn-conv-related")).toBeDisabled();
+    expect(mockedAttacksApi.changeMainConversation).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onRetryTargetResolution).toHaveBeenCalledTimes(1);
+  });
+
   // -----------------------------------------------------------------------
   // Target info display for various target types
   // -----------------------------------------------------------------------

--- a/frontend/src/components/Chat/ChatWindow.tsx
+++ b/frontend/src/components/Chat/ChatWindow.tsx
@@ -32,7 +32,13 @@ import { toApiError } from '../../services/errors'
 import { buildMessagePieces, backendMessagesToFrontend } from '../../utils/messageMapper'
 import { exportConversation } from '../../utils/conversationExport'
 import type { ExportFormat } from '../../utils/conversationExport'
-import type { Message, MessageAttachment, TargetInstance, TargetInfo } from '../../types'
+import type {
+  AttackTargetResolutionStatus,
+  Message,
+  MessageAttachment,
+  TargetInstance,
+  TargetInfo,
+} from '../../types'
 import { targetInfoMatchesTarget } from '../../utils/targetIdentity'
 import type { ViewName } from '../Sidebar/Navigation'
 import { useChatWindowStyles } from './ChatWindow.styles'
@@ -80,6 +86,10 @@ interface ChatWindowProps {
   attackLabels?: Record<string, string> | null
   /** Target info that the current attack was started with (for cross-target guard). */
   attackTarget?: TargetInfo | null
+  /** Result of resolving the persisted attack target against the current registry. */
+  targetResolutionStatus?: AttackTargetResolutionStatus
+  /** Re-run target registry resolution after a transient or unavailable result. */
+  onRetryTargetResolution?: () => void
   /** True while a historical attack is being loaded from the history view. */
   isLoadingAttack?: boolean
   /** Number of related (non-main) conversations in the loaded attack. */
@@ -99,6 +109,8 @@ export default function ChatWindow({
   onNavigate,
   attackLabels,
   attackTarget,
+  targetResolutionStatus = 'idle',
+  onRetryTargetResolution,
   isLoadingAttack,
   relatedConversationCount,
 }: ChatWindowProps) {
@@ -206,6 +218,21 @@ export default function ChatWindow({
   const pendingUserMessagesRef = useRef<Map<string, Message[]>>(new Map())
 
   const supportsSystemPrompt = activeTarget?.capabilities?.supports_system_prompt === true
+  const isTargetResolutionLocked = Boolean(
+    attackResultId
+    && ['loading', 'unavailable', 'ambiguous', 'error', 'legacy'].includes(targetResolutionStatus),
+  )
+  const currentOperator = labels?.operator
+  const attackOperator = attackLabels?.operator
+  const isOperatorLocked = Boolean(
+    attackResultId && attackLabels && attackOperator && currentOperator && attackOperator !== currentOperator,
+  )
+  const isCrossTargetLocked = Boolean(
+    attackResultId
+    && attackTarget
+    && activeTarget
+    && !targetInfoMatchesTarget(attackTarget, activeTarget),
+  )
 
   // Clear internal messages when attack state is reset (e.g. New Attack).
   // Uses the "adjust state during render" pattern (see React docs:
@@ -299,7 +326,15 @@ export default function ChatWindow({
   }, [attackResultId, activeConversationId, isNarrowScreen, onSelectConversation, loadConversation])
 
   const handleSend = async (originalValue: string, convertedValue: string | undefined, attachments: MessageAttachment[]) => {
-    if (!activeTarget) { return }
+    if (
+      !activeTarget
+      || isLoadingAttack
+      || isOperatorLocked
+      || isCrossTargetLocked
+      || isTargetResolutionLocked
+    ) {
+      return
+    }
 
     // Capture all piece conversions upfront before any async work or state clears
     const conversions = { ...activePieceConversions }
@@ -497,7 +532,7 @@ export default function ChatWindow({
   }
 
   const handleNewConversation = useCallback(async () => {
-    if (!attackResultId) { return }
+    if (!attackResultId || isOperatorLocked || isCrossTargetLocked || isTargetResolutionLocked) { return }
 
     try {
       const response = await attacksApi.createConversation(attackResultId, {})
@@ -506,7 +541,14 @@ export default function ChatWindow({
     } catch {
       // Silently fail
     }
-  }, [attackResultId, isNarrowScreen, onSelectConversation])
+  }, [
+    attackResultId,
+    isCrossTargetLocked,
+    isNarrowScreen,
+    isOperatorLocked,
+    isTargetResolutionLocked,
+    onSelectConversation,
+  ])
 
   // -------------------------------------------------------------------
   // Message action handlers (4 buttons on each assistant message)
@@ -526,7 +568,7 @@ export default function ChatWindow({
 
   /** 2. Create a new conversation in the same attack and copy ONLY this message to its input box */
   const handleCopyToNewConversation = useCallback(async (messageIndex: number) => {
-    if (!attackResultId) { return }
+    if (!attackResultId || isOperatorLocked || isCrossTargetLocked || isTargetResolutionLocked) { return }
     const msg = messages[messageIndex]
     if (!msg) { return }
 
@@ -547,11 +589,27 @@ export default function ChatWindow({
       // If creating fails, fall back to current conversation
       if (msg.content) inputBoxRef.current?.setText(msg.content)
     }
-  }, [attackResultId, isNarrowScreen, messages, onSelectConversation])
+  }, [
+    attackResultId,
+    isCrossTargetLocked,
+    isNarrowScreen,
+    isOperatorLocked,
+    isTargetResolutionLocked,
+    messages,
+    onSelectConversation,
+  ])
 
   /** 3. Branch into a new conversation within the same attack (clone up to clicked message) */
   const handleBranchConversation = useCallback(async (messageIndex: number) => {
-    if (!attackResultId || !activeConversationId) { return }
+    if (
+      !attackResultId
+      || !activeConversationId
+      || isOperatorLocked
+      || isCrossTargetLocked
+      || isTargetResolutionLocked
+    ) {
+      return
+    }
 
     try {
       const response = await attacksApi.createConversation(attackResultId, {
@@ -567,7 +625,15 @@ export default function ChatWindow({
     } catch (err) {
       console.error('Failed to branch into new conversation:', err)
     }
-  }, [attackResultId, activeConversationId, isNarrowScreen, onSelectConversation])
+  }, [
+    attackResultId,
+    activeConversationId,
+    isCrossTargetLocked,
+    isNarrowScreen,
+    isOperatorLocked,
+    isTargetResolutionLocked,
+    onSelectConversation,
+  ])
 
   /** 4. Branch into a brand-new attack (clone up to clicked message with new labels) */
   const handleBranchAttack = useCallback(async (messageIndex: number) => {
@@ -592,7 +658,14 @@ export default function ChatWindow({
   }, [activeTarget, activeConversationId, labels, onConversationCreated])
 
   const handleChangeMainConversation = useCallback(async (convId: string) => {
-    if (!attackResultId) { return }
+    if (
+      !attackResultId
+      || isOperatorLocked
+      || isCrossTargetLocked
+      || isTargetResolutionLocked
+    ) {
+      return
+    }
 
     try {
       await attacksApi.changeMainConversation(attackResultId, convId)
@@ -600,27 +673,14 @@ export default function ChatWindow({
     } catch (err) {
       console.error('Failed to change main conversation:', err)
     }
-  }, [attackResultId])
+  }, [
+    attackResultId,
+    isCrossTargetLocked,
+    isOperatorLocked,
+    isTargetResolutionLocked,
+  ])
 
   const singleTurnLimitReached = activeTarget?.capabilities?.supports_multi_turn === false && messages.some(m => m.role === 'user')
-
-  // Operator locking: if the loaded attack's operator differs from the current
-  // user's operator label, the conversation should be read-only.
-  const currentOperator = labels?.operator
-  const attackOperator = attackLabels?.operator
-  const isOperatorLocked = Boolean(
-    attackResultId && attackLabels && attackOperator && currentOperator && attackOperator !== currentOperator
-  )
-
-  // Cross-target guard: if viewing a historical attack whose target differs
-  // from the currently configured target, prevent sending new messages.
-  // The user can "Continue with your target" to branch into a new attack with their target.
-  const isCrossTargetLocked = Boolean(
-    attackResultId &&
-    attackTarget &&
-    activeTarget &&
-    !targetInfoMatchesTarget(attackTarget, activeTarget)
-  )
 
   // "Continue with your target" — clone the current conversation into a new attack
   const handleUseAsTemplate = useCallback(async () => {
@@ -769,7 +829,7 @@ export default function ChatWindow({
           isLoading={isLoadingAttack || isLoadingMessages || awaitingConversationLoad}
           isSingleTurn={activeTarget?.capabilities?.supports_multi_turn === false}
           isOperatorLocked={isOperatorLocked}
-          isCrossTarget={isCrossTargetLocked}
+          isCrossTarget={isCrossTargetLocked || isTargetResolutionLocked}
           noTargetSelected={!activeTarget}
           globalMarkdown={globalMarkdown}
         />
@@ -780,12 +840,22 @@ export default function ChatWindow({
           supportsSystemPrompt={supportsSystemPrompt}
           systemPrompt={systemPrompt}
           onSystemPromptChange={setSystemPrompt}
-          disabled={isSending || !activeTarget || singleTurnLimitReached || isOperatorLocked || isCrossTargetLocked}
+          disabled={
+            isSending
+            || !activeTarget
+            || isLoadingAttack
+            || singleTurnLimitReached
+            || isOperatorLocked
+            || isCrossTargetLocked
+            || isTargetResolutionLocked
+          }
           activeTarget={activeTarget}
           singleTurnLimitReached={singleTurnLimitReached}
           onNewConversation={handleNewConversation}
           operatorLocked={isOperatorLocked}
           crossTargetLocked={isCrossTargetLocked}
+          targetResolutionStatus={targetResolutionStatus}
+          onRetryTargetResolution={onRetryTargetResolution}
           onUseAsTemplate={handleUseAsTemplate}
           attackOperator={isOperatorLocked ? attackOperator ?? undefined : undefined}
           noTargetSelected={!activeTarget}
@@ -849,6 +919,7 @@ export default function ChatWindow({
             !activeTarget ? 'Configure a target to enable this action.'
             : isOperatorLocked ? 'Cannot modify — attack belongs to a different operator.'
             : isCrossTargetLocked ? 'Cannot modify — attack was created with a different target.'
+            : isTargetResolutionLocked ? 'Cannot modify — the attack target could not be safely resolved.'
             : undefined
           }
           refreshKey={panelRefreshKey}

--- a/frontend/src/components/Chat/ChatWindow.tsx
+++ b/frontend/src/components/Chat/ChatWindow.tsx
@@ -39,7 +39,7 @@ import type {
   TargetInstance,
   TargetInfo,
 } from '../../types'
-import { targetInfoMatchesTarget } from '../../utils/targetIdentity'
+import { isTargetResolutionBlocking, targetInfoMatchesTarget } from '../../utils/targetIdentity'
 import type { ViewName } from '../Sidebar/Navigation'
 import { useChatWindowStyles } from './ChatWindow.styles'
 
@@ -220,7 +220,7 @@ export default function ChatWindow({
   const supportsSystemPrompt = activeTarget?.capabilities?.supports_system_prompt === true
   const isTargetResolutionLocked = Boolean(
     attackResultId
-    && ['loading', 'unavailable', 'ambiguous', 'error', 'legacy'].includes(targetResolutionStatus),
+    && isTargetResolutionBlocking(targetResolutionStatus),
   )
   const currentOperator = labels?.operator
   const attackOperator = attackLabels?.operator
@@ -233,6 +233,7 @@ export default function ChatWindow({
     && activeTarget
     && !targetInfoMatchesTarget(attackTarget, activeTarget),
   )
+  const isMutationLocked = isOperatorLocked || isCrossTargetLocked || isTargetResolutionLocked
 
   // Clear internal messages when attack state is reset (e.g. New Attack).
   // Uses the "adjust state during render" pattern (see React docs:
@@ -329,9 +330,7 @@ export default function ChatWindow({
     if (
       !activeTarget
       || isLoadingAttack
-      || isOperatorLocked
-      || isCrossTargetLocked
-      || isTargetResolutionLocked
+      || isMutationLocked
     ) {
       return
     }
@@ -532,7 +531,7 @@ export default function ChatWindow({
   }
 
   const handleNewConversation = useCallback(async () => {
-    if (!attackResultId || isOperatorLocked || isCrossTargetLocked || isTargetResolutionLocked) { return }
+    if (!attackResultId || isMutationLocked) { return }
 
     try {
       const response = await attacksApi.createConversation(attackResultId, {})
@@ -543,10 +542,8 @@ export default function ChatWindow({
     }
   }, [
     attackResultId,
-    isCrossTargetLocked,
     isNarrowScreen,
-    isOperatorLocked,
-    isTargetResolutionLocked,
+    isMutationLocked,
     onSelectConversation,
   ])
 
@@ -568,7 +565,7 @@ export default function ChatWindow({
 
   /** 2. Create a new conversation in the same attack and copy ONLY this message to its input box */
   const handleCopyToNewConversation = useCallback(async (messageIndex: number) => {
-    if (!attackResultId || isOperatorLocked || isCrossTargetLocked || isTargetResolutionLocked) { return }
+    if (!attackResultId || isMutationLocked) { return }
     const msg = messages[messageIndex]
     if (!msg) { return }
 
@@ -591,10 +588,8 @@ export default function ChatWindow({
     }
   }, [
     attackResultId,
-    isCrossTargetLocked,
     isNarrowScreen,
-    isOperatorLocked,
-    isTargetResolutionLocked,
+    isMutationLocked,
     messages,
     onSelectConversation,
   ])
@@ -604,9 +599,7 @@ export default function ChatWindow({
     if (
       !attackResultId
       || !activeConversationId
-      || isOperatorLocked
-      || isCrossTargetLocked
-      || isTargetResolutionLocked
+      || isMutationLocked
     ) {
       return
     }
@@ -628,10 +621,8 @@ export default function ChatWindow({
   }, [
     attackResultId,
     activeConversationId,
-    isCrossTargetLocked,
     isNarrowScreen,
-    isOperatorLocked,
-    isTargetResolutionLocked,
+    isMutationLocked,
     onSelectConversation,
   ])
 
@@ -660,9 +651,7 @@ export default function ChatWindow({
   const handleChangeMainConversation = useCallback(async (convId: string) => {
     if (
       !attackResultId
-      || isOperatorLocked
-      || isCrossTargetLocked
-      || isTargetResolutionLocked
+      || isMutationLocked
     ) {
       return
     }
@@ -675,9 +664,7 @@ export default function ChatWindow({
     }
   }, [
     attackResultId,
-    isCrossTargetLocked,
-    isOperatorLocked,
-    isTargetResolutionLocked,
+    isMutationLocked,
   ])
 
   const singleTurnLimitReached = activeTarget?.capabilities?.supports_multi_turn === false && messages.some(m => m.role === 'user')
@@ -845,9 +832,7 @@ export default function ChatWindow({
             || !activeTarget
             || isLoadingAttack
             || singleTurnLimitReached
-            || isOperatorLocked
-            || isCrossTargetLocked
-            || isTargetResolutionLocked
+            || isMutationLocked
           }
           activeTarget={activeTarget}
           singleTurnLimitReached={singleTurnLimitReached}

--- a/frontend/src/components/Chat/ChatWindow.tsx
+++ b/frontend/src/components/Chat/ChatWindow.tsx
@@ -224,15 +224,18 @@ export default function ChatWindow({
   )
   const currentOperator = labels?.operator
   const attackOperator = attackLabels?.operator
+  // Existing attacks are operator-locked when their operator differs from the current one.
   const isOperatorLocked = Boolean(
     attackResultId && attackLabels && attackOperator && currentOperator && attackOperator !== currentOperator,
   )
+  // They are cross-target locked when the selected target's canonical hash differs from the persisted target.
   const isCrossTargetLocked = Boolean(
     attackResultId
     && attackTarget
     && activeTarget
     && !targetInfoMatchesTarget(attackTarget, activeTarget),
   )
+  // Any failed invariant keeps all mutation controls and handlers read-only.
   const isMutationLocked = isOperatorLocked || isCrossTargetLocked || isTargetResolutionLocked
 
   // Clear internal messages when attack state is reset (e.g. New Attack).

--- a/frontend/src/hooks/useAttackTargetResolution.ts
+++ b/frontend/src/hooks/useAttackTargetResolution.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { targetsApi } from '@/services/api'
+import { toApiError } from '@/services/errors'
 import type {
   AttackTargetResolutionStatus,
   TargetInfo,
@@ -10,6 +11,7 @@ import {
   resolveTargetByIdentifierHash,
   targetIdentifierHash,
 } from '@/utils/targetIdentity'
+import type { TargetHashResolution } from '@/utils/targetIdentity'
 
 const TARGET_PAGE_SIZE = 200
 const TARGET_MAX_PAGES = 100
@@ -75,6 +77,24 @@ async function listAllTargets(): Promise<TargetInstance[]> {
   return targets
 }
 
+async function resolvePersistedTarget(target: TargetInfo): Promise<TargetHashResolution> {
+  if (target.target_registry_name) {
+    try {
+      const namedTarget = await targetsApi.getTarget(target.target_registry_name)
+      if (
+        typeof namedTarget?.identifier?.hash === 'string'
+        && targetIdentifierHash(namedTarget) === target.identifier_hash
+      ) {
+        return { status: 'resolved' as const, target: namedTarget }
+      }
+    } catch (error) {
+      if (toApiError(error).status !== 404) throw error
+    }
+  }
+
+  return resolveTargetByIdentifierHash(target.identifier_hash, await listAllTargets())
+}
+
 export function useAttackTargetResolution({
   attackId,
   attackLoadSequence,
@@ -117,10 +137,9 @@ export function useAttackTargetResolution({
     let cancelled = false
     const resolveTarget = async (): Promise<void> => {
       try {
-        const targets = await listAllTargets()
+        const resolution = await resolvePersistedTarget(attackTarget)
         if (cancelled) return
 
-        const resolution = resolveTargetByIdentifierHash(attackTarget.identifier_hash, targets)
         const currentSelection = selectionRef.current
         if (currentSelection.source === 'explicit') {
           if (
@@ -128,10 +147,7 @@ export function useAttackTargetResolution({
             || targetIdentifierHash(currentSelection.target) !== attackTarget.identifier_hash
           ) return
 
-          if (
-            resolution.status === 'resolved'
-            && resolution.target.target_registry_name === currentSelection.target.target_registry_name
-          ) {
+          if (resolution.status === 'resolved') {
             setRegistryResolution({
               attackId,
               attackLoadSequence,
@@ -143,7 +159,7 @@ export function useAttackTargetResolution({
           setRegistryResolution({
             attackId,
             attackLoadSequence,
-            status: resolution.status === 'resolved' ? 'unavailable' : resolution.status,
+            status: resolution.status,
           })
           return
         }

--- a/frontend/src/hooks/useAttackTargetResolution.ts
+++ b/frontend/src/hooks/useAttackTargetResolution.ts
@@ -1,0 +1,217 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { targetsApi } from '@/services/api'
+import type {
+  AttackTargetResolutionStatus,
+  TargetInfo,
+  TargetInstance,
+} from '@/types'
+import {
+  resolveTargetByIdentifierHash,
+  targetIdentifierHash,
+} from '@/utils/targetIdentity'
+
+const TARGET_PAGE_SIZE = 200
+
+interface TargetSelection {
+  target: TargetInstance | null
+  source: 'none' | 'explicit' | 'route'
+  attackId: string | null
+}
+
+interface RegistryResolution {
+  attackId: string | null
+  attackLoadSequence: number
+  status: 'idle' | 'resolved' | 'unavailable' | 'ambiguous' | 'error'
+  target?: TargetInstance
+}
+
+interface UseAttackTargetResolutionOptions {
+  attackId: string | null
+  attackLoadSequence: number
+  attackTarget: TargetInfo | null
+}
+
+interface UseAttackTargetResolutionResult {
+  activeTarget: TargetInstance | null
+  setExplicitTarget: (target: TargetInstance) => void
+  resolutionStatus: AttackTargetResolutionStatus
+  retryResolution: () => void
+}
+
+function hasCompleteIdentifier(target: TargetInfo | null): target is TargetInfo {
+  return Boolean(
+    target
+    && typeof target.identifier_hash === 'string'
+    && target.identifier_hash.length > 0,
+  )
+}
+
+async function listAllTargets(): Promise<TargetInstance[]> {
+  const targets: TargetInstance[] = []
+  const seenCursors = new Set<string>()
+  let cursor: string | undefined
+
+  do {
+    const response = await targetsApi.listTargets(TARGET_PAGE_SIZE, cursor)
+    targets.push(...response.items)
+    if (!response.pagination.has_more) break
+
+    const nextCursor = response.pagination.next_cursor ?? undefined
+    if (!nextCursor || seenCursors.has(nextCursor)) {
+      throw new Error('Target registry pagination did not advance')
+    }
+    seenCursors.add(nextCursor)
+    cursor = nextCursor
+  } while (cursor)
+
+  return targets
+}
+
+export function useAttackTargetResolution({
+  attackId,
+  attackLoadSequence,
+  attackTarget,
+}: UseAttackTargetResolutionOptions): UseAttackTargetResolutionResult {
+  const [selection, setSelection] = useState<TargetSelection>({
+    target: null,
+    source: 'none',
+    attackId: null,
+  })
+  const selectionRef = useRef(selection)
+  const [registryResolution, setRegistryResolution] = useState<RegistryResolution>({
+    attackId: null,
+    attackLoadSequence: 0,
+    status: 'idle',
+  })
+  const [retryCount, setRetryCount] = useState(0)
+  const [explicitSelectionCount, setExplicitSelectionCount] = useState(0)
+
+  const setExplicitTarget = useCallback((target: TargetInstance): void => {
+    const next: TargetSelection = { target, source: 'explicit', attackId: null }
+    selectionRef.current = next
+    setSelection(next)
+    setRegistryResolution({ attackId: null, attackLoadSequence: 0, status: 'idle' })
+    setExplicitSelectionCount((count) => count + 1)
+  }, [])
+
+  useEffect(() => {
+    if (!attackId || !hasCompleteIdentifier(attackTarget)) return
+    const initialSelection = selectionRef.current
+    if (
+      initialSelection.source === 'explicit'
+      && (
+        !initialSelection.target
+        || targetIdentifierHash(initialSelection.target) !== attackTarget.identifier_hash
+      )
+    ) return
+
+    let cancelled = false
+    const resolveTarget = async (): Promise<void> => {
+      try {
+        const targets = await listAllTargets()
+        if (cancelled) return
+
+        const resolution = resolveTargetByIdentifierHash(attackTarget.identifier_hash, targets)
+        const currentSelection = selectionRef.current
+        if (currentSelection.source === 'explicit') {
+          if (
+            !currentSelection.target
+            || targetIdentifierHash(currentSelection.target) !== attackTarget.identifier_hash
+          ) return
+
+          if (
+            resolution.status === 'resolved'
+            && resolution.target.target_registry_name === currentSelection.target.target_registry_name
+          ) {
+            setRegistryResolution({
+              attackId,
+              attackLoadSequence,
+              status: 'resolved',
+              target: resolution.target,
+            })
+            return
+          }
+          setRegistryResolution({
+            attackId,
+            attackLoadSequence,
+            status: resolution.status === 'resolved' ? 'unavailable' : resolution.status,
+          })
+          return
+        }
+
+        if (resolution.status === 'resolved') {
+          const nextSelection: TargetSelection = {
+            target: resolution.target,
+            source: 'route',
+            attackId,
+          }
+          selectionRef.current = nextSelection
+          setSelection(nextSelection)
+          setRegistryResolution({
+            attackId,
+            attackLoadSequence,
+            status: 'resolved',
+            target: resolution.target,
+          })
+          return
+        }
+        setRegistryResolution({ attackId, attackLoadSequence, status: resolution.status })
+      } catch {
+        if (cancelled) return
+        const currentSelection = selectionRef.current
+        if (
+          currentSelection.source === 'explicit'
+          && currentSelection.target
+          && targetIdentifierHash(currentSelection.target) !== attackTarget.identifier_hash
+        ) return
+        setRegistryResolution({ attackId, attackLoadSequence, status: 'error' })
+      }
+    }
+
+    void resolveTarget()
+    return () => {
+      cancelled = true
+    }
+  }, [attackId, attackLoadSequence, attackTarget, explicitSelectionCount, retryCount])
+
+  const resolutionStatus = useMemo<AttackTargetResolutionStatus>(() => {
+    if (!attackId) return 'idle'
+    if (!hasCompleteIdentifier(attackTarget)) return 'legacy'
+    if (selection.source === 'explicit' && selection.target) {
+      if (targetIdentifierHash(selection.target) !== attackTarget.identifier_hash) {
+        return 'explicit-mismatch'
+      }
+    }
+    if (
+      registryResolution.attackId !== attackId
+      || registryResolution.attackLoadSequence !== attackLoadSequence
+    ) return 'loading'
+    return registryResolution.status
+  }, [attackId, attackLoadSequence, attackTarget, registryResolution, selection])
+
+  const activeTarget = useMemo<TargetInstance | null>(() => {
+    if (selection.source !== 'route') return selection.target
+    if (!attackId) return null
+    if (
+      resolutionStatus === 'resolved'
+      && selection.attackId === attackId
+      && registryResolution.target === selection.target
+    ) {
+      return selection.target
+    }
+    return null
+  }, [attackId, registryResolution.target, resolutionStatus, selection])
+
+  const retryResolution = useCallback((): void => {
+    setRegistryResolution({ attackId: null, attackLoadSequence: 0, status: 'idle' })
+    setRetryCount((count) => count + 1)
+  }, [])
+
+  return {
+    activeTarget,
+    setExplicitTarget,
+    resolutionStatus,
+    retryResolution,
+  }
+}

--- a/frontend/src/hooks/useAttackTargetResolution.ts
+++ b/frontend/src/hooks/useAttackTargetResolution.ts
@@ -12,6 +12,7 @@ import {
 } from '@/utils/targetIdentity'
 
 const TARGET_PAGE_SIZE = 200
+const TARGET_MAX_PAGES = 100
 
 interface TargetSelection {
   target: TargetInstance | null
@@ -30,6 +31,7 @@ interface UseAttackTargetResolutionOptions {
   attackId: string | null
   attackLoadSequence: number
   attackTarget: TargetInfo | null
+  attackTargetSource: 'persisted' | 'active-selection'
 }
 
 interface UseAttackTargetResolutionResult {
@@ -51,8 +53,13 @@ async function listAllTargets(): Promise<TargetInstance[]> {
   const targets: TargetInstance[] = []
   const seenCursors = new Set<string>()
   let cursor: string | undefined
+  let pageCount = 0
 
   do {
+    pageCount += 1
+    if (pageCount > TARGET_MAX_PAGES) {
+      throw new Error('Target registry pagination exceeded the page limit')
+    }
     const response = await targetsApi.listTargets(TARGET_PAGE_SIZE, cursor)
     targets.push(...response.items)
     if (!response.pagination.has_more) break
@@ -72,6 +79,7 @@ export function useAttackTargetResolution({
   attackId,
   attackLoadSequence,
   attackTarget,
+  attackTargetSource,
 }: UseAttackTargetResolutionOptions): UseAttackTargetResolutionResult {
   const [selection, setSelection] = useState<TargetSelection>({
     target: null,
@@ -84,19 +92,19 @@ export function useAttackTargetResolution({
     attackLoadSequence: 0,
     status: 'idle',
   })
-  const [retryCount, setRetryCount] = useState(0)
-  const [explicitSelectionCount, setExplicitSelectionCount] = useState(0)
+  const [resolutionAttempt, setResolutionAttempt] = useState(0)
 
   const setExplicitTarget = useCallback((target: TargetInstance): void => {
     const next: TargetSelection = { target, source: 'explicit', attackId: null }
     selectionRef.current = next
     setSelection(next)
     setRegistryResolution({ attackId: null, attackLoadSequence: 0, status: 'idle' })
-    setExplicitSelectionCount((count) => count + 1)
+    setResolutionAttempt((attempt) => attempt + 1)
   }, [])
 
   useEffect(() => {
     if (!attackId || !hasCompleteIdentifier(attackTarget)) return
+    if (attackTargetSource === 'active-selection') return
     const initialSelection = selectionRef.current
     if (
       initialSelection.source === 'explicit'
@@ -173,7 +181,7 @@ export function useAttackTargetResolution({
     return () => {
       cancelled = true
     }
-  }, [attackId, attackLoadSequence, attackTarget, explicitSelectionCount, retryCount])
+  }, [attackId, attackLoadSequence, attackTarget, attackTargetSource, resolutionAttempt])
 
   const resolutionStatus = useMemo<AttackTargetResolutionStatus>(() => {
     if (!attackId) return 'idle'
@@ -182,13 +190,15 @@ export function useAttackTargetResolution({
       if (targetIdentifierHash(selection.target) !== attackTarget.identifier_hash) {
         return 'explicit-mismatch'
       }
+      if (attackTargetSource === 'active-selection') return 'resolved'
     }
+    if (attackTargetSource === 'active-selection') return 'unavailable'
     if (
       registryResolution.attackId !== attackId
       || registryResolution.attackLoadSequence !== attackLoadSequence
     ) return 'loading'
     return registryResolution.status
-  }, [attackId, attackLoadSequence, attackTarget, registryResolution, selection])
+  }, [attackId, attackLoadSequence, attackTarget, attackTargetSource, registryResolution, selection])
 
   const activeTarget = useMemo<TargetInstance | null>(() => {
     if (selection.source !== 'route') return selection.target
@@ -205,7 +215,7 @@ export function useAttackTargetResolution({
 
   const retryResolution = useCallback((): void => {
     setRegistryResolution({ attackId: null, attackLoadSequence: 0, status: 'idle' })
-    setRetryCount((count) => count + 1)
+    setResolutionAttempt((attempt) => attempt + 1)
   }, [])
 
   return {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -239,6 +239,16 @@ export interface TargetInfo {
   identifier_hash: string
 }
 
+export type AttackTargetResolutionStatus =
+  | 'idle'
+  | 'loading'
+  | 'resolved'
+  | 'explicit-mismatch'
+  | 'unavailable'
+  | 'ambiguous'
+  | 'error'
+  | 'legacy'
+
 export interface AttackSummary {
   attack_result_id: string
   conversation_id: string

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -234,6 +234,7 @@ export interface TargetCatalogResponse {
 
 export interface TargetInfo {
   target_type: string
+  target_registry_name?: string | null
   endpoint?: string | null
   model_name?: string | null
   identifier_hash: string

--- a/frontend/src/utils/targetIdentity.test.ts
+++ b/frontend/src/utils/targetIdentity.test.ts
@@ -4,6 +4,7 @@ import {
   targetIdentifierHash,
   targetInfoMatchesTarget,
   targetModelName,
+  resolveTargetByIdentifierHash,
   targetType,
   targetUnderlyingModelName,
 } from './targetIdentity'
@@ -87,6 +88,67 @@ describe('targetIdentity', () => {
           target,
         ),
       ).toBe(false)
+    })
+  })
+
+  describe('resolveTargetByIdentifierHash', () => {
+    it('resolves only one exact full-hash match', () => {
+      const nearDuplicate = makeTarget({
+        target_registry_name: 'near_duplicate',
+        target_type: 'OpenAIChatTarget',
+        endpoint: 'https://example.test',
+        model_name: 'gpt-test',
+        identifier_hash: 'full-hash-1234-near',
+      })
+      const exact = makeTarget({
+        target_registry_name: 'exact',
+        target_type: 'OpenAIChatTarget',
+        endpoint: 'https://example.test',
+        model_name: 'gpt-test',
+        identifier_hash: 'full-hash-1234',
+      })
+
+      expect(resolveTargetByIdentifierHash('full-hash-1234', [nearDuplicate, exact])).toEqual({
+        status: 'resolved',
+        target: exact,
+      })
+    })
+
+    it('reports duplicate registry identities as ambiguous', () => {
+      const first = makeTarget({
+        target_registry_name: 'duplicate_a',
+        identifier_hash: 'same-full-hash',
+      })
+      const second = makeTarget({
+        target_registry_name: 'duplicate_b',
+        identifier_hash: 'same-full-hash',
+      })
+
+      expect(resolveTargetByIdentifierHash('same-full-hash', [first, second])).toEqual({
+        status: 'ambiguous',
+      })
+    })
+
+    it('does not resolve a Round Robin attack to an inner target', () => {
+      const composite = makeTarget({
+        target_registry_name: 'round_robin',
+        target_type: 'RoundRobinTarget',
+        identifier_hash: 'round-robin-root-hash',
+        inner_targets: [
+          {
+            target_registry_name: 'inner',
+            identifier_hash: 'inner-target-hash',
+          },
+        ],
+      })
+
+      expect(resolveTargetByIdentifierHash('inner-target-hash', [composite])).toEqual({
+        status: 'unavailable',
+      })
+      expect(resolveTargetByIdentifierHash('round-robin-root-hash', [composite])).toEqual({
+        status: 'resolved',
+        target: composite,
+      })
     })
   })
 

--- a/frontend/src/utils/targetIdentity.ts
+++ b/frontend/src/utils/targetIdentity.ts
@@ -1,4 +1,4 @@
-import type { TargetInfo, TargetInstance } from '../types'
+import type { AttackTargetResolutionStatus, TargetInfo, TargetInstance } from '../types'
 
 /**
  * Helpers for reading a target's identity off its embedded `identifier`.
@@ -83,4 +83,13 @@ export function resolveTargetByIdentifierHash(
 /** Whether persisted attack target information identifies the active target. */
 export function targetInfoMatchesTarget(targetInfo: TargetInfo, target: TargetInstance): boolean {
   return targetInfo.identifier_hash === targetIdentifierHash(target)
+}
+
+/** Whether target resolution must keep an existing attack read-only. */
+export function isTargetResolutionBlocking(status: AttackTargetResolutionStatus): boolean {
+  return status === 'loading'
+    || status === 'unavailable'
+    || status === 'ambiguous'
+    || status === 'error'
+    || status === 'legacy'
 }

--- a/frontend/src/utils/targetIdentity.ts
+++ b/frontend/src/utils/targetIdentity.ts
@@ -50,6 +50,36 @@ export function targetIdentifierHash(target: TargetInstance): string {
   return target.identifier.hash
 }
 
+export type TargetHashResolution =
+  | { status: 'resolved'; target: TargetInstance }
+  | { status: 'unavailable' | 'ambiguous' }
+
+/**
+ * Resolves a persisted canonical identifier hash to one registered root target.
+ *
+ * Inner targets are intentionally excluded: a composite attack is bound to the
+ * composite's identifier, not to one of its children.
+ */
+export function resolveTargetByIdentifierHash(
+  identifierHash: string,
+  targets: TargetInstance[],
+): TargetHashResolution {
+  if (!identifierHash) return { status: 'unavailable' }
+
+  const uniqueTargets = new Map<string, TargetInstance>()
+  for (const target of targets) {
+    uniqueTargets.set(target.target_registry_name, target)
+  }
+  const matches = [...uniqueTargets.values()].filter(
+    (target) => targetIdentifierHash(target) === identifierHash,
+  )
+
+  if (matches.length === 1) {
+    return { status: 'resolved', target: matches[0] }
+  }
+  return { status: matches.length === 0 ? 'unavailable' : 'ambiguous' }
+}
+
 /** Whether persisted attack target information identifies the active target. */
 export function targetInfoMatchesTarget(targetInfo: TargetInfo, target: TargetInstance): boolean {
   return targetInfo.identifier_hash === targetIdentifierHash(target)

--- a/pyrit/backend/models/attacks.py
+++ b/pyrit/backend/models/attacks.py
@@ -26,9 +26,10 @@ from pyrit.models import (
 
 
 class TargetInfo(BaseModel):
-    """Target information extracted from the stored attack-strategy identifier."""
+    """Target identity plus an optional persisted registry lookup hint."""
 
     target_type: str = Field(..., description="Target class name (e.g., 'OpenAIChatTarget')")
+    target_registry_name: str | None = Field(None, description="Registry alias used to create the attack")
     endpoint: str | None = Field(None, description="Target endpoint URL")
     model_name: str | None = Field(None, description="Model or deployment name")
     identifier_hash: str = Field(..., description="Canonical target identifier hash")
@@ -247,8 +248,10 @@ class AttackSummary(AttackResult):
         target_id = identifier.get_child("objective_target") if identifier else None
         if not target_id:
             return None
+        target_registry_name = self.metadata.get("target_registry_name")
         return TargetInfo(
             target_type=target_id.class_name,
+            target_registry_name=target_registry_name if isinstance(target_registry_name, str) else None,
             endpoint=cast("str | None", target_id.params.get("endpoint") or None),
             model_name=cast("str | None", target_id.params.get("model_name") or None),
             identifier_hash=target_id.hash,

--- a/pyrit/backend/services/attack_service.py
+++ b/pyrit/backend/services/attack_service.py
@@ -361,6 +361,7 @@ class AttackService:
             timestamp=now,
             metadata={
                 "created_at": now.isoformat(),
+                "target_registry_name": request.target_registry_name,
             },
             labels=labels,
         )

--- a/tests/unit/backend/test_attack_service.py
+++ b/tests/unit/backend/test_attack_service.py
@@ -713,6 +713,8 @@ class TestCreateAttack:
             assert result.conversation_id is not None
             assert result.created_at is not None
             mock_memory.add_attack_results_to_memory.assert_called_once()
+            stored_attack = mock_memory.add_attack_results_to_memory.call_args.kwargs["attack_results"][0]
+            assert stored_attack.metadata["target_registry_name"] == "target-1"
 
     async def test_create_attack_stores_prepended_conversation(self, attack_service, mock_memory) -> None:
         """Test that create_attack stores prepended conversation messages."""

--- a/tests/unit/backend/test_mappers.py
+++ b/tests/unit/backend/test_mappers.py
@@ -51,6 +51,7 @@ def _make_attack_result(
     conversation_id: str = "attack-1",
     has_target: bool = True,
     target_identifier: ComponentIdentifier | None = None,
+    target_registry_name: str | None = None,
     name: str = "Test Attack",
     outcome: AttackOutcome = AttackOutcome.UNDETERMINED,
 ) -> AttackResult:
@@ -86,6 +87,7 @@ def _make_attack_result(
         metadata={
             "created_at": now.isoformat(),
             "updated_at": now.isoformat(),
+            **({"target_registry_name": target_registry_name} if target_registry_name else {}),
         },
         labels={"test_ar_label": "test_ar_value"},
     )
@@ -185,6 +187,24 @@ class TestAttackResultToSummary:
         assert summary.target.target_type == "RoundRobinTarget"
         assert summary.target.model_name is None
         assert summary.target.identifier_hash == target_identifier.hash
+
+    async def test_target_includes_persisted_registry_name(self) -> None:
+        """The registry alias is exposed as a lookup hint without changing canonical identity."""
+        ar = _make_attack_result(target_registry_name="configured-target")
+
+        summary = await attack_result_to_summary_async(ar, stats=ConversationStats(message_count=0))
+
+        assert summary.target is not None
+        assert summary.target.target_registry_name == "configured-target"
+
+    async def test_legacy_target_omits_registry_name(self) -> None:
+        """Attacks created before registry aliases were persisted remain backward compatible."""
+        ar = _make_attack_result()
+
+        summary = await attack_result_to_summary_async(ar, stats=ConversationStats(message_count=0))
+
+        assert summary.target is not None
+        assert summary.target.target_registry_name is None
 
     async def test_empty_pieces_gives_zero_messages(self) -> None:
         """Test mapping with no message pieces."""


### PR DESCRIPTION
## Description

Opening or reloading an existing conversation restored its messages but not its target, leaving the composer and mutation actions disabled. This change restores write capability only after the persisted attack target resolves to a currently registered root target with the same complete canonical identifier hash.

New GUI attacks now persist the registry alias used to create them as a backward-compatible lookup hint. Reloads first request that named target and enable writes only after exact full-hash validation. Legacy attacks, removed aliases, reused aliases with hash drift, and route-conflicting aliases fall back to complete paginated registry resolution with duplicate detection. Auth, network, and server failures remain read-only with retry rather than being masked. Explicitly selected different targets and the existing cross-target lock are preserved, and the backend retains its independent send-time hash guard. The alias is never authoritative, and localStorage is not used for target identity.

## Tests and Documentation

Added focused backend, unit, and component coverage for alias persistence and serialization, direct named lookup, legacy fallback, renamed/removed/reused aliases, malformed reserved-route responses, exact and near-duplicate hashes, duplicate identities, explicit cross-target selection, same-identity aliases, registry auth/5xx retry, pagination failures, stale route races, and Round Robin root versus inner identities. Added deterministic Playwright coverage for direct-link and reload restoration.

Validated with the affected backend suites (309 tests), focused frontend suites (213 tests), TypeScript type-check, ESLint, Ruff, ty, production build, and the isolated Playwright deep-link/reload scenario. Documentation changes were not required; JupyText was not applicable.