### PR TITLE
FIX: preserve content and word boundaries in NatoConverter

### DIFF
--- a/pyrit/converter/nato_converter.py
+++ b/pyrit/converter/nato_converter.py
@@ -13,7 +13,8 @@ class NatoConverter(Converter):
     This converter transforms standard text into NATO phonetic alphabet format,
     where each letter is replaced with its corresponding NATO phonetic code word
     (e.g., "A" becomes "Alfa", "B" becomes "Bravo"). Only alphabetic characters
-    are converted; non-alphabetic characters are ignored.
+    are converted; non-alphabetic characters (digits, punctuation) are preserved
+    as-is, and spaces act as separators.
 
     The NATO phonetic alphabet is the most widely used spelling alphabet, designed
     to improve clarity of voice communication. This converter can be used to test
@@ -90,6 +91,6 @@ class NatoConverter(Converter):
         Returns:
             str: The NATO phonetic alphabet representation, with code words separated by spaces.
         """
-        output = [self._NATO_MAP[char] for char in text.upper() if char in self._NATO_MAP]
+        output = [self._NATO_MAP.get(char, char) for char in text.upper() if char != " "]
 
         return " ".join(output)

--- a/pyrit/converter/nato_converter.py
+++ b/pyrit/converter/nato_converter.py
@@ -2,19 +2,18 @@
 # Licensed under the MIT license.
 
 
-from pyrit.converter.converter import Converter, ConverterResult
-from pyrit.models import PromptDataType
+from pyrit.converter.word_level_converter import WordLevelConverter
 
 
-class NatoConverter(Converter):
+class NatoConverter(WordLevelConverter):
     """
     Converts text into NATO phonetic alphabet representation.
 
     This converter transforms standard text into NATO phonetic alphabet format,
-    where each letter is replaced with its corresponding NATO phonetic code word
-    (e.g., "A" becomes "Alfa", "B" becomes "Bravo"). Only alphabetic characters
-    are converted; non-alphabetic characters (digits, punctuation) are preserved
-    as-is, and spaces act as separators.
+    where each ASCII letter is replaced with its corresponding NATO phonetic code
+    word (e.g., "A" becomes "Alfa", "B" becomes "Bravo"). Characters outside the
+    ASCII alphabet are preserved with their original casing. Spaces are represented
+    by ``<space>`` so word boundaries remain distinct from code-word separators.
 
     The NATO phonetic alphabet is the most widely used spelling alphabet, designed
     to improve clarity of voice communication. This converter can be used to test
@@ -24,12 +23,14 @@ class NatoConverter(Converter):
     Reference: https://en.wikipedia.org/wiki/NATO_phonetic_alphabet
 
     Example:
-        Input: "Hello"
-        Output: "Hotel Echo Lima Lima Oscar"
+        Input: "Hello world"
+        Output: "Hotel Echo Lima Lima Oscar <space> Whiskey Oscar Romeo Lima Delta"
     """
 
     SUPPORTED_INPUT_TYPES = ("text",)
     SUPPORTED_OUTPUT_TYPES = ("text",)
+
+    _WORD_SEPARATOR = "<space>"
 
     _NATO_MAP = {
         "A": "Alfa",
@@ -60,37 +61,34 @@ class NatoConverter(Converter):
         "Z": "Zulu",
     }
 
-    async def convert_async(self, *, prompt: str, input_type: PromptDataType = "text") -> ConverterResult:
+    async def convert_word_async(self, word: str) -> str:
         """
-        Convert the given text into NATO phonetic alphabet representation.
+        Convert one word into NATO phonetic alphabet representation.
 
         Args:
-            prompt (str): The text to be converted to NATO phonetic alphabet.
-            input_type (PromptDataType, optional): Type of input data. Defaults to "text".
+            word (str): The word to convert.
 
         Returns:
-            ConverterResult: The text converted to NATO phonetic alphabet format.
-
-        Raises:
-            ValueError: If the input type is not supported (only "text" is supported).
+            str: The converted word, with code words separated by spaces.
         """
-        if not self.input_supported(input_type):
-            raise ValueError("Input type not supported")
+        output = [self._NATO_MAP.get(char.upper(), char) if char.isascii() else char for char in word]
+        return " ".join(output)
 
-        nato_text = self._convert_to_nato(prompt)
-
-        return ConverterResult(output_text=nato_text, output_type="text")
-
-    def _convert_to_nato(self, text: str) -> str:
+    def join_words(self, words: list[str]) -> str:
         """
-        Convert text to NATO phonetic alphabet representation.
+        Join converted words while preserving every source-space boundary.
 
         Args:
-            text (str): The text to convert.
+            words (list[str]): The converted words.
 
         Returns:
-            str: The NATO phonetic alphabet representation, with code words separated by spaces.
+            str: The converted words separated by explicit space tokens.
         """
-        output = [self._NATO_MAP.get(char, char) for char in text.upper() if char != " "]
+        output: list[str] = []
+        for index, word in enumerate(words):
+            if index:
+                output.append(self._WORD_SEPARATOR)
+            if word:
+                output.append(word)
 
         return " ".join(output)

--- a/tests/unit/converter/test_nato_converter.py
+++ b/tests/unit/converter/test_nato_converter.py
@@ -4,6 +4,7 @@
 import pytest
 
 from pyrit.converter import ConverterResult, NatoConverter
+from pyrit.converter.text_selection_strategy import WordIndexSelectionStrategy
 
 
 async def test_nato_converter_simple_text():
@@ -56,7 +57,7 @@ async def test_nato_converter_with_numbers():
 
 
 async def test_nato_converter_with_spaces():
-    """Test that spaces are ignored in NATO conversion."""
+    """Test that word boundaries remain distinct from code-word separators."""
     converter = NatoConverter()
     prompt = "a b c"
 
@@ -64,8 +65,7 @@ async def test_nato_converter_with_spaces():
 
     assert isinstance(result, ConverterResult)
     assert result.output_type == "text"
-    # Spaces should be ignored
-    assert result.output_text == "Alfa Bravo Charlie"
+    assert result.output_text == "Alfa <space> Bravo <space> Charlie"
 
 
 async def test_nato_converter_with_punctuation():
@@ -78,7 +78,7 @@ async def test_nato_converter_with_punctuation():
     assert isinstance(result, ConverterResult)
     assert result.output_type == "text"
     # Punctuation is preserved as-is so the encoded prompt keeps its full content
-    assert result.output_text == "Hotel Echo Lima Lima Oscar , Whiskey Oscar Romeo Lima Delta !"
+    assert result.output_text == "Hotel Echo Lima Lima Oscar , <space> Whiskey Oscar Romeo Lima Delta !"
 
 
 async def test_nato_converter_empty_string():
@@ -109,6 +109,34 @@ async def test_nato_converter_no_letters():
     assert result.output_text == "1 2 3 ! @ #"
 
 
+async def test_nato_converter_space_only_prompt():
+    """Test that a non-empty whitespace prompt remains non-empty."""
+    converter = NatoConverter()
+
+    result = await converter.convert_async(prompt="   ", input_type="text")
+
+    assert result.output_text == "<space> <space> <space>"
+
+
+@pytest.mark.parametrize("prompt", ["é", "ß", "ı", "ñ"])
+async def test_nato_converter_preserves_unmapped_unicode(prompt: str):
+    """Test that Unicode characters are preserved without case conversion."""
+    converter = NatoConverter()
+
+    result = await converter.convert_async(prompt=prompt, input_type="text")
+
+    assert result.output_text == prompt
+
+
+async def test_nato_converter_word_selection_strategy():
+    """Test that NATO conversion supports the shared word selection strategies."""
+    converter = NatoConverter(word_selection_strategy=WordIndexSelectionStrategy(indices=[1]))
+
+    result = await converter.convert_async(prompt="abc def", input_type="text")
+
+    assert result.output_text == "abc <space> Delta Echo Foxtrot"
+
+
 async def test_nato_converter_all_letters():
     """Test NATO conversion with all letters of the alphabet."""
     converter = NatoConverter()
@@ -130,7 +158,7 @@ async def test_nato_converter_input_type_not_supported():
     """Test that non-text input types raise ValueError."""
     converter = NatoConverter()
 
-    with pytest.raises(ValueError, match="Input type not supported"):
+    with pytest.raises(ValueError, match="Input type image_path not supported"):
         await converter.convert_async(prompt="test", input_type="image_path")
 
 

--- a/tests/unit/converter/test_nato_converter.py
+++ b/tests/unit/converter/test_nato_converter.py
@@ -43,7 +43,7 @@ async def test_nato_converter_mixed_case():
 
 
 async def test_nato_converter_with_numbers():
-    """Test that numbers are ignored in NATO conversion."""
+    """Test that numbers are preserved in NATO conversion."""
     converter = NatoConverter()
     prompt = "a1b2c3"
 
@@ -51,8 +51,8 @@ async def test_nato_converter_with_numbers():
 
     assert isinstance(result, ConverterResult)
     assert result.output_type == "text"
-    # Only letters should be converted
-    assert result.output_text == "Alfa Bravo Charlie"
+    # Digits are preserved as-is so the encoded prompt keeps its full content
+    assert result.output_text == "Alfa 1 Bravo 2 Charlie 3"
 
 
 async def test_nato_converter_with_spaces():
@@ -69,7 +69,7 @@ async def test_nato_converter_with_spaces():
 
 
 async def test_nato_converter_with_punctuation():
-    """Test that punctuation is ignored in NATO conversion."""
+    """Test that punctuation is preserved in NATO conversion."""
     converter = NatoConverter()
     prompt = "Hello, world!"
 
@@ -77,8 +77,8 @@ async def test_nato_converter_with_punctuation():
 
     assert isinstance(result, ConverterResult)
     assert result.output_type == "text"
-    # Only letters should be converted
-    assert result.output_text == "Hotel Echo Lima Lima Oscar Whiskey Oscar Romeo Lima Delta"
+    # Punctuation is preserved as-is so the encoded prompt keeps its full content
+    assert result.output_text == "Hotel Echo Lima Lima Oscar , Whiskey Oscar Romeo Lima Delta !"
 
 
 async def test_nato_converter_empty_string():
@@ -94,7 +94,11 @@ async def test_nato_converter_empty_string():
 
 
 async def test_nato_converter_no_letters():
-    """Test NATO conversion with no alphabetic characters."""
+    """Test NATO conversion with no alphabetic characters.
+
+    Regression: non-empty input must never convert to an empty prompt
+    (digits/punctuation are preserved rather than erased).
+    """
     converter = NatoConverter()
     prompt = "123!@#"
 
@@ -102,7 +106,7 @@ async def test_nato_converter_no_letters():
 
     assert isinstance(result, ConverterResult)
     assert result.output_type == "text"
-    assert result.output_text == ""
+    assert result.output_text == "1 2 3 ! @ #"
 
 
 async def test_nato_converter_all_letters():


### PR DESCRIPTION
## Root Cause

`NatoConverter` uppercased the entire prompt and retained only characters present in its A-Z map. This silently deleted digits, punctuation, Unicode, and spaces. As a result:

- `"123!@#"` became an empty prompt.
- `"HI THERE"` and `"HITHERE"` produced identical output because word boundaries disappeared.
- A passthrough implementation based on `text.upper()` would also mutate or expand unmapped Unicode such as `é`, `ß`, and `ı`.

That changes prompt semantics and is inconsistent with the prompt-fidelity behavior of sibling converters.

## Fix

Refactor `NatoConverter` to inherit from the existing `WordLevelConverter` abstraction:

- Implement NATO encoding in `convert_word_async`.
- Convert only ASCII letters; preserve digits, punctuation, and unmapped Unicode with their original value and casing.
- Join source words with an explicit `<space>` token so word boundaries remain distinguishable from the spaces between NATO code words.
- Reuse shared input validation and word-selection strategies.

Examples:

- `"Hello, world!"` → `"Hotel Echo Lima Lima Oscar , <space> Whiskey Oscar Romeo Lima Delta !"`
- `"123!@#"` → `"1 2 3 ! @ #"`
- `"HI THERE"` → `"Hotel India <space> Tango Hotel Echo Romeo Echo"`, distinct from `"HITHERE"`
- Unmapped Unicode such as `é`, `ß`, `ı`, and `ñ` remains unchanged.

## Tests

Coverage includes letters and casing, digits, punctuation, empty and space-only prompts, Unicode passthrough, explicit word boundaries, word-selection strategies, and unsupported input types.

Targeted converter suites pass: 32 tests. Ruff formatting/linting and repository commit hooks also pass.

## Diff Scope

Two files: `pyrit/converter/nato_converter.py` and `tests/unit/converter/test_nato_converter.py`.

## AI Disclosure

The bug analysis and implementation were AI-assisted, then reviewed and validated against the converter contracts and targeted test suites.

Closes #2398