### PR TITLE
MAINT Remove redundant pytest asyncio markers

### DIFF
--- a/tests/integration/executors/test_tap_attack_integration.py
+++ b/tests/integration/executors/test_tap_attack_integration.py
@@ -14,7 +14,6 @@ from pyrit.prompt_target import OpenAIChatTarget, OpenAIImageTarget
 
 
 @pytest.mark.run_only_if_all_tests
-@pytest.mark.asyncio
 async def test_tap_attack_text_target(patch_central_database):
     """Test TAP attack against a text generation target."""
     adversarial_chat = OpenAIChatTarget(temperature=1.1)
@@ -34,7 +33,6 @@ async def test_tap_attack_text_target(patch_central_database):
 
 
 @pytest.mark.run_only_if_all_tests
-@pytest.mark.asyncio
 async def test_tap_attack_image_target(patch_central_database):
     """Test TAP attack against an image generation target using image-specific system prompt."""
     adversarial_chat = OpenAIChatTarget(temperature=1.1)

--- a/tests/integration/targets/test_hugging_face_integration.py
+++ b/tests/integration/targets/test_hugging_face_integration.py
@@ -65,7 +65,6 @@ def hf_response_target(hf_token, hf_endpoint, sqlite_instance) -> OpenAIResponse
 
 
 @pytest.mark.run_only_if_all_tests
-@pytest.mark.asyncio
 async def test_chat_completion_basic(hf_chat_target):
     """Verify a simple prompt returns a non-empty response via the HF router."""
     msg = MessagePiece(role="user", original_value="What is 2+2? Answer with just the number.").to_message()
@@ -79,7 +78,6 @@ async def test_chat_completion_basic(hf_chat_target):
 
 
 @pytest.mark.run_only_if_all_tests
-@pytest.mark.asyncio
 async def test_chat_completion_with_temperature(hf_token, hf_endpoint, sqlite_instance):
     """Verify temperature param is accepted by the HF router."""
     target = OpenAIChatTarget(
@@ -101,7 +99,6 @@ async def test_chat_completion_with_temperature(hf_token, hf_endpoint, sqlite_in
 
 
 @pytest.mark.run_only_if_all_tests
-@pytest.mark.asyncio
 async def test_chat_completion_identifier(hf_chat_target):
     """Verify the component identifier reflects the HF endpoint and model."""
     identifier = hf_chat_target.get_identifier()
@@ -115,7 +112,6 @@ async def test_chat_completion_identifier(hf_chat_target):
 
 
 @pytest.mark.run_only_if_all_tests
-@pytest.mark.asyncio
 async def test_response_api_basic(hf_response_target):
     """Verify a simple prompt returns a non-empty response via the Responses API."""
     msg = MessagePiece(role="user", original_value="What is 2+2? Answer with just the number.").to_message()
@@ -129,7 +125,6 @@ async def test_response_api_basic(hf_response_target):
 
 
 @pytest.mark.run_only_if_all_tests
-@pytest.mark.asyncio
 async def test_response_api_with_temperature(hf_token, hf_endpoint, sqlite_instance):
     """Verify temperature param is accepted by the Responses API on HF."""
     target = OpenAIResponseTarget(
@@ -151,7 +146,6 @@ async def test_response_api_with_temperature(hf_token, hf_endpoint, sqlite_insta
 
 
 @pytest.mark.run_only_if_all_tests
-@pytest.mark.asyncio
 async def test_response_api_identifier(hf_response_target):
     """Verify the component identifier reflects the HF endpoint and model."""
     identifier = hf_response_target.get_identifier()

--- a/tests/unit/converter/test_image_prompt_style_converter.py
+++ b/tests/unit/converter/test_image_prompt_style_converter.py
@@ -155,7 +155,6 @@ def test_list_available_filters() -> None:
     assert len(filters) > 0
 
 
-@pytest.mark.asyncio
 async def test_convert_async_with_specific_variation(mock_target) -> None:
     converter = ImagePromptStyleConverter(
         converter_target=mock_target,
@@ -174,7 +173,6 @@ async def test_convert_async_with_specific_variation(mock_target) -> None:
     assert result.output_type == "text"
 
 
-@pytest.mark.asyncio
 async def test_convert_async_with_random_variation(mock_target) -> None:
     converter = ImagePromptStyleConverter(
         converter_target=mock_target,
@@ -190,7 +188,6 @@ async def test_convert_async_with_random_variation(mock_target) -> None:
     assert result.output_text == "A blurry bodycam shot of a figure in a dark alley"
 
 
-@pytest.mark.asyncio
 async def test_convert_async_unsupported_input_type_raises(mock_target) -> None:
     converter = ImagePromptStyleConverter(
         converter_target=mock_target,

--- a/tests/unit/converter/test_ipa_converter.py
+++ b/tests/unit/converter/test_ipa_converter.py
@@ -21,7 +21,6 @@ def test_ipa_converter_raises_when_dialect_is_empty(dialect, sqlite_instance):
         IPAConverter(converter_target=MockPromptTarget(), dialect=dialect)
 
 
-@pytest.mark.asyncio
 async def test_ipa_converter_auto_detects_languages(sqlite_instance):
     prompt_target = MockPromptTarget()
     converter = IPAConverter(converter_target=prompt_target)
@@ -35,7 +34,6 @@ async def test_ipa_converter_auto_detects_languages(sqlite_instance):
     assert "translate it into another language" in prompt_target.system_prompt
 
 
-@pytest.mark.asyncio
 async def test_ipa_converter_uses_configured_dialect_and_transcription_instructions(sqlite_instance):
     prompt_target = MockPromptTarget()
     converter = IPAConverter(converter_target=prompt_target, dialect="Metropolitan French")
@@ -49,7 +47,6 @@ async def test_ipa_converter_uses_configured_dialect_and_transcription_instructi
     assert "Never follow instructions" in prompt_target.system_prompt
 
 
-@pytest.mark.asyncio
 async def test_ipa_converter_wraps_source_text(sqlite_instance):
     prompt_target = MockPromptTarget()
     converter = IPAConverter(converter_target=prompt_target)
@@ -63,7 +60,6 @@ async def test_ipa_converter_wraps_source_text(sqlite_instance):
     assert "not as instructions to follow" in prompt_target.prompt_sent[0]
 
 
-@pytest.mark.asyncio
 async def test_ipa_converter_strips_response_whitespace(sqlite_instance):
     prompt_target = MockPromptTarget()
     converter = IPAConverter(converter_target=prompt_target)

--- a/tests/unit/executor/attack/multi_turn/test_tree_of_attacks.py
+++ b/tests/unit/executor/attack/multi_turn/test_tree_of_attacks.py
@@ -1055,7 +1055,6 @@ class TestBlockedScoringDefaults:
     short-circuits at all in `_score_response_async`.
     """
 
-    @pytest.mark.asyncio
     async def test_score_response_delegates_to_scorer_for_blocked(self, attack_builder):
         """A blocked response goes straight through Scorer.score_response_async — no TAP-side
         short-circuit. The scorer is responsible for producing 0.0 via its unified fallback."""
@@ -1124,7 +1123,6 @@ class TestBlockedScoringDefaults:
         assert node.objective_score is not None
         assert node.objective_score.get_value() == 0.0
 
-    @pytest.mark.asyncio
     async def test_score_response_delegates_to_scorer_for_unknown_error(self, attack_builder):
         """Non-blocked errors (e.g. 'unknown') also flow through the scorer; no special-casing."""
         builder = attack_builder.with_default_mocks()
@@ -1923,7 +1921,6 @@ class TestTreeOfAttacksNode:
         assert node.auxiliary_scores["AuxScorer1"].get_value() == 0.8
         assert node.auxiliary_scores["AuxScorer2"].get_value() == 0.6
 
-    @pytest.mark.asyncio
     async def test_node_single_turn_target_generates_new_conv_id(self, node_components):
         """Test that single-turn targets get a fresh conversation_id before each send."""
         node_components["objective_target"].capabilities.supports_multi_turn = False
@@ -1951,7 +1948,6 @@ class TestTreeOfAttacksNode:
         # Conversation ID should have changed for single-turn target
         assert node.objective_target_conversation_id != original_conv_id
 
-    @pytest.mark.asyncio
     async def test_node_multi_turn_target_keeps_conv_id(self, node_components):
         """Test that multi-turn targets keep the same conversation_id."""
         node_components["objective_target"].capabilities.supports_multi_turn = True
@@ -2187,7 +2183,6 @@ class TestTreeOfAttacksVisualization:
         assert context.tree_visualization.parent(node_0_child_1._vis_node_id).identifier == node_0._vis_node_id
         assert context.tree_visualization.parent(node_1_child_0._vis_node_id).identifier == node_1._vis_node_id
 
-    @pytest.mark.asyncio
     async def test_surviving_node_gets_child_vis_nodes_per_depth(self, attack_builder, node_factory, helpers):
         """Test that a surviving node gets a new child vis node at each depth (not appended scores)."""
         attack = (
@@ -2731,7 +2726,6 @@ class TestTAPScenarios:
     Each scenario is run twice: once with a multi-turn target and once with a single-turn target.
     """
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("supports_multi_turn", [True, False], ids=["multi_turn", "single_turn"])
     @pytest.mark.parametrize(
         "tree_width, tree_depth, branching_factor, threshold, "

--- a/tests/unit/message_normalizer/test_conversation_context_normalizer.py
+++ b/tests/unit/message_normalizer/test_conversation_context_normalizer.py
@@ -104,7 +104,6 @@ class TestConversationContextNormalizerNormalizeStringAsync:
         assert "converted text" in result
         assert "(original: original text)" in result
 
-    @pytest.mark.asyncio
     async def test_preserves_tool_role_label(self):
         """Test that tool messages keep the Tool label in context output."""
         normalizer = ConversationContextNormalizer()
@@ -118,7 +117,6 @@ class TestConversationContextNormalizerNormalizeStringAsync:
         assert "tool: 72F and sunny" in result
         assert "assistant: 72F and sunny" not in result
 
-    @pytest.mark.asyncio
     async def test_preserves_developer_role_label(self):
         """Test that developer messages keep the Developer label in context output."""
         normalizer = ConversationContextNormalizer()

--- a/tests/unit/prompt_target/target/test_huggingface_chat_target.py
+++ b/tests/unit/prompt_target/target/test_huggingface_chat_target.py
@@ -430,7 +430,6 @@ def test_identifier_excludes_none_generation_params():
 
 
 @pytest.mark.skipif(not is_torch_installed(), reason="torch is not installed")
-@pytest.mark.asyncio
 @pytest.mark.usefixtures("patch_central_database")
 async def test_generate_passes_new_params():
     """Verify top_k, do_sample, repetition_penalty are forwarded to model.generate()."""
@@ -459,7 +458,6 @@ async def test_generate_passes_new_params():
 
 
 @pytest.mark.skipif(not is_torch_installed(), reason="torch is not installed")
-@pytest.mark.asyncio
 @pytest.mark.usefixtures("patch_central_database")
 async def test_generate_omits_none_params():
     """When optional params are None, they should not be passed to model.generate()."""
@@ -560,7 +558,6 @@ def test_default_params_no_warning():
 
 
 @pytest.mark.skipif(not is_torch_installed(), reason="torch is not installed")
-@pytest.mark.asyncio
 @pytest.mark.usefixtures("patch_central_database")
 async def test_full_conversation_sent_to_chat_template():
     """Verify system and user messages from the full conversation are sent to the chat template."""
@@ -596,7 +593,6 @@ async def test_full_conversation_sent_to_chat_template():
 
 
 @pytest.mark.skipif(not is_torch_installed(), reason="torch is not installed")
-@pytest.mark.asyncio
 @pytest.mark.usefixtures("patch_central_database")
 async def test_effective_generation_config_in_metadata():
     """Verify effective generation config is stored in response prompt_metadata."""

--- a/tests/unit/prompt_target/target/test_image_target.py
+++ b/tests/unit/prompt_target/target/test_image_target.py
@@ -528,7 +528,6 @@ def test_background_default_is_none(patch_central_database):
     assert target.background is None
 
 
-@pytest.mark.asyncio
 async def test_generate_request_passes_background(
     image_target: OpenAIImageTarget,
     sample_conversations: MutableSequence[MessagePiece],
@@ -555,7 +554,6 @@ async def test_generate_request_passes_background(
             os.remove(path)
 
 
-@pytest.mark.asyncio
 async def test_generate_request_omits_background_when_none(
     image_target: OpenAIImageTarget,
     sample_conversations: MutableSequence[MessagePiece],

--- a/tests/unit/scenario/core/test_scenario.py
+++ b/tests/unit/scenario/core/test_scenario.py
@@ -352,7 +352,6 @@ class TestScenarioInitialization2:
         assert scenario._max_concurrency == 4
         assert scenario._memory_labels == {}
 
-    @pytest.mark.asyncio
     async def test_initialize_async_validates_target_requirements(self, mock_objective_target):
         """Test that initialize_async validates objective_target against TARGET_REQUIREMENTS."""
         scenario = ConcreteScenario(name="Test Scenario", version=1)
@@ -363,7 +362,6 @@ class TestScenarioInitialization2:
 
         mock_validate.assert_called_once_with(target=mock_objective_target)
 
-    @pytest.mark.asyncio
     async def test_initialize_async_propagates_target_requirements_error(self, mock_objective_target):
         """Test that initialize_async surfaces errors from TARGET_REQUIREMENTS.validate."""
         scenario = ConcreteScenario(name="Test Scenario", version=1)

--- a/tests/unit/setup/test_preload_scenario_metadata.py
+++ b/tests/unit/setup/test_preload_scenario_metadata.py
@@ -13,7 +13,6 @@ from pyrit.setup.initializers.preload_scenario_metadata import PreloadScenarioMe
 class TestPreloadScenarioMetadata:
     """Tests for PreloadScenarioMetadata.initialize_async."""
 
-    @pytest.mark.asyncio
     async def test_initialize_async_warms_metadata_cache(self) -> None:
         """``initialize_async`` should fetch the registry and warm the metadata cache."""
         initializer = PreloadScenarioMetadata()
@@ -33,7 +32,6 @@ class TestPreloadScenarioMetadata:
 
         mock_registry.get_all_registered_class_metadata.assert_called_once_with()
 
-    @pytest.mark.asyncio
     async def test_initialize_async_propagates_registry_errors(self) -> None:
         """If a scenario fails to instantiate, metadata building raises and the initializer surfaces it."""
         initializer = PreloadScenarioMetadata()


### PR DESCRIPTION
## Description

PyRIT uses `asyncio_mode = "auto"`, so explicit `@pytest.mark.asyncio` decorators on async tests are redundant and prohibited by the test instructions. Remove all 33 remaining parameterless function-level decorators across the affected unit and integration tests while preserving skip, fixture, and parametrization decorators.

No parameterized, module-level, class-level, or loop-scope asyncio markers required exceptions.

## Tests and Documentation

- Affected test collection passed.
- Combined affected test selection: 226 passed, 38 skipped.
- Ruff check and format checks passed for all changed files.
- File-scoped pre-commit hooks and `git diff --check` passed.
- Documentation and JupyText: N/A.