### PR TITLE
MAINT: Publish the backend log from the shared test jobs

### DIFF
--- a/.azuredevops/test-job-template.yml
+++ b/.azuredevops/test-job-template.yml
@@ -130,6 +130,52 @@ jobs:
           make ${{ parameters.makeTarget }}
         fi
   - bash: |
+      set -uo pipefail
+      artifact_dir="$(Build.ArtifactStagingDirectory)/backend-logs"
+      mkdir -p "$artifact_dir"
+
+      # ServerLauncher writes the backend log to tempfile.gettempdir(), which honours
+      # TMPDIR/TEMP/TMP before falling back to /tmp, so check the agent temp directory too.
+      log_found=false
+      for candidate in "${TMPDIR:-}" "${TEMP:-}" "${TMP:-}" "${AGENT_TEMPDIRECTORY:-}" /tmp; do
+        [ -n "$candidate" ] || continue
+        if [ -f "$candidate/pyrit_backend.log" ]; then
+          log_found=true
+          # Only claim success, and only ask for a publish, if the copy actually landed;
+          # publishing an empty directory would report a log that isn't there. Report the
+          # size too, because a zero byte log is a real outcome and an empty artifact
+          # otherwise looks like this step failed.
+          if cp_error=$(cp "$candidate/pyrit_backend.log" "$artifact_dir/pyrit_backend.log" 2>&1); then
+            log_bytes=$(wc -c <"$artifact_dir/pyrit_backend.log")
+            echo "Collected backend log from $candidate ($log_bytes bytes)"
+            echo "##vso[task.setvariable variable=backendLogFound]true"
+          else
+            echo "##vso[task.logissue type=warning]Found pyrit_backend.log in $candidate but failed to copy it: $cp_error"
+          fi
+          break
+        fi
+      done
+
+      # Distinguish the two outcomes: a job that never launches a backend is expected to have
+      # no log, whereas a log that was found but could not be collected is a real problem.
+      if [ "${log_found:-false}" = false ]; then
+        echo "No pyrit_backend.log found; this job did not launch a backend."
+      fi
+    displayName: "Collect pyrit_backend log"
+    name: collect_backend_log
+    condition: always()
+  - task: PublishPipelineArtifact@1
+    displayName: "Publish pyrit_backend log"
+    condition: and(always(), eq(variables['backendLogFound'], 'true'))
+    # Publishing a diagnostic log must never change the outcome of the test job.
+    continueOnError: true
+    inputs:
+      targetPath: $(Build.ArtifactStagingDirectory)/backend-logs
+      # BuildId stays the same when a failed job is retried, and pipeline artifacts cannot be
+      # overwritten, so JobAttempt is needed to keep each attempt's artifact name unique.
+      artifactName: backend-logs-${{ parameters.jobName }}-$(Build.BuildId)-attempt-$(System.JobAttempt)
+      publishLocation: pipeline
+  - bash: |
       rm -f ~/.pyrit/.env ~/.pyrit/.env.local
     name: clean_up_env_files
     condition: always()


### PR DESCRIPTION
## Description
The end-to-end and integration jobs launch `pyrit_backend` through `ServerLauncher`, which writes the server log to a file in the system temp directory and then throws it away when the agent is torn down. A failing job therefore reports only the client side of the failure, which means a backend that is alive but unresponsive is indistinguishable from one that never started at all.

That distinction is exactly what we could not make while debugging the current End to End Tests failures: every one of the failures is a client-side read timeout, and the server's own account of what it was doing is discarded along with the agent.

This collects the log and publishes it as a pipeline artifact, following the pattern `adversarial-benchmark.yml` already uses:

- The collection step runs under `condition: always()`, so a job that fails, or times out at the 360-minute cap, still yields the log.
- `ServerLauncher` writes to `tempfile.gettempdir()`, which honours `TMPDIR`/`TEMP`/`TMP` before falling back to `/tmp`, so the step checks the agent temp directory as well as `/tmp`.
- A missing file is not an error. Jobs that never launch a backend log one line and move on.
- The publish task is skipped unless the copy actually landed, so we never publish an empty artifact that claims a log is there when it isn't.

Only `.azuredevops/test-job-template.yml` changes. No product code, no test code, and no behaviour change for any job — this adds diagnostics only.

Part of the v1.1.0 release wave with #2510, #2511 and #2512.


## Tests and Documentation

This is pipeline YAML, so no unit test can cover it. I validated it by extracting the script body and executing it against all three paths:

- Log present in the temp directory: copied, `backendLogFound=true`, artifact published. Step exits 0.
- No log present, i.e. a job that never starts a backend: prints "No pyrit_backend.log found", publish skipped. Step exits 0.
- Log present but the copy fails, tested with an unwritable staging directory: flag not set, publish skipped. Step still exits 0.

The third case is worth calling out, because the first version of this step got it wrong. `set -uo pipefail` does not include `-e`, so a failing `cp` is silent: the step would have claimed success, set `backendLogFound=true`, and published an empty directory while simultaneously printing "No pyrit_backend.log found". The step now gates both the success message and the `setvariable` on the copy actually succeeding, so the flag is set only when the file has really landed.

No documentation changes, since this touches only pipeline YAML. JupyText was not run and is not applicable here: no notebooks, docs or public APIs are affected by this change.
