### PR TITLE
FIX: Better Preserving Score Metadata per category

### DIFF
--- a/pyrit/score/float_scale/float_scale_score_aggregator.py
+++ b/pyrit/score/float_scale/float_scale_score_aggregator.py
@@ -215,6 +215,7 @@ def _create_aggregator_by_category(
     result_func: FloatScaleOp,
     aggregate_description: str,
     group_by_category: bool = True,
+    use_selected_score_metadata: bool = False,
 ) -> FloatScaleAggregatorFunc:
     """
     Create a float-scale aggregator that can optionally group scores by category.
@@ -232,6 +233,8 @@ def _create_aggregator_by_category(
         result_func (FloatScaleOp): Function applied to the list of float values to compute the aggregation result.
         aggregate_description (str): Base description for the aggregated result.
         group_by_category (bool): Whether to group scores by category. Defaults to True.
+        use_selected_score_metadata (bool): Whether conflicting metadata is resolved from scores whose
+            value matches the aggregate. Defaults to False.
 
     Returns:
         FloatScaleMultiScoreAggregator: Aggregator function that reduces a sequence of float-scale Scores
@@ -299,8 +302,14 @@ def _create_aggregator_by_category(
                     _undetermined_result(category_scores, name=name, metadata=metadata, category=category_list)
                 )
                 continue
-            result = result_func(float_values)
-            result = max(0.0, min(1.0, result))
+            raw_result = result_func(float_values)
+            if use_selected_score_metadata:
+                selected_score = next(
+                    score for score, value in zip(category_scores, float_values, strict=True) if value == raw_result
+                )
+                selected_metadata = selected_score.score_metadata or {}
+                metadata.update(selected_metadata)
+            result = max(0.0, min(1.0, raw_result))
 
             # Build description and rationale for this category group
             if len(category_scores) == 1:
@@ -350,6 +359,7 @@ class FloatScaleScorerByCategory:
         result_func=max,
         aggregate_description="Maximum value among constituent scorers",
         group_by_category=True,
+        use_selected_score_metadata=True,
     )
 
     MIN: FloatScaleAggregatorFunc = _create_aggregator_by_category(
@@ -357,6 +367,7 @@ class FloatScaleScorerByCategory:
         result_func=min,
         aggregate_description="Minimum value among constituent scorers",
         group_by_category=True,
+        use_selected_score_metadata=True,
     )
 
 

--- a/tests/unit/score/test_azure_content_filter.py
+++ b/tests/unit/score/test_azure_content_filter.py
@@ -230,8 +230,10 @@ async def test_azure_content_filter_scorer_chunks_long_text(patch_central_databa
         scorer = AzureContentFilterScorer(api_key="foo", endpoint="bar", harm_categories=[TextCategory.HATE])
 
         mock_client = AsyncMock()
-        # Mock returns for two chunks
-        mock_client.analyze_text.return_value = {"categoriesAnalysis": [{"severity": "3", "category": "Hate"}]}
+        mock_client.analyze_text.side_effect = [
+            {"categoriesAnalysis": [{"severity": "2", "category": "Hate"}]},
+            {"categoriesAnalysis": [{"severity": "5", "category": "Hate"}]},
+        ]
         scorer._azure_cf_client = mock_client
 
         # Create text longer than 10,000 characters (will be split into 2 chunks)
@@ -241,6 +243,8 @@ async def test_azure_content_filter_scorer_chunks_long_text(patch_central_databa
         scores = await scorer.score_text_async(text=long_text)
         assert len(scores) == 1  # One score per category
         assert scores[0].score_category == ["Hate"]
+        assert scores[0].score_value == str(5.0 / 7)
+        assert scores[0].score_metadata == {"azure_severity": 5}
         assert mock_client.analyze_text.call_count == 2  # Called once per chunk
 
 

--- a/tests/unit/score/test_float_scale_score_aggregator.py
+++ b/tests/unit/score/test_float_scale_score_aggregator.py
@@ -215,6 +215,50 @@ def test_by_category_min():
     assert violence_result.value == 0.2
 
 
+def test_by_category_extrema_resolve_conflicting_metadata_from_selected_score() -> None:
+    scores = [
+        _mk_score(0.3, category=["Hate"], metadata={"severity": 2, "low_only": 1}),
+        _mk_score(0.7, category=["Hate"], metadata={"severity": 5, "high_only": 1}),
+    ]
+
+    max_result = FloatScaleScorerByCategory.MAX(scores)[0]
+    min_result = FloatScaleScorerByCategory.MIN(scores)[0]
+
+    assert max_result.value == 0.7
+    assert max_result.metadata == {"severity": 5, "low_only": 1, "high_only": 1}
+    assert min_result.value == 0.3
+    assert min_result.metadata == {"severity": 2, "low_only": 1, "high_only": 1}
+
+
+def test_by_category_max_keeps_categories_and_metadata_separate() -> None:
+    scores = [
+        _mk_score(0.3, category=["Hate"], metadata={"severity": 2}),
+        _mk_score(0.7, category=["Hate"], metadata={"severity": 5}),
+        _mk_score(0.8, category=["Violence"], metadata={"severity": 6}),
+        _mk_score(0.4, category=["Violence"], metadata={"severity": 3}),
+    ]
+
+    results = FloatScaleScorerByCategory.MAX(scores)
+
+    assert [(result.category, result.value, result.metadata) for result in results] == [
+        (["Hate"], 0.7, {"severity": 5}),
+        (["Violence"], 0.8, {"severity": 6}),
+    ]
+
+
+def test_by_category_max_uses_first_winner_metadata_for_ties() -> None:
+    scores = [
+        _mk_score(0.7, category=["Hate"], metadata={"source": "first"}),
+        _mk_score(0.7, category=["Hate"], metadata={"source": "second"}),
+        _mk_score(0.3, category=["Hate"], metadata={"source": "lower"}),
+    ]
+
+    result = FloatScaleScorerByCategory.MAX(scores)[0]
+
+    assert result.value == 0.7
+    assert result.metadata == {"source": "first"}
+
+
 def test_by_category_empty_strings_treated_as_uncategorized():
     """Test that empty string categories are grouped together as uncategorized."""
     scores = [


### PR DESCRIPTION
## Rationale

Category-aware aggregation could discard useful score metadata when constituent scores in the same category had different values. This caused Azure Content Safety results for long, chunked text to lose `azure_severity`, even though the aggregate score correctly selected the highest severity.

## New behavior

Category-aware maximum and minimum aggregation now preserve metadata from the score that produced the selected result. Categories remain independent, and ties use the first winning score in stable input order. Average and cross-category aggregation continue to omit conflicting metadata because no single constituent owns those aggregate results.

This keeps aggregate values and their metadata aligned and prevents intermittent metadata loss when chunk or frame scores differ.