### PR TITLE
FIX Prevent blocking file I/O on async paths

### DIFF
--- a/pyrit/backend/routes/version.py
+++ b/pyrit/backend/routes/version.py
@@ -3,9 +3,11 @@
 
 """API routes for version information."""
 
+import asyncio
 import json
 import logging
 from pathlib import Path
+from typing import Any
 
 from fastapi import APIRouter, Request
 from pydantic import BaseModel
@@ -16,6 +18,20 @@ from pyrit.memory import CentralMemory
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/version", tags=["version"])
+
+
+def _load_build_info(build_info_path: Path) -> dict[str, Any]:
+    """
+    Load Docker build metadata from disk.
+
+    Args:
+        build_info_path: Path to the build metadata JSON file.
+
+    Returns:
+        dict[str, Any]: Parsed build metadata.
+    """
+    with open(build_info_path) as file:
+        return json.load(file)
 
 
 class VersionResponse(BaseModel):
@@ -49,14 +65,13 @@ async def get_version_async(request: Request) -> VersionResponse:
 
     # Try to load build info from Docker
     build_info_path = Path("/app/build_info.json")
-    if build_info_path.exists():
+    if await asyncio.to_thread(build_info_path.exists):
         try:
-            with open(build_info_path) as f:
-                build_info = json.load(f)
-                source = build_info.get("source")
-                commit = build_info.get("commit")
-                modified = build_info.get("modified")
-                display = build_info.get("display", version)
+            build_info = await asyncio.to_thread(_load_build_info, build_info_path)
+            source = build_info.get("source")
+            commit = build_info.get("commit")
+            modified = build_info.get("modified")
+            display = build_info.get("display", version)
         except Exception as e:
             logger.warning(f"Failed to load build info: {e}")
 

--- a/pyrit/cli/pyrit_scan.py
+++ b/pyrit/cli/pyrit_scan.py
@@ -20,6 +20,8 @@ from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, get_args, get_origin
 
+import aiofiles
+
 from pyrit.cli._cli_args import (
     ARG_HELP,
     _parse_initializer_arg,
@@ -761,12 +763,13 @@ async def _handle_add_initializer_async(*, client: Any, parsed_args: Namespace) 
     from pyrit.cli.api_client import ServerNotAvailableError
 
     for script_path_str in parsed_args.files:
-        script_path = Path(script_path_str).resolve()
-        if not script_path.exists():
+        script_path = await asyncio.to_thread(Path(script_path_str).resolve)
+        if not await asyncio.to_thread(script_path.exists):
             print(f"Error: File not found: {script_path}")
             return 1
         try:
-            script_content = script_path.read_text()
+            async with aiofiles.open(script_path) as script_file:
+                script_content = await script_file.read()
             await client.register_initializer_async(
                 name=script_path.stem,
                 script_content=script_content,

--- a/pyrit/datasets/seed_datasets/remote/figstep_dataset.py
+++ b/pyrit/datasets/seed_datasets/remote/figstep_dataset.py
@@ -10,6 +10,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Literal
 
+import aiofiles
 from typing_extensions import override
 
 from pyrit.common.net_utility import make_request_and_raise_if_error_async
@@ -28,6 +29,19 @@ if TYPE_CHECKING:
     from pyrit.models.seeds.seed_group import SeedUnion
 
 logger = logging.getLogger(__name__)
+
+
+def _directory_has_entries(path: Path) -> bool:
+    """
+    Check whether a directory exists and contains at least one entry.
+
+    Args:
+        path: Directory path to inspect.
+
+    Returns:
+        bool: True when the directory exists and is non-empty.
+    """
+    return path.exists() and any(path.iterdir())
 
 
 class FigStepCategory(Enum):
@@ -267,7 +281,12 @@ class _FigStepDataset(_RemoteDatasetLoader):
         )
 
         required_keys = {"dataset", "category_id", "task_id", "category_name", "question", "instruction"}
-        rows = self._fetch_from_url(source=self.source, source_type=self.source_type, cache=cache)
+        rows = await asyncio.to_thread(
+            self._fetch_from_url,
+            source=self.source,
+            source_type=self.source_type,
+            cache=cache,
+        )
 
         pro_extract_dir: Path | None = None
         pro_benign_sentences: list[str] | None = None
@@ -579,7 +598,7 @@ class _FigStepDataset(_RemoteDatasetLoader):
             Path: Local directory containing the extracted sub-figures.
         """
         extract_dir = DB_DATA_PATH / "seed-prompt-entries" / f"figstep_pro_subfigures_{self.COMMIT_SHA}"
-        if cache and extract_dir.exists() and any(extract_dir.iterdir()):
+        if cache and await asyncio.to_thread(_directory_has_entries, extract_dir):
             return extract_dir
 
         logger.info(f"[FigStep] Downloading FigStep-Pro sub-figures from {self.FIGSTEP_PRO_ZIP_URL}")
@@ -613,8 +632,9 @@ class _FigStepDataset(_RemoteDatasetLoader):
         """
         cache_path = DB_DATA_PATH / "seed-prompt-entries" / f"figstep_benign_sentences_{self.COMMIT_SHA}.txt"
 
-        if cache and cache_path.exists():
-            text = cache_path.read_text(encoding="utf-8")
+        if cache and await asyncio.to_thread(cache_path.exists):
+            async with aiofiles.open(cache_path, encoding="utf-8") as cache_file:
+                text = await cache_file.read()
         else:
             logger.info(f"[FigStep] Fetching benign sentences from {self.BENIGN_SENTENCES_URL}")
             response = await make_request_and_raise_if_error_async(
@@ -623,8 +643,9 @@ class _FigStepDataset(_RemoteDatasetLoader):
                 follow_redirects=True,
             )
             text = response.text
-            cache_path.parent.mkdir(parents=True, exist_ok=True)
-            cache_path.write_text(text, encoding="utf-8")
+            await asyncio.to_thread(cache_path.parent.mkdir, parents=True, exist_ok=True)
+            async with aiofiles.open(cache_path, "w", encoding="utf-8") as cache_file:
+                await cache_file.write(text)
 
         lines = [line.strip() for line in text.splitlines() if line.strip()]
         if lines and lines[0].lower() == "sentence":
@@ -646,6 +667,23 @@ class _FigStepDataset(_RemoteDatasetLoader):
 
         Returns:
             list[str]: Sub-image paths sorted by split index. Empty if none exist.
+        """
+        return await asyncio.to_thread(
+            self._find_figstep_pro_sub_images,
+            row_idx=row_idx,
+            extract_dir=extract_dir,
+        )
+
+    def _find_figstep_pro_sub_images(self, *, row_idx: int, extract_dir: Path) -> list[str]:
+        """
+        Find and sort the extracted sub-images for one FigStep-Pro row.
+
+        Args:
+            row_idx: Zero-based row index.
+            extract_dir: Root directory containing the extracted images.
+
+        Returns:
+            list[str]: Sub-image paths sorted by split index.
         """
         splits_dir = extract_dir / f"image_{row_idx}_splits"
         if not splits_dir.is_dir():

--- a/pyrit/datasets/seed_datasets/remote/vlguard_dataset.py
+++ b/pyrit/datasets/seed_datasets/remote/vlguard_dataset.py
@@ -8,7 +8,7 @@ import os
 import uuid
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, cast
 
 from huggingface_hub import hf_hub_download
 from typing_extensions import override
@@ -25,6 +25,34 @@ if TYPE_CHECKING:
     from pyrit.models.seeds.seed_group import SeedUnion
 
 logger = logging.getLogger(__name__)
+
+
+def _cache_is_valid(*, json_path: Path, image_dir: Path) -> bool:
+    """
+    Check whether both cached metadata and extracted images are available.
+
+    Args:
+        json_path: Path to the cached metadata file.
+        image_dir: Path to the extracted image directory.
+
+    Returns:
+        bool: True when the complete cache is available.
+    """
+    return json_path.exists() and image_dir.exists() and any(image_dir.iterdir())
+
+
+def _load_metadata(json_path: Path) -> list[dict[str, str]]:
+    """
+    Load VLGuard metadata from its JSON file.
+
+    Args:
+        json_path: Path to the metadata file.
+
+    Returns:
+        list[dict[str, str]]: Parsed VLGuard metadata.
+    """
+    with open(json_path, encoding="utf-8") as file:
+        return cast("list[dict[str, str]]", json.load(file))
 
 
 class VLGuardCategory(Enum):
@@ -221,7 +249,7 @@ class _VLGuardDataset(_RemoteDatasetLoader):
                 continue
 
             image_path = image_dir / image_filename
-            if not image_path.exists():
+            if not await asyncio.to_thread(image_path.exists):
                 logger.warning(f"Image not found: {image_path}")
                 continue
 
@@ -317,16 +345,15 @@ class _VLGuardDataset(_RemoteDatasetLoader):
             tuple[list[dict], Path]: Tuple of (metadata list, image directory path).
         """
         cache_dir = DB_DATA_PATH / "seed-prompt-entries" / "vlguard"
-        cache_dir.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(cache_dir.mkdir, parents=True, exist_ok=True)
 
         json_path = cache_dir / "test.json"
         image_dir = cache_dir / "test"
 
         # Use cache if available
-        if cache and json_path.exists() and image_dir.exists() and any(image_dir.iterdir()):
+        if cache and await asyncio.to_thread(_cache_is_valid, json_path=json_path, image_dir=image_dir):
             logger.info("Using cached VLGuard dataset")
-            with open(json_path, encoding="utf-8") as f:
-                metadata: list[dict[str, str]] = json.load(f)
+            metadata = await asyncio.to_thread(_load_metadata, json_path)
             return metadata, image_dir
 
         logger.info("Downloading VLGuard dataset from HuggingFace...")
@@ -352,11 +379,10 @@ class _VLGuardDataset(_RemoteDatasetLoader):
 
         # Extract images from zip
         zip_path = cache_dir / "test.zip"
-        if zip_path.exists():
+        if await asyncio.to_thread(zip_path.exists):
             logger.info("Extracting VLGuard test images...")
             await asyncio.to_thread(safe_extract_zip, source=zip_path, dest_dir=cache_dir)
 
-        with open(json_path, encoding="utf-8") as f:
-            metadata: list[dict[str, str]] = json.load(f)
+        metadata = await asyncio.to_thread(_load_metadata, json_path)
 
         return metadata, image_dir

--- a/tests/unit/backend/test_api_routes.py
+++ b/tests/unit/backend/test_api_routes.py
@@ -38,6 +38,7 @@ from pyrit.backend.models.targets import (
     TargetCatalogResponse,
     TargetListResponse,
 )
+from pyrit.backend.routes import version as version_routes
 from pyrit.backend.routes.labels import get_label_options
 from pyrit.models import ConverterIdentifier, MessagePiece, TargetCapabilities, TargetIdentifier
 from pyrit.models.catalog.target import TargetInstance
@@ -1204,7 +1205,11 @@ class TestVersionRoutes:
             temp_path = f.name
 
         try:
-            with patch("pyrit.backend.routes.version.Path") as mock_path_class:
+            to_thread_mock = AsyncMock(side_effect=lambda func, *args, **kwargs: func(*args, **kwargs))
+            with (
+                patch("pyrit.backend.routes.version.Path") as mock_path_class,
+                patch("pyrit.backend.routes.version.asyncio.to_thread", new=to_thread_mock),
+            ):
                 mock_path_instance = MagicMock()
                 mock_path_instance.exists.return_value = True
                 mock_path_class.return_value = mock_path_instance
@@ -1223,6 +1228,7 @@ class TestVersionRoutes:
                     response = client.get("/api/version")
 
             assert response.status_code == status.HTTP_200_OK
+            to_thread_mock.assert_any_await(version_routes._load_build_info, mock_path_instance)
         finally:
             os.unlink(temp_path)
 

--- a/tests/unit/cli/test_pyrit_scan.py
+++ b/tests/unit/cli/test_pyrit_scan.py
@@ -1359,6 +1359,24 @@ class TestMainExtraPaths:
         assert "Registered initializer 'myinit'" in capsys.readouterr().out
         mock_client.register_initializer_async.assert_awaited_once()
 
+    async def test_handle_add_initializer_reads_with_aiofiles(self, tmp_path):
+        script = tmp_path / "myinit.py"
+        script.write_text("content read outside the event loop")
+        parsed_args = Namespace(files=[str(script)])
+        client = AsyncMock()
+        async_file = MagicMock()
+        async_file.__aenter__ = AsyncMock(return_value=async_file)
+        async_file.__aexit__ = AsyncMock(return_value=None)
+        async_file.read = AsyncMock(return_value="# stub initializer\n")
+
+        with patch("pyrit.cli.pyrit_scan.aiofiles.open", return_value=async_file) as open_mock:
+            result = await pyrit_scan._handle_add_initializer_async(client=client, parsed_args=parsed_args)
+
+        assert result == 0
+        open_mock.assert_called_once_with(script.resolve())
+        async_file.read.assert_awaited_once()
+        assert client.register_initializer_async.await_args.kwargs["script_content"] == "# stub initializer\n"
+
     @patch(
         "pyrit.cli._server_launcher.ServerLauncher.probe_health_async",
         new_callable=AsyncMock,

--- a/tests/unit/datasets/test_figstep_dataset.py
+++ b/tests/unit/datasets/test_figstep_dataset.py
@@ -19,7 +19,7 @@ from pyrit.datasets.seed_datasets.seed_dataset_provider import SeedDatasetProvid
 from pyrit.models import SeedDataset, SeedObjective, SeedPrompt
 
 
-def _make_row(**overrides) -> dict[str, str]:
+def _make_row(**overrides: str) -> dict[str, str]:
     base = {
         "dataset": "ForbidQI",
         "category_id": "1",
@@ -136,6 +136,30 @@ class TestFigStepDataset:
         assert image_prompt.sequence == 0
         assert text_prompt.sequence == 0
         assert objective.prompt_group_id == image_prompt.prompt_group_id == text_prompt.prompt_group_id
+
+    async def test_fetch_figstep_offloads_synchronous_row_loading(self):
+        loader = _FigStepDataset()
+        to_thread_mock = AsyncMock(side_effect=lambda func, *args, **kwargs: func(*args, **kwargs))
+        with (
+            patch.object(loader, "_fetch_from_url", return_value=[_make_row()]) as fetch_mock,
+            patch.object(
+                loader,
+                "_fetch_figstep_image_async",
+                new=AsyncMock(return_value="/fake/figstep.png"),
+            ),
+            patch(
+                "pyrit.datasets.seed_datasets.remote.figstep_dataset.asyncio.to_thread",
+                new=to_thread_mock,
+            ),
+        ):
+            await loader.fetch_dataset_async(cache=False)
+
+        to_thread_mock.assert_awaited_once_with(
+            fetch_mock,
+            source=loader.source,
+            source_type=loader.source_type,
+            cache=False,
+        )
 
     async def test_fetch_figstep_preserves_question_as_objective(self):
         rows = [_make_row(question="Custom harmful question")]

--- a/tests/unit/datasets/test_vlguard_dataset.py
+++ b/tests/unit/datasets/test_vlguard_dataset.py
@@ -12,6 +12,7 @@ from pyrit.datasets.seed_datasets.remote.vlguard_dataset import (
     VLGuardCategory,
     VLGuardSubcategory,
     VLGuardSubset,
+    _load_metadata,
     _VLGuardDataset,
 )
 from pyrit.models import SeedDataset, SeedPrompt
@@ -397,12 +398,20 @@ class TestVLGuardDataset:
         json_path.write_text(json.dumps(test_metadata), encoding="utf-8")
 
         loader = _VLGuardDataset()
+        to_thread_mock = AsyncMock(side_effect=lambda func, *args, **kwargs: func(*args, **kwargs))
 
-        with patch("pyrit.datasets.seed_datasets.remote.vlguard_dataset.DB_DATA_PATH", tmp_path):
+        with (
+            patch("pyrit.datasets.seed_datasets.remote.vlguard_dataset.DB_DATA_PATH", tmp_path),
+            patch(
+                "pyrit.datasets.seed_datasets.remote.vlguard_dataset.asyncio.to_thread",
+                new=to_thread_mock,
+            ),
+        ):
             metadata, result_dir = await loader._download_dataset_files_async(cache=True)
 
         assert metadata == test_metadata
         assert result_dir == image_dir
+        assert any(thread_call.args == (_load_metadata, json_path) for thread_call in to_thread_mock.await_args_list)
 
     async def test_download_dataset_files_downloads_when_no_cache(self, tmp_path):
         """Test that _download_dataset_files_async downloads and extracts when cache is empty."""


### PR DESCRIPTION
## Description

Async backend, CLI, and dataset-loading paths were performing synchronous file and filesystem operations, which could block the event loop and serialize concurrent work.

This change moves straightforward asynchronous file reads and writes to `aiofiles`, and runs blocking JSON parsing, synchronous dataset loading, and path-heavy filesystem checks through `asyncio.to_thread`. Existing exception behavior, ordering, caching semantics, and public APIs are preserved.

## Tests and Documentation

Added deterministic unit coverage for the new event-loop-safe boundaries in the version route, initializer upload flow, FigStep loader, and VLGuard loader.

Validated with the focused 86-test suite, Ruff format/check, changed-file `ty`, the async-suffix check, commit hooks, and `git diff --check`.

Documentation and JupyText: N/A.