### PR TITLE
FIX get_kwarg_param skips the type check when the value is falsy

### DIFF
--- a/pyrit/common/utils.py
+++ b/pyrit/common/utils.py
@@ -193,14 +193,21 @@ def get_kwarg_param(
 
     value = kwargs.pop(param_name)
 
-    if not value:
+    if value is None:
         if not required:
             return default_value
         raise ValueError(f"Parameter '{param_name}' must be provided and non-empty")
 
+    # Type checked before emptiness so a falsy value of the wrong type still raises
+    # TypeError rather than silently falling back to the default.
     if not isinstance(value, expected_type):
         raise TypeError(
             f"Parameter '{param_name}' must be of type {expected_type.__name__}, got {type(value).__name__}"
         )
+
+    if not value:
+        if not required:
+            return default_value
+        raise ValueError(f"Parameter '{param_name}' must be provided and non-empty")
 
     return value

--- a/tests/unit/common/test_helper_functions.py
+++ b/tests/unit/common/test_helper_functions.py
@@ -240,6 +240,24 @@ class TestGetKwargParam:
         with pytest.raises(ValueError, match="Parameter 'param1' must be provided and non-empty"):
             get_kwarg_param(kwargs=kwargs, param_name="param1", expected_type=str, required=True)
 
+    def test_get_kwarg_param_falsy_wrong_type_optional_raises(self):
+        """A falsy value of the wrong type raises TypeError instead of returning the default."""
+        kwargs = {"param1": ""}
+        with pytest.raises(TypeError, match="Parameter 'param1' must be of type int, got str"):
+            get_kwarg_param(kwargs=kwargs, param_name="param1", expected_type=int, required=False, default_value=1)
+
+    def test_get_kwarg_param_empty_collection_wrong_type_optional_raises(self):
+        """An empty collection of the wrong type raises TypeError rather than falling back."""
+        kwargs = {"param1": []}
+        with pytest.raises(TypeError, match="Parameter 'param1' must be of type dict, got list"):
+            get_kwarg_param(kwargs=kwargs, param_name="param1", expected_type=dict, required=False, default_value={})
+
+    def test_get_kwarg_param_falsy_wrong_type_required_raises_type_error(self):
+        """A required falsy value of the wrong type reports the type, not emptiness."""
+        kwargs = {"param1": 0}
+        with pytest.raises(TypeError, match="Parameter 'param1' must be of type str, got int"):
+            get_kwarg_param(kwargs=kwargs, param_name="param1", expected_type=str, required=True)
+
     def test_get_kwarg_param_wrong_type(self):
         """Test that TypeError is raised when parameter is wrong type."""
         kwargs = {"param1": 123}


### PR DESCRIPTION
## Description

Fixes #2600.

`get_kwarg_param` returned before it reached `isinstance`, so a falsy value of the wrong type was never type checked. An optional parameter got the default back instead of a `TypeError`, and a required one got a `ValueError` about emptiness that says nothing about the type.

The order is now: presence, then `None`, then type, then emptiness. `None` gets its own branch so it keeps the meaning it had before, absent rather than wrongly typed, which is what the existing tests assert.

Behaviour that did not change: an empty string against `expected_type=str` still counts as absent, `None` still counts as absent, and a valid falsy value such as `0` against `expected_type=int` still falls back to the default. That last one is arguable and I raised it on the issue, but it is a separate call from this fix and I left it alone.

## Tests and Documentation

Three tests added to `TestGetKwargParam` in `tests/unit/common/test_helper_functions.py`, one per case in the issue: a falsy wrong type on an optional parameter, an empty collection of the wrong type on an optional parameter, and a falsy wrong type on a required parameter.

All three fail on `main` and pass with the change. The 17 existing tests in that class are untouched and still pass.

`tests/unit/common` and `tests/unit/executor` are green, 1596 passed. No documentation changes, so no JupyText run.