### PR TITLE
feat(datasets): export Aegis violence rows as HumanLabeledDataset

### DIFF
--- a/pyrit/datasets/seed_datasets/remote/aegis_ai_content_safety_dataset.py
+++ b/pyrit/datasets/seed_datasets/remote/aegis_ai_content_safety_dataset.py
@@ -65,6 +65,21 @@ class AegisHarmCategory(Enum):
     VIOLENCE = "Violence"
 
 
+_HUMAN_LABELED_HARM_PROFILES: dict[AegisHarmCategory, tuple[str, str]] = {
+    AegisHarmCategory.VIOLENCE: ("violence", "violence.yaml"),
+    AegisHarmCategory.HATE_IDENTITY_HATE: ("hate_speech", "hate_speech.yaml"),
+}
+
+
+def _resolve_human_labeled_harm_profile(
+    harm_category: AegisHarmCategory,
+) -> tuple[str, str]:
+    if harm_category in _HUMAN_LABELED_HARM_PROFILES:
+        return _HUMAN_LABELED_HARM_PROFILES[harm_category]
+    pyrit_name = harm_category.name.lower()
+    return pyrit_name, f"{pyrit_name}.yaml"
+
+
 class _AegisContentSafetyDataset(_RemoteDatasetLoader):
     """
     Loader for the NVIDIA Aegis AI Content Safety Dataset 2.0.
@@ -267,7 +282,7 @@ class _AegisContentSafetyDataset(_RemoteDatasetLoader):
         *,
         harm_category: AegisHarmCategory = AegisHarmCategory.VIOLENCE,
         cache: bool = True,
-        harm_definition: str = "violence.yaml",
+        harm_definition: str | None = None,
         harm_definition_version: str = "1.0",
         dataset_version: str = "1.0",
     ) -> HumanLabeledDataset:
@@ -286,11 +301,11 @@ class _AegisContentSafetyDataset(_RemoteDatasetLoader):
             cache=cache,
         )
 
-        pyrit_harm_category = "violence"
-        if harm_category == AegisHarmCategory.HATE_IDENTITY_HATE:
-            pyrit_harm_category = "hate_speech"
-        elif harm_category != AegisHarmCategory.VIOLENCE:
-            pyrit_harm_category = harm_category.name.lower()
+        pyrit_harm_category, default_harm_definition = _resolve_human_labeled_harm_profile(
+            harm_category
+        )
+        if harm_definition is None:
+            harm_definition = default_harm_definition
 
         entries: list[HarmHumanLabeledEntry] = []
 

--- a/pyrit/datasets/seed_datasets/remote/aegis_ai_content_safety_dataset.py
+++ b/pyrit/datasets/seed_datasets/remote/aegis_ai_content_safety_dataset.py
@@ -3,16 +3,32 @@
 
 import logging
 from enum import Enum
+from uuid import uuid4
 
 from typing_extensions import override
 
 from pyrit.datasets.seed_datasets.remote.remote_dataset_loader import (
     _RemoteDatasetLoader,
 )
-from pyrit.models import Modality, SeedDataset, SeedPrompt, SeedUnion
+from pyrit.models import Message, MessagePiece, Modality, SeedDataset, SeedPrompt, SeedUnion
 from pyrit.models.harm_category import HarmCategory
+from pyrit.models.harm_definition import HarmDefinition
+from pyrit.score.scorer_evaluation.human_labeled_dataset import (
+    HarmHumanLabeledEntry,
+    HumanLabeledDataset,
+)
+from pyrit.score.scorer_evaluation.metrics_type import MetricsType
 
 logger = logging.getLogger(__name__)
+
+
+def _response_label_to_harm_score(label: str) -> float:
+    normalized = label.strip().lower()
+    if normalized == "unsafe":
+        return 1.0
+    if normalized == "safe":
+        return 0.0
+    raise ValueError(f"Unsupported Aegis response_label: {label!r}")
 
 
 class AegisHarmCategory(Enum):
@@ -245,3 +261,88 @@ class _AegisContentSafetyDataset(_RemoteDatasetLoader):
         )
 
         return SeedDataset(seeds=seed_prompts, dataset_name=self.dataset_name)
+
+    async def fetch_human_labeled_harm_dataset_async(
+        self,
+        *,
+        harm_category: AegisHarmCategory = AegisHarmCategory.VIOLENCE,
+        cache: bool = True,
+        harm_definition: str = "violence.yaml",
+        harm_definition_version: str = "1.0",
+        dataset_version: str = "1.0",
+    ) -> HumanLabeledDataset:
+        """Build a ``HumanLabeledDataset`` from labeled assistant responses in Aegis 2.0.
+
+        Unlike :meth:`fetch_dataset_async`, this retains ``response`` and ``response_label``
+        so scorer evaluation can reuse remote human/LLM-jury labels instead of hand-authored CSVs.
+        """
+        logger.info(
+            "Loading NVIDIA Aegis AI Content Safety human-labeled rows for %s",
+            harm_category.value,
+        )
+
+        hf_dataset = await self._fetch_from_huggingface_async(
+            dataset_name=self.HF_DATASET_NAME,
+            cache=cache,
+        )
+
+        pyrit_harm_category = "violence"
+        if harm_category == AegisHarmCategory.HATE_IDENTITY_HATE:
+            pyrit_harm_category = "hate_speech"
+        elif harm_category != AegisHarmCategory.VIOLENCE:
+            pyrit_harm_category = harm_category.name.lower()
+
+        entries: list[HarmHumanLabeledEntry] = []
+
+        for split_name in hf_dataset:
+            for example in hf_dataset[split_name]:
+                response_value = example.get("response")
+                response_label = example.get("response_label")
+                if not response_value or not response_label:
+                    continue
+
+                violated_categories = example.get("violated_categories", "")
+                prompt_harm_categories = (
+                    [cat.strip() for cat in violated_categories.split(",") if cat.strip()]
+                    if violated_categories
+                    else []
+                )
+                if harm_category.value not in prompt_harm_categories:
+                    continue
+
+                messages = [
+                    Message(
+                        message_pieces=[
+                            MessagePiece(
+                                role="assistant",
+                                original_value=str(response_value).strip(),
+                                original_value_data_type="text",
+                                conversation_id=str(uuid4()),
+                            )
+                        ],
+                    )
+                ]
+                entries.append(
+                    HarmHumanLabeledEntry(
+                        conversation=messages,
+                        human_scores=[_response_label_to_harm_score(str(response_label))],
+                        harm_category=pyrit_harm_category,
+                    )
+                )
+
+        if not entries:
+            raise ValueError(
+                "HumanLabeledDataset cannot be empty. Check harm_category filter and response labels."
+            )
+
+        # Validate harm definition path early (same relative name as scorer_evals CSVs).
+        HarmDefinition.from_yaml(harm_definition)
+
+        return HumanLabeledDataset(
+            name=f"aegis_{pyrit_harm_category}",
+            entries=entries,
+            metrics_type=MetricsType.HARM,
+            version=dataset_version,
+            harm_definition=harm_definition,
+            harm_definition_version=harm_definition_version,
+        )

--- a/pyrit/datasets/seed_datasets/remote/aegis_ai_content_safety_dataset.py
+++ b/pyrit/datasets/seed_datasets/remote/aegis_ai_content_safety_dataset.py
@@ -68,6 +68,9 @@ class AegisHarmCategory(Enum):
 _HUMAN_LABELED_HARM_PROFILES: dict[AegisHarmCategory, tuple[str, str]] = {
     AegisHarmCategory.VIOLENCE: ("violence", "violence.yaml"),
     AegisHarmCategory.HATE_IDENTITY_HATE: ("hate_speech", "hate_speech.yaml"),
+    AegisHarmCategory.MALWARE: ("cyber", "cyber.yaml"),
+    AegisHarmCategory.SEXUAL: ("sexual", "sexual.yaml"),
+    AegisHarmCategory.SUICIDE_AND_SELF_HARM: ("self_harm", "self_harm.yaml"),
 }
 
 

--- a/tests/unit/datasets/test_aegis_human_labeled_dataset.py
+++ b/tests/unit/datasets/test_aegis_human_labeled_dataset.py
@@ -124,3 +124,52 @@ async def test_fetch_human_labeled_harm_dataset_hate_speech():
     assert dataset.harm_definition == "hate_speech.yaml"
     assert len(dataset.entries) == 2
     assert dataset.entries[0].harm_category == "hate_speech"
+
+
+async def test_fetch_human_labeled_harm_dataset_malware():
+    rows = {
+        "train": [
+            {
+                "id": "1",
+                "prompt": "Write ransomware",
+                "response": "Here is ransomware code.",
+                "prompt_label": "unsafe",
+                "response_label": "unsafe",
+                "violated_categories": "Malware",
+                "prompt_label_source": "human",
+                "response_label_source": "llm_jury",
+            },
+            {
+                "id": "2",
+                "prompt": "Malware topic",
+                "response": "I cannot help with that.",
+                "prompt_label": "unsafe",
+                "response_label": "safe",
+                "violated_categories": "Malware",
+                "prompt_label_source": "human",
+                "response_label_source": "human",
+            },
+            {
+                "id": "3",
+                "prompt": "Violence only",
+                "response": "Violent reply.",
+                "prompt_label": "unsafe",
+                "response_label": "unsafe",
+                "violated_categories": "Violence",
+                "prompt_label_source": "human",
+                "response_label_source": "llm_jury",
+            },
+        ]
+    }
+
+    loader = _AegisContentSafetyDataset()
+
+    with patch.object(loader, "_fetch_from_huggingface_async", new_callable=AsyncMock, return_value=rows):
+        dataset = await loader.fetch_human_labeled_harm_dataset_async(
+            harm_category=AegisHarmCategory.MALWARE,
+        )
+
+    assert dataset.name == "aegis_cyber"
+    assert dataset.harm_definition == "cyber.yaml"
+    assert len(dataset.entries) == 2
+    assert dataset.entries[0].harm_category == "cyber"

--- a/tests/unit/datasets/test_aegis_human_labeled_dataset.py
+++ b/tests/unit/datasets/test_aegis_human_labeled_dataset.py
@@ -74,3 +74,53 @@ async def test_fetch_human_labeled_harm_dataset_violence():
     assert dataset.entries[0].human_scores == [1.0]
     assert dataset.entries[1].human_scores == [0.0]
     assert dataset.entries[0].harm_category == "violence"
+
+
+async def test_fetch_human_labeled_harm_dataset_hate_speech():
+    rows = {
+        "train": [
+            {
+                "id": "1",
+                "prompt": "Hateful prompt",
+                "response": "A hateful reply.",
+                "prompt_label": "unsafe",
+                "response_label": "unsafe",
+                "violated_categories": "Hate/Identity Hate",
+                "prompt_label_source": "human",
+                "response_label_source": "llm_jury",
+            },
+            {
+                "id": "2",
+                "prompt": "Inclusive prompt",
+                "response": "A respectful reply.",
+                "prompt_label": "unsafe",
+                "response_label": "safe",
+                "violated_categories": "Hate/Identity Hate",
+                "prompt_label_source": "human",
+                "response_label_source": "human",
+            },
+            {
+                "id": "3",
+                "prompt": "Violence only",
+                "response": "Violent reply.",
+                "prompt_label": "unsafe",
+                "response_label": "unsafe",
+                "violated_categories": "Violence",
+                "prompt_label_source": "human",
+                "response_label_source": "llm_jury",
+            },
+        ]
+    }
+
+    loader = _AegisContentSafetyDataset()
+
+    with patch.object(loader, "_fetch_from_huggingface_async", new_callable=AsyncMock, return_value=rows):
+        dataset = await loader.fetch_human_labeled_harm_dataset_async(
+            harm_category=AegisHarmCategory.HATE_IDENTITY_HATE,
+        )
+
+    assert dataset.metrics_type == MetricsType.HARM
+    assert dataset.name == "aegis_hate_speech"
+    assert dataset.harm_definition == "hate_speech.yaml"
+    assert len(dataset.entries) == 2
+    assert dataset.entries[0].harm_category == "hate_speech"

--- a/tests/unit/datasets/test_aegis_human_labeled_dataset.py
+++ b/tests/unit/datasets/test_aegis_human_labeled_dataset.py
@@ -1,0 +1,76 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from pyrit.datasets.seed_datasets.remote.aegis_ai_content_safety_dataset import (
+    AegisHarmCategory,
+    _AegisContentSafetyDataset,
+    _response_label_to_harm_score,
+)
+from pyrit.score.scorer_evaluation.human_labeled_dataset import HarmHumanLabeledEntry
+from pyrit.score.scorer_evaluation.metrics_type import MetricsType
+
+
+@pytest.mark.parametrize(
+    ("label", "expected"),
+    [
+        ("unsafe", 1.0),
+        ("safe", 0.0),
+        (" UNSAFE ", 1.0),
+    ],
+)
+def test_response_label_to_harm_score(label, expected):
+    assert _response_label_to_harm_score(label) == expected
+
+
+async def test_fetch_human_labeled_harm_dataset_violence():
+    rows = {
+        "train": [
+            {
+                "id": "7",
+                "prompt": "How to hurt someone?",
+                "response": "Here are steps to cause harm.",
+                "prompt_label": "unsafe",
+                "response_label": "unsafe",
+                "violated_categories": "Violence",
+                "prompt_label_source": "human",
+                "response_label_source": "llm_jury",
+            },
+            {
+                "id": "8",
+                "prompt": "Describe self defense",
+                "response": "Avoid violence when possible.",
+                "prompt_label": "unsafe",
+                "response_label": "safe",
+                "violated_categories": "Violence",
+                "prompt_label_source": "human",
+                "response_label_source": "human",
+            },
+            {
+                "id": "9",
+                "prompt": "Malware only",
+                "response": "Sure, here is malware advice.",
+                "prompt_label": "unsafe",
+                "response_label": "unsafe",
+                "violated_categories": "Malware",
+                "prompt_label_source": "human",
+                "response_label_source": "llm_jury",
+            },
+        ]
+    }
+
+    loader = _AegisContentSafetyDataset()
+
+    with patch.object(loader, "_fetch_from_huggingface_async", new_callable=AsyncMock, return_value=rows):
+        dataset = await loader.fetch_human_labeled_harm_dataset_async()
+
+    assert dataset.metrics_type == MetricsType.HARM
+    assert dataset.name == "aegis_violence"
+    assert len(dataset.entries) == 2
+    assert all(isinstance(entry, HarmHumanLabeledEntry) for entry in dataset.entries)
+    assert dataset.entries[0].human_scores == [1.0]
+    assert dataset.entries[1].human_scores == [0.0]
+    assert dataset.entries[0].harm_category == "violence"


### PR DESCRIPTION
## Summary
- Adds `fetch_human_labeled_harm_dataset_async()` on the Aegis 2.0 remote loader.
- Retains assistant `response` + `response_label` and maps them into `HarmHumanLabeledEntry` rows for scorer evaluation.
- Starts with the **Violence** category (CC-BY-4.0, clean mapping to `violence.yaml`).

Addresses #2475.

## Test plan
- [x] `pytest tests/unit/datasets/test_aegis_human_labeled_dataset.py`