### PR TITLE
FIX associate converter parameter labels with their controls

### DIFF
--- a/frontend/src/components/Chat/ConverterPanel/ConverterParams.test.tsx
+++ b/frontend/src/components/Chat/ConverterPanel/ConverterParams.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react'
+import { FluentProvider, webLightTheme } from '@fluentui/react-components'
+import ConverterParams from './ConverterParams'
+import type { ConverterCatalogEntry } from '../../../types'
+
+const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <FluentProvider theme={webLightTheme}>{children}</FluentProvider>
+)
+
+const converter: ConverterCatalogEntry = {
+  converter_type: 'VigenereConverter',
+  supported_input_types: ['text'],
+  supported_output_types: ['text'],
+  is_llm_based: false,
+  description: 'Vigenere cipher.',
+  parameters: [
+    { name: 'key', type_name: 'str', required: true, default: null, choices: null, description: 'Cipher key.' },
+    { name: 'append_description', type_name: 'bool', required: false, default: 'false', choices: null, description: 'Append description.' },
+    { name: 'mode', type_name: 'str', required: false, default: 'fast', choices: ['fast', 'slow'], description: 'Speed mode.' },
+    { name: 'template_file_path', type_name: 'str', required: false, default: null, choices: null, description: 'Path to template.' },
+  ],
+}
+
+function renderParams(overrides: Partial<React.ComponentProps<typeof ConverterParams>> = {}) {
+  return render(
+    <TestWrapper>
+      <ConverterParams
+        converter={converter}
+        paramValues={{}}
+        paramsExpanded
+        showValidation={false}
+        onParamChange={jest.fn()}
+        onFileBrowse={jest.fn()}
+        onToggleExpanded={jest.fn()}
+        {...overrides}
+      />
+    </TestWrapper>,
+  )
+}
+
+describe('ConverterParams accessible names', () => {
+  it('exposes text, boolean, choice, and file controls by their visible parameter names', () => {
+    renderParams()
+
+    expect(screen.getByRole('textbox', { name: 'key' })).toBeInTheDocument()
+    expect(screen.getByRole('switch', { name: 'append_description' })).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: 'mode' })).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: 'template_file_path' })).toBeInTheDocument()
+  })
+
+  it('keeps required, error, and type hint associated with the text control', () => {
+    renderParams({ showValidation: true })
+
+    const key = screen.getByRole('textbox', { name: 'key' })
+    expect(key).toBeRequired()
+    expect(key).toBeInvalid()
+    expect(key).toHaveAccessibleDescription(/Required/)
+    expect(key).toHaveAccessibleDescription(/str/)
+  })
+
+  it('keeps boolean state visible without using it as the accessible name', () => {
+    renderParams({ paramValues: { append_description: 'true' } })
+
+    expect(screen.getByRole('switch', { name: 'append_description' })).toBeChecked()
+    expect(screen.getByText('True')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/Chat/ConverterPanel/ConverterParams.tsx
+++ b/frontend/src/components/Chat/ConverterPanel/ConverterParams.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, mergeClasses, Select, Switch, Text, Tooltip } from '@fluentui/react-components'
+import { Button, Field, Input, mergeClasses, Select, Switch, Text, Tooltip } from '@fluentui/react-components'
 import { ChevronDownRegular, ChevronRightRegular, InfoRegular } from '@fluentui/react-icons'
 import type { ConverterCatalogEntry, Parameter } from '../../../types'
 import { useConverterPanelStyles } from './ConverterPanel.styles'
@@ -68,6 +68,23 @@ function ConverterParameterViewer({ param, value, isMissing, onChange }: ParamIn
   )
 }
 
+function ParameterNameLabel({ param }: { param: Parameter }) {
+  const styles = useConverterPanelStyles()
+
+  return (
+    <span className={styles.paramLabel}>
+      {param.name}
+      {param.description && (
+        <Tooltip content={param.description} relationship="description">
+          <span className={styles.paramInfo} onClick={(e) => e.preventDefault()}>
+            <InfoRegular fontSize={12} />
+          </span>
+        </Tooltip>
+      )}
+    </span>
+  )
+}
+
 export interface ConverterParamsProps {
   converter: ConverterCatalogEntry
   paramValues: Record<string, string>
@@ -97,23 +114,28 @@ export default function ConverterParams({ converter, paramValues, paramsExpanded
       </Button>
       {paramsExpanded && (converter.parameters ?? []).map((param) => {
         const isMissing = showValidation && param.required && !paramValues[param.name]?.trim()
+        const isChecked = (paramValues[param.name] ?? (typeof param.default === 'string' ? param.default : 'false')).toLowerCase() === 'true'
+        const typeHint = param.type_name !== 'bool' && !param.choices ? param.type_name : undefined
+
         return (
-          <div key={param.name} className={styles.paramBlock}>
-            <span className={styles.paramLabel}>
-              <Text size={200} weight="semibold">{param.name}{param.required ? ' *' : ''}</Text>
-              {param.description && (
-                <Tooltip content={param.description} relationship="description">
-                  <span className={styles.paramInfo}><InfoRegular fontSize={12} /></span>
-                </Tooltip>
-              )}
-            </span>
+          <Field
+            key={param.name}
+            className={styles.paramBlock}
+            label={<ParameterNameLabel param={param} />}
+            required={param.required}
+            validationMessage={isMissing ? 'Required' : undefined}
+            validationState={isMissing ? 'error' : undefined}
+            hint={typeHint}
+          >
             {param.type_name === 'bool' ? (
-              <Switch
-                checked={(paramValues[param.name] ?? (typeof param.default === 'string' ? param.default : 'false')).toLowerCase() === 'true'}
-                onChange={(_, data) => onParamChange(param.name, data.checked ? 'true' : 'false')}
-                label={(paramValues[param.name] ?? (typeof param.default === 'string' ? param.default : 'false')).toLowerCase() === 'true' ? 'True' : 'False'}
-                data-testid={`param-${param.name}`}
-              />
+              <div className={styles.filePickerRow}>
+                <Switch
+                  checked={isChecked}
+                  onChange={(_, data) => onParamChange(param.name, data.checked ? 'true' : 'false')}
+                  data-testid={`param-${param.name}`}
+                />
+                <Text size={200} aria-hidden="true">{isChecked ? 'True' : 'False'}</Text>
+              </div>
             ) : param.choices ? (
               <ConverterParameterChoiceViewer param={param} value={paramValues[param.name]} isMissing={isMissing} onChange={onParamChange} />
             ) : /path|file/i.test(param.name) || /path|file/i.test(param.description ?? '') ? (
@@ -121,13 +143,7 @@ export default function ConverterParams({ converter, paramValues, paramsExpanded
             ) : (
               <ConverterParameterViewer param={param} value={paramValues[param.name]} isMissing={isMissing} onChange={onParamChange} />
             )}
-            {isMissing && (
-              <Text size={100} className={styles.paramErrorText}>Required</Text>
-            )}
-            {param.type_name !== 'bool' && !param.choices && (
-              <Text size={100} className={styles.hintText}>{param.type_name}</Text>
-            )}
-          </div>
+          </Field>
         )
       })}
     </div>


### PR DESCRIPTION
## Description
Fixes #2506. Converter parameter fields now use Fluent `Field` so the visible name is the accessible name for text, boolean, choice, and file controls. Required, error, and type hint stay attached to the same field.

## Tests and Documentation
- Added `ConverterParams.test.tsx` role/name coverage for the four control variants.
- `npx jest src/components/Chat/ConverterPanel/ConverterParams.test.tsx src/components/Chat/ConverterPanel.test.tsx --no-coverage` (53 passed)

