### PR TITLE
FEAT Add target visibility controls to frontend

### DIFF
--- a/frontend/src/components/Config/TargetTable.styles.ts
+++ b/frontend/src/components/Config/TargetTable.styles.ts
@@ -113,9 +113,6 @@ export const useTargetTableStyles = makeStyles({
       },
     },
   },
-  hiddenTargetsToggle: {
-    marginLeft: 'auto',
-  },
   actionCell: {
     width: '220px',
   },

--- a/frontend/src/components/Config/TargetTable.styles.ts
+++ b/frontend/src/components/Config/TargetTable.styles.ts
@@ -36,6 +36,10 @@ export const useTargetTableStyles = makeStyles({
     overflowWrap: 'anywhere',
     wordBreak: 'break-word',
   },
+  hiddenRow: {
+    backgroundColor: tokens.colorNeutralBackground2,
+    opacity: 0.65,
+  },
   endpointCell: {
     overflowWrap: 'break-word',
     wordBreak: 'break-all',
@@ -108,6 +112,17 @@ export const useTargetTableStyles = makeStyles({
         minHeight: MINIMUM_TOUCH_TARGET_SIZE,
       },
     },
+  },
+  hiddenTargetsToggle: {
+    marginLeft: 'auto',
+  },
+  actionCell: {
+    width: '220px',
+  },
+  rowActions: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.spacingHorizontalXS,
   },
   rowAction: {
     ...mobileTouchTarget,

--- a/frontend/src/components/Config/TargetTable.test.tsx
+++ b/frontend/src/components/Config/TargetTable.test.tsx
@@ -1,8 +1,11 @@
 import { render, screen, fireEvent, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { FluentProvider, webLightTheme } from '@fluentui/react-components'
+
 import { makeTarget } from '@/test-utils/targetFixtures'
+import type { TargetInstance } from '@/types'
+
 import TargetTable from './TargetTable'
-import type { TargetInstance } from '../../types'
 
 jest.mock('./TargetTable.styles', () => ({
   useTargetTableStyles: () => new Proxy({}, { get: () => '' }),
@@ -62,6 +65,7 @@ describe('TargetTable', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    window.localStorage.clear()
   })
 
   it('should render a flat table with all targets visible', () => {
@@ -338,6 +342,50 @@ describe('TargetTable', () => {
 
     fireEvent.change(select, { target: { value: '' } })
     expect(screen.getByText('dall-e-3')).toBeInTheDocument()
+  })
+
+  it('should hide a target and persist the choice across remounts', async () => {
+    const user = userEvent.setup()
+    const firstRender = render(
+      <TestWrapper>
+        <TargetTable {...defaultProps} />
+      </TestWrapper>
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Hide openai_chat_gpt4' }))
+
+    expect(screen.queryByText('gpt-4')).not.toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: 'Show hidden targets (1)' })).not.toBeChecked()
+
+    firstRender.unmount()
+    render(
+      <TestWrapper>
+        <TargetTable {...defaultProps} />
+      </TestWrapper>
+    )
+
+    expect(screen.queryByText('gpt-4')).not.toBeInTheDocument()
+    expect(screen.getByText('dall-e-3')).toBeInTheDocument()
+  })
+
+  it('should show hidden targets and allow unhiding them', async () => {
+    const user = userEvent.setup()
+    render(
+      <TestWrapper>
+        <TargetTable {...defaultProps} />
+      </TestWrapper>
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Hide azure_image_dalle' }))
+    expect(screen.queryByText('dall-e-3')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('checkbox', { name: 'Show hidden targets (1)' }))
+    expect(screen.getByText('dall-e-3')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Unhide azure_image_dalle' }))
+
+    expect(screen.getByText('dall-e-3')).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: 'Show hidden targets (0)' })).toBeDisabled()
   })
 
   it('should not show filter when only one target type exists', () => {

--- a/frontend/src/components/Config/TargetTable.test.tsx
+++ b/frontend/src/components/Config/TargetTable.test.tsx
@@ -368,7 +368,7 @@ describe('TargetTable', () => {
     expect(screen.getByText('dall-e-3')).toBeInTheDocument()
   })
 
-  it('should show hidden targets and allow unhiding them', async () => {
+  it('should show hidden targets and allow restoring them', async () => {
     const user = userEvent.setup()
     render(
       <TestWrapper>
@@ -382,10 +382,39 @@ describe('TargetTable', () => {
     await user.click(screen.getByRole('checkbox', { name: 'Show hidden targets (1)' }))
     expect(screen.getByText('dall-e-3')).toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: 'Unhide azure_image_dalle' }))
+    await user.click(screen.getByRole('button', { name: 'Show azure_image_dalle' }))
 
     expect(screen.getByText('dall-e-3')).toBeInTheDocument()
     expect(screen.getByRole('checkbox', { name: 'Show hidden targets (0)' })).toBeDisabled()
+  })
+
+  it('should hide registry entries independently when they share an identifier', async () => {
+    const user = userEvent.setup()
+    const duplicateTargets = [
+      makeTarget({
+        target_registry_name: 'first_registry_name',
+        target_type: 'OpenAIChatTarget',
+        model_name: 'shared-model',
+        identifier_hash: 'shared-identifier-hash',
+      }),
+      makeTarget({
+        target_registry_name: 'second_registry_name',
+        target_type: 'OpenAIChatTarget',
+        model_name: 'shared-model',
+        identifier_hash: 'shared-identifier-hash',
+      }),
+    ]
+    render(
+      <TestWrapper>
+        <TargetTable {...defaultProps} targets={duplicateTargets} />
+      </TestWrapper>
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Hide first_registry_name' }))
+
+    expect(screen.queryByText('first_registry_name')).not.toBeInTheDocument()
+    expect(screen.getByText('second_registry_name')).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: 'Show hidden targets (1)' })).toBeInTheDocument()
   })
 
   it('should not show filter when only one target type exists', () => {

--- a/frontend/src/components/Config/TargetTable.tsx
+++ b/frontend/src/components/Config/TargetTable.tsx
@@ -37,7 +37,6 @@ import {
 import type { TargetInstance } from '@/types'
 import {
   targetEndpoint,
-  targetIdentifierHash,
   targetModelName,
   targetType,
   targetUnderlyingModelName,
@@ -45,7 +44,7 @@ import {
 
 import { useTargetTableStyles } from './TargetTable.styles'
 
-const HIDDEN_TARGETS_STORAGE_KEY = 'pyrit.hiddenTargetIdentifierHashes'
+const HIDDEN_TARGETS_STORAGE_KEY = 'pyrit.hiddenTargetRegistryNames'
 
 interface TargetTableProps {
   targets: TargetInstance[]
@@ -53,7 +52,7 @@ interface TargetTableProps {
   onSetActiveTarget: (target: TargetInstance) => void
 }
 
-function readStoredHiddenTargetHashes(): Set<string> {
+function readStoredHiddenTargetRegistryNames(): Set<string> {
   if (typeof window === 'undefined') return new Set()
   try {
     const raw = window.localStorage.getItem(HIDDEN_TARGETS_STORAGE_KEY)
@@ -66,12 +65,12 @@ function readStoredHiddenTargetHashes(): Set<string> {
   }
 }
 
-function persistHiddenTargetHashes(hiddenTargetHashes: Set<string>): void {
+function persistHiddenTargetRegistryNames(hiddenTargetRegistryNames: Set<string>): void {
   if (typeof window === 'undefined') return
   try {
     window.localStorage.setItem(
       HIDDEN_TARGETS_STORAGE_KEY,
-      JSON.stringify([...hiddenTargetHashes].sort()),
+      JSON.stringify([...hiddenTargetRegistryNames].sort()),
     )
   } catch {
     /* localStorage may be unavailable (private mode, quota, sandboxed iframe). */
@@ -287,8 +286,8 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
   const styles = useTargetTableStyles()
   const typeFilterId = useId()
   const [typeFilter, setTypeFilter] = useState('')
-  const [hiddenTargetHashes, setHiddenTargetHashes] = useState<Set<string>>(
-    () => readStoredHiddenTargetHashes(),
+  const [hiddenTargetRegistryNames, setHiddenTargetRegistryNames] = useState<Set<string>>(
+    () => readStoredHiddenTargetRegistryNames(),
   )
   const [showHiddenTargets, setShowHiddenTargets] = useState(false)
   // Tracks which RoundRobinTarget rows are expanded to show inner targets.
@@ -317,15 +316,15 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
   )
 
   const hiddenTargetCount = useMemo(
-    () => targets.filter((target) => hiddenTargetHashes.has(targetIdentifierHash(target))).length,
-    [hiddenTargetHashes, targets],
+    () => targets.filter((target) => hiddenTargetRegistryNames.has(target.target_registry_name)).length,
+    [hiddenTargetRegistryNames, targets],
   )
 
   const displayedTargets = useMemo(
     () => showHiddenTargets
       ? targets
-      : targets.filter((target) => !hiddenTargetHashes.has(targetIdentifierHash(target))),
-    [hiddenTargetHashes, showHiddenTargets, targets],
+      : targets.filter((target) => !hiddenTargetRegistryNames.has(target.target_registry_name)),
+    [hiddenTargetRegistryNames, showHiddenTargets, targets],
   )
 
   const filteredTargets = useMemo(
@@ -339,15 +338,14 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
     activeTarget?.target_registry_name === target.target_registry_name
 
   const setTargetHidden = (target: TargetInstance, hidden: boolean): void => {
-    const nextHiddenTargetHashes = new Set(hiddenTargetHashes)
-    const identifierHash = targetIdentifierHash(target)
+    const nextHiddenTargetRegistryNames = new Set(hiddenTargetRegistryNames)
     if (hidden) {
-      nextHiddenTargetHashes.add(identifierHash)
+      nextHiddenTargetRegistryNames.add(target.target_registry_name)
     } else {
-      nextHiddenTargetHashes.delete(identifierHash)
+      nextHiddenTargetRegistryNames.delete(target.target_registry_name)
     }
-    setHiddenTargetHashes(nextHiddenTargetHashes)
-    persistHiddenTargetHashes(nextHiddenTargetHashes)
+    setHiddenTargetRegistryNames(nextHiddenTargetRegistryNames)
+    persistHiddenTargetRegistryNames(nextHiddenTargetRegistryNames)
   }
 
   return (
@@ -491,7 +489,7 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
           {filteredTargets.map((target) => {
             const expanded = expandedRows.has(target.target_registry_name)
             const expandable = hasInnerTargets(target)
-            const hidden = hiddenTargetHashes.has(targetIdentifierHash(target))
+            const hidden = hiddenTargetRegistryNames.has(target.target_registry_name)
             // Extract weights from target_specific_params so we can show per-inner-target weight
             const weights = target.target_specific_params?.weights as number[] | undefined
 
@@ -526,10 +524,10 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
                         size="small"
                         icon={hidden ? <EyeRegular /> : <EyeOffRegular />}
                         onClick={() => setTargetHidden(target, !hidden)}
-                        aria-label={`${hidden ? 'Unhide' : 'Hide'} ${target.target_registry_name}`}
+                        aria-label={`${hidden ? 'Show' : 'Hide'} ${target.target_registry_name}`}
                         data-testid={`toggle-target-visibility-${target.target_registry_name}`}
                       >
-                        {hidden ? 'Unhide' : 'Hide'}
+                        {hidden ? 'Show' : 'Hide'}
                       </Button>
                     </div>
                   </TableCell>

--- a/frontend/src/components/Config/TargetTable.tsx
+++ b/frontend/src/components/Config/TargetTable.tsx
@@ -409,6 +409,13 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
       )}
 
       <div className={styles.filterRow}>
+        <Checkbox
+          checked={showHiddenTargets && hiddenTargetCount > 0}
+          disabled={hiddenTargetCount === 0}
+          label={`Show hidden targets (${hiddenTargetCount})`}
+          onChange={(_, data) => setShowHiddenTargets(data.checked === true)}
+          data-testid="show-hidden-targets"
+        />
         {targetTypes.length > 1 && (
           <>
             <label htmlFor={typeFilterId}>
@@ -427,14 +434,6 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
             </Select>
           </>
         )}
-        <Checkbox
-          className={styles.hiddenTargetsToggle}
-          checked={showHiddenTargets && hiddenTargetCount > 0}
-          disabled={hiddenTargetCount === 0}
-          label={`Show hidden targets (${hiddenTargetCount})`}
-          onChange={(_, data) => setShowHiddenTargets(data.checked === true)}
-          data-testid="show-hidden-targets"
-        />
       </div>
 
       <Table aria-label="Target instances" className={styles.table}>

--- a/frontend/src/components/Config/TargetTable.tsx
+++ b/frontend/src/components/Config/TargetTable.tsx
@@ -11,6 +11,8 @@ import {
   Text,
   Tooltip,
   Select,
+  Checkbox,
+  mergeClasses,
 } from '@fluentui/react-components'
 import {
   CheckmarkRegular,
@@ -28,15 +30,52 @@ import {
   ArrowHookUpLeftRegular,
   ChevronRightRegular,
   ChevronDownRegular,
+  EyeOffRegular,
+  EyeRegular,
 } from '@fluentui/react-icons'
-import type { TargetInstance } from '../../types'
-import { targetEndpoint, targetModelName, targetType, targetUnderlyingModelName } from '../../utils/targetIdentity'
+
+import type { TargetInstance } from '@/types'
+import {
+  targetEndpoint,
+  targetIdentifierHash,
+  targetModelName,
+  targetType,
+  targetUnderlyingModelName,
+} from '@/utils/targetIdentity'
+
 import { useTargetTableStyles } from './TargetTable.styles'
+
+const HIDDEN_TARGETS_STORAGE_KEY = 'pyrit.hiddenTargetIdentifierHashes'
 
 interface TargetTableProps {
   targets: TargetInstance[]
   activeTarget: TargetInstance | null
   onSetActiveTarget: (target: TargetInstance) => void
+}
+
+function readStoredHiddenTargetHashes(): Set<string> {
+  if (typeof window === 'undefined') return new Set()
+  try {
+    const raw = window.localStorage.getItem(HIDDEN_TARGETS_STORAGE_KEY)
+    if (!raw) return new Set()
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return new Set()
+    return new Set(parsed.filter((value): value is string => typeof value === 'string'))
+  } catch {
+    return new Set()
+  }
+}
+
+function persistHiddenTargetHashes(hiddenTargetHashes: Set<string>): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(
+      HIDDEN_TARGETS_STORAGE_KEY,
+      JSON.stringify([...hiddenTargetHashes].sort()),
+    )
+  } catch {
+    /* localStorage may be unavailable (private mode, quota, sandboxed iframe). */
+  }
 }
 
 /** Format target_specific_params into a short human-readable string. */
@@ -248,6 +287,10 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
   const styles = useTargetTableStyles()
   const typeFilterId = useId()
   const [typeFilter, setTypeFilter] = useState('')
+  const [hiddenTargetHashes, setHiddenTargetHashes] = useState<Set<string>>(
+    () => readStoredHiddenTargetHashes(),
+  )
+  const [showHiddenTargets, setShowHiddenTargets] = useState(false)
   // Tracks which RoundRobinTarget rows are expanded to show inner targets.
   // We use a Set of target_registry_name strings — when a name is in the set,
   // that row's sub-rows are visible.
@@ -273,13 +316,39 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
     [targets],
   )
 
+  const hiddenTargetCount = useMemo(
+    () => targets.filter((target) => hiddenTargetHashes.has(targetIdentifierHash(target))).length,
+    [hiddenTargetHashes, targets],
+  )
+
+  const displayedTargets = useMemo(
+    () => showHiddenTargets
+      ? targets
+      : targets.filter((target) => !hiddenTargetHashes.has(targetIdentifierHash(target))),
+    [hiddenTargetHashes, showHiddenTargets, targets],
+  )
+
   const filteredTargets = useMemo(
-    () => typeFilter ? targets.filter(t => targetType(t) === typeFilter) : targets,
-    [targets, typeFilter],
+    () => typeFilter
+      ? displayedTargets.filter((target) => targetType(target) === typeFilter)
+      : displayedTargets,
+    [displayedTargets, typeFilter],
   )
 
   const isActive = (target: TargetInstance): boolean =>
     activeTarget?.target_registry_name === target.target_registry_name
+
+  const setTargetHidden = (target: TargetInstance, hidden: boolean): void => {
+    const nextHiddenTargetHashes = new Set(hiddenTargetHashes)
+    const identifierHash = targetIdentifierHash(target)
+    if (hidden) {
+      nextHiddenTargetHashes.add(identifierHash)
+    } else {
+      nextHiddenTargetHashes.delete(identifierHash)
+    }
+    setHiddenTargetHashes(nextHiddenTargetHashes)
+    persistHiddenTargetHashes(nextHiddenTargetHashes)
+  }
 
   return (
     <div className={styles.tableContainer} data-testid="target-table-scroll-region">
@@ -341,29 +410,39 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
         </Table>
       )}
 
-      {targetTypes.length > 1 && (
-        <div className={styles.filterRow}>
-          <label htmlFor={typeFilterId}>
-            <Text size={200}>Filter by type:</Text>
-          </label>
-          <Select
-            id={typeFilterId}
-            className={styles.filterSelect}
-            value={typeFilter}
-            onChange={(_, data) => setTypeFilter(data.value)}
-          >
-            <option value="">All types</option>
-            {targetTypes.map(t => (
-              <option key={t} value={t}>{t}</option>
-            ))}
-          </Select>
-        </div>
-      )}
+      <div className={styles.filterRow}>
+        {targetTypes.length > 1 && (
+          <>
+            <label htmlFor={typeFilterId}>
+              <Text size={200}>Filter by type:</Text>
+            </label>
+            <Select
+              id={typeFilterId}
+              className={styles.filterSelect}
+              value={typeFilter}
+              onChange={(_, data) => setTypeFilter(data.value)}
+            >
+              <option value="">All types</option>
+              {targetTypes.map((targetTypeName) => (
+                <option key={targetTypeName} value={targetTypeName}>{targetTypeName}</option>
+              ))}
+            </Select>
+          </>
+        )}
+        <Checkbox
+          className={styles.hiddenTargetsToggle}
+          checked={showHiddenTargets && hiddenTargetCount > 0}
+          disabled={hiddenTargetCount === 0}
+          label={`Show hidden targets (${hiddenTargetCount})`}
+          onChange={(_, data) => setShowHiddenTargets(data.checked === true)}
+          data-testid="show-hidden-targets"
+        />
+      </div>
 
       <Table aria-label="Target instances" className={styles.table}>
         <TableHeader className={styles.stickyHeader}>
           <TableRow>
-            <TableHeaderCell style={{ width: '120px' }} />
+            <TableHeaderCell className={styles.actionCell}>Actions</TableHeaderCell>
             <TableHeaderCell style={{ width: '180px' }}>
               <Tooltip content={COLUMN_TOOLTIPS.registryName} relationship="description">
                 <span className={styles.helpHeader}>Registry Name</span>
@@ -412,30 +491,47 @@ export default function TargetTable({ targets, activeTarget, onSetActiveTarget }
           {filteredTargets.map((target) => {
             const expanded = expandedRows.has(target.target_registry_name)
             const expandable = hasInnerTargets(target)
+            const hidden = hiddenTargetHashes.has(targetIdentifierHash(target))
             // Extract weights from target_specific_params so we can show per-inner-target weight
             const weights = target.target_specific_params?.weights as number[] | undefined
 
             return (
               <React.Fragment key={target.target_registry_name}>
                 <TableRow
-                  className={isActive(target) ? styles.activeRow : undefined}
+                  className={mergeClasses(
+                    isActive(target) && styles.activeRow,
+                    hidden && styles.hiddenRow,
+                  )}
                   data-testid={`target-row-${target.target_registry_name}`}
                 >
-                  <TableCell>
-                    {isActive(target) ? (
-                      <Badge appearance="filled" color="brand" icon={<CheckmarkRegular />}>
-                        Active
-                      </Badge>
-                    ) : (
+                  <TableCell className={styles.actionCell}>
+                    <div className={styles.rowActions}>
+                      {isActive(target) ? (
+                        <Badge appearance="filled" color="brand" icon={<CheckmarkRegular />}>
+                          Active
+                        </Badge>
+                      ) : (
+                        <Button
+                          className={styles.rowAction}
+                          appearance="primary"
+                          size="small"
+                          onClick={() => onSetActiveTarget(target)}
+                        >
+                          Set Active
+                        </Button>
+                      )}
                       <Button
                         className={styles.rowAction}
-                        appearance="primary"
+                        appearance="subtle"
                         size="small"
-                        onClick={() => onSetActiveTarget(target)}
+                        icon={hidden ? <EyeRegular /> : <EyeOffRegular />}
+                        onClick={() => setTargetHidden(target, !hidden)}
+                        aria-label={`${hidden ? 'Unhide' : 'Hide'} ${target.target_registry_name}`}
+                        data-testid={`toggle-target-visibility-${target.target_registry_name}`}
                       >
-                        Set Active
+                        {hidden ? 'Unhide' : 'Hide'}
                       </Button>
-                    )}
+                    </div>
                   </TableCell>
                   <TableCell className={styles.registryNameCell}>
                     <Text size={200} className={styles.registryNameText}>{target.target_registry_name}</Text>


### PR DESCRIPTION
## Description
Target tables can become cluttered with targets a user does not currently need. Add browser-persisted per-target hide controls and a Show hidden targets toggle.

<img width="666" height="591" alt="image" src="https://github.com/user-attachments/assets/6eb705dc-2e60-4b6c-98a7-f95a7a38d160" />

