### PR TITLE
FEAT: Display version in top left

### DIFF
--- a/frontend/src/components/Layout/MainLayout.test.tsx
+++ b/frontend/src/components/Layout/MainLayout.test.tsx
@@ -109,11 +109,14 @@ describe("MainLayout", () => {
     });
   });
 
-  it("displays version from API in tooltip", async () => {
+  it("displays the version, commit, and database for a development release", async () => {
     mockedVersionApi.getVersion.mockResolvedValue({
-      version: "1.0.0",
-      display: "v1.0.0-beta",
+      version: "1.1.0.dev0",
+      commit: "729b7dd0446cc95412345662a1a921e2a4bf1979",
+      display: "729b7dd0446cc95412345662a1a921e2a4bf1979",
+      database_info: "AzureSQLMemory (airtprod)",
     });
+    const user = userEvent.setup();
 
     renderWithProvider(
       <MainLayout {...defaultProps}>
@@ -124,6 +127,42 @@ describe("MainLayout", () => {
     await waitFor(() => {
       expect(mockedVersionApi.getVersion).toHaveBeenCalled();
     });
+
+    await user.hover(screen.getByAltText("Co-PyRIT Logo"));
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("PyRIT 1.1.0.dev0");
+    expect(tooltip).toHaveTextContent(
+      "Commit: 729b7dd0446cc95412345662a1a921e2a4bf1979"
+    );
+    expect(tooltip).toHaveTextContent("AzureSQLMemory (airtprod)");
+  });
+
+  it("does not display the commit for a release version", async () => {
+    mockedVersionApi.getVersion.mockResolvedValue({
+      version: "1.1.0",
+      commit: "729b7dd0446cc95412345662a1a921e2a4bf1979",
+      display: "729b7dd0446cc95412345662a1a921e2a4bf1979",
+      database_info: "AzureSQLMemory (airtprod)",
+    });
+    const user = userEvent.setup();
+
+    renderWithProvider(
+      <MainLayout {...defaultProps}>
+        <div>Content</div>
+      </MainLayout>
+    );
+
+    await waitFor(() => {
+      expect(mockedVersionApi.getVersion).toHaveBeenCalled();
+    });
+
+    await user.hover(screen.getByAltText("Co-PyRIT Logo"));
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("PyRIT 1.1.0");
+    expect(tooltip).not.toHaveTextContent("Commit:");
+    expect(tooltip).toHaveTextContent("AzureSQLMemory (airtprod)");
   });
 
   it("displays 'Unknown' when version API fails", async () => {

--- a/frontend/src/components/Layout/MainLayout.tsx
+++ b/frontend/src/components/Layout/MainLayout.tsx
@@ -27,12 +27,14 @@ export default function MainLayout({
 }: MainLayoutProps) {
   const styles = useMainLayoutStyles()
   const [version, setVersion] = useState<string>('Loading...')
+  const [commit, setCommit] = useState<string | null>(null)
   const [databaseInfo, setDatabaseInfo] = useState<string | null>(null)
 
   useEffect(() => {
     versionApi.getVersion()
       .then(data => {
-        setVersion(data.display || data.version)
+        setVersion(data.version)
+        setCommit(data.version.includes('.dev') ? data.commit ?? null : null)
         setDatabaseInfo(data.database_info ?? null)
       })
       .catch(() => setVersion('Unknown'))
@@ -41,7 +43,16 @@ export default function MainLayout({
   return (
     <div className={styles.root}>
       <div className={styles.topBar}>
-        <Tooltip content={<>{`PyRIT ${version}`}{databaseInfo && <><br />{databaseInfo}</>}</>} relationship="label">
+        <Tooltip
+          content={
+            <>
+              {`PyRIT ${version}`}
+              {commit && <><br />{`Commit: ${commit}`}</>}
+              {databaseInfo && <><br />{databaseInfo}</>}
+            </>
+          }
+          relationship="label"
+        >
           <img
             src="/roakey.png"
             alt="Co-PyRIT Logo"


### PR DESCRIPTION
## Summary

Previously, the top-left tooltip used the API `display` value. Git-based deployments therefore showed the commit hash in place of the PyRIT version.

Now, the tooltip always shows `PyRIT <version>`. Development releases also show `Commit: <commit>` when commit metadata is available, followed by the configured memory database.

## Screenshot

![PyRIT version tooltip](https://github.com/user-attachments/assets/c004fba0-470c-4e9c-8778-831e4a5ca53c)