### PR TITLE
FIX: keep saved initializer settings visible when catalog loading fails

### DIFF
--- a/frontend/src/components/Initializers/Initializers.test.tsx
+++ b/frontend/src/components/Initializers/Initializers.test.tsx
@@ -259,6 +259,16 @@ describe('Initializers', () => {
     expect(within(baselineRow).queryByRole('button', { name: 'Apply now' })).not.toBeInTheDocument()
   })
 
+  it('should keep saved settings visible when catalog loading fails', async () => {
+    mockedInitializersApi.listRegistered.mockRejectedValue(new Error('Service Unavailable'))
+
+    renderInitializers()
+
+    expect(await screen.findByTestId('baseline-initializer-row-target')).toBeInTheDocument()
+    expect(screen.getByTestId('initializer-row-additional-1')).toBeInTheDocument()
+    expect(screen.getByText('Service Unavailable')).toBeInTheDocument()
+  })
+
   it('should remove an additional initializer and show success feedback', async () => {
     const user = userEvent.setup()
     renderInitializers()

--- a/frontend/src/components/Initializers/Initializers.tsx
+++ b/frontend/src/components/Initializers/Initializers.tsx
@@ -38,26 +38,32 @@ export default function Initializers() {
     let cancelled = false
 
     const loadInitializersAsync = async (): Promise<void> => {
-      try {
-        const [settingsResponse, registeredResponse] = await Promise.all([
-          initializersApi.getSettings(),
-          initializersApi.listRegistered(),
-        ])
-        if (cancelled) {
-          return
-        }
-        setSettings(settingsResponse)
-        setRegisteredInitializers(registeredResponse.items)
-      } catch (error) {
-        if (cancelled) {
-          return
-        }
-        setStatusMessage({ intent: 'error', text: toApiError(error).detail })
-      } finally {
-        if (!cancelled) {
-          setLoading(false)
-        }
+      const [settingsResult, registeredResult] = await Promise.allSettled([
+        initializersApi.getSettings(),
+        initializersApi.listRegistered(),
+      ])
+      if (cancelled) {
+        return
       }
+
+      if (settingsResult.status === 'fulfilled') {
+        setSettings(settingsResult.value)
+      } else {
+        setStatusMessage({ intent: 'error', text: toApiError(settingsResult.reason).detail })
+      }
+
+      if (registeredResult.status === 'fulfilled') {
+        setRegisteredInitializers(registeredResult.value.items)
+      } else {
+        const catalogError = toApiError(registeredResult.reason).detail
+        setStatusMessage((current: StatusMessage | null) =>
+          current
+            ? { intent: 'error', text: `${current.text} ${catalogError}` }
+            : { intent: 'error', text: catalogError },
+        )
+      }
+
+      setLoading(false)
     }
 
     void loadInitializersAsync()


### PR DESCRIPTION
Uses `Promise.allSettled` instead of `Promise.all` so a catalog endpoint failure doesn't clear successfully fetched settings from the UI.

Fixes #2348