### PR TITLE
MAINT: Fix build-book pipeline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Checkout ${{ matrix.ref }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ matrix.ref }}
+          ref: ${{ github.event_name == 'pull_request' && matrix.slug == 'latest' && github.event.pull_request.head.sha || matrix.ref }}
 
       - name: Resolve commit SHA
         # matrix.ref is a branch name (e.g. "releases/v0.13.0") that can move,

--- a/build_scripts/gen_api_md.py
+++ b/build_scripts/gen_api_md.py
@@ -689,7 +689,12 @@ def collect_top_level_modules(api_json_dir: Path) -> list[dict]:
     modules: list[dict] = []
     for jf in sorted(api_json_dir.glob("*.json")):
         data = json.loads(jf.read_text(encoding="utf-8"))
-        modules.extend(_expand_module(data))
+        if jf.stem.endswith("_all"):
+            submodules = [member for member in data.get("members", []) if member.get("kind") == "module"]
+            for submodule in submodules:
+                modules.extend(_expand_module(submodule))
+        else:
+            modules.extend(_expand_module(data))
 
     # Drop excluded and empty modules
     return [

--- a/pyrit/memory/memory_models.py
+++ b/pyrit/memory/memory_models.py
@@ -1251,7 +1251,7 @@ class EmbeddingMessageWithSimilarity(BaseModel):
     """
     Represents an embedding message with its similarity score.
 
-    Parameters:
+    Attributes:
         uuid (uuid.UUID): The UUID of the embedding message.
         metric (str): The metric used to calculate the similarity score.
         score (float): The similarity score (default is 0.0).


### PR DESCRIPTION
## Description
This PR fixes the Pydantic model docstring in `pyrit/memory/memory_models.py` from Parameters to Attributes and restores API reference generation after package exports were converted to lazy imports in previous PR: 
* update `gen_api_md` to treat `_all.json` files as aggregate module collections
* expand aggregate API documetanation from each child module instead of classifying the root `pyrit` module by helper public functions


## Tests and Documentation
reran tests and build book tests
