### PR TITLE
FIX: meet 44px touch-target minimum for Initializers controls

### DIFF
--- a/frontend/src/components/Initializers/AdditionalInitializers.tsx
+++ b/frontend/src/components/Initializers/AdditionalInitializers.tsx
@@ -196,6 +196,7 @@ export default function AdditionalInitializers({
         <Button
           appearance="primary"
           icon={<AddRegular />}
+          className={pageStyles.touchTarget}
           onClick={() => setAddDialogOpen(true)}
           disabled={creating || !initializerName}
         >

--- a/frontend/src/components/Initializers/Initializers.styles.ts
+++ b/frontend/src/components/Initializers/Initializers.styles.ts
@@ -1,5 +1,7 @@
 import { makeStyles, tokens } from '@fluentui/react-components'
 
+import { mobileTouchTargetHeight } from '@/styles/touchTargets'
+
 export const useInitializersStyles = makeStyles({
   root: {
     display: 'flex',
@@ -52,6 +54,10 @@ export const useInitializersStyles = makeStyles({
   },
   addInitializerSelect: {
     minWidth: '220px',
+    ...mobileTouchTargetHeight,
+  },
+  touchTarget: {
+    ...mobileTouchTargetHeight,
   },
   baselineList: {
     display: 'flex',

--- a/frontend/src/components/Initializers/Initializers.tsx
+++ b/frontend/src/components/Initializers/Initializers.tsx
@@ -164,6 +164,7 @@ export default function Initializers() {
           <Button
             appearance="subtle"
             icon={<ArrowSyncRegular />}
+            className={styles.touchTarget}
             onClick={refreshSettings}
             disabled={loading}
           >


### PR DESCRIPTION
## Description
Fixes #2350.

Applies the existing `mobileTouchTargetHeight` coarse-pointer helper to the Initializers Refresh button, additional-initializer select, and Add initializer button so their touch targets meet the 44px minimum without changing desktop sizing or layout.

## Tests and Documentation

- `git diff --check origin/main...HEAD`
- Not run: frontend Jest/type checks because local `npm install`/`npm ci` hung or failed in this worktree environment.