### PR TITLE
FIX initializer edit save failures

### DIFF
--- a/frontend/src/components/Initializers/AdditionalInitializers.test.tsx
+++ b/frontend/src/components/Initializers/AdditionalInitializers.test.tsx
@@ -138,7 +138,7 @@ describe('AdditionalInitializers', () => {
     registeredInitializers: [targetInitializer, scorerInitializer],
     creating: false,
     onAdd: jest.fn().mockResolvedValue(true),
-    onSave: jest.fn().mockResolvedValue(undefined),
+    onSave: jest.fn().mockResolvedValue(true),
     onApply: jest.fn().mockResolvedValue(undefined),
     onRemove: jest.fn().mockResolvedValue(undefined),
   }
@@ -335,6 +335,28 @@ describe('AdditionalInitializers', () => {
     await user.click(await within(dialog).findByRole('button', { name: 'Add', hidden: true }))
 
     expect(defaultProps.onAdd).toHaveBeenCalledWith('tagged_target', { tags: ['default', 'scorer'] })
+  })
+
+  it('should keep the edit dialog open when save fails', async () => {
+    const user = userEvent.setup()
+    const onSave = jest.fn().mockResolvedValue(false)
+
+    render(
+      <TestWrapper>
+        <AdditionalInitializers {...defaultProps} onSave={onSave} />
+      </TestWrapper>,
+    )
+
+    const row = screen.getByTestId('initializer-row-additional-1')
+    fireEvent.click(within(row).getByRole('button', { name: 'Edit' }))
+
+    const dialog = await screen.findByRole('dialog', {}, { timeout: 3000 })
+    await within(dialog).findByText('Edit target initializer')
+    const editor = within(dialog).getByTestId('param-tags')
+    fireEvent.change(editor, { target: { value: 'modified' } })
+    await user.click(await within(dialog).findByRole('button', { name: 'Save', hidden: true }))
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
   })
 
   it('should hide the parameters editor and submit null for a no-parameter initializer', async () => {

--- a/frontend/src/components/Initializers/AdditionalInitializers.test.tsx
+++ b/frontend/src/components/Initializers/AdditionalInitializers.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { FluentProvider, webLightTheme } from '@fluentui/react-components'
+import { useState } from 'react'
 
 import type { AdditionalInitializerSetting, RegisteredInitializer } from '@/types'
 
@@ -139,6 +140,7 @@ describe('AdditionalInitializers', () => {
     creating: false,
     onAdd: jest.fn().mockResolvedValue(true),
     onSave: jest.fn().mockResolvedValue(true),
+    onClearSaveError: jest.fn(),
     onApply: jest.fn().mockResolvedValue(undefined),
     onRemove: jest.fn().mockResolvedValue(undefined),
   }
@@ -337,13 +339,34 @@ describe('AdditionalInitializers', () => {
     expect(defaultProps.onAdd).toHaveBeenCalledWith('tagged_target', { tags: ['default', 'scorer'] })
   })
 
-  it('should keep the edit dialog open when save fails', async () => {
+  it('should keep the edit dialog open and show an inline error when save fails', async () => {
     const user = userEvent.setup()
-    const onSave = jest.fn().mockResolvedValue(false)
+    const onSave = jest.fn()
+    const onClearSaveError = jest.fn()
+
+    function TestComponent() {
+      const [saveErrors, setSaveErrors] = useState<Record<string, string>>({})
+
+      return (
+        <AdditionalInitializers
+          {...defaultProps}
+          saveErrors={saveErrors}
+          onSave={async (id, request) => {
+            onSave(id, request)
+            setSaveErrors({ [id]: 'Mock save failure' })
+            return false
+          }}
+          onClearSaveError={(id) => {
+            onClearSaveError(id)
+            setSaveErrors({})
+          }}
+        />
+      )
+    }
 
     render(
       <TestWrapper>
-        <AdditionalInitializers {...defaultProps} onSave={onSave} />
+        <TestComponent />
       </TestWrapper>,
     )
 
@@ -356,7 +379,13 @@ describe('AdditionalInitializers', () => {
     fireEvent.change(editor, { target: { value: 'modified' } })
     await user.click(await within(dialog).findByRole('button', { name: 'Save', hidden: true }))
 
-    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('dialog', { hidden: true })).toBeInTheDocument()
+    expect(await within(dialog).findByRole('alert', { hidden: true })).toHaveTextContent('Mock save failure')
+    expect(editor).toHaveValue('modified')
+
+    await user.click(within(dialog).getByRole('button', { name: 'Cancel', hidden: true }))
+
+    expect(onClearSaveError).toHaveBeenCalledWith('additional-1')
   })
 
   it('should hide the parameters editor and submit null for a no-parameter initializer', async () => {

--- a/frontend/src/components/Initializers/AdditionalInitializers.tsx
+++ b/frontend/src/components/Initializers/AdditionalInitializers.tsx
@@ -29,7 +29,7 @@ interface AdditionalInitializersProps {
   applyingInitializerId?: string | null
   deletingInitializerId?: string | null
   onAdd: (initializerName: string, parameters: Record<string, unknown> | null) => Promise<boolean>
-  onSave: (id: string, request: UpdateAdditionalInitializerRequest) => Promise<void>
+  onSave: (id: string, request: UpdateAdditionalInitializerRequest) => Promise<boolean>
   onApply: (id: string, initializerName: string, parameters?: Record<string, unknown> | null) => Promise<void>
   onRemove: (id: string) => Promise<void>
 }
@@ -40,7 +40,7 @@ interface AdditionalInitializerCardProps {
   isSaving: boolean
   isApplying: boolean
   isDeleting: boolean
-  onSave: (id: string, request: UpdateAdditionalInitializerRequest) => Promise<void>
+  onSave: (id: string, request: UpdateAdditionalInitializerRequest) => Promise<boolean>
   onApply: (id: string, initializerName: string, parameters?: Record<string, unknown> | null) => Promise<void>
   onRemove: (id: string) => Promise<void>
 }
@@ -61,8 +61,10 @@ function AdditionalInitializerCard({
   const isBusy = isSaving || isApplying || isDeleting
 
   const handleEditSubmit = async (parameters: Record<string, unknown> | null): Promise<void> => {
-    await onSave(item.id, { parameters, order_index: item.order_index ?? null })
-    setEditOpen(false)
+    const saved = await onSave(item.id, { parameters, order_index: item.order_index ?? null })
+    if (saved) {
+      setEditOpen(false)
+    }
   }
 
   return (

--- a/frontend/src/components/Initializers/AdditionalInitializers.tsx
+++ b/frontend/src/components/Initializers/AdditionalInitializers.tsx
@@ -26,10 +26,12 @@ interface AdditionalInitializersProps {
   registeredInitializers: RegisteredInitializer[]
   creating: boolean
   savingInitializerId?: string | null
+  saveErrors?: Record<string, string>
   applyingInitializerId?: string | null
   deletingInitializerId?: string | null
   onAdd: (initializerName: string, parameters: Record<string, unknown> | null) => Promise<boolean>
   onSave: (id: string, request: UpdateAdditionalInitializerRequest) => Promise<boolean>
+  onClearSaveError: (id: string) => void
   onApply: (id: string, initializerName: string, parameters?: Record<string, unknown> | null) => Promise<void>
   onRemove: (id: string) => Promise<void>
 }
@@ -40,7 +42,9 @@ interface AdditionalInitializerCardProps {
   isSaving: boolean
   isApplying: boolean
   isDeleting: boolean
+  saveError?: string | null
   onSave: (id: string, request: UpdateAdditionalInitializerRequest) => Promise<boolean>
+  onClearSaveError: (id: string) => void
   onApply: (id: string, initializerName: string, parameters?: Record<string, unknown> | null) => Promise<void>
   onRemove: (id: string) => Promise<void>
 }
@@ -51,7 +55,9 @@ function AdditionalInitializerCard({
   isSaving,
   isApplying,
   isDeleting,
+  saveError,
   onSave,
+  onClearSaveError,
   onApply,
   onRemove,
 }: AdditionalInitializerCardProps) {
@@ -64,6 +70,13 @@ function AdditionalInitializerCard({
     const saved = await onSave(item.id, { parameters, order_index: item.order_index ?? null })
     if (saved) {
       setEditOpen(false)
+    }
+  }
+
+  const handleEditOpenChange = (open: boolean): void => {
+    setEditOpen(open)
+    if (!open) {
+      onClearSaveError(item.id)
     }
   }
 
@@ -131,8 +144,9 @@ function AdditionalInitializerCard({
           initializer={initializer}
           initialParameters={item.parameters}
           submitting={isSaving}
+          externalError={saveError}
           onSubmit={handleEditSubmit}
-          onOpenChange={setEditOpen}
+          onOpenChange={handleEditOpenChange}
         />
       )}
     </div>
@@ -144,10 +158,12 @@ export default function AdditionalInitializers({
   registeredInitializers,
   creating,
   savingInitializerId = null,
+  saveErrors = {},
   applyingInitializerId = null,
   deletingInitializerId = null,
   onAdd,
   onSave,
+  onClearSaveError,
   onApply,
   onRemove,
 }: AdditionalInitializersProps) {
@@ -217,7 +233,9 @@ export default function AdditionalInitializers({
               isSaving={savingInitializerId === item.id}
               isApplying={applyingInitializerId === item.id}
               isDeleting={deletingInitializerId === item.id}
+              saveError={saveErrors[item.id] ?? null}
               onSave={onSave}
+              onClearSaveError={onClearSaveError}
               onApply={onApply}
               onRemove={onRemove}
             />

--- a/frontend/src/components/Initializers/InitializerParametersDialog.test.tsx
+++ b/frontend/src/components/Initializers/InitializerParametersDialog.test.tsx
@@ -207,4 +207,37 @@ describe('InitializerParametersDialog', () => {
     expect(screen.getByRole('button', { name: 'Add...' })).toBeDisabled()
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
   })
+
+  it('displays externalError when provided', () => {
+    render(
+      <TestWrapper>
+        <InitializerParametersDialog
+          {...baseProps}
+          initializer={numericInitializer}
+          externalError="Server error: something went wrong"
+        />
+      </TestWrapper>,
+    )
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Server error: something went wrong')
+  })
+
+  it('prefers validation error over externalError', async () => {
+    const user = userEvent.setup()
+    const onSubmit = jest.fn().mockResolvedValue(undefined)
+    render(
+      <TestWrapper>
+        <InitializerParametersDialog
+          {...baseProps}
+          onSubmit={onSubmit}
+          initializer={requiredInitializer}
+          externalError="Server error"
+        />
+      </TestWrapper>,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Add' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('label is required.')
+  })
 })

--- a/frontend/src/components/Initializers/InitializerParametersDialog.test.tsx
+++ b/frontend/src/components/Initializers/InitializerParametersDialog.test.tsx
@@ -147,6 +147,21 @@ describe('InitializerParametersDialog', () => {
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ flag: true, tags: ['a'] }))
   })
 
+  it('toggles the intended multiselect option when clicking checkbox label text', async () => {
+    const user = userEvent.setup()
+    const onSubmit = jest.fn().mockResolvedValue(undefined)
+    render(
+      <TestWrapper>
+        <InitializerParametersDialog {...baseProps} onSubmit={onSubmit} initializer={allKindsInitializer} />
+      </TestWrapper>,
+    )
+
+    await user.click(screen.getByText('b'))
+    await user.click(screen.getByRole('button', { name: 'Add', hidden: true }))
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ tags: ['b'] }))
+  })
+
   it('unchecks a multiselect choice and picks a select value', async () => {
     const user = userEvent.setup()
     const onSubmit = jest.fn().mockResolvedValue(undefined)

--- a/frontend/src/components/Initializers/InitializerParametersDialog.tsx
+++ b/frontend/src/components/Initializers/InitializerParametersDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import {
   Button,
   Checkbox,
@@ -52,6 +52,7 @@ export default function InitializerParametersDialog({
     getInitialFormValues(parameters, initialParameters),
   )
   const [error, setError] = useState<string | null>(null)
+  const submitInProgressRef = useRef(false)
 
   const acceptsParameters = parameters.length > 0
 
@@ -61,6 +62,15 @@ export default function InitializerParametersDialog({
   }
 
   const handleSubmit = async (): Promise<void> => {
+    submitInProgressRef.current = true
+    try {
+      await submitForm()
+    } finally {
+      submitInProgressRef.current = false
+    }
+  }
+
+  const submitForm = async (): Promise<void> => {
     if (!acceptsParameters) {
       setError(null)
       await onSubmit(null)
@@ -82,7 +92,15 @@ export default function InitializerParametersDialog({
   const submitLabel = mode === 'add' ? 'Add' : 'Save'
 
   return (
-    <Dialog open={open} onOpenChange={(_, data) => onOpenChange(data.open)}>
+    <Dialog
+      open={open}
+      onOpenChange={(_, data) => {
+        if (!data.open && submitInProgressRef.current) {
+          return
+        }
+        onOpenChange(data.open)
+      }}
+    >
       <DialogSurface>
         <DialogBody>
           <DialogTitle>{title}</DialogTitle>

--- a/frontend/src/components/Initializers/InitializerParametersDialog.tsx
+++ b/frontend/src/components/Initializers/InitializerParametersDialog.tsx
@@ -31,6 +31,7 @@ interface InitializerParametersDialogProps {
   initializer: RegisteredInitializer | null
   initialParameters?: Record<string, unknown> | null
   submitting?: boolean
+  externalError?: string | null
   onSubmit: (parameters: Record<string, unknown> | null) => void | Promise<void>
   onOpenChange: (open: boolean) => void
 }
@@ -41,6 +42,7 @@ export default function InitializerParametersDialog({
   initializer,
   initialParameters = null,
   submitting = false,
+  externalError = null,
   onSubmit,
   onOpenChange,
 }: InitializerParametersDialogProps) {
@@ -112,9 +114,9 @@ export default function InitializerParametersDialog({
                 This initializer takes no parameters.
               </Text>
             )}
-            {error && (
+            {(error || externalError) && (
               <Text role="alert" className={styles.errorText}>
-                {error}
+                {error || externalError}
               </Text>
             )}
           </DialogContent>

--- a/frontend/src/components/Initializers/InitializerParametersDialog.tsx
+++ b/frontend/src/components/Initializers/InitializerParametersDialog.tsx
@@ -191,6 +191,7 @@ function ParameterField({ parameter, value, disabled, onChange }: ParameterField
           {(parameter.choices ?? []).map((choice) => (
             <Checkbox
               key={choice}
+              id={`param-${parameter.name}-${choice}`}
               label={choice}
               checked={selected.includes(choice)}
               disabled={disabled}

--- a/frontend/src/components/Initializers/Initializers.test.tsx
+++ b/frontend/src/components/Initializers/Initializers.test.tsx
@@ -237,6 +237,22 @@ describe('Initializers', () => {
     })
   })
 
+  it('should show save errors in the edit dialog and preserve edits', async () => {
+    const user = userEvent.setup()
+    mockedInitializersApi.updateAdditional.mockRejectedValue(new Error('Mock save failure'))
+    renderInitializers()
+
+    await screen.findByTestId('initializer-row-additional-1')
+    const dialog = await openDialogByButton(user, 'Edit', 'Edit scorer initializer')
+    const editor = within(dialog).getByTestId('param-tags')
+    fireEvent.change(editor, { target: { value: 'relaxed' } })
+    await user.click(await within(dialog).findByRole('button', { name: 'Save', hidden: true }))
+
+    expect(screen.getByRole('dialog', { hidden: true })).toBeInTheDocument()
+    expect(await within(dialog).findByRole('alert', { hidden: true })).toHaveTextContent('Mock save failure')
+    expect(editor).toHaveValue('relaxed')
+  })
+
   it('should apply an additional initializer', async () => {
     const user = userEvent.setup()
     renderInitializers()

--- a/frontend/src/components/Initializers/Initializers.tsx
+++ b/frontend/src/components/Initializers/Initializers.tsx
@@ -31,6 +31,7 @@ export default function Initializers() {
   const [refetchCount, setRefetchCount] = useState(0)
   const [creating, setCreating] = useState(false)
   const [savingInitializerId, setSavingInitializerId] = useState<string | null>(null)
+  const [saveErrors, setSaveErrors] = useState<Record<string, string>>({})
   const [applyingInitializerId, setApplyingInitializerId] = useState<string | null>(null)
   const [deletingInitializerId, setDeletingInitializerId] = useState<string | null>(null)
 
@@ -106,17 +107,32 @@ export default function Initializers() {
     request: UpdateAdditionalInitializerRequest,
   ): Promise<boolean> => {
     setSavingInitializerId(id)
+    setSaveErrors((currentErrors) => {
+      const remainingErrors = { ...currentErrors }
+      delete remainingErrors[id]
+      return remainingErrors
+    })
     try {
       await initializersApi.updateAdditional(id, request)
       setStatusMessage({ intent: 'success', text: 'Saved additional initializer.' })
       await refetchSettingsOnly()
       return true
     } catch (error) {
-      setStatusMessage({ intent: 'error', text: toApiError(error).detail })
+      const detail = toApiError(error).detail
+      setStatusMessage({ intent: 'error', text: detail })
+      setSaveErrors((currentErrors) => ({ ...currentErrors, [id]: detail }))
       return false
     } finally {
       setSavingInitializerId(null)
     }
+  }
+
+  const clearSaveError = (id: string): void => {
+    setSaveErrors((currentErrors) => {
+      const remainingErrors = { ...currentErrors }
+      delete remainingErrors[id]
+      return remainingErrors
+    })
   }
 
   const handleApply = async (
@@ -195,10 +211,12 @@ export default function Initializers() {
             registeredInitializers={registeredInitializers}
             creating={creating}
             savingInitializerId={savingInitializerId}
+            saveErrors={saveErrors}
             applyingInitializerId={applyingInitializerId}
             deletingInitializerId={deletingInitializerId}
             onAdd={handleAdd}
             onSave={handleSave}
+            onClearSaveError={clearSaveError}
             onApply={handleApply}
             onRemove={handleRemove}
           />

--- a/frontend/src/components/Initializers/Initializers.tsx
+++ b/frontend/src/components/Initializers/Initializers.tsx
@@ -104,14 +104,16 @@ export default function Initializers() {
   const handleSave = async (
     id: string,
     request: UpdateAdditionalInitializerRequest,
-  ): Promise<void> => {
+  ): Promise<boolean> => {
     setSavingInitializerId(id)
     try {
       await initializersApi.updateAdditional(id, request)
       setStatusMessage({ intent: 'success', text: 'Saved additional initializer.' })
       await refetchSettingsOnly()
+      return true
     } catch (error) {
       setStatusMessage({ intent: 'error', text: toApiError(error).detail })
+      return false
     } finally {
       setSavingInitializerId(null)
     }


### PR DESCRIPTION
Fixes #2347

Keeps edited initializer values in the dialog when save fails and shows the error inline. Also fixes checkbox label clicks for initializer multiselect parameters.