### PR TITLE
DOC: correct the .python-version claim in the contributor install guide

### DIFF
--- a/doc/getting_started/install_local_dev.md
+++ b/doc/getting_started/install_local_dev.md
@@ -33,7 +33,8 @@ Set up a PyRIT development environment on your local machine.
    wget -qO- https://astral.sh/uv/install.sh | sh
    ```
 
-2. **Python 3.12**: uv will automatically download and use the correct Python version based on `.python-version`
+2. **Python 3.10-3.14**: PyRIT supports these versions, and CI tests all of them. The repository does
+   not pin an interpreter, so `uv` selects a compatible one for you (downloading it if needed).
 
 3. **Git**. Git is required to clone the repo locally. It is available to download [here](https://git-scm.com/downloads).
     ```bash
@@ -46,7 +47,7 @@ Set up a PyRIT development environment on your local machine.
 
 1. Navigate to the directory where you cloned the PyRIT repo.
 
-2. The repository includes a `.python-version` file that pins Python 3.12. Run:
+2. From the root of your clone, run:
 
 ```bash
 uv sync
@@ -54,10 +55,13 @@ uv sync
 
 This command will:
 - Create a `.venv` directory with a virtual environment
-- Install Python 3.12 if not already available
+- Download a supported Python version if none is already available
 - Install PyRIT in editable mode; `uv sync` by default installs in editable mode so no extra flag is necessary
 - Install all dependencies including dev tools (pytest, ruff, etc.) via the `dev` dependency group
 - Create a `uv.lock` file for reproducible builds
+
+To pin your checkout to a single version, run `uv python pin 3.12`. That writes a
+`.python-version` file, which is local to your working copy and not tracked by the repository.
 
 
 3. Verify Installation


### PR DESCRIPTION
## Description

The contributor install guide tells you the repo pins Python 3.12 via a `.python-version` file. There is no such file:

```
$ git ls-files | grep python-version      # no match
$ git log --all -- .python-version        # no history; never committed
```

`doc/getting_started/install_local_dev.md` asserts it in three places:

- "uv will automatically download and use the correct Python version based on `.python-version`"
- "The repository includes a `.python-version` file that pins Python 3.12."
- "Install Python 3.12 if not already available"

What actually happens is that `uv sync` resolves against `requires-python = ">=3.10, <3.15"` and uses whatever interpreter it already has. Following this page on a clean macOS checkout gave me a **3.13.7** venv, not 3.12 — so a new contributor is told their environment is pinned when it is not, and can silently end up on a different version from the one the page describes.

For what it is worth, the `# .python-version` line in `.gitignore` is inherited from GitHub's standard Python template (it sits inside the commented `# pyenv` block) and is not evidence of a deliberate pin.

## Changes

Replaces the claim with what the project actually guarantees:

- states the supported range as 3.10-3.14, matching `requires-python` and the `build_and_test.yml` matrix (`["3.10", "3.11", "3.12", "3.13", "3.14"]`)
- notes that no interpreter is pinned and `uv` selects a compatible one
- points contributors who *do* want a pin at `uv python pin <version>`, noting the resulting file is local and untracked

Happy to go the other way instead if pinning 3.12 was the actual intent — in that case the fix is to commit a `.python-version` file and I can swap this PR for that.

Documentation only; no code or behavior changes.

## Tests and Documentation

`pre-commit run --files doc/getting_started/install_local_dev.md` passes, including the `Validate Documentation Structure` hook.

No JupyText run needed — this page is prose Markdown with no paired notebook and no executable cells.
