### PR TITLE
FIX: Support empty template list in Encoding scenario

### DIFF
--- a/pyrit/scenario/scenarios/garak/encoding.py
+++ b/pyrit/scenario/scenarios/garak/encoding.py
@@ -172,13 +172,16 @@ class Encoding(Scenario):
                 successfully decoded the payload. Defaults to DecodingScorer with encoding_scenario
                 category.
             encoding_templates (Sequence[str] | None): Templates used to construct the decoding
-                prompts. Defaults to AskToDecodeConverter.garak_templates.
+                prompts. An empty list is supported and will pass the raw encoded prompts.
+                Defaults to AskToDecodeConverter.garak_templates if None.
             scenario_result_id (str | None): Optional ID of an existing scenario result to resume.
         """
         objective_scorer = objective_scorer or DecodingScorer(categories=["encoding_scenario"])
         self._scorer_config = AttackScoringConfig(objective_scorer=objective_scorer)
 
-        self._encoding_templates = encoding_templates or AskToDecodeConverter.garak_templates
+        self._encoding_templates = (
+            AskToDecodeConverter.garak_templates if encoding_templates is None else encoding_templates
+        )
 
         super().__init__(
             version=self.VERSION,

--- a/tests/unit/scenario/garak/test_encoding.py
+++ b/tests/unit/scenario/garak/test_encoding.py
@@ -456,6 +456,39 @@ class TestEncodingAtomicAttacks:
                 assert isinstance(run.attack_technique.attack, PromptSendingAttack)
                 assert len(run._seed_groups) == len(mock_attack_seed_groups)
 
+    async def test_get_prompt_attacks_with_empty_templates(
+        self, mock_objective_target, mock_objective_scorer, mock_attack_seed_groups, mock_dataset_config
+    ):
+        """Test that an explicitly empty template list creates only the raw attack."""
+        from unittest.mock import patch
+
+        with patch.object(
+            Encoding,
+            "_resolve_seed_groups_by_dataset_async",
+            new_callable=AsyncMock,
+            return_value={"memory": mock_attack_seed_groups},
+        ):
+            scenario = Encoding(
+                objective_scorer=mock_objective_scorer,
+                encoding_templates=[],
+            )
+            scenario.set_params_from_args(
+                args={
+                    "objective_target": mock_objective_target,
+                    "dataset_config": mock_dataset_config,
+                }
+            )
+            await scenario.initialize_async()
+
+            attack_runs = scenario._get_prompt_attacks(
+                converters=[Base64Converter()],
+                encoding_name="base64",
+                variant_slug="base64",
+                context=scenario._build_scenario_context(seed_groups_by_dataset={"memory": mock_attack_seed_groups}),
+            )
+
+            assert [attack.atomic_attack_name for attack in attack_runs] == ["base64_raw"]
+
     async def test_attack_runs_include_objectives(
         self,
         mock_objective_target,


### PR DESCRIPTION
## Description

The Encoding scenario always creates an atomic attack passing the "raw" encoded string as is to the target. It is a valid use case to use only this specific atomic attack, particularly for non-reasoning models.

However, there is currently no mechanism built in the scenario to allow that: if the user does not pass a template list or passes an empty list, the scenario defaults to the Garak templates.

This PR implements a simple fix: if the user passes an empty list, the scenario will pass only the "raw" encoded string. If the template list is not provided or is `None`, the fallback behavior to Garak templates is unchanged.

## Tests and Documentation

Added one unit test to confirm only the "raw" attack is active when an empty template list is passed.