### PR TITLE
Fix dataset filters matching datasets that never declare the filtered axis

### DIFF
--- a/pyrit/datasets/seed_datasets/seed_dataset_provider.py
+++ b/pyrit/datasets/seed_datasets/seed_dataset_provider.py
@@ -222,8 +222,17 @@ class SeedDatasetProvider(ABC):
             filter_vals = getattr(criterion, field.name)
             meta_vals = getattr(metadata, field.name)
 
-            if filter_vals is None or meta_vals is None:
+            if filter_vals is None:
                 continue
+
+            # `meta_vals is None` means the dataset never declared this axis, which
+            # is not the same as declaring it and matching. Skipping here dropped
+            # the filtered axis entirely, so every dataset silent on that axis came
+            # back as a match. It also disagreed with get_all_dataset_names_async,
+            # which excludes datasets carrying no metadata at all - a dataset with
+            # partial metadata was treated as better qualified than one with none.
+            if meta_vals is None:
+                return False
 
             if strict_match:
                 if filter_vals - meta_vals:

--- a/pyrit/datasets/seed_datasets/seed_dataset_provider.py
+++ b/pyrit/datasets/seed_datasets/seed_dataset_provider.py
@@ -225,12 +225,7 @@ class SeedDatasetProvider(ABC):
             if filter_vals is None:
                 continue
 
-            # `meta_vals is None` means the dataset never declared this axis, which
-            # is not the same as declaring it and matching. Skipping here dropped
-            # the filtered axis entirely, so every dataset silent on that axis came
-            # back as a match. It also disagreed with get_all_dataset_names_async,
-            # which excludes datasets carrying no metadata at all - a dataset with
-            # partial metadata was treated as better qualified than one with none.
+            # A requested axis cannot match metadata that does not declare it.
             if meta_vals is None:
                 return False
 

--- a/tests/unit/datasets/test_seed_dataset_provider.py
+++ b/tests/unit/datasets/test_seed_dataset_provider.py
@@ -371,6 +371,39 @@ class TestMetadataParsingRemote:
             dataset_filter=SeedDatasetFilter(modalities={"audio"}),
         )
 
+    def test_undeclared_axis_does_not_match(self):
+        """A dataset silent on a filtered axis does not satisfy that axis."""
+        metadata = SeedDatasetMetadata(tags={"safety"}, size={"small"}, source_type={"local"})
+        assert not SeedDatasetProvider._match_filter_to_metadata(
+            metadata=metadata,
+            dataset_filter=SeedDatasetFilter(modalities={"audio"}),
+        )
+        assert not SeedDatasetProvider._match_filter_to_metadata(
+            metadata=metadata,
+            dataset_filter=SeedDatasetFilter(harm_categories={"violence"}),
+        )
+        # An axis the dataset does declare is still matched normally.
+        assert SeedDatasetProvider._match_filter_to_metadata(
+            metadata=metadata,
+            dataset_filter=SeedDatasetFilter(tags={"safety"}),
+        )
+
+    def test_undeclared_axis_does_not_match_strict(self):
+        """strict_match also rejects a dataset silent on the filtered axis."""
+        metadata = SeedDatasetMetadata(tags={"safety"}, size={"small"}, source_type={"local"})
+        assert not SeedDatasetProvider._match_filter_to_metadata(
+            metadata=metadata,
+            dataset_filter=SeedDatasetFilter(modalities={"audio"}, strict_match=True),
+        )
+
+    def test_undeclared_axis_does_not_mask_a_declared_mismatch(self):
+        """Two filtered axes, one declared and mismatching: still no match."""
+        metadata = SeedDatasetMetadata(modalities={"text"})
+        assert not SeedDatasetProvider._match_filter_to_metadata(
+            metadata=metadata,
+            dataset_filter=SeedDatasetFilter(modalities={"text"}, harm_categories={"violence"}),
+        )
+
     def test_sources(self):
         """Source filter checks membership."""
         metadata = SeedDatasetMetadata(source_type={"remote"})

--- a/tests/unit/datasets/test_seed_dataset_provider.py
+++ b/tests/unit/datasets/test_seed_dataset_provider.py
@@ -396,8 +396,8 @@ class TestMetadataParsingRemote:
             dataset_filter=SeedDatasetFilter(modalities={"audio"}, strict_match=True),
         )
 
-    def test_undeclared_axis_does_not_mask_a_declared_mismatch(self):
-        """Two filtered axes, one declared and mismatching: still no match."""
+    def test_undeclared_axis_does_not_match_when_another_axis_matches(self):
+        """An undeclared axis fails even when another filtered axis matches."""
         metadata = SeedDatasetMetadata(modalities={"text"})
         assert not SeedDatasetProvider._match_filter_to_metadata(
             metadata=metadata,


### PR DESCRIPTION
## The bug

`SeedDatasetProvider._match_single_criterion` skips a field when the dataset's metadata for it is `None`:

```python
for field in dc_fields(SeedDatasetMetadata):
    filter_vals = getattr(criterion, field.name)
    meta_vals = getattr(metadata, field.name)

    if filter_vals is None or meta_vals is None:
        continue
```

`meta_vals is None` means the dataset **never declared that axis**, which is not the same as declaring it and matching. Skipping drops the filtered axis entirely, so the method returns `True` for every dataset that is simply silent about it.

## Why this is a bug rather than a design choice

Two things in the file say so.

The docstring on this method (`Match a dataset's metadata against filter criteria`):

> Within each criterion, ALL specified fields must match (AND across fields).

And `get_all_dataset_names_async`, seven lines earlier, makes the opposite call for the neighbouring case:

```python
# Datasets without metadata are skipped for all other filters
if not metadata:
    continue
```

A dataset carrying **no** metadata is excluded. A dataset carrying **partial** metadata that is silent on the filtered axis is included. A dataset that says nothing at all is treated as less qualified than one that says nothing about the thing you asked for.

The skip also happens **before** the `strict_match` split, so `strict_match=True` is affected identically — the stricter mode is no stricter here.

## Reproduction

Running the matcher verbatim against a dataset that declares `tags`, `size` and `source_type` but is silent on `modalities` and `harm_categories`:

```
case                                                        current   correct
filter modalities={audio} vs dataset SILENT on modalities      True     False
filter modalities={audio} vs dataset DECLARING {text,image}   False     False
filter harm_categories={nonexistent} vs SILENT                 True     False
same, strict_match=True                                        True     False
filter tags={safety} vs dataset DECLARING tags                 True      True
```

The second and fifth rows are controls: the check behaves correctly the moment the dataset declares the axis. This is purely the `None` path.

## Scale

**839 of the 840 YAML dataset files under `pyrit/datasets` never declare `modalities`.** Every one of them currently satisfies a `modalities` filter. The same shape applies to `harm_categories`, which most locally-registered datasets also leave unset.

`get_all_dataset_names_async` is the public discovery entry point and feeds `fetch_datasets_async`, so in practice this is a user filtering for audio datasets, or for one harm category, and being handed a set dominated by datasets that say nothing about either. Nothing is logged.

## The change

Separate the two `None` cases. A filter that does not name an axis still skips it; a dataset that does not declare a named axis no longer matches it.

## Tests

Three added to `TestMetadataParsingRemote`, all failing on `main`:

- an undeclared axis does not match, for both `modalities` and `harm_categories`, while a declared axis still matches normally
- the same under `strict_match=True`
- an undeclared axis does not mask a declared mismatch when two axes are filtered at once

Nothing in the existing suite locked in the old behaviour — the metadata-filter and strict-match tests all construct metadata that declares the axis under test.

## What I did not verify

I did not run the full unit suite, only `tests/unit/datasets`. I also have not confirmed whether "undeclared axis is a wildcard" was ever the intent; I argue against it from the docstring and from the `if not metadata: continue` precedent, but if it was deliberate then the docstring and that neighbouring branch are the things that need changing instead, and I would rather be told.

Written with AI assistance; I have read and can explain every line.