### PR TITLE
FIX: validate SneakyBits marker characters

### DIFF
--- a/pyrit/converter/token_smuggling/sneaky_bits_smuggler_converter.py
+++ b/pyrit/converter/token_smuggling/sneaky_bits_smuggler_converter.py
@@ -38,11 +38,16 @@ class SneakyBitsSmugglerConverter(SmugglerConverter):
             one_char (str | None): Character to represent binary 1 in ``sneaky_bits`` mode (default: U+2064).
 
         Raises:
-            ValueError: If an unsupported action or ``encoding_mode`` is provided.
+            ValueError: If the action is unsupported, marker values are not single characters, or markers are equal.
         """
         super().__init__(action=action)
         self.zero_char = zero_char if zero_char is not None else "\u2062"  # Invisible Times
         self.one_char = one_char if one_char is not None else "\u2064"  # Invisible Plus
+
+        if len(self.zero_char) != 1 or len(self.one_char) != 1:
+            raise ValueError("zero_char and one_char must each be exactly one character")
+        if self.zero_char == self.one_char:
+            raise ValueError("zero_char and one_char must be distinct")
 
     def _build_identifier(self) -> ComponentIdentifier:
         """

--- a/pyrit/converter/token_smuggling/sneaky_bits_smuggler_converter.py
+++ b/pyrit/converter/token_smuggling/sneaky_bits_smuggler_converter.py
@@ -38,12 +38,14 @@ class SneakyBitsSmugglerConverter(SmugglerConverter):
             one_char (str | None): Character to represent binary 1 in ``sneaky_bits`` mode (default: U+2064).
 
         Raises:
-            ValueError: If the action is unsupported, marker values are not single characters, or markers are equal.
+            ValueError: If the action is unsupported or markers are not distinct, single-character strings.
         """
         super().__init__(action=action)
         self.zero_char = zero_char if zero_char is not None else "\u2062"  # Invisible Times
         self.one_char = one_char if one_char is not None else "\u2064"  # Invisible Plus
 
+        if not isinstance(self.zero_char, str) or not isinstance(self.one_char, str):
+            raise ValueError("zero_char and one_char must be strings")
         if len(self.zero_char) != 1 or len(self.one_char) != 1:
             raise ValueError("zero_char and one_char must each be exactly one character")
         if self.zero_char == self.one_char:

--- a/tests/unit/converter/test_sneaky_bits_smuggler_converter.py
+++ b/tests/unit/converter/test_sneaky_bits_smuggler_converter.py
@@ -31,6 +31,25 @@ async def test_sneaky_bits_custom_chars():
     assert len(result.output_text) == 8  # 1 ASCII byte = 8 bits
 
 
+@pytest.mark.parametrize(
+    ("zero_char", "one_char"),
+    [
+        ("", "1"),
+        ("00", "1"),
+        ("0", ""),
+        ("0", "11"),
+    ],
+)
+def test_sneaky_bits_custom_chars_must_be_single_characters(zero_char: str, one_char: str):
+    with pytest.raises(ValueError, match="exactly one character"):
+        SneakyBitsSmugglerConverter(zero_char=zero_char, one_char=one_char)
+
+
+def test_sneaky_bits_custom_chars_must_be_distinct():
+    with pytest.raises(ValueError, match="must be distinct"):
+        SneakyBitsSmugglerConverter(zero_char="x", one_char="x")
+
+
 async def test_sneaky_bits_empty():
     converter = SneakyBitsSmugglerConverter(action="encode")
     result = await converter.convert_async(prompt="", input_type="text")

--- a/tests/unit/converter/test_sneaky_bits_smuggler_converter.py
+++ b/tests/unit/converter/test_sneaky_bits_smuggler_converter.py
@@ -31,6 +31,28 @@ async def test_sneaky_bits_custom_chars():
     assert len(result.output_text) == 8  # 1 ASCII byte = 8 bits
 
 
+def test_sneaky_bits_none_chars_use_defaults() -> None:
+    converter = SneakyBitsSmugglerConverter(zero_char=None, one_char=None)
+    assert converter.zero_char == "\u2062"
+    assert converter.one_char == "\u2064"
+
+
+@pytest.mark.parametrize(
+    ("zero_char", "one_char"),
+    [
+        (["0"], "1"),
+        (b"0", "1"),
+        (0, "1"),
+        ("0", ["1"]),
+        ("0", b"1"),
+        ("0", 1),
+    ],
+)
+def test_sneaky_bits_custom_chars_must_be_strings(*, zero_char: object, one_char: object) -> None:
+    with pytest.raises(ValueError, match="^zero_char and one_char must be strings$"):
+        SneakyBitsSmugglerConverter(zero_char=zero_char, one_char=one_char)
+
+
 @pytest.mark.parametrize(
     ("zero_char", "one_char"),
     [


### PR DESCRIPTION
## Description

`SneakyBitsSmugglerConverter` accepts custom `zero_char` and `one_char` marker strings, but encoding and decoding require each marker to be exactly one character and require the two markers to be distinct.

Multi-character markers are emitted as multiple code points and cannot round-trip reliably; they can also make `_build_identifier()` fail when it calls `ord()`. Identical markers make binary 0 and 1 indistinguishable and silently corrupt decoded output.

This change validates both invariants during initialization and raises a clear `ValueError` for invalid marker configuration.

## Tests

Adds regression coverage for empty or multi-character markers and identical zero/one markers.