### PR TITLE
FIX: report Unicode tag presence correctly when decoding

### DIFF
--- a/pyrit/converter/token_smuggling/ascii_smuggler_converter.py
+++ b/pyrit/converter/token_smuggling/ascii_smuggler_converter.py
@@ -95,16 +95,18 @@ class AsciiSmugglerConverter(SmugglerConverter):
             str: The decoded message.
         """
         decoded_message = ""
+        hidden_tags_found = False
         for char in message:
             code_point = ord(char)
             if 0xE0000 <= code_point <= 0xE007F:
+                hidden_tags_found = True
                 decoded_char = chr(code_point - 0xE0000)
                 if not 0x20 <= ord(decoded_char) <= 0x7E:
                     logger.info(f"Potential unicode tag detected: {decoded_char}")
                 else:
                     decoded_message += decoded_char
 
-        if len(decoded_message) != len(message):
+        if hidden_tags_found:
             logger.info("Hidden Unicode Tags discovered.")
         else:
             logger.info("No hidden Unicode Tag characters discovered.")

--- a/tests/unit/converter/test_ascii_smuggler_converter.py
+++ b/tests/unit/converter/test_ascii_smuggler_converter.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import logging
+
 import pytest
 
 from pyrit.converter import AsciiSmugglerConverter, ConverterResult
@@ -22,6 +24,27 @@ async def test_ascii_smuggler_decode_roundtrip():
     decoder = AsciiSmugglerConverter(action="decode")
     decoded = await decoder.convert_async(prompt=encoded.output_text, input_type="text")
     assert decoded.output_text == "hello"
+
+
+async def test_ascii_smuggler_decode_reports_hidden_tags(caplog):
+    encoder = AsciiSmugglerConverter(action="encode")
+    encoded = await encoder.convert_async(prompt="hello", input_type="text")
+
+    caplog.set_level(logging.INFO)
+    decoder = AsciiSmugglerConverter(action="decode")
+    await decoder.convert_async(prompt=encoded.output_text, input_type="text")
+
+    assert "Hidden Unicode Tags discovered." in caplog.messages
+    assert "No hidden Unicode Tag characters discovered." not in caplog.messages
+
+
+async def test_ascii_smuggler_decode_reports_no_hidden_tags_for_plain_text(caplog):
+    caplog.set_level(logging.INFO)
+    decoder = AsciiSmugglerConverter(action="decode")
+    await decoder.convert_async(prompt="hello", input_type="text")
+
+    assert "No hidden Unicode Tag characters discovered." in caplog.messages
+    assert "Hidden Unicode Tags discovered." not in caplog.messages
 
 
 async def test_ascii_smuggler_with_unicode_tags():


### PR DESCRIPTION
## Description

Fixes the logging-only Unicode-tag detection defect described in #2539.

`AsciiSmugglerConverter.decode_message` currently infers whether hidden Unicode tags were present by comparing decoded and input string lengths. This can report that no hidden tags were found for a fully hidden payload.

This change tracks whether a Unicode Tag code point was actually encountered and uses that signal for logging.

## Tests

Adds regression coverage for fully hidden payloads and ordinary plaintext.