### PR TITLE
FIX: label the converted prompt editor

### DIFF
--- a/frontend/src/components/Chat/ChatInputArea.test.tsx
+++ b/frontend/src/components/Chat/ChatInputArea.test.tsx
@@ -753,7 +753,8 @@ describe("ChatInputArea", () => {
     expect(screen.getByTestId("converted-indicator")).toBeInTheDocument();
 
     // Edit the converted value
-    const convertedInput = screen.getByTestId("converted-value-input");
+    const convertedInput = screen.getByRole("textbox", { name: /converted prompt/i });
+    expect(convertedInput).toHaveValue("aGVsbG8=");
     await user.clear(convertedInput);
     await user.type(convertedInput, "new");
     expect(onConvertedValueChange).toHaveBeenCalled();

--- a/frontend/src/components/Chat/ChatInputArea.tsx
+++ b/frontend/src/components/Chat/ChatInputArea.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect, useRef, forwardRef, useImperativeHandle, KeyboardEvent, Ref } from 'react'
+import { useState, useEffect, useLayoutEffect, useRef, useId, forwardRef, useImperativeHandle, KeyboardEvent, Ref } from 'react'
 import {
   Button,
   Caption1,
@@ -241,6 +241,7 @@ interface TextInputRowsProps {
 
 function TextInputRows({ input, convertedValue, convertedFileChip, disabled, textareaRef, convertedRef, onInput, onKeyDown, onConvertedValueChange, onClearConvertedFileChip, styles, textInputClassName }: TextInputRowsProps) {
   const hasConversion = Boolean(convertedValue) || Boolean(convertedFileChip)
+  const convertedTextareaId = useId()
   return (
     <>
       <div className={styles.textRow}>
@@ -261,8 +262,11 @@ function TextInputRows({ input, convertedValue, convertedFileChip, disabled, tex
       </div>
       {convertedValue && (
         <div className={styles.convertedRow} data-testid="converted-indicator">
-          <span className={styles.convertedBadge}>Converted</span>
+          <label htmlFor={convertedTextareaId} className={styles.convertedBadge}>
+            Converted prompt
+          </label>
           <textarea
+            id={convertedTextareaId}
             ref={convertedRef}
             className={styles.convertedTextarea}
             value={convertedValue}


### PR DESCRIPTION
## Description

Closes #2440.

The converted prompt editor now uses its visible badge as an associated `<label>`. Screen readers can identify the editable converted value as `Converted prompt`, while the existing layout and editing behavior remain unchanged.

The existing conversion test now locates the textarea by accessible role and name and verifies its initial value.

## Tests and Documentation

- `npm test -- --runInBand src/components/Chat/ChatInputArea.test.tsx src/components/Chat/ChatWindow.test.tsx` (147 passed)
- `npm run type-check`
- `npm exec eslint -- src/components/Chat/ChatInputArea.tsx src/components/Chat/ChatInputArea.test.tsx`

No documentation changes are needed for this accessibility bug fix.
