### PR TITLE
FIX remove nested main landmarks

### DIFF
--- a/frontend/src/components/Configuration/Configuration.test.tsx
+++ b/frontend/src/components/Configuration/Configuration.test.tsx
@@ -29,7 +29,9 @@ const mockedInitializersApi = jest.mocked(initializersApi)
 function renderPage(): void {
   render(
     <FluentProvider theme={webLightTheme}>
-      <Configuration />
+      <main>
+        <Configuration />
+      </main>
     </FluentProvider>,
   )
 }
@@ -84,6 +86,7 @@ describe('Configuration', () => {
   it('should load and display configuration content', async () => {
     renderPage()
 
+    expect(screen.getAllByRole('main')).toHaveLength(1)
     expect(screen.getByRole('heading', { level: 1, name: 'Configuration' })).toBeInTheDocument()
     expect(await screen.findByLabelText('Configuration YAML')).toHaveValue('operator: alice\n')
     expect(screen.getByRole('navigation', { name: 'Configuration files' })).toBeInTheDocument()

--- a/frontend/src/components/Configuration/Configuration.tsx
+++ b/frontend/src/components/Configuration/Configuration.tsx
@@ -111,7 +111,7 @@ export default function Configuration() {
   }
 
   return (
-    <main className={styles.root}>
+    <div className={styles.root}>
       <div className={styles.header}>
         <Text as="h1" size={600} weight="semibold">Configuration</Text>
       </div>
@@ -182,6 +182,6 @@ export default function Configuration() {
           </Field>
         </EditorWorkspace>
       )}
-    </main>
+    </div>
   )
 }

--- a/frontend/src/components/History/HistoryPage.test.tsx
+++ b/frontend/src/components/History/HistoryPage.test.tsx
@@ -1,0 +1,36 @@
+import { FluentProvider, webLightTheme } from '@fluentui/react-components'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import HistoryPage, { type HistoryTab } from './HistoryPage'
+
+function renderPage(onTabChange: (tab: HistoryTab) => void): void {
+  render(
+    <FluentProvider theme={webLightTheme}>
+      <main>
+        <HistoryPage selectedTab="attacks" onTabChange={onTabChange}>
+          <div>Attack history</div>
+        </HistoryPage>
+      </main>
+    </FluentProvider>,
+  )
+}
+
+describe('HistoryPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should keep the application main landmark unnested', async () => {
+    const user = userEvent.setup()
+    const onTabChange = jest.fn()
+    renderPage(onTabChange)
+
+    expect(screen.getAllByRole('main')).toHaveLength(1)
+    expect(screen.getByRole('heading', { level: 1, name: 'History' })).toBeInTheDocument()
+    expect(screen.getByText('Attack history')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('tab', { name: 'Scanner' }))
+    expect(onTabChange).toHaveBeenCalledWith('scanner')
+  })
+})

--- a/frontend/src/components/History/HistoryPage.tsx
+++ b/frontend/src/components/History/HistoryPage.tsx
@@ -23,7 +23,7 @@ export default function HistoryPage({ selectedTab, onTabChange, children }: Hist
   }
 
   return (
-    <main className={styles.root}>
+    <div className={styles.root}>
       <header className={styles.header}>
         <Text as="h1" size={600} weight="semibold">History</Text>
         <TabList selectedValue={selectedTab} onTabSelect={handleTabSelect}>
@@ -32,6 +32,6 @@ export default function HistoryPage({ selectedTab, onTabChange, children }: Hist
         </TabList>
       </header>
       <div className={styles.content}>{children}</div>
-    </main>
+    </div>
   )
 }

--- a/frontend/src/components/History/ScenarioHistory.test.tsx
+++ b/frontend/src/components/History/ScenarioHistory.test.tsx
@@ -60,7 +60,9 @@ const defaultProps = {
 function renderHistory(props = defaultProps) {
   return render(
     <FluentProvider theme={webLightTheme}>
-      <ScenarioHistory {...props} />
+      <main>
+        <ScenarioHistory {...props} />
+      </main>
     </FluentProvider>,
   )
 }
@@ -88,6 +90,7 @@ describe('ScenarioHistory', () => {
     renderHistory({ ...defaultProps, onOpenRun })
 
     const row = await screen.findByTestId('scenario-history-row-run-1')
+    expect(screen.getAllByRole('main')).toHaveLength(1)
     expect(screen.getByText('foundry.red_team')).toBeInTheDocument()
     expect(screen.getByText('RedTeamScenario · v3')).toBeInTheDocument()
     expect(screen.getByText('gpt-4o')).toBeInTheDocument()

--- a/frontend/src/components/History/ScenarioHistory.tsx
+++ b/frontend/src/components/History/ScenarioHistory.tsx
@@ -224,7 +224,7 @@ export default function ScenarioHistory({
   const displayLoading = loading || filtersPending
 
   return (
-    <main className={styles.root}>
+    <div className={styles.root}>
       <header className={styles.header}>
         <div className={styles.headerRow}>
           {showTitle && <Text as="h1" size={500} weight="semibold">Scanner History</Text>}
@@ -359,7 +359,7 @@ export default function ScenarioHistory({
           </Button>
         </div>
       )}
-    </main>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Description

- Replace the page-level `main` elements in Configuration, History, and Scanner History with non-landmark containers.
- Preserve the existing layout classes, headings, tabs, and page behavior while leaving `MainLayout` as the single document-level `main`.
- Add focused component coverage that renders each affected page under an application `main` and asserts there is exactly one main landmark.

Closes #2595

## Tests and Documentation

- `npm test -- --runInBand src/components/Configuration/Configuration.test.tsx src/components/History/HistoryPage.test.tsx src/components/History/ScenarioHistory.test.tsx` (16 passed)
- `npm run type-check`
- `npm run lint`
- `npm run build`
- Full local suite: 1408 passed; the unrelated `LabelsBar` click-away timing test failed in the full run but passed when rerun in isolation.

No documentation update is needed because this only corrects the existing document landmark structure without changing user-facing behavior.