### PR TITLE
MAINT: Making Score Label Clearer in GUI

### DIFF
--- a/frontend/src/components/Chat/MessageList.test.tsx
+++ b/frontend/src/components/Chat/MessageList.test.tsx
@@ -153,7 +153,7 @@ describe("MessageList", () => {
       name: /score 0.9 from selfaskscalescorer, objective score/i,
     });
     expect(scoreButton).toBeInTheDocument();
-    expect(scoreButton).toHaveTextContent("0.9");
+    expect(scoreButton).toHaveTextContent("Score: 0.9");
 
     await user.click(scoreButton);
 
@@ -198,10 +198,10 @@ describe("MessageList", () => {
     const scoreButton = screen.getByRole("button", {
       name: /score undetermined from selfaskscalescorer, piece 1 · text/i,
     });
-    expect(scoreButton).toHaveTextContent("undetermined");
+    expect(scoreButton).toHaveTextContent("Score: undetermined");
 
     await user.hover(scoreButton);
-    expect(await screen.findByRole("tooltip")).toHaveTextContent("undetermined");
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Score: undetermined");
 
     await user.unhover(scoreButton);
     await user.click(scoreButton);
@@ -306,12 +306,15 @@ describe("MessageList", () => {
     });
     expect(screen.getAllByRole("tab")).toEqual([objectiveTab, auxiliaryTab]);
     expect(objectiveTab).toHaveTextContent("False");
+    expect(objectiveTab).not.toHaveTextContent("Score:");
     expect(objectiveTab).not.toHaveTextContent("OldScorer");
     expect(objectiveTab).not.toHaveTextContent("Objective");
     expect(auxiliaryTab).toHaveTextContent("0.9");
+    expect(auxiliaryTab).not.toHaveTextContent("Score:");
     expect(auxiliaryTab).not.toHaveTextContent("NewScorer");
     expect(objectiveTab).toHaveAttribute("aria-selected", "true");
     expect(screen.getByRole("tabpanel")).toHaveAttribute("aria-labelledby", objectiveTab.id);
+    expect(screen.getByText("Score:")).toBeInTheDocument();
     expect(screen.getByText("true_false")).toBeInTheDocument();
     expect(screen.getByText("OldScorer")).toBeInTheDocument();
     expect(screen.getByText("Yes")).toBeInTheDocument();
@@ -334,7 +337,7 @@ describe("MessageList", () => {
         name: /view 2 scores, displayed score false from oldscorer, objective score/i,
       })
     ).toBeInTheDocument();
-    expect(stackedScoreButton).toHaveTextContent("False");
+    expect(stackedScoreButton).toHaveTextContent("Score: False");
   });
 
   it("should preserve a long stacked-score value outside its ellipsized chip", async () => {
@@ -499,7 +502,7 @@ describe("MessageList", () => {
     const stackedScoreButton = screen.getByRole("button", {
       name: /view 2 scores, displayed score 0.9 from newscorer/i,
     });
-    expect(stackedScoreButton).toHaveTextContent("0.9");
+    expect(stackedScoreButton).toHaveTextContent("Score: 0.9");
 
     await user.click(stackedScoreButton);
     await user.click(screen.getByRole("tab", {
@@ -507,7 +510,7 @@ describe("MessageList", () => {
     }));
 
     expect(screen.getByText("OldScorer")).toBeInTheDocument();
-    expect(stackedScoreButton).toHaveTextContent("0.9");
+    expect(stackedScoreButton).toHaveTextContent("Score: 0.9");
   });
 
   it("should not show a stacked control when the message has only one score", () => {

--- a/frontend/src/components/Chat/MessageList.tsx
+++ b/frontend/src/components/Chat/MessageList.tsx
@@ -109,6 +109,10 @@ function scoreDisplayValue(score: DisplayScore): string {
   return score.score_value ?? score.status ?? ''
 }
 
+function scoreDisplayLabel(score: DisplayScore): string {
+  return `Score: ${scoreDisplayValue(score)}`
+}
+
 function ScoreDetails({ score, testId }: { score: DisplayScore; testId: string }) {
   const styles = useMessageListStyles()
   const categories = score.score_category?.filter(Boolean) ?? []
@@ -117,7 +121,7 @@ function ScoreDetails({ score, testId }: { score: DisplayScore; testId: string }
     <div className={styles.scoreSurface} data-testid={testId}>
       <Text weight="semibold">Score details</Text>
       <div className={styles.scoreRow}>
-        <Text size={200} weight="semibold" className={styles.scoreLabel}>Value</Text>
+        <Text size={200} weight="semibold" className={styles.scoreLabel}>Score</Text>
         <Badge appearance="tint" color="brand" size="small" className={styles.scoreValue}>{scoreDisplayValue(score)}</Badge>
       </div>
       <div className={styles.scoreRow}>
@@ -157,10 +161,11 @@ function ScoreDetails({ score, testId }: { score: DisplayScore; testId: string }
 function MessageScore({ score, groupId, scoreIndex }: { score: DisplayScore; groupId: string | number; scoreIndex: number }) {
   const styles = useMessageListStyles()
   const displayValue = scoreDisplayValue(score)
+  const displayLabel = scoreDisplayLabel(score)
 
   return (
     <Popover withArrow>
-      <Tooltip content={displayValue} relationship="description" withArrow>
+      <Tooltip content={displayLabel} relationship="description" withArrow>
         <PopoverTrigger disableButtonEnhancement>
           <Button
             appearance="subtle"
@@ -170,7 +175,7 @@ function MessageScore({ score, groupId, scoreIndex }: { score: DisplayScore; gro
             data-testid={`message-score-${groupId}-${scoreIndex}`}
           >
             <Badge appearance="tint" color="brand" size="medium" className={styles.scoreChipValue}>
-              {displayValue}
+              {displayLabel}
             </Badge>
           </Button>
         </PopoverTrigger>
@@ -390,7 +395,7 @@ function MessageScores({ scores, groupId }: { scores: DisplayScore[]; groupId: s
         unstable_disableAutoFocus
         onOpenChange={(_event: unknown, data: { open: boolean }) => setIsScorePopoverOpen(data.open)}
       >
-        <Tooltip content={scoreDisplayValue(displayedScore)} relationship="description" withArrow>
+        <Tooltip content={scoreDisplayLabel(displayedScore)} relationship="description" withArrow>
           <PopoverTrigger disableButtonEnhancement>
             <Button
               appearance="subtle"
@@ -403,13 +408,14 @@ function MessageScores({ scores, groupId }: { scores: DisplayScore[]; groupId: s
                 <span className={styles.scoreStackOvalBack} />
                 <span className={styles.scoreStackOvalMiddle} />
                 <span className={styles.scoreStackOvalFront}>
-                  {scoreDisplayValue(displayedScore)}
+                  {scoreDisplayLabel(displayedScore)}
                 </span>
               </span>
             </Button>
           </PopoverTrigger>
         </Tooltip>
         <PopoverSurface className={styles.multiScorePopover}>
+          <Text size={200} weight="semibold">Score:</Text>
           <div ref={tabBarRef} className={styles.scoreTabBar} data-score-tab-bar>
             <TabList
               selectedValue={selectedScore.id}


### PR DESCRIPTION
## Description
Adding "Score: " before the score is shown to make the scores more clear in CoPyRIT

Screenshot: 
<img width="952" height="377" alt="image" src="https://github.com/user-attachments/assets/e40fcb12-3cd9-4759-aebb-65b064e951e8" />


## Tests and Documentation
fixed tests in `MessageList.test.tsx` to expect the "Score: " before the value is shown
