### PR TITLE
Add technique to default deployment initializers

### DIFF
--- a/infra/DEPLOY_NEW_INSTANCE.md
+++ b/infra/DEPLOY_NEW_INSTANCE.md
@@ -17,7 +17,7 @@ All authenticated users on a GUI instance are **fully trusted**. Any user with E
 | `az login` with Graph permissions | The script creates Entra app registrations, which requires Graph API access. Run `az login --scope https://graph.microsoft.com//.default` |
 | Azure permissions | **Owner** (or Contributor + User Access Administrator) on the subscription, and **Application Administrator** in Entra ID for app registrations and Graph API operations |
 | Container image pushed to ACR | Build and push before deploying (see [Building the Image](#building-the-image)) |
-| A `.env` file with runtime config | Copy and fill in `infra/env.demo.template`. Contains target endpoints and content safety config. `AZURE_SQL_DB_CONNECTION_STRING` and `AZURE_STORAGE_ACCOUNT_DB_DATA_CONTAINER_URL` are auto-injected by the script — you can omit them. Required for the default `target` initializer. Targets can also be created manually in the GUI if deploying with the `target` initializer only |
+| A `.env` file with runtime config | Copy and fill in `infra/env.demo.template`. Contains target endpoints and content safety config. `AZURE_SQL_DB_CONNECTION_STRING` and `AZURE_STORAGE_ACCOUNT_DB_DATA_CONTAINER_URL` are auto-injected by the script — you can omit them. Required for the default `target,technique` initializers. Targets can also be created manually in the GUI if deploying with the `target` initializer only |
 
 ### What the deployment creates (script + Bicep)
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -552,7 +552,7 @@ The backend can load `.pyrit_conf` directly from Azure Blob Storage. Set `pyritC
 | .pyrit_conf field | Bicep param | Env var | Notes |
 | --- | --- | --- | --- |
 | Complete file | `pyritConfigFileUri` | `PYRIT_CONFIG_FILE` | Optional Azure Blob URI loaded with managed identity |
-| `initializers` | `pyritInitializer` | `PYRIT_INITIALIZER` | Default `target`: `target` populates the TargetRegistry (read by the GUI); |
+| `initializers` | `pyritInitializer` | `PYRIT_INITIALIZER` | Default `target,technique`: populates the target and attack technique registries used by the GUI and scenarios |
 | `operator` | — | Set per-user in the GUI |  |
 | `operation` | — | Set per-user in the GUI |  |
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -87,8 +87,8 @@ param sqlDatabaseName string
 // Note: operator and operation are per-user settings configured in the GUI,
 // not deployment-level config.
 
-@description('PyRIT initializer to run. Default "target" registers target configs.')
-param pyritInitializer string = 'target'
+@description('Comma-separated PyRIT initializers to run. Defaults register target configs and attack techniques.')
+param pyritInitializer string = 'target,technique'
 
 @secure()
 @description('Optional Azure Blob HTTPS URI for the backend .pyrit_conf. The deployment helper accepts credential-free managed-identity URIs only. When empty, start.sh generates config from the SQL and initializer parameters.')

--- a/infra/parameters.demo.json
+++ b/infra/parameters.demo.json
@@ -32,7 +32,7 @@
       "value": "REPLACE_SQL_DATABASE"
     },
     "pyritInitializer": {
-      "value": "target"
+      "value": "target,technique"
     },
     "pyritConfigFileUri": {
       "value": ""

--- a/infra/parameters.example.json
+++ b/infra/parameters.example.json
@@ -31,7 +31,7 @@
       "value": "YOUR_DATABASE_NAME"
     },
     "pyritInitializer": {
-      "value": "target"
+      "value": "target,technique"
     },
     "pyritConfigFileUri": {
       "value": ""

--- a/tests/unit/infra/test_bicep_topology.py
+++ b/tests/unit/infra/test_bicep_topology.py
@@ -94,6 +94,7 @@ class TestBicepTopology(unittest.TestCase):
         assert template["parameters"]["disableContainerAppsPublicAccess"]["defaultValue"] is False
         assert "adminGroupObjectId" in template["parameters"]
         assert template["parameters"]["pyritConfigFileUri"]["defaultValue"] == ""
+        assert template["parameters"]["pyritInitializer"]["defaultValue"] == "target,technique"
         assert "fail(" in template["variables"]["validatedAllowedGroupObjectIds"]
         assert "fail(" in template["variables"]["validatedAdminGroupObjectId"]
 


### PR DESCRIPTION
## Summary
- default GUI deployments to both `target` and `technique` initializers
- update deployment parameter examples and documentation
- assert the initializer default in the compiled Bicep topology test

This ensures `AttackTechniqueRegistry` is populated when scenarios are requested.

## Testing
- `PYRIT_REQUIRE_BICEP=true python tests/unit/infra/test_bicep_topology.py -v`