### PR TITLE
DOC: Update bibliography publication metadata

### DIFF
--- a/doc/references.bib
+++ b/doc/references.bib
@@ -73,12 +73,12 @@
   url       = {https://arxiv.org/abs/2407.15549},
 }
 
-@misc{mazeika2023tdc,
-  title     = {The Trojan Detection Challenge 2023 ({LLM} Edition)},
-  author    = {Mantas Mazeika and Andy Zou and Norman Mu and Long Phan and Zifan Wang and Chunru Yu and Adam Khoja and Fengqing Jiang and Aidan O'Gara and Ellie Sakhaee and Zhen Xiang and Arezoo Rajabi and Dan Hendrycks and Radha Poovendran and Bo Li and David Forsyth},
+@inproceedings{mazeika2023tdc,
+  title     = {The Trojan Detection Challenge ({LLM} Edition)},
+  author    = {Mantas Mazeika and Andy Zou and Norman Mu and Long Phan and Zifan Wang and Chunru Yu and Adam Khoja and Fengqing Jiang and Aidan O'Gara and Zhen Xiang and Arezoo Rajabi and Dan Hendrycks and Radha Poovendran and Bo Li and David Forsyth},
+  booktitle = {NeurIPS Competition Track},
   year      = {2023},
-  url       = {https://proceedings.mlr.press/v220/mazeika23a.html},
-  note      = {NeurIPS Trojan Detection Challenge series. Official challenge site may be unavailable; using the proceedings page for archival access.},
+  url       = {https://neurips.cc/virtual/2023/competition/66583},
 }
 
 @misc{promptfoo2025ccp,
@@ -149,7 +149,8 @@
   number    = {22},
   pages     = {23951--23959},
   year      = {2025},
-  url       = {https://arxiv.org/abs/2311.05608},
+  url       = {https://doi.org/10.1609/aaai.v39i22.34568},
+  doi       = {10.1609/aaai.v39i22.34568},
   note      = {Introduces the {SafeBench} typographic-image jailbreak benchmark (AAAI 2025 Oral)},
 }
 
@@ -544,7 +545,7 @@
 }
 
 @article{choi2026xlsafetybench,
-  title     = {{XL-SafetyBench}: A Country-Grounded Cross-Cultural Benchmark for LLM Safety and Cultural Sensitivity},
+  title     = {{XL-SafetyBench}: A Country-Grounded Cross-Cultural Benchmark for {LLM} Safety and Cultural Sensitivity},
   author    = {Dasol Choi and Eugenia Kim and Jaewon Noh and Sang Seo and Eunmi Kim and Myunggyo Oh and Yunjin Park and Brigitta Jesica Kartono and Josef Pichlmeier and Helena Berndt and Sai Krishna Mendu and Glenn Johannes Tungka and {\"O}zlem G{\"o}k{\c{c}}e and Suresh Gehlot and Katherine Pratt and Amanda Minnich and Haon Park},
   journal   = {arXiv preprint arXiv:2605.05662},
   year      = {2026},
@@ -704,15 +705,18 @@
   title     = {Safe Inputs but Unsafe Output: Benchmarking Cross-modality Safety Alignment of Large Vision-Language Models},
   author    = {Siyin Wang and Xingsong Ye and Qinyuan Cheng and Junwen Duan and Shimin Li and Jinlan Fu and Xipeng Qiu and Xuanjing Huang},
   booktitle = {Findings of the Association for Computational Linguistics: NAACL 2025},
+  pages     = {3563--3605},
   year      = {2025},
-  url       = {https://arxiv.org/abs/2406.15279},
+  publisher = {Association for Computational Linguistics},
+  url       = {https://aclanthology.org/2025.findings-naacl.198/},
+  doi       = {10.18653/v1/2025.findings-naacl.198},
   note      = {Introduces the {SIUO} (Safe Inputs but Unsafe Output) benchmark},
 }
 
 @inproceedings{darkbench2025,
   title     = {{DarkBench}: Benchmarking Dark Patterns in Large Language Models},
   author    = {Esben Kran and Hieu Minh "Jord" Nguyen and Akash Kundu and Sami Jawhar and Jinsuk Park and Mateusz Maria Jurewicz},
-  booktitle = {International Conference on Learning Representations (ICLR)},
+  booktitle = {International Conference on Learning Representations ({ICLR})},
   year      = {2025},
   url       = {https://arxiv.org/abs/2503.10728},
   note      = {Oral presentation at ICLR 2025},


### PR DESCRIPTION
## Description

- Replace the Trojan Detection Challenge citation with official NeurIPS competition metadata
- Add canonical AAAI and ACL publication metadata for FigStep and SIUO
- Protect LLM and ICLR acronyms from BibTeX case normalization

## Tests and Documentation

- `uv run pre-commit run --files doc/references.bib`
- Verified all bibliography keys are unique and all citation keys resolve