### PR TITLE
MAINT: PyRIT 1.2.0 dev bump

### DIFF
--- a/.github/docs-versions.yml
+++ b/.github/docs-versions.yml
@@ -9,13 +9,16 @@
 # after `latest`, and update `default:` / `stable:` if the new release should become the
 # landing page. The picker renders this list in file order, so the newest release goes first.
 
-default: "1.0.1"  # served at the site root (microsoft.github.io/PyRIT/)
-stable: "1.0.1"   # served at /stable/ and shown as "(stable)" in the picker
+default: "1.1.0"  # served at the site root (microsoft.github.io/PyRIT/)
+stable: "1.1.0"   # served at /stable/ and shown as "(stable)" in the picker
 
 versions:
   - slug: latest
     name: "latest (dev, main)"
     ref: main
+  - slug: "1.1.0"
+    name: "1.1.0"
+    ref: releases/v1.1.0
   - slug: "1.0.1"
     name: "1.0.1"
     ref: releases/v1.0.1

--- a/doc/contributing/10_release_process.md
+++ b/doc/contributing/10_release_process.md
@@ -80,8 +80,8 @@ PyRIT is past `1.0.0`, its first "stable" release, so in practice:
   for removal in a future major version, so treat step 3 as applying to whichever version
   number you are incrementing.
 
-`main` always carries a `.dev0` version for the next planned release (e.g., `1.1.0.dev0` while
-`1.0.1` is the latest published release). There are circumstances when we might want to release
+`main` always carries a `.dev0` version for the next planned release (e.g., `1.2.0.dev0` while
+`1.1.0` is the latest published release). There are circumstances when we might want to release
 versions that aren't final; consult
 https://packaging.python.org/en/latest/discussions/versioning/ to determine whether
 there should be any postfixes on the release version.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pyrit-frontend",
-  "version": "1.1.0-dev.0",
+  "version": "1.2.0-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pyrit-frontend",
-      "version": "1.1.0-dev.0",
+      "version": "1.2.0-dev.0",
       "dependencies": {
         "@azure/msal-browser": "^5.19.0",
         "@azure/msal-react": "^5.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyrit-frontend",
-  "version": "1.1.0-dev.0",
+  "version": "1.2.0-dev.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyrit"
-version = "1.1.0.dev0"
+version = "1.2.0.dev0"
 description = "The Python Risk Identification Tool for LLMs (PyRIT) is a library used to assess the robustness of LLMs"
 authors = [
     { name = "Microsoft AI Red Team", email = "airedteam@microsoft.com" },

--- a/pyrit/_version.py
+++ b/pyrit/_version.py
@@ -7,4 +7,4 @@
 # as component identifiers and memory models reference ``pyrit.__version__``
 # and can be imported transitively while the package is still initializing.
 # Remove the development suffix when releasing and keep this value in sync with pyproject.toml.
-__version__ = "1.1.0.dev0"
+__version__ = "1.2.0.dev0"

--- a/uv.lock
+++ b/uv.lock
@@ -5292,7 +5292,7 @@ wheels = [
 
 [[package]]
 name = "pyrit"
-version = "1.1.0.dev0"
+version = "1.2.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- bump Python package metadata to `1.2.0.dev0` and frontend metadata to `1.2.0-dev.0`
- register `1.1.0` as the default and stable documentation release
- update the release-process example to reflect the post-v1.1.0 development state

This is the post-v1.1.0 release-process step 10 update for `main`.

## Validation

- confirmed all project-owned version fields are consistent
- confirmed the documentation version configuration resolves with `1.1.0` as default and stable
- `uv run --no-sync pytest tests/unit/build_scripts/test_resolve_docs_matrix.py -q` (13 passed)
- `uv run --no-sync pre-commit run --all-files`