### PR TITLE
MAINT: Updating title to see the version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/png" href="/roakey.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>PyRIT - Python Risk Identification Tool</title>
+    <title>Co-PyRIT</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/Layout/MainLayout.test.tsx
+++ b/frontend/src/components/Layout/MainLayout.test.tsx
@@ -66,15 +66,12 @@ describe("MainLayout", () => {
       </MainLayout>
     );
 
-    expect(screen.getByText("Co-PyRIT")).toBeInTheDocument();
     expect(
       screen.getByText("Python Risk Identification Tool")
     ).toBeInTheDocument();
 
-    // Wait for async useEffect to complete
-    await waitFor(() => {
-      expect(mockedVersionApi.getVersion).toHaveBeenCalled();
-    });
+    expect(await screen.findByText("Co-PyRIT 1.0.0")).toBeInTheDocument();
+    expect(document.title).toBe("Co-PyRIT 1.0.0");
   });
 
   it("renders children content", async () => {
@@ -179,6 +176,8 @@ describe("MainLayout", () => {
     await waitFor(() => {
       expect(mockedVersionApi.getVersion).toHaveBeenCalled();
     });
+    expect(screen.getByText("Co-PyRIT")).toBeInTheDocument();
+    expect(document.title).toBe("Co-PyRIT");
   });
 
   it("renders a 'Take a tour' button in the top bar when onStartTour is provided", async () => {

--- a/frontend/src/components/Layout/MainLayout.tsx
+++ b/frontend/src/components/Layout/MainLayout.tsx
@@ -36,11 +36,17 @@ export default function MainLayout({
     versionApi.getVersion()
       .then(data => {
         setVersion(data.version)
+        document.title = `Co-PyRIT ${data.version}`
         setCommit(data.version.includes('.dev') ? data.commit ?? null : null)
         setDatabaseInfo(data.database_info ?? null)
       })
-      .catch(() => setVersion('Unknown'))
+      .catch(() => {
+        setVersion('Unknown')
+        document.title = 'Co-PyRIT'
+      })
   }, [])
+
+  const title = version === 'Unknown' ? 'Co-PyRIT' : `Co-PyRIT ${version}`
 
   return (
     <div className={styles.root}>
@@ -61,7 +67,7 @@ export default function MainLayout({
             className={styles.logo}
           />
         </Tooltip>
-        <Text className={styles.title}>Co-PyRIT</Text>
+        <Text className={styles.title}>{title}</Text>
         <Text className={styles.subtitle}>Python Risk Identification Tool</Text>
         <div className={styles.spacer} />
         {onStartTour && (

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,8 +6,6 @@ import { AuthProvider } from './auth/AuthProvider'
 import { ThemeProvider } from './hooks/useTheme'
 import './styles/global.css'
 
-document.title = 'Co-PyRIT'
-
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ThemeProvider>


### PR DESCRIPTION
## Summary
- use the Roakey raccoon image as the favicon
- show the PyRIT version in the Co-PyRIT header and browser title
- keep the plain `Co-PyRIT` title when version retrieval fails