### PR TITLE
MAINT Centralize history flattenability checks

### DIFF
--- a/pyrit/executor/attack/component/conversation_manager.py
+++ b/pyrit/executor/attack/component/conversation_manager.py
@@ -17,6 +17,7 @@ from pyrit.executor.attack.component.prepended_history_send_context import (
 )
 from pyrit.memory import CentralMemory
 from pyrit.message_normalizer import ConversationContextNormalizer
+from pyrit.message_normalizer._helpers import get_unflattenable_converter_output_types
 from pyrit.models import (
     ChatMessageRole,
     ComponentIdentifier,
@@ -577,17 +578,10 @@ class ConversationManager:
         Raises:
             ValueError: If an applied converter produced non-text prepended history.
         """
-        output_types = {
-            converted_piece.converted_value_data_type
-            for source_piece, converted_piece in zip(
-                source_message.message_pieces,
-                converted_message.message_pieces,
-                strict=True,
-            )
-            if len(converted_piece.converter_identifiers) > len(source_piece.converter_identifiers)
-            and not converted_piece.not_in_memory
-            and converted_piece.converted_value_data_type != "text"
-        }
+        output_types = get_unflattenable_converter_output_types(
+            source_messages=[source_message],
+            converted_messages=[converted_message],
+        )
         if output_types:
             raise ValueError(
                 "Cannot flatten prepended conversation for a target without editable history after "

--- a/pyrit/executor/attack/multi_turn/tree_of_attacks.py
+++ b/pyrit/executor/attack/multi_turn/tree_of_attacks.py
@@ -43,6 +43,7 @@ from pyrit.executor.attack.core.attack_config import (
 from pyrit.executor.attack.core.attack_strategy import AttackStrategy
 from pyrit.executor.attack.multi_turn import MultiTurnAttackContext
 from pyrit.memory import CentralMemory
+from pyrit.message_normalizer._helpers import get_unflattenable_converter_output_types
 from pyrit.models import (
     AtomicAttackIdentifier,
     AttackOutcome,
@@ -112,16 +113,7 @@ def _validate_stateful_clone_history_compatibility(
     ) or objective_target.configuration.includes(capability=CapabilityName.EDITABLE_HISTORY):
         return
 
-    non_text_output_types = {
-        piece.converted_value_data_type
-        for message in messages
-        for piece in message.message_pieces
-        if piece.converted_value_data_type != "text"
-        and (
-            piece.original_value != piece.converted_value
-            or piece.original_value_data_type != piece.converted_value_data_type
-        )
-    }
+    non_text_output_types = get_unflattenable_converter_output_types(converted_messages=messages)
     if non_text_output_types:
         raise ValueError(
             "Tree of Attacks cannot clone a stateful objective-target conversation without editable history "

--- a/pyrit/message_normalizer/_helpers.py
+++ b/pyrit/message_normalizer/_helpers.py
@@ -10,9 +10,58 @@ several input messages into one fresh user-role ``Message`` built via
 empty ``prompt_metadata``, callers must explicitly carry request-level metadata
 forward so downstream normalizers still see it.
 ``build_squashed_user_message`` centralizes that propagation rule.
+
+This module also owns the shared rule for whether converter output can be
+flattened into text without losing media semantics.
 """
 
-from pyrit.models import Message, MessagePiece
+from collections.abc import Sequence
+
+from pyrit.models import Message, MessagePiece, PromptDataType
+
+
+def get_unflattenable_converter_output_types(
+    *,
+    converted_messages: Sequence[Message],
+    source_messages: Sequence[Message] | None = None,
+) -> set[PromptDataType]:
+    """
+    Return converter output types that cannot be represented by text flattening.
+
+    Stored history is treated as converted when its original and converted
+    representations differ. When source messages are provided, only converters
+    added by the current conversion pass count, and ephemeral pieces are ignored.
+
+    Args:
+        converted_messages (Sequence[Message]): Messages containing converter output.
+        source_messages (Sequence[Message] | None): Optional messages from before
+            the current conversion pass.
+
+    Returns:
+        set[PromptDataType]: Non-text converter output types.
+    """
+    if source_messages is None:
+        converted_pieces = (
+            piece
+            for message in converted_messages
+            for piece in message.message_pieces
+            if piece.original_value != piece.converted_value
+            or piece.original_value_data_type != piece.converted_value_data_type
+        )
+    else:
+        converted_pieces = (
+            converted_piece
+            for source_message, converted_message in zip(source_messages, converted_messages, strict=True)
+            for source_piece, converted_piece in zip(
+                source_message.message_pieces,
+                converted_message.message_pieces,
+                strict=True,
+            )
+            if len(converted_piece.converter_identifiers) > len(source_piece.converter_identifiers)
+            and not converted_piece.not_in_memory
+        )
+
+    return {piece.converted_value_data_type for piece in converted_pieces if piece.converted_value_data_type != "text"}
 
 
 def format_message_piece_for_context(*, piece: MessagePiece) -> str:

--- a/pyrit/message_normalizer/history_squash_normalizer.py
+++ b/pyrit/message_normalizer/history_squash_normalizer.py
@@ -5,7 +5,10 @@ import copy
 import logging
 import uuid
 
-from pyrit.message_normalizer._helpers import format_message_piece_for_context
+from pyrit.message_normalizer._helpers import (
+    format_message_piece_for_context,
+    get_unflattenable_converter_output_types,
+)
 from pyrit.message_normalizer.conversation_context_normalizer import ConversationContextNormalizer
 from pyrit.message_normalizer.generic_system_squash import GenericSystemSquashNormalizer
 from pyrit.message_normalizer.message_normalizer import MessageListNormalizer, MessageStringNormalizer
@@ -87,10 +90,14 @@ class HistorySquashNormalizer(MessageListNormalizer[Message]):
         self._warn_on_non_text_history(messages=history)
 
         original_view = self._build_original_view(messages=messages)
-        converted_view = self._build_converted_view(messages=messages)
+        converted_view = (
+            self._build_converted_view(messages=messages)
+            if self._contains_converted_values(messages=messages)
+            else None
+        )
         original_text = await self._normalize_context_async(messages=original_view)
         converted_text = original_text
-        if self._contains_converted_values(messages=messages):
+        if converted_view is not None:
             converted_text = await self._normalize_context_async(messages=converted_view)
 
         return [
@@ -168,13 +175,13 @@ class HistorySquashNormalizer(MessageListNormalizer[Message]):
 
     @staticmethod
     def _filter_live_non_text_pieces(*, messages: list[Message]) -> list[Message]:
-        filtered = copy.deepcopy(messages)
+        filtered = list(messages)
         live_message = filtered[-1]
         text_pieces = [piece for piece in live_message.message_pieces if piece.converted_value_data_type == "text"]
         if not text_pieces:
             filtered.pop()
         else:
-            live_message.message_pieces = text_pieces
+            filtered[-1] = live_message.model_copy(update={"message_pieces": text_pieces})
         return filtered
 
     @staticmethod
@@ -207,16 +214,7 @@ class HistorySquashNormalizer(MessageListNormalizer[Message]):
 
     @staticmethod
     def _validate_flattenable_converter_output(*, messages: list[Message]) -> None:
-        output_types = {
-            piece.converted_value_data_type
-            for message in messages
-            for piece in message.message_pieces
-            if piece.converted_value_data_type != "text"
-            and (
-                piece.original_value != piece.converted_value
-                or piece.original_value_data_type != piece.converted_value_data_type
-            )
-        }
+        output_types = get_unflattenable_converter_output_types(converted_messages=messages)
         if output_types:
             raise ValueError(
                 "Cannot flatten conversation history after request converters produced "

--- a/tests/unit/message_normalizer/test_helpers.py
+++ b/tests/unit/message_normalizer/test_helpers.py
@@ -3,8 +3,11 @@
 
 import pytest
 
-from pyrit.message_normalizer._helpers import build_squashed_user_message
-from pyrit.models import Message, MessagePiece
+from pyrit.message_normalizer._helpers import (
+    build_squashed_user_message,
+    get_unflattenable_converter_output_types,
+)
+from pyrit.models import ComponentIdentifier, Message, MessagePiece
 
 
 def _message(*, role: str, content: str, metadata: dict | None = None) -> Message:
@@ -12,6 +15,59 @@ def _message(*, role: str, content: str, metadata: dict | None = None) -> Messag
         message_pieces=[
             MessagePiece(role=role, original_value=content, prompt_metadata=metadata or {}),
         ]
+    )
+
+
+def test_get_unflattenable_converter_output_types_ignores_unchanged_native_media():
+    native_audio = MessagePiece(
+        role="user",
+        original_value="native.wav",
+        original_value_data_type="audio_path",
+    )
+    converted_image = MessagePiece(
+        role="user",
+        original_value="prompt",
+        converted_value="converted.png",
+        converted_value_data_type="image_path",
+    )
+
+    output_types = get_unflattenable_converter_output_types(
+        converted_messages=[Message(message_pieces=[native_audio, converted_image])]
+    )
+
+    assert output_types == {"image_path"}
+
+
+def test_get_unflattenable_converter_output_types_uses_current_pass_lineage():
+    prior_identifier = ComponentIdentifier(class_name="PriorConverter", class_module="tests")
+    source_piece = MessagePiece(
+        role="user",
+        original_value="prompt",
+        converted_value="existing.png",
+        converted_value_data_type="image_path",
+        converter_identifiers=[prior_identifier],
+    )
+    converted_piece = source_piece.model_copy(deep=True)
+    source_messages = [Message(message_pieces=[source_piece])]
+    converted_messages = [Message(message_pieces=[converted_piece])]
+
+    assert not get_unflattenable_converter_output_types(
+        source_messages=source_messages,
+        converted_messages=converted_messages,
+    )
+
+    converted_piece.converter_identifiers.append(
+        ComponentIdentifier(class_name="CurrentConverter", class_module="tests")
+    )
+    assert get_unflattenable_converter_output_types(
+        source_messages=source_messages,
+        converted_messages=converted_messages,
+    ) == {"image_path"}
+
+    converted_piece.not_in_memory = True
+    assert not get_unflattenable_converter_output_types(
+        source_messages=source_messages,
+        converted_messages=converted_messages,
     )
 
 

--- a/tests/unit/message_normalizer/test_history_squash_normalizer.py
+++ b/tests/unit/message_normalizer/test_history_squash_normalizer.py
@@ -233,15 +233,17 @@ async def test_history_squash_rejects_converted_non_text_history():
 
 
 async def test_history_squash_preserves_original_list():
-    """Normalize should not mutate the input list."""
+    """Normalize should not mutate the input messages."""
     messages = [
         _make_message("user", "hello"),
         _make_message("assistant", "hi"),
         _make_message("user", "bye"),
     ]
-    original_len = len(messages)
+    original_messages = [message.model_copy(deep=True) for message in messages]
+
     await HistorySquashNormalizer().normalize_async(messages)
-    assert len(messages) == original_len
+
+    assert messages == original_messages
 
 
 async def test_history_squash_propagates_last_message_metadata():


### PR DESCRIPTION
## Description

Conversation flattening had duplicate checks for converted non-text output across prepended history, history squashing, and TAP branch cloning. Keeping these checks separate made it easy for their handling of native media, converter lineage, and non-persisted pieces to drift.

This change centralizes flattenability detection in the message normalizer helpers while preserving each caller's conditions and error message. It also avoids building an unused converted history view and replaces an unnecessary full deep copy with a shallow list copy plus a copied final message, preserving input immutability.

## Tests and Documentation

- Added helper coverage for unchanged native media, current-pass converter lineage, and non-persisted pieces.
- Strengthened HistorySquashNormalizer input immutability coverage.
- Ran focused message-normalizer, ConversationManager, TAP, and prepended-history tests: 221 passed.
- Ran Ruff check and format verification on all changed files.
- Ran targeted `ty check` and `git diff --check`.
- Documentation: N/A. No public API or user-facing behavior changed.
- JupyText: N/A. No notebooks changed.