### PR TITLE
MAINT Consolidate chat attachment copying

### DIFF
--- a/frontend/src/components/Chat/ChatWindow.test.tsx
+++ b/frontend/src/components/Chat/ChatWindow.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { FluentProvider, webLightTheme } from "@fluentui/react-components";
 import ChatWindow from "./ChatWindow";
 import { makeTarget } from "@/test-utils/targetFixtures";
-import { Message, TargetCapabilities, TargetInfo, TargetInstance } from "../../types";
+import { Message, MessageAttachment, TargetCapabilities, TargetInfo, TargetInstance } from "../../types";
 import { attacksApi, convertersApi } from "../../services/api";
 import * as messageMapper from "../../utils/messageMapper";
 
@@ -2258,10 +2258,38 @@ describe("ChatWindow Integration", () => {
   // -----------------------------------------------------------------------
 
   it("should create a new conversation and copy message when copy-to-new-conv is clicked", async () => {
+    const user = userEvent.setup();
     const onSelectConversation = jest.fn();
     const mockMessages: Message[] = [
       { role: "user", content: "hello" },
-      { role: "assistant", content: "reply text to copy" },
+      {
+        role: "assistant",
+        content: "reply text to copy",
+        attachments: [
+          {
+            type: "image",
+            name: "first.png",
+            url: "data:image/png;base64,aW1hZ2U=",
+            mimeType: "image/png",
+            pieceId: "piece-image",
+            metadata: { source: "generated" },
+          },
+          {
+            type: "file",
+            name: "excluded.pdf",
+            url: "data:application/pdf;base64,cGRm",
+            mimeType: "application/pdf",
+          },
+          {
+            type: "audio",
+            name: "second.wav",
+            url: "data:audio/wav;base64,YXVkaW8=",
+            mimeType: "audio/wav",
+            pieceId: "piece-audio",
+            metadata: { voice: "alloy" },
+          },
+        ],
+      },
     ];
 
     mockedAttacksApi.getMessages.mockResolvedValue({ messages: [] });
@@ -2288,12 +2316,15 @@ describe("ChatWindow Integration", () => {
     });
 
     const copyBtn = screen.getByTestId("copy-to-new-conv-btn-1");
-    await userEvent.click(copyBtn);
+    await user.click(copyBtn);
 
     await waitFor(() => {
       expect(mockedAttacksApi.createConversation).toHaveBeenCalledWith("ar-copy-new", {});
       expect(onSelectConversation).toHaveBeenCalledWith("new-conv-copy");
     });
+    expect(await screen.findByText(/first\.png/)).toBeInTheDocument();
+    expect(screen.getByText(/second\.wav/)).toBeInTheDocument();
+    expect(screen.getAllByTestId(/^remove-attachment-/)).toHaveLength(2);
   });
 
   it("should fall back when createConversation fails in copy-to-new-conversation", async () => {
@@ -3052,30 +3083,58 @@ describe("ChatWindow Integration", () => {
   // -----------------------------------------------------------------------
 
   it("should copy message with attachments to input box", async () => {
+    const user = userEvent.setup();
+    const copiedAttachments: MessageAttachment[] = [
+      {
+        type: "image",
+        name: "first.png",
+        url: "data:image/png;base64,aW1hZ2U=",
+        mimeType: "image/png",
+        size: 12,
+        pieceId: "piece-image",
+        metadata: { source: "generated" },
+      },
+      {
+        type: "file",
+        name: "excluded.pdf",
+        url: "data:application/pdf;base64,cGRm",
+        mimeType: "application/pdf",
+        pieceId: "piece-file",
+        metadata: { source: "document" },
+      },
+      {
+        type: "audio",
+        name: "second.wav",
+        url: "data:audio/wav;base64,YXVkaW8=",
+        mimeType: "audio/wav",
+        pieceId: "piece-audio",
+        metadata: { voice: "alloy" },
+      },
+    ];
     const mockMessages: Message[] = [
       { role: "user", content: "hello" },
       {
         role: "assistant",
         content: "Here is an image",
-        attachments: [
-          {
-            type: "image" as const,
-            name: "test.png",
-            url: "data:image/png;base64,iVBORw0KGgo=",
-            mimeType: "image/png",
-            size: 12,
-          },
-        ],
+        attachments: copiedAttachments,
       },
     ];
 
     mockedAttacksApi.getMessages.mockResolvedValue({ messages: [] });
     mockedMapper.backendMessagesToFrontend.mockReturnValue(mockMessages);
+    mockedMapper.buildMessagePieces.mockResolvedValue([]);
+    mockedAttacksApi.addMessage.mockResolvedValue(makeTextResponse("done") as never);
 
     render(
       <TestWrapper>
         <ChatWindow
           {...defaultProps}
+          activeTarget={{
+            ...mockTarget,
+            capabilities: buildCapabilities({
+              supported_input_modalities: ["image_path", "audio_path"],
+            }),
+          }}
           attackResultId="ar-copy-att"
           conversationId="conv-copy-att"
           activeConversationId="conv-copy-att"
@@ -3088,12 +3147,23 @@ describe("ChatWindow Integration", () => {
     });
 
     const copyBtn = screen.getByTestId("copy-to-input-btn-1");
-    await userEvent.click(copyBtn);
+    await user.click(copyBtn);
 
-    // The text should appear in the input area
     await waitFor(() => {
       const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
       expect(textarea.value).toBe("Here is an image");
+    });
+    expect(screen.getByText(/first\.png/)).toBeInTheDocument();
+    expect(screen.getByText(/second\.wav/)).toBeInTheDocument();
+    expect(screen.getAllByTestId(/^remove-attachment-/)).toHaveLength(2);
+
+    await user.click(screen.getByRole("button", { name: /send/i }));
+
+    await waitFor(() => {
+      expect(mockedMapper.buildMessagePieces).toHaveBeenCalledWith(
+        "Here is an image",
+        [copiedAttachments[0], copiedAttachments[2]]
+      );
     });
   });
 

--- a/frontend/src/components/Chat/ChatWindow.tsx
+++ b/frontend/src/components/Chat/ChatWindow.tsx
@@ -554,17 +554,28 @@ export default function ChatWindow({
   // Message action handlers (4 buttons on each assistant message)
   // -------------------------------------------------------------------
 
+  const copyMessageToInput = useCallback((message: Message): void => {
+    const inputBox = inputBoxRef.current
+    if (!inputBox) { return }
+
+    if (message.content) {
+      inputBox.setText(message.content)
+    }
+    if (!message.attachments) { return }
+
+    for (const attachment of message.attachments) {
+      if (attachment.type !== 'file') {
+        inputBox.addAttachment(attachment)
+      }
+    }
+  }, [])
+
   /** 1. Copy the clicked message's content/attachments into the current conversation's input box */
   const handleCopyToInput = useCallback((messageIndex: number) => {
     const msg = messages[messageIndex]
     if (!msg) { return }
-    if (msg.content) { inputBoxRef.current?.setText(msg.content) }
-    if (msg.attachments) {
-      msg.attachments.filter(a => a.type !== 'file').forEach(att => {
-        inputBoxRef.current?.addAttachment(att)
-      })
-    }
-  }, [messages])
+    copyMessageToInput(msg)
+  }, [copyMessageToInput, messages])
 
   /** 2. Create a new conversation in the same attack and copy ONLY this message to its input box */
   const handleCopyToNewConversation = useCallback(async (messageIndex: number) => {
@@ -578,12 +589,7 @@ export default function ChatWindow({
       setIsPanelOpen(!isNarrowScreen)
       // Small delay so the panel/messages update first
       setTimeout(() => {
-        if (msg.content) inputBoxRef.current?.setText(msg.content)
-        if (msg.attachments) {
-          msg.attachments.filter(a => a.type !== 'file').forEach(att => {
-            inputBoxRef.current?.addAttachment(att)
-          })
-        }
+        copyMessageToInput(msg)
       }, 100)
     } catch {
       // If creating fails, fall back to current conversation
@@ -591,6 +597,7 @@ export default function ChatWindow({
     }
   }, [
     attackResultId,
+    copyMessageToInput,
     isNarrowScreen,
     isMutationLocked,
     messages,

--- a/frontend/src/components/Chat/ChatWindow.tsx
+++ b/frontend/src/components/Chat/ChatWindow.tsx
@@ -561,9 +561,7 @@ export default function ChatWindow({
     if (message.content) {
       inputBox.setText(message.content)
     }
-    if (!message.attachments) { return }
-
-    for (const attachment of message.attachments) {
+    for (const attachment of message.attachments ?? []) {
       if (attachment.type !== 'file') {
         inputBox.addAttachment(attachment)
       }


### PR DESCRIPTION
`ChatWindow` duplicated the same message-to-input attachment loop in its direct copy and copy-to-new-conversation actions, making the two paths easy to change inconsistently.

This extracts a shared, component-local copy operation for the identical success behavior. It preserves non-file attachment ordering and metadata, keeps the delayed new-conversation update unchanged, and leaves the distinct text-only creation-failure fallback separate.

Focused tests cover both shared call paths, file filtering, attachment order and metadata preservation, and the failure fallback.

Validation:
- Focused `ChatWindow` Jest tests
- ESLint on changed files
- Frontend TypeScript type-check
- `git diff --check`