### PR TITLE
FIX: surface auth config fetch failures instead of treating them as auth-disabled

### DIFF
--- a/frontend/src/auth/AuthProvider.test.tsx
+++ b/frontend/src/auth/AuthProvider.test.tsx
@@ -161,6 +161,7 @@ describe("AuthProvider", () => {
     await waitFor(() => {
       expect(screen.getByText("Authentication Error")).toBeVisible();
       expect(screen.getByText("Config fetch failed")).toBeVisible();
+      expect(screen.getByText("Reload the page to try again.")).toBeVisible();
     });
   });
 

--- a/frontend/src/auth/AuthProvider.tsx
+++ b/frontend/src/auth/AuthProvider.tsx
@@ -119,6 +119,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       <div style={{ padding: '2rem', textAlign: 'center', color: 'red' }}>
         <h2>Authentication Error</h2>
         <p>{error}</p>
+        <p>Reload the page to try again.</p>
       </div>
     )
   }

--- a/frontend/src/auth/msalConfig.test.ts
+++ b/frontend/src/auth/msalConfig.test.ts
@@ -73,22 +73,24 @@ describe("msalConfig", () => {
       expect(global.fetch).toHaveBeenCalledWith("/api/auth/config");
     });
 
-    it("returns empty config when response is not ok", async () => {
-      (global.fetch as jest.Mock).mockResolvedValue({ ok: false });
+    it("throws when response is not ok (transient failure is not auth-disabled)", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: "Service Unavailable",
+      });
 
       const { fetchAuthConfig } = await import("./msalConfig");
-      const result = await fetchAuthConfig();
 
-      expect(result).toEqual({ clientId: "", tenantId: "", allowedGroupIds: "" });
+      await expect(fetchAuthConfig()).rejects.toThrow("/api/auth/config returned 503 Service Unavailable");
     });
 
-    it("returns empty config on network error", async () => {
+    it("throws on network error (transient failure is not auth-disabled)", async () => {
       (global.fetch as jest.Mock).mockRejectedValue(new Error("Network error"));
 
       const { fetchAuthConfig } = await import("./msalConfig");
-      const result = await fetchAuthConfig();
 
-      expect(result).toEqual({ clientId: "", tenantId: "", allowedGroupIds: "" });
+      await expect(fetchAuthConfig()).rejects.toThrow("Failed to reach /api/auth/config");
     });
   });
 });

--- a/frontend/src/auth/msalConfig.test.ts
+++ b/frontend/src/auth/msalConfig.test.ts
@@ -86,11 +86,15 @@ describe("msalConfig", () => {
     });
 
     it("throws on network error (transient failure is not auth-disabled)", async () => {
-      (global.fetch as jest.Mock).mockRejectedValue(new Error("Network error"));
+      const networkError = new Error("Network error");
+      (global.fetch as jest.Mock).mockRejectedValue(networkError);
 
       const { fetchAuthConfig } = await import("./msalConfig");
 
-      await expect(fetchAuthConfig()).rejects.toThrow("Failed to reach /api/auth/config");
+      await expect(fetchAuthConfig()).rejects.toMatchObject({
+        message: "Failed to reach /api/auth/config: Network error",
+        cause: networkError,
+      });
     });
   });
 });

--- a/frontend/src/auth/msalConfig.ts
+++ b/frontend/src/auth/msalConfig.ts
@@ -27,12 +27,17 @@ export async function fetchAuthConfig(): Promise<AuthConfig> {
   let response: Response
   try {
     response = await fetch('/api/auth/config')
-  } catch (e) {
+  } catch (error) {
     // A network error (e.g., backend not running yet) is a transient
     // infrastructure failure, not proof that auth is disabled. Surface it so
     // AuthProvider can show its error state instead of rendering the shell
     // while protected APIs return 401.
-    throw new Error(`Failed to reach /api/auth/config: ${e instanceof Error ? e.message : String(e)}`)
+    const fetchError = new Error(
+      `Failed to reach /api/auth/config: ${error instanceof Error ? error.message : String(error)}`,
+    )
+    // ErrorOptions requires ES2022, while this project targets ES2020.
+    Object.defineProperty(fetchError, 'cause', { value: error })
+    throw fetchError
   }
   if (!response.ok) {
     // HTTP-level failures on the config endpoint are equally inconclusive.

--- a/frontend/src/auth/msalConfig.ts
+++ b/frontend/src/auth/msalConfig.ts
@@ -24,17 +24,21 @@ export interface AuthConfig {
 }
 
 export async function fetchAuthConfig(): Promise<AuthConfig> {
+  let response: Response
   try {
-    const response = await fetch('/api/auth/config')
-    if (!response.ok) {
-      // Auth endpoint not available — treat as auth disabled
-      return { clientId: '', tenantId: '', allowedGroupIds: '' }
-    }
-    return (await response.json()) as AuthConfig
-  } catch {
-    // Network error (e.g., backend not running yet) — treat as auth disabled
-    return { clientId: '', tenantId: '', allowedGroupIds: '' }
+    response = await fetch('/api/auth/config')
+  } catch (e) {
+    // A network error (e.g., backend not running yet) is a transient
+    // infrastructure failure, not proof that auth is disabled. Surface it so
+    // AuthProvider can show its error state instead of rendering the shell
+    // while protected APIs return 401.
+    throw new Error(`Failed to reach /api/auth/config: ${e instanceof Error ? e.message : String(e)}`)
   }
+  if (!response.ok) {
+    // HTTP-level failures on the config endpoint are equally inconclusive.
+    throw new Error(`/api/auth/config returned ${response.status} ${response.statusText}`)
+  }
+  return (await response.json()) as AuthConfig
 }
 
 export function buildMsalConfig(authConfig: AuthConfig): Configuration {


### PR DESCRIPTION
## Root Cause

`fetchAuthConfig()` in `frontend/src/auth/msalConfig.ts` collapsed both non-2xx responses and network errors into an empty `AuthConfig`. `AuthProvider` reads an empty config as "authentication disabled", so a transient failure of `/api/auth/config` rendered the normal app shell while protected APIs returned raw `Missing or invalid Authorization header` text. There was no login control, error surface, or recovery path (#2441).

## Fix

The two failure paths in `fetchAuthConfig` now throw with contextual messages instead of returning an empty config. Wrapped network errors preserve the original error as their `cause`.

`AuthProvider` renders its Authentication Error page for these failures and now tells users to reload the page to try again. A 200 response carrying an empty config still means auth is disabled for local development, and that path is unchanged.

## Test

- Updated the two `fetchAuthConfig` tests that asserted the old swallow behavior. Non-2xx and network errors now reject with contextual messages, and the network test verifies the original error is preserved as the cause.
- Updated the `AuthProvider` error-state test to verify the reload guidance.
- `msalConfig.test.ts` and `AuthProvider.test.tsx`: 22/22 passing locally.
- Verified in a browser that a failed config request renders the Authentication Error page with reload guidance, and that reloading recovers after the backend becomes available.

## Diff Scope

- `frontend/src/auth/msalConfig.ts`: surface config fetch failures and preserve network error context
- `frontend/src/auth/msalConfig.test.ts`: cover HTTP failures, network failures, and error cause preservation
- `frontend/src/auth/AuthProvider.tsx`: add reload guidance to the authentication error state
- `frontend/src/auth/AuthProvider.test.tsx`: verify the reload guidance

Development was AI-assisted with human review of all changes.

Fixes #2441
