### PR TITLE
MAINT: Improving JSON parsing logic to raise JSONException on empty required strings

### DIFF
--- a/pyrit/executor/attack/component/adversarial_conversation_manager.py
+++ b/pyrit/executor/attack/component/adversarial_conversation_manager.py
@@ -300,7 +300,7 @@ def _parse_adversarial_reply(response_text: str, *, schema: JsonSchemaDefinition
     ``schema`` is None (no declared schema), only the ``next_message`` invariant is enforced. Markdown
     code fences are stripped and keys are normalized from camelCase to snake_case before validation, so
     a backend that drifts to ``nextMessage`` still parses without burning a retry. ``next_message`` is
-    the one field the attack loop consumes and is always required; ``rationale`` /
+    the one field the attack loop consumes and must contain non-whitespace text; ``rationale`` /
     ``last_response_summary`` carry the attacker's own reasoning.
 
     Args:
@@ -313,7 +313,7 @@ def _parse_adversarial_reply(response_text: str, *, schema: JsonSchemaDefinition
 
     Raises:
         InvalidJsonException: If the reply is not valid JSON, does not decode to an object, is
-            missing a required key, carries a key the schema forbids, or omits ``next_message``.
+            missing a required key, carries a key the schema forbids, or has no usable ``next_message``.
     """
     cleaned = remove_markdown_json(response_text)
     try:
@@ -345,8 +345,14 @@ def _parse_adversarial_reply(response_text: str, *, schema: JsonSchemaDefinition
             message=f"Response is missing the '{_NEXT_MESSAGE_KEY}' field the attack loop sends: {cleaned}"
         )
 
+    next_message = str(normalized[_NEXT_MESSAGE_KEY])
+    if not next_message.strip():
+        raise InvalidJsonException(
+            message=f"Response field '{_NEXT_MESSAGE_KEY}' must contain non-whitespace text: {cleaned}"
+        )
+
     return AdversarialReply(
-        next_message=str(normalized[_NEXT_MESSAGE_KEY]),
+        next_message=next_message,
         rationale=normalized.get("rationale"),
         last_response_summary=normalized.get("last_response_summary"),
         raw=response_text,

--- a/tests/unit/executor/attack/component/test_adversarial_conversation_manager.py
+++ b/tests/unit/executor/attack/component/test_adversarial_conversation_manager.py
@@ -212,6 +212,20 @@ def test_parse_reply_requires_next_message_even_without_required_list():
         _parse_adversarial_reply('{"surprise": "x"}', schema=OTHER_SCHEMA)
 
 
+@pytest.mark.parametrize("next_message", ["", " \t\n"], ids=["empty", "whitespace"])
+def test_parse_reply_rejects_blank_next_message(next_message: str) -> None:
+    response = json.dumps(
+        {
+            "next_message": next_message,
+            "rationale": "r",
+            "last_response_summary": "s",
+        }
+    )
+
+    with pytest.raises(InvalidJsonException, match="must contain non-whitespace text"):
+        _parse_adversarial_reply(response, schema=SCHEMA)
+
+
 def test_parse_reply_coerces_non_string_next_message():
     # A non-enforcing target can emit a JSON number for next_message; the attack loop needs a
     # str, so the value is coerced rather than rejected (matches crescendo's own str() handling).
@@ -635,6 +649,26 @@ class TestGetNextMessageAsync:
         normalizer = _normalizer(None)
         normalizer.send_prompt_async.side_effect = [
             Message.from_prompt(prompt="totally not json", role="assistant"),
+            Message.from_prompt(prompt=VALID_JSON, role="assistant"),
+        ]
+        manager = _manager(
+            adversarial_system_prompt=_system_prompt(schema=SCHEMA),
+            prompt_normalizer=normalizer,
+        )
+
+        turn = await manager.get_next_message_async(turn_index=1, last_response=_response_message())
+
+        assert turn.reply is not None
+        assert turn.reply.next_message == "hello target"
+        assert normalizer.send_prompt_async.call_count == 2
+
+    async def test_blank_next_message_retries_then_succeeds(self) -> None:
+        normalizer = _normalizer(None)
+        normalizer.send_prompt_async.side_effect = [
+            Message.from_prompt(
+                prompt='{"next_message": "", "rationale": "r", "last_response_summary": "s"}',
+                role="assistant",
+            ),
             Message.from_prompt(prompt=VALID_JSON, role="assistant"),
         ]
         manager = _manager(


### PR DESCRIPTION
## Description

Reject blank `next_message` values while parsing adversarial-chat responses. This causes the existing JSON retry path to run before an empty user message reaches the objective target.

## Tests and Documentation

Added unit coverage for empty and whitespace-only values and for retrying after an empty value. Documentation changes are not applicable.

Full pre-commit was run. Code-quality hooks passed. The memory migration and type-check hooks could not run successfully because the local environment could not resolve the locked project dependencies from the configured package index.