### PR TITLE
FIX: size Initializer selector touch target

### DIFF
--- a/frontend/e2e/touch-targets.spec.ts
+++ b/frontend/e2e/touch-targets.spec.ts
@@ -150,6 +150,37 @@ async function installTouchTargetMocks(page: Page): Promise<void> {
       );
       return;
     }
+    if (apiPath === "/initializers/settings" && method === "GET") {
+      await route.fulfill(
+        jsonResponse({
+          baseline: [],
+          additional: [],
+        })
+      );
+      return;
+    }
+    if (apiPath === "/initializers" && method === "GET") {
+      await route.fulfill(
+        jsonResponse({
+          items: [
+            {
+              initializer_name: "load_default_datasets",
+              initializer_type: "DatasetInitializer",
+              description: "Loads the default datasets.",
+              required_env_vars: [],
+              supported_parameters: [],
+            },
+          ],
+          pagination: {
+            limit: 200,
+            has_more: false,
+            next_cursor: null,
+            prev_cursor: null,
+          },
+        })
+      );
+      return;
+    }
     if (apiPath === "/targets/catalog") {
       await route.fulfill(
         jsonResponse({
@@ -403,6 +434,15 @@ test.describe("Mobile touch targets", () => {
     await expectNoDocumentOverflow(page);
   });
 
+  test("keeps the Initializer selector at least 44px", async ({ page }) => {
+    await page.goto("/initializers");
+
+    await expectMinimumTouchTarget(
+      page.getByRole("combobox", { name: "Initializer to add" })
+    );
+    await expectNoDocumentOverflow(page);
+  });
+
   test("keeps Chat message, input, and conversation controls at least 44px", async ({
     page,
   }) => {
@@ -521,6 +561,11 @@ test("preserves compact desktop controls and existing sidebar dimensions", async
   );
   await expectCompactDesktopTarget(
     page.getByRole("button", { name: "Expand inner targets" })
+  );
+
+  await page.goto("/initializers");
+  await expectCompactDesktopTarget(
+    page.getByRole("combobox", { name: "Initializer to add" })
   );
 
   await startChatWithMessages(page);

--- a/frontend/src/components/Initializers/Initializers.styles.ts
+++ b/frontend/src/components/Initializers/Initializers.styles.ts
@@ -1,6 +1,10 @@
 import { makeStyles, tokens } from '@fluentui/react-components'
 
-import { mobileTouchTargetHeight } from '@/styles/touchTargets'
+import {
+  MINIMUM_TOUCH_TARGET_SIZE,
+  TOUCH_INPUT_QUERY,
+  mobileTouchTargetHeight,
+} from '@/styles/touchTargets'
 
 export const useInitializersStyles = makeStyles({
   root: {
@@ -55,6 +59,11 @@ export const useInitializersStyles = makeStyles({
   addInitializerSelect: {
     minWidth: '220px',
     ...mobileTouchTargetHeight,
+    '& > select': {
+      [TOUCH_INPUT_QUERY]: {
+        minHeight: MINIMUM_TOUCH_TARGET_SIZE,
+      },
+    },
   },
   touchTarget: {
     ...mobileTouchTargetHeight,


### PR DESCRIPTION
## Description

Follow-up to #2350 and #2391. The Initializers page still rendered the accessible `Initializer to add` combobox at 32px high on coarse-pointer devices because the prior minimum height only reached Fluent UI's wrapper.

Apply the shared 44px coarse-pointer minimum to the native `<select>` slot while preserving the compact desktop layout, semantics, keyboard interaction, and menu behavior. Add focused browser coverage that measures the real combobox at a 390x844 touch viewport and confirms desktop sizing remains compact.

## Tests and Documentation

- `npm --prefix frontend test -- --runInBand src/components/Initializers/Initializers.test.tsx src/components/Initializers/AdditionalInitializers.test.tsx` (25 passed)
- `npm --prefix frontend run test:e2e -- --project=mock --grep "Initializer selector"`
- `npm --prefix frontend run test:e2e -- --project=mock --grep "preserves compact desktop controls"`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run type-check`
- `npm --prefix frontend run build`
- Impeccable detector: 0 findings
- Documentation: N/A