### PR TITLE
TEST Remove Crescendo cancellation timing race

### DIFF
--- a/tests/unit/scenario/core/test_scenario_crescendo_resume.py
+++ b/tests/unit/scenario/core/test_scenario_crescendo_resume.py
@@ -627,7 +627,8 @@ async def test_crescendo_scenario_cancellation_preserves_progress_and_resumes_on
             wraps=first_attack._teardown_async,
         ) as first_teardown:
             scenario_task = asyncio.create_task(first_scenario.run_async())
-            await asyncio.wait_for(cancellation_started.wait(), timeout=5)
+            await cancellation_started.wait()
+            assert not scenario_task.done()
             scenario_task.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await scenario_task


### PR DESCRIPTION
## Why

The Crescendo cancellation/resume regression test could fail on a loaded runner because it imposed a five-second wall-clock timeout while mocked async boundaries could execute in one long event-loop turn.

## What changed

Wait for the mocked objective target's explicit cancellation lifecycle event instead of racing it against a timer. The test also verifies that the scenario task is still in flight before cancelling it, preserving the intended cancellation and resume coverage without depending on runner speed.

## Validation

- Focused test file: 2 passed
- Cancellation/resume test repeated 5 times: all passed
- Ruff check and format check
- Targeted ty check
- Applicable pre-commit hooks
- `git diff --check`