### PR TITLE
FIX TrueFalseResponseHandler: strip whitespace before validating verdict

### DIFF
--- a/pyrit/score/response_handler.py
+++ b/pyrit/score/response_handler.py
@@ -303,7 +303,10 @@ class TrueFalseResponseHandler(ResponseHandler):
             objective=objective,
         )
 
-        normalized_value = score.raw_score_value.lower()
+        # Strip surrounding whitespace before comparing: a judge that returns
+        # "true\n" or " false" is giving a valid verdict, and should not be
+        # rejected as out-of-domain over incidental whitespace.
+        normalized_value = score.raw_score_value.strip().lower()
         if normalized_value not in {"true", "false"}:
             raise InvalidJsonException(
                 message=f"True/false score_value must be 'true' or 'false', not {score.raw_score_value!r}."

--- a/tests/unit/score/test_response_handler.py
+++ b/tests/unit/score/test_response_handler.py
@@ -43,6 +43,29 @@ def test_true_false_response_handler_accepts_boolean_values(json_value: str, exp
     assert score.raw_score_value == expected
 
 
+@pytest.mark.parametrize(
+    ("json_value", "expected"),
+    [
+        ('"true "', "true"),
+        ('" false"', "false"),
+        ('"True\\n"', "true"),
+        ('"  FALSE  "', "false"),
+    ],
+)
+def test_true_false_response_handler_strips_whitespace_around_verdict(json_value: str, expected: str) -> None:
+    # A judge returning a valid verdict with incidental surrounding whitespace
+    # (e.g. a trailing newline) must not be rejected as out-of-domain.
+    handler = TrueFalseResponseHandler(response_handler=JsonSchemaResponseHandler())
+
+    score = handler.parse(
+        response_text=f'{{"score_value": {json_value}, "rationale": "test"}}',
+        scorer_identifier=SCORER_IDENTIFIER,
+        scored_prompt_id="test-id",
+    )
+
+    assert score.raw_score_value == expected
+
+
 def test_true_false_response_handler_rejects_value_outside_domain() -> None:
     handler = TrueFalseResponseHandler(response_handler=JsonSchemaResponseHandler())
 


### PR DESCRIPTION
## Description

`TrueFalseResponseHandler.parse` lowercases the parsed score value but does not strip it before checking membership in `{"true", "false"}`:

```python
normalized_value = score.raw_score_value.lower()
if normalized_value not in {"true", "false"}:
    raise InvalidJsonException(...)
```

`raw_score_value` comes straight from `str(parsed_response[score_value_output_key])`, so a judge that returns a valid verdict with incidental surrounding whitespace - `"true\n"`, `" false"`, `"True "` - is rejected as out-of-domain. Targets that do not natively enforce the JSON schema can easily emit this, and the result is that a usable true/false judgment is thrown away (and the JSON retry path is triggered, burning a call).

The numeric path already tolerates this, since `float("3.0 ")` succeeds; only the string-compared true/false domain is whitespace-sensitive.

Fix: `strip()` before `lower()` so incidental whitespace no longer invalidates an otherwise-valid verdict. The stored `raw_score_value` remains the clean `"true"`/`"false"`.

Same class as #2133 (parse the raw score robustly before validating it).

## Tests and Documentation

Added a parametrized regression test in `tests/unit/score/test_response_handler.py` covering `"true "`, `" false"`, `"True\n"`, and `"  FALSE  "` -> all now normalize to the expected verdict. Out-of-domain values (e.g. `"refusal"`) are still rejected.

`pytest tests/unit/score/test_response_handler.py tests/unit/score/test_self_ask_true_false.py tests/unit/score/test_general_true_false_scorer.py` -> 46 passed. `ruff` and `black` clean. No documentation changes needed (internal parsing behavior only).