### PR TITLE
Add confirmation dialog before removing an initializer

### DIFF
--- a/frontend/src/components/ConfirmDialog.test.tsx
+++ b/frontend/src/components/ConfirmDialog.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FluentProvider, webLightTheme } from '@fluentui/react-components'
+
+import ConfirmDialog from './ConfirmDialog'
+
+const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <FluentProvider theme={webLightTheme}>{children}</FluentProvider>
+)
+
+describe('ConfirmDialog', () => {
+  const defaultProps = {
+    open: true,
+    title: 'Delete item',
+    onConfirm: jest.fn(),
+    onCancel: jest.fn(),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render title and content when open', () => {
+    render(
+      <TestWrapper>
+        <ConfirmDialog {...defaultProps}>Are you sure?</ConfirmDialog>
+      </TestWrapper>,
+    )
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('Delete item')).toBeInTheDocument()
+    expect(screen.getByText('Are you sure?')).toBeInTheDocument()
+  })
+
+  it('should not render when closed', () => {
+    render(
+      <TestWrapper>
+        <ConfirmDialog {...defaultProps} open={false}>Are you sure?</ConfirmDialog>
+      </TestWrapper>,
+    )
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('should call onConfirm when confirm button is clicked', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <TestWrapper>
+        <ConfirmDialog {...defaultProps}>Are you sure?</ConfirmDialog>
+      </TestWrapper>,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Confirm' }))
+
+    expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1)
+    expect(defaultProps.onCancel).not.toHaveBeenCalled()
+  })
+
+  it('should call onCancel when cancel button is clicked', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <TestWrapper>
+        <ConfirmDialog {...defaultProps}>Are you sure?</ConfirmDialog>
+      </TestWrapper>,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(defaultProps.onCancel).toHaveBeenCalledTimes(1)
+    expect(defaultProps.onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('should use custom button labels', () => {
+    render(
+      <TestWrapper>
+        <ConfirmDialog {...defaultProps} confirmLabel="Remove" cancelLabel="Keep">
+          Content
+        </ConfirmDialog>
+      </TestWrapper>,
+    )
+
+    expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Keep' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,0 +1,44 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogBody,
+  DialogContent,
+  DialogSurface,
+  DialogTitle,
+} from '@fluentui/react-components'
+
+interface ConfirmDialogProps {
+  open: boolean
+  title: string
+  confirmLabel?: string
+  cancelLabel?: string
+  onConfirm: () => void
+  onCancel: () => void
+  children: React.ReactNode
+}
+
+export default function ConfirmDialog({
+  open,
+  title,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  onConfirm,
+  onCancel,
+  children,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={(_e, data) => { if (!data.open) onCancel() }}>
+      <DialogSurface>
+        <DialogBody>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogContent>{children}</DialogContent>
+          <DialogActions>
+            <Button appearance="secondary" onClick={onCancel}>{cancelLabel}</Button>
+            <Button appearance="primary" onClick={onConfirm}>{confirmLabel}</Button>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/Initializers/AdditionalInitializers.test.tsx
+++ b/frontend/src/components/Initializers/AdditionalInitializers.test.tsx
@@ -227,7 +227,7 @@ describe('AdditionalInitializers', () => {
     expect(defaultProps.onApply).toHaveBeenCalledWith('additional-1', 'target', { tags: ['default'] })
   })
 
-  it('should call onRemove with the additional initializer id', async () => {
+  it('should call onRemove with the additional initializer id after confirming', async () => {
     const user = userEvent.setup()
 
     render(
@@ -238,7 +238,30 @@ describe('AdditionalInitializers', () => {
 
     await user.click(within(screen.getByTestId('initializer-row-additional-1')).getByRole('button', { name: 'Remove' }))
 
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText(/remove the/i)).toBeInTheDocument()
+    expect(within(dialog).getByText('target')).toBeInTheDocument()
+
+    await user.click(within(dialog).getByRole('button', { name: 'Remove' }))
+
     expect(defaultProps.onRemove).toHaveBeenCalledWith('additional-1')
+  })
+
+  it('should not call onRemove when the confirmation dialog is cancelled', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <TestWrapper>
+        <AdditionalInitializers {...defaultProps} />
+      </TestWrapper>,
+    )
+
+    await user.click(within(screen.getByTestId('initializer-row-additional-1')).getByRole('button', { name: 'Remove' }))
+
+    const dialog = await screen.findByRole('dialog')
+    await user.click(within(dialog).getByRole('button', { name: 'Cancel' }))
+
+    expect(defaultProps.onRemove).not.toHaveBeenCalled()
   })
 
   it('should show a validation error when a required parameter is missing', async () => {

--- a/frontend/src/components/Initializers/AdditionalInitializers.tsx
+++ b/frontend/src/components/Initializers/AdditionalInitializers.tsx
@@ -1,6 +1,11 @@
 import { useState } from 'react'
 
-import { Button, Select, Text, Tooltip } from '@fluentui/react-components'
+import {
+  Button,
+  Select,
+  Text,
+  Tooltip,
+} from '@fluentui/react-components'
 import { AddRegular } from '@fluentui/react-icons'
 
 import type {
@@ -14,6 +19,7 @@ import { formatInitializerParameters, formatSupportedParameterSummary } from './
 import { resolveRegisteredInitializer } from './initializerLookup'
 import InitializerParametersDialog from './InitializerParametersDialog'
 import { useInitializersStyles } from './Initializers.styles'
+import ConfirmDialog from '../ConfirmDialog'
 
 interface AdditionalInitializersProps {
   items: AdditionalInitializerSetting[]
@@ -51,6 +57,7 @@ function AdditionalInitializerCard({
 }: AdditionalInitializerCardProps) {
   const styles = useAdditionalInitializersStyles()
   const [editOpen, setEditOpen] = useState(false)
+  const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false)
   const isBusy = isSaving || isApplying || isDeleting
 
   const handleEditSubmit = async (parameters: Record<string, unknown> | null): Promise<void> => {
@@ -97,10 +104,23 @@ function AdditionalInitializerCard({
         >
           {isApplying ? 'Applying...' : 'Apply now'}
         </Button>
-        <Button appearance="subtle" onClick={() => void onRemove(item.id)} disabled={isBusy}>
+        <Button appearance="subtle" onClick={() => setConfirmRemoveOpen(true)} disabled={isBusy}>
           {isDeleting ? 'Removing...' : 'Remove'}
         </Button>
       </div>
+
+      <ConfirmDialog
+        open={confirmRemoveOpen}
+        title="Remove initializer"
+        confirmLabel="Remove"
+        onConfirm={() => {
+          setConfirmRemoveOpen(false)
+          void onRemove(item.id)
+        }}
+        onCancel={() => setConfirmRemoveOpen(false)}
+      >
+        Are you sure you want to remove the <Text weight="semibold">{item.initializer_name}</Text> initializer? This action cannot be undone.
+      </ConfirmDialog>
 
       {editOpen && (
         <InitializerParametersDialog

--- a/frontend/src/components/Initializers/Initializers.test.tsx
+++ b/frontend/src/components/Initializers/Initializers.test.tsx
@@ -266,6 +266,9 @@ describe('Initializers', () => {
     const row = await screen.findByTestId('initializer-row-additional-1')
     await user.click(within(row).getByRole('button', { name: 'Remove' }))
 
+    const dialog = await screen.findByRole('dialog')
+    await user.click(within(dialog).getByRole('button', { name: 'Remove' }))
+
     await waitFor(() => {
       expect(mockedInitializersApi.deleteAdditional).toHaveBeenCalledWith('additional-1')
       expect(screen.getByText('Removed additional initializer.')).toBeInTheDocument()


### PR DESCRIPTION
Fixes #2349

Clicking "Remove" on an initializer now shows a confirmation dialog instead of immediately deleting it. Also adds a reusable `ConfirmDialog` component for any future destructive actions that need a safety net.

<img width="1397" height="1096" alt="image" src="https://github.com/user-attachments/assets/6c44d384-8009-4bbb-a4c2-0249d0be4fe7" />
