### PR TITLE
FEAT: add OrcaRouter as a named OpenAI-compatible target

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -132,6 +132,10 @@ OPEN_ROUTER_ENDPOINT="https://openrouter.ai/api/v1"
 OPEN_ROUTER_KEY="sk-or-v1-xxxxx"
 OPEN_ROUTER_CLAUDE_MODEL="anthropic/claude-3.7-sonnet"
 
+ORCA_ROUTER_ENDPOINT="https://api.orcarouter.ai/v1"
+ORCA_ROUTER_KEY="sk-orca-xxxxx"
+ORCA_ROUTER_MODEL="orcarouter/auto"
+
 OLLAMA_CHAT_ENDPOINT="http://127.0.0.1:11434/v1"
 OLLAMA_MODEL="llama2"
 

--- a/doc/getting_started/populating_secrets.md
+++ b/doc/getting_started/populating_secrets.md
@@ -83,6 +83,16 @@ OPENAI_CHAT_MODEL="anthropic/claude-3.7-sonnet"
 Get your API key from [openrouter.ai](https://openrouter.ai/).
 :::
 
+:::{tab-item} OrcaRouter
+```bash
+OPENAI_CHAT_ENDPOINT="https://api.orcarouter.ai/v1"
+OPENAI_CHAT_KEY="sk-orca-your-key-here"
+OPENAI_CHAT_MODEL="orcarouter/auto"
+```
+
+Get your API key from [orcarouter.ai](https://www.orcarouter.ai/).
+:::
+
 ::::
 
 ```{note}

--- a/pyrit/setup/initializers/targets.py
+++ b/pyrit/setup/initializers/targets.py
@@ -267,6 +267,13 @@ ENV_TARGET_CONFIGS: list[TargetConfig] = [
         model_var="OPEN_ROUTER_CLAUDE_MODEL",
     ),
     TargetConfig(
+        registry_name="orca_router",
+        target_class=OpenAIChatTarget,
+        endpoint_var="ORCA_ROUTER_ENDPOINT",
+        key_var="ORCA_ROUTER_KEY",
+        model_var="ORCA_ROUTER_MODEL",
+    ),
+    TargetConfig(
         registry_name="ollama",
         target_class=OpenAIChatTarget,
         endpoint_var="OLLAMA_CHAT_ENDPOINT",
@@ -497,6 +504,7 @@ class TargetInitializer(PyRITInitializer):
     - AZURE_FOUNDRY_MISTRAL_LARGE_* - Azure AI Foundry Mistral Large
     - GROQ_* - Groq API
     - OPEN_ROUTER_* - OpenRouter API
+    - ORCA_ROUTER_* - OrcaRouter API
     - OLLAMA_* - Ollama local
     - GOOGLE_GEMINI_* - Google Gemini (OpenAI-compatible)
 

--- a/tests/integration/targets/test_targets_and_secrets.py
+++ b/tests/integration/targets/test_targets_and_secrets.py
@@ -1071,6 +1071,7 @@ async def test_openai_chat_target_with_sync_token_provider(sqlite_instance: SQLi
     [
         ("GROQ_ENDPOINT", "GROQ_KEY", "GROQ_LLAMA_MODEL"),
         ("OPEN_ROUTER_ENDPOINT", "OPEN_ROUTER_KEY", "OPEN_ROUTER_CLAUDE_MODEL"),
+        ("ORCA_ROUTER_ENDPOINT", "ORCA_ROUTER_KEY", "ORCA_ROUTER_MODEL"),
         ("OLLAMA_CHAT_ENDPOINT", "", "OLLAMA_MODEL"),
     ],
 )

--- a/tests/unit/setup/test_targets_initializer.py
+++ b/tests/unit/setup/test_targets_initializer.py
@@ -157,6 +157,21 @@ class TestTargetInitializerInitialize:
         assert target is not None
         assert target._model_name == "llama2"
 
+    async def test_registers_orca_router_with_env_vars(self):
+        """Test that the OrcaRouter target is registered when its env vars are set."""
+        os.environ["ORCA_ROUTER_ENDPOINT"] = "https://api.orcarouter.ai/v1"
+        os.environ["ORCA_ROUTER_KEY"] = "test_key"
+        os.environ["ORCA_ROUTER_MODEL"] = "orcarouter/auto"
+
+        init = TargetInitializer()
+        await init.initialize_async()
+
+        registry = TargetRegistry.get_registry_singleton()
+        assert "orca_router" in registry.instances
+        target = registry.instances.get("orca_router")
+        assert target is not None
+        assert target._model_name == "orcarouter/auto"
+
     async def test_azure_target_uses_entra_auth(self):
         """Test that Azure targets use Entra auth (token provider) instead of API key."""
         os.environ["AZURE_OPENAI_GPT4O_ENDPOINT"] = "https://my-deployment.openai.azure.com/openai/v1"
@@ -205,6 +220,7 @@ class TestTargetInitializerTargetConfigs:
         assert "ollama" in registry_names
         assert "groq" in registry_names
         assert "google_gemini" in registry_names
+        assert "orca_router" in registry_names
 
     def test_target_configs_have_unique_registry_names(self):
         """Guard against typos: every ``registry_name`` in ``ENV_TARGET_CONFIGS`` must be unique.


### PR DESCRIPTION
## Description

This registers [OrcaRouter](https://www.orcarouter.ai) the same way the existing `open_router` provider is wired in the environment-variable-driven `TargetInitializer`, so the registry, `.env_example`, docs and tests stay consistent. OrcaRouter is an OpenAI-compatible gateway: one `ORCA_ROUTER_API_KEY` (keys start with `sk-orca-`) unlocks 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single `https://api.orcarouter.ai/v1` endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Specifically:

- `pyrit/setup/initializers/targets.py`: add an `orca_router` `TargetConfig` mirroring the existing `open_router` entry (`OpenAIChatTarget` driven by `ORCA_ROUTER_ENDPOINT` / `ORCA_ROUTER_KEY` / `ORCA_ROUTER_MODEL`), plus a line for the new endpoint in the initializer's supported-endpoints docstring.
- `.env_example`: document the `ORCA_ROUTER_*` variables next to the existing `OPEN_ROUTER_*` block.
- `doc/getting_started/populating_secrets.md`: add an OrcaRouter tab alongside the OpenRouter tab.
- Tests: unit coverage in `tests/unit/setup/test_targets_initializer.py` (expected-config assertion + registration-from-env-vars test) and an entry in the optional live-connection integration test in `tests/integration/targets/test_targets_and_secrets.py`.

I'm an engineer on the OrcaRouter team.

## Tests and Documentation

- `tests/unit/setup/test_targets_initializer.py`: 60 passed, including the new `orca_router` registration test.
- `tests/unit/registry/` + `tests/unit/setup/`: 738 passed.
- `ruff check` and `ruff format --check`: clean on all changed files.
- Live check against the real OrcaRouter API (`https://api.orcarouter.ai/v1`, model `orcarouter/auto`): the `TargetInitializer` registers the `orca_router` target and `OpenAIChatTarget` returns a normal completion (`response_error='none'`).
- Documentation updated: `.env_example`, `doc/getting_started/populating_secrets.md`, and the `TargetInitializer` docstring.
