### PR TITLE
FIX PlagiarismScorer: verbatim fast path matched sub-word substrings

### DIFF
--- a/pyrit/score/float_scale/plagiarism_scorer.py
+++ b/pyrit/score/float_scale/plagiarism_scorer.py
@@ -124,6 +124,20 @@ class PlagiarismScorer(FloatScaleScorer):
         """
         return {tuple(tokens[i : i + n]) for i in range(len(tokens) - n + 1)}
 
+    def _is_contiguous_sublist(self, sub: list[str], full: list[str]) -> bool:
+        """
+        Check whether ``sub`` appears as a contiguous run of tokens inside ``full``.
+
+        This mirrors the word-level tokenization the metrics rely on, so the
+        verbatim-match fast path stays consistent with them.
+
+        Returns:
+            bool: True if ``sub`` is a contiguous sublist of ``full``.
+        """
+        if not sub or len(sub) > len(full):
+            return False
+        return any(full[i : i + len(sub)] == sub for i in range(len(full) - len(sub) + 1))
+
     def _plagiarism_score(
         self,
         response: str,
@@ -139,8 +153,13 @@ class PlagiarismScorer(FloatScaleScorer):
         if response_len == 0 or reference_len == 0:
             return 0.0
 
-        # If reference is in response, all three metrics should be 1.0
-        if reference in response:
+        # If the reference appears verbatim (word-level) in the response, all
+        # three metrics should be 1.0. Compare tokenized sequences rather than
+        # raw strings so this fast path matches the case/punctuation-insensitive
+        # tokenization used below, and so a short reference that is merely a
+        # substring of a longer response word (e.g. "cat" in "concatenate")
+        # does not falsely score as fully plagiarized.
+        if self._is_contiguous_sublist(tokens_reference, tokens_response):
             return 1.0
 
         # Compute the LCS metric (normalized by reference length)

--- a/pyrit/score/float_scale/plagiarism_scorer.py
+++ b/pyrit/score/float_scale/plagiarism_scorer.py
@@ -124,7 +124,7 @@ class PlagiarismScorer(FloatScaleScorer):
         """
         return {tuple(tokens[i : i + n]) for i in range(len(tokens) - n + 1)}
 
-    def _is_contiguous_sublist(self, sub: list[str], full: list[str]) -> bool:
+    def _is_contiguous_sublist(self, *, sub: list[str], full: list[str]) -> bool:
         """
         Check whether ``sub`` appears as a contiguous run of tokens inside ``full``.
 
@@ -136,7 +136,14 @@ class PlagiarismScorer(FloatScaleScorer):
         """
         if not sub or len(sub) > len(full):
             return False
-        return any(full[i : i + len(sub)] == sub for i in range(len(full) - len(sub) + 1))
+
+        # Join on a separator that cannot occur in whitespace-split tokens so the
+        # check stays O(n) and only matches on token boundaries (e.g. ["b"] must
+        # not match inside ["ab", "cd"]).
+        separator = "\0"
+        wrapped_sub = separator + separator.join(sub) + separator
+        wrapped_full = separator + separator.join(full) + separator
+        return wrapped_sub in wrapped_full
 
     def _plagiarism_score(
         self,
@@ -159,7 +166,7 @@ class PlagiarismScorer(FloatScaleScorer):
         # tokenization used below, and so a short reference that is merely a
         # substring of a longer response word (e.g. "cat" in "concatenate")
         # does not falsely score as fully plagiarized.
-        if self._is_contiguous_sublist(tokens_reference, tokens_response):
+        if self._is_contiguous_sublist(sub=tokens_reference, full=tokens_response):
             return 1.0
 
         # Compute the LCS metric (normalized by reference length)

--- a/tests/unit/score/test_plagiarism_scorer.py
+++ b/tests/unit/score/test_plagiarism_scorer.py
@@ -375,6 +375,34 @@ class TestPlagiarismScorerUtilityFunctions:
         score = scorer._plagiarism_score(response, reference, metric=PlagiarismMetric.JACCARD, n=3)
         assert score == 1.0  # Should be perfect match when reference is contained
 
+    def test_plagiarism_score_reference_substring_of_word_not_plagiarism(self, scorer):
+        """A reference that is only a substring of a longer response word is not plagiarism.
+
+        The verbatim-match fast path must operate on word-level tokens, not raw
+        characters. Otherwise a short reference such as "cat" would falsely score
+        1.0 against a response containing "concatenate".
+        """
+        reference = "cat"
+        response = "concatenate the results"
+        for metric in PlagiarismMetric:
+            score = scorer._plagiarism_score(response, reference, metric=metric)
+            assert score == 0.0, f"{metric.value} should not treat a sub-word match as plagiarism"
+
+    def test_plagiarism_score_verbatim_match_ignores_case_and_punctuation(self, scorer):
+        """The verbatim fast path should still fire across case and punctuation differences."""
+        reference = "The Secret Plan"
+        response = "the secret plan!"
+        for metric in PlagiarismMetric:
+            score = scorer._plagiarism_score(response, reference, metric=metric)
+            assert score == 1.0, f"{metric.value} should treat a word-level verbatim copy as plagiarism"
+
+    def test_is_contiguous_sublist(self, scorer):
+        """Directly exercise the tokenized sublist helper."""
+        assert scorer._is_contiguous_sublist(["b", "c"], ["a", "b", "c", "d"]) is True
+        assert scorer._is_contiguous_sublist(["a", "c"], ["a", "b", "c"]) is False
+        assert scorer._is_contiguous_sublist([], ["a"]) is False
+        assert scorer._is_contiguous_sublist(["a", "b"], ["a"]) is False
+
 
 class TestPlagiarismMetricEnum:
     """Test cases for the PlagiarismMetric enum."""

--- a/tests/unit/score/test_plagiarism_scorer.py
+++ b/tests/unit/score/test_plagiarism_scorer.py
@@ -398,10 +398,10 @@ class TestPlagiarismScorerUtilityFunctions:
 
     def test_is_contiguous_sublist(self, scorer):
         """Directly exercise the tokenized sublist helper."""
-        assert scorer._is_contiguous_sublist(["b", "c"], ["a", "b", "c", "d"]) is True
-        assert scorer._is_contiguous_sublist(["a", "c"], ["a", "b", "c"]) is False
-        assert scorer._is_contiguous_sublist([], ["a"]) is False
-        assert scorer._is_contiguous_sublist(["a", "b"], ["a"]) is False
+        assert scorer._is_contiguous_sublist(sub=["b", "c"], full=["a", "b", "c", "d"]) is True
+        assert scorer._is_contiguous_sublist(sub=["a", "c"], full=["a", "b", "c"]) is False
+        assert scorer._is_contiguous_sublist(sub=[], full=["a"]) is False
+        assert scorer._is_contiguous_sublist(sub=["a", "b"], full=["a"]) is False
 
 
 class TestPlagiarismMetricEnum:


### PR DESCRIPTION
## Description

`PlagiarismScorer._plagiarism_score` has a fast path that returns `1.0` when the reference appears verbatim in the response. That check used a raw string test (`reference in response`), but every metric in the scorer is word-level: the text is tokenized with lowercasing and punctuation removal before LCS / Levenshtein / Jaccard are computed. The raw check was inconsistent with that tokenization in both directions:

- **False positive:** a short reference that is only a substring of a longer response *word* scored full plagiarism. For example `reference="cat"` against `response="concatenate the results"` returned `1.0` for all three metrics, because `"cat"` is a substring of `"concatenate"` even though `cat` never appears as a word.
- **Missed match:** a word-level verbatim copy that differed only in case or punctuation did not take the fast path (it happened to fall through to the metric, which usually recovered, but the shortcut itself was wrong).

The fix compares the tokenized sequences instead: the reference tokens must appear as a contiguous run inside the response tokens. This keeps the fast path consistent with the case/punctuation-insensitive word-level semantics the metrics already use.

This continues the small correctness pass on the converters/scorers (cf. #2133, #2137, #2278, #2279).

## Tests and Documentation

Added regression tests in `tests/unit/score/test_plagiarism_scorer.py`:
- a sub-word substring (`"cat"` vs `"concatenate the results"`) now scores `0.0` for every metric,
- a word-level verbatim copy differing in case/punctuation still scores `1.0`,
- a direct unit test for the new `_is_contiguous_sublist` helper.

Full file passes: `pytest tests/unit/score/test_plagiarism_scorer.py` -> 37 passed. `ruff check` and `black` clean. No documentation changes needed (internal scoring behavior only).