### PR TITLE
MAINT: Consolidate GCG attack manager logging

### DIFF
--- a/pyrit/executor/promptgen/gcg/attack/base/attack_manager.py
+++ b/pyrit/executor/promptgen/gcg/attack/base/attack_manager.py
@@ -72,6 +72,83 @@ class NpEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, o)
 
 
+def _filter_mpa_kwargs(**kwargs: Any) -> dict[str, Any]:
+    """Return options whose names use the ``mpa_`` prefix."""
+    return {key[4:]: value for key, value in kwargs.items() if key.startswith("mpa_")}
+
+
+def _initialize_attack_log(
+    *,
+    logfile: str | None,
+    goals: list[str],
+    targets: list[str],
+    test_goals: list[str],
+    test_targets: list[str],
+    control_init: str,
+    test_prefixes: list[str],
+    workers: list[ModelWorker],
+    test_workers: list[ModelWorker],
+    additional_params: dict[str, Any] | None = None,
+) -> None:
+    """Initialize an attack log while preserving its established JSON schema."""
+    if logfile is None:
+        return
+
+    with open(logfile, "w") as f:
+        params: dict[str, Any] = {
+            "goals": goals,
+            "targets": targets,
+            "test_goals": test_goals,
+            "test_targets": test_targets,
+        }
+        if additional_params:
+            params.update(additional_params)
+        params.update(
+            {
+                "control_init": control_init,
+                "test_prefixes": test_prefixes,
+                "models": [_get_worker_log_params(worker) for worker in workers],
+                "test_models": [_get_worker_log_params(worker) for worker in test_workers],
+            }
+        )
+
+        json.dump(
+            {
+                "params": params,
+                "controls": [],
+                "losses": [],
+                "runtimes": [],
+                "tests": [],
+            },
+            f,
+            indent=4,
+        )
+
+
+def _update_attack_log_params(*, logfile: str | None, params: dict[str, Any]) -> None:
+    """Add run parameters to an initialized attack log."""
+    if logfile is None:
+        return
+
+    with open(logfile) as f:
+        log = json.load(f)
+
+    for key, value in params.items():
+        log["params"][key] = value
+
+    with open(logfile, "w") as f:
+        json.dump(log, f, indent=4)
+
+
+def _get_worker_log_params(worker: ModelWorker) -> dict[str, Any]:
+    """Return the model metadata recorded for one worker."""
+    return {
+        "model_path": worker.model.name_or_path,
+        "tokenizer_path": worker.tokenizer.name_or_path,
+        "chat_template": worker.tokenizer.chat_template,
+    }
+
+
 def get_embedding_layer(model: Any) -> Any:
     """
     Return the token embedding layer for a supported causal language model.
@@ -1153,53 +1230,26 @@ class ProgressiveMultiPromptAttack:
         self.managers = managers
         self.mpa_kwargs = ProgressiveMultiPromptAttack.filter_mpa_kwargs(**kwargs)
 
-        if logfile is not None:
-            with open(logfile, "w") as f:
-                json.dump(
-                    {
-                        "params": {
-                            "goals": goals,
-                            "targets": targets,
-                            "test_goals": test_goals,
-                            "test_targets": test_targets,
-                            "progressive_goals": progressive_goals,
-                            "progressive_models": progressive_models,
-                            "control_init": control_init,
-                            "test_prefixes": test_prefixes,
-                            "models": [
-                                {
-                                    "model_path": worker.model.name_or_path,
-                                    "tokenizer_path": worker.tokenizer.name_or_path,
-                                    "chat_template": worker.tokenizer.chat_template,
-                                }
-                                for worker in self.workers
-                            ],
-                            "test_models": [
-                                {
-                                    "model_path": worker.model.name_or_path,
-                                    "tokenizer_path": worker.tokenizer.name_or_path,
-                                    "chat_template": worker.tokenizer.chat_template,
-                                }
-                                for worker in self.test_workers
-                            ],
-                        },
-                        "controls": [],
-                        "losses": [],
-                        "runtimes": [],
-                        "tests": [],
-                    },
-                    f,
-                    indent=4,
-                )
+        _initialize_attack_log(
+            logfile=logfile,
+            goals=goals,
+            targets=targets,
+            test_goals=test_goals,
+            test_targets=test_targets,
+            control_init=control_init,
+            test_prefixes=test_prefixes,
+            workers=self.workers,
+            test_workers=self.test_workers,
+            additional_params={
+                "progressive_goals": progressive_goals,
+                "progressive_models": progressive_models,
+            },
+        )
 
     @staticmethod
     def filter_mpa_kwargs(**kwargs: Any) -> dict[str, Any]:
         """Return options whose names use the ``mpa_`` prefix."""
-        mpa_kwargs: dict[str, Any] = {}
-        for key in kwargs:
-            if key.startswith("mpa_"):
-                mpa_kwargs[key[4:]] = kwargs[key]
-        return mpa_kwargs
+        return _filter_mpa_kwargs(**kwargs)
 
     def run(
         self,
@@ -1251,24 +1301,22 @@ class ProgressiveMultiPromptAttack:
         Returns:
             tuple[str, int]: The final control suffix and completed step count.
         """
-        if self.logfile is not None:
-            with open(self.logfile) as f:
-                log = json.load(f)
-
-            log["params"]["n_steps"] = n_steps
-            log["params"]["test_steps"] = test_steps
-            log["params"]["batch_size"] = batch_size
-            log["params"]["topk"] = topk
-            log["params"]["temp"] = temp
-            log["params"]["allow_non_ascii"] = allow_non_ascii
-            log["params"]["target_weight"] = target_weight
-            log["params"]["control_weight"] = control_weight
-            log["params"]["anneal"] = anneal
-            log["params"]["incr_control"] = incr_control
-            log["params"]["stop_on_success"] = stop_on_success
-
-            with open(self.logfile, "w") as f:
-                json.dump(log, f, indent=4)
+        _update_attack_log_params(
+            logfile=self.logfile,
+            params={
+                "n_steps": n_steps,
+                "test_steps": test_steps,
+                "batch_size": batch_size,
+                "topk": topk,
+                "temp": temp,
+                "allow_non_ascii": allow_non_ascii,
+                "target_weight": target_weight,
+                "control_weight": control_weight,
+                "anneal": anneal,
+                "incr_control": incr_control,
+                "stop_on_success": stop_on_success,
+            },
+        )
 
         num_goals = 1 if self.progressive_goals else len(self.goals)
         num_workers = 1 if self.progressive_models else len(self.workers)
@@ -1405,51 +1453,22 @@ class IndividualPromptAttack:
         self.managers = managers
         self.mpa_kwargs = IndividualPromptAttack.filter_mpa_kwargs(**kwargs)
 
-        if logfile is not None:
-            with open(logfile, "w") as f:
-                json.dump(
-                    {
-                        "params": {
-                            "goals": goals,
-                            "targets": targets,
-                            "test_goals": test_goals,
-                            "test_targets": test_targets,
-                            "control_init": control_init,
-                            "test_prefixes": test_prefixes,
-                            "models": [
-                                {
-                                    "model_path": worker.model.name_or_path,
-                                    "tokenizer_path": worker.tokenizer.name_or_path,
-                                    "chat_template": worker.tokenizer.chat_template,
-                                }
-                                for worker in self.workers
-                            ],
-                            "test_models": [
-                                {
-                                    "model_path": worker.model.name_or_path,
-                                    "tokenizer_path": worker.tokenizer.name_or_path,
-                                    "chat_template": worker.tokenizer.chat_template,
-                                }
-                                for worker in self.test_workers
-                            ],
-                        },
-                        "controls": [],
-                        "losses": [],
-                        "runtimes": [],
-                        "tests": [],
-                    },
-                    f,
-                    indent=4,
-                )
+        _initialize_attack_log(
+            logfile=logfile,
+            goals=goals,
+            targets=targets,
+            test_goals=test_goals,
+            test_targets=test_targets,
+            control_init=control_init,
+            test_prefixes=test_prefixes,
+            workers=self.workers,
+            test_workers=self.test_workers,
+        )
 
     @staticmethod
     def filter_mpa_kwargs(**kwargs: Any) -> dict[str, Any]:
         """Return options whose names use the ``mpa_`` prefix."""
-        mpa_kwargs: dict[str, Any] = {}
-        for key in kwargs:
-            if key.startswith("mpa_"):
-                mpa_kwargs[key[4:]] = kwargs[key]
-        return mpa_kwargs
+        return _filter_mpa_kwargs(**kwargs)
 
     def run(
         self,
@@ -1501,24 +1520,22 @@ class IndividualPromptAttack:
         Returns:
             tuple[str, int]: The final control suffix and configured step count.
         """
-        if self.logfile is not None:
-            with open(self.logfile) as f:
-                log = json.load(f)
-
-            log["params"]["n_steps"] = n_steps
-            log["params"]["test_steps"] = test_steps
-            log["params"]["batch_size"] = batch_size
-            log["params"]["topk"] = topk
-            log["params"]["temp"] = temp
-            log["params"]["allow_non_ascii"] = allow_non_ascii
-            log["params"]["target_weight"] = target_weight
-            log["params"]["control_weight"] = control_weight
-            log["params"]["anneal"] = anneal
-            log["params"]["incr_control"] = incr_control
-            log["params"]["stop_on_success"] = stop_on_success
-
-            with open(self.logfile, "w") as f:
-                json.dump(log, f, indent=4)
+        _update_attack_log_params(
+            logfile=self.logfile,
+            params={
+                "n_steps": n_steps,
+                "test_steps": test_steps,
+                "batch_size": batch_size,
+                "topk": topk,
+                "temp": temp,
+                "allow_non_ascii": allow_non_ascii,
+                "target_weight": target_weight,
+                "control_weight": control_weight,
+                "anneal": anneal,
+                "incr_control": incr_control,
+                "stop_on_success": stop_on_success,
+            },
+        )
 
         stop_inner_on_success = stop_on_success
 
@@ -1630,51 +1647,22 @@ class EvaluateAttack:
         if len(self.workers) != 1:
             raise ValueError("EvaluateAttack requires exactly 1 worker")
 
-        if logfile is not None:
-            with open(logfile, "w") as f:
-                json.dump(
-                    {
-                        "params": {
-                            "goals": goals,
-                            "targets": targets,
-                            "test_goals": test_goals,
-                            "test_targets": test_targets,
-                            "control_init": control_init,
-                            "test_prefixes": test_prefixes,
-                            "models": [
-                                {
-                                    "model_path": worker.model.name_or_path,
-                                    "tokenizer_path": worker.tokenizer.name_or_path,
-                                    "chat_template": worker.tokenizer.chat_template,
-                                }
-                                for worker in self.workers
-                            ],
-                            "test_models": [
-                                {
-                                    "model_path": worker.model.name_or_path,
-                                    "tokenizer_path": worker.tokenizer.name_or_path,
-                                    "chat_template": worker.tokenizer.chat_template,
-                                }
-                                for worker in self.test_workers
-                            ],
-                        },
-                        "controls": [],
-                        "losses": [],
-                        "runtimes": [],
-                        "tests": [],
-                    },
-                    f,
-                    indent=4,
-                )
+        _initialize_attack_log(
+            logfile=logfile,
+            goals=goals,
+            targets=targets,
+            test_goals=test_goals,
+            test_targets=test_targets,
+            control_init=control_init,
+            test_prefixes=test_prefixes,
+            workers=self.workers,
+            test_workers=self.test_workers,
+        )
 
     @staticmethod
     def filter_mpa_kwargs(**kwargs: Any) -> dict[str, Any]:
         """Return options whose names use the ``mpa_`` prefix."""
-        mpa_kwargs: dict[str, Any] = {}
-        for key in kwargs:
-            if key.startswith("mpa_"):
-                mpa_kwargs[key[4:]] = kwargs[key]
-        return mpa_kwargs
+        return _filter_mpa_kwargs(**kwargs)
 
     @torch.no_grad()  # type: ignore[misc, untyped-decorator, unused-ignore]
     def run(
@@ -1698,14 +1686,7 @@ class EvaluateAttack:
         model, tokenizer = self.workers[0].model, self.workers[0].tokenizer
         tokenizer.padding_side = "left"
 
-        if self.logfile is not None:
-            with open(self.logfile) as f:
-                log = json.load(f)
-
-            log["params"]["num_tests"] = len(controls)
-
-            with open(self.logfile, "w") as f:
-                json.dump(log, f, indent=4)
+        _update_attack_log_params(logfile=self.logfile, params={"num_tests": len(controls)})
 
         total_jb, total_em, total_outputs = [], [], []
         test_total_jb, test_total_em, test_total_outputs = [], [], []

--- a/pyrit/executor/promptgen/gcg/attack/base/attack_manager.py
+++ b/pyrit/executor/promptgen/gcg/attack/base/attack_manager.py
@@ -72,11 +72,6 @@ class NpEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, o)
 
 
-def _filter_mpa_kwargs(**kwargs: Any) -> dict[str, Any]:
-    """Return options whose names use the ``mpa_`` prefix."""
-    return {key[4:]: value for key, value in kwargs.items() if key.startswith("mpa_")}
-
-
 def _initialize_attack_log(
     *,
     logfile: str | None,
@@ -1249,7 +1244,7 @@ class ProgressiveMultiPromptAttack:
     @staticmethod
     def filter_mpa_kwargs(**kwargs: Any) -> dict[str, Any]:
         """Return options whose names use the ``mpa_`` prefix."""
-        return _filter_mpa_kwargs(**kwargs)
+        return {key[4:]: value for key, value in kwargs.items() if key.startswith("mpa_")}
 
     def run(
         self,
@@ -1468,7 +1463,7 @@ class IndividualPromptAttack:
     @staticmethod
     def filter_mpa_kwargs(**kwargs: Any) -> dict[str, Any]:
         """Return options whose names use the ``mpa_`` prefix."""
-        return _filter_mpa_kwargs(**kwargs)
+        return {key[4:]: value for key, value in kwargs.items() if key.startswith("mpa_")}
 
     def run(
         self,
@@ -1662,7 +1657,7 @@ class EvaluateAttack:
     @staticmethod
     def filter_mpa_kwargs(**kwargs: Any) -> dict[str, Any]:
         """Return options whose names use the ``mpa_`` prefix."""
-        return _filter_mpa_kwargs(**kwargs)
+        return {key[4:]: value for key, value in kwargs.items() if key.startswith("mpa_")}
 
     @torch.no_grad()  # type: ignore[misc, untyped-decorator, unused-ignore]
     def run(

--- a/tests/unit/executor/promptgen/gcg/test_multi_prompt_attack.py
+++ b/tests/unit/executor/promptgen/gcg/test_multi_prompt_attack.py
@@ -2,6 +2,11 @@
 # Licensed under the MIT license.
 
 
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
 import numpy as np
 import pytest
 
@@ -12,6 +17,218 @@ attack_manager_mod = pytest.importorskip(
 IndividualPromptAttack = attack_manager_mod.IndividualPromptAttack
 MultiPromptAttack = attack_manager_mod.MultiPromptAttack
 ProgressiveMultiPromptAttack = attack_manager_mod.ProgressiveMultiPromptAttack
+EvaluateAttack = attack_manager_mod.EvaluateAttack
+
+
+class _StubMultiPromptAttack:
+    def run(self, **kwargs: Any) -> tuple[str, float, int]:
+        return "updated control", 0.5, 1
+
+
+class _RecordingMultiPromptAttackFactory:
+    def __init__(self, *, logfile: Path) -> None:
+        self._logfile = logfile
+        self.params_at_creation: dict[str, Any] | None = None
+
+    def __call__(self, *args: Any) -> _StubMultiPromptAttack:
+        with self._logfile.open() as f:
+            self.params_at_creation = json.load(f)["params"]
+        return _StubMultiPromptAttack()
+
+
+def _make_worker(*, name: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        model=SimpleNamespace(name_or_path=f"{name}-model"),
+        tokenizer=SimpleNamespace(name_or_path=f"{name}-tokenizer", chat_template=f"{name}-template"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("attack_class", "additional_kwargs", "expected_param_keys"),
+    [
+        (
+            IndividualPromptAttack,
+            {},
+            [
+                "goals",
+                "targets",
+                "test_goals",
+                "test_targets",
+                "control_init",
+                "test_prefixes",
+                "models",
+                "test_models",
+            ],
+        ),
+        (
+            ProgressiveMultiPromptAttack,
+            {"progressive_goals": False, "progressive_models": True},
+            [
+                "goals",
+                "targets",
+                "test_goals",
+                "test_targets",
+                "progressive_goals",
+                "progressive_models",
+                "control_init",
+                "test_prefixes",
+                "models",
+                "test_models",
+            ],
+        ),
+        (
+            EvaluateAttack,
+            {},
+            [
+                "goals",
+                "targets",
+                "test_goals",
+                "test_targets",
+                "control_init",
+                "test_prefixes",
+                "models",
+                "test_models",
+            ],
+        ),
+    ],
+)
+def test_attack_manager_initializes_exact_log_schema(
+    *,
+    tmp_path: Path,
+    attack_class: type[Any],
+    additional_kwargs: dict[str, Any],
+    expected_param_keys: list[str],
+) -> None:
+    logfile = tmp_path / "attack.json"
+
+    attack_class(
+        goals=["goal"],
+        targets=["target"],
+        workers=[_make_worker(name="train")],
+        control_init="control",
+        test_prefixes=["prefix"],
+        logfile=str(logfile),
+        managers={"MPA": _StubMultiPromptAttack},
+        test_goals=["test goal"],
+        test_targets=["test target"],
+        test_workers=[_make_worker(name="test")],
+        **additional_kwargs,
+    )
+
+    with logfile.open() as f:
+        log = json.load(f)
+
+    assert list(log) == ["params", "controls", "losses", "runtimes", "tests"]
+    assert list(log["params"]) == expected_param_keys
+    assert log["params"]["models"] == [
+        {
+            "model_path": "train-model",
+            "tokenizer_path": "train-tokenizer",
+            "chat_template": "train-template",
+        }
+    ]
+    assert log["params"]["test_models"] == [
+        {
+            "model_path": "test-model",
+            "tokenizer_path": "test-tokenizer",
+            "chat_template": "test-template",
+        }
+    ]
+    assert log["controls"] == []
+    assert log["losses"] == []
+    assert log["runtimes"] == []
+    assert log["tests"] == []
+
+
+@pytest.mark.parametrize(
+    ("attack_class", "additional_kwargs"),
+    [
+        (IndividualPromptAttack, {}),
+        (
+            ProgressiveMultiPromptAttack,
+            {"progressive_goals": False, "progressive_models": False},
+        ),
+    ],
+)
+def test_attack_manager_records_run_params_before_creating_mpa(
+    *,
+    tmp_path: Path,
+    attack_class: type[Any],
+    additional_kwargs: dict[str, Any],
+) -> None:
+    logfile = tmp_path / "attack.json"
+    factory = _RecordingMultiPromptAttackFactory(logfile=logfile)
+    attack = attack_class(
+        goals=["goal"],
+        targets=["target"],
+        workers=[_make_worker(name="train")],
+        logfile=str(logfile),
+        managers={"MPA": factory},
+        **additional_kwargs,
+    )
+
+    attack.run(
+        n_steps=1,
+        batch_size=2,
+        topk=3,
+        temp=0.5,
+        allow_non_ascii=False,
+        target_weight=0.75,
+        control_weight=0.25,
+        anneal=False,
+        test_steps=4,
+        incr_control=False,
+        stop_on_success=False,
+        verbose=False,
+        filter_cand=False,
+    )
+
+    assert factory.params_at_creation is not None
+    assert list(factory.params_at_creation)[-11:] == [
+        "n_steps",
+        "test_steps",
+        "batch_size",
+        "topk",
+        "temp",
+        "allow_non_ascii",
+        "target_weight",
+        "control_weight",
+        "anneal",
+        "incr_control",
+        "stop_on_success",
+    ]
+    assert {key: factory.params_at_creation[key] for key in list(factory.params_at_creation)[-11:]} == {
+        "n_steps": 1,
+        "test_steps": 4,
+        "batch_size": 2,
+        "topk": 3,
+        "temp": 0.5,
+        "allow_non_ascii": False,
+        "target_weight": 0.75,
+        "control_weight": 0.25,
+        "anneal": False,
+        "incr_control": False,
+        "stop_on_success": False,
+    }
+
+
+def test_evaluate_attack_records_test_count_and_empty_result_contract(tmp_path: Path) -> None:
+    logfile = tmp_path / "attack.json"
+    attack = EvaluateAttack(
+        goals=["goal"],
+        targets=["target"],
+        workers=[_make_worker(name="train")],
+        logfile=str(logfile),
+        managers={"MPA": _StubMultiPromptAttack},
+    )
+
+    result = attack.run(steps=0, controls=[], batch_size=1, verbose=False)
+
+    with logfile.open() as f:
+        params = json.load(f)["params"]
+    assert list(params)[-1] == "num_tests"
+    assert params["num_tests"] == 0
+    assert result == ([], [], [], [], [], [])
 
 
 class TestFilterMpaKwargs:


### PR DESCRIPTION
## Description

The GCG attack-manager variants duplicated JSON log initialization and parameter updates, allowing their schemas and recorded run metadata to drift. This consolidates that behavior into shared helpers so individual, progressive, and evaluation attacks initialize the same structured log, capture model and tokenizer metadata consistently, and persist run parameters before constructing the multi-prompt attack.

The evaluation path also records the test count and preserves a stable empty-result contract when no controls are supplied. Unit coverage verifies the exact schemas, update ordering, filtering behavior, and result partitioning.

## Tests and Documentation

- Added targeted unit coverage in `tests/unit/executor/promptgen/gcg/test_multi_prompt_attack.py`.
- `uv run pytest tests\unit\executor\promptgen\gcg\test_multi_prompt_attack.py -q -rs` was attempted locally; the module was skipped because the optional GCG dependencies (`torch`, `mlflow`, etc.) are not installed.
- Documentation changes are not applicable.