### PR TITLE
FIX: make combine_list order-deterministic and drop the duplicated workaround

### DIFF
--- a/pyrit/common/utils.py
+++ b/pyrit/common/utils.py
@@ -56,24 +56,34 @@ def combine_dict(existing_dict: dict[str, Any] | None = None, new_dict: dict[str
     return result
 
 
-def combine_list(list1: str | list[str], list2: str | list[str]) -> list[str]:
+def combine_list(
+    list1: str | list[str] | None,
+    list2: str | list[str] | None,
+) -> list[str]:
     """
     Combine two lists or strings into a single list with unique values.
 
+    Order is preserved: items appear in first-occurrence order, taking ``list1``
+    before ``list2``. ``None`` is treated as empty and a bare string as a
+    single-element list.
+
     Args:
-        list1 (str | list[str]): First list or string to combine.
-        list2 (str | list[str]): Second list or string to combine.
+        list1 (str | list[str] | None): First list or string to combine.
+        list2 (str | list[str] | None): Second list or string to combine.
 
     Returns:
-        list: Combined list containing unique values from both inputs.
+        list: Combined list containing unique values from both inputs, in
+            first-occurrence order.
     """
-    if isinstance(list1, str):
-        list1 = [list1]
-    if isinstance(list2, str):
-        list2 = [list2]
 
-    # Merge and keep only unique values
-    return list(set(list1 + list2))
+    def _as_list(value: str | list[str] | None) -> list[str]:
+        if not value:
+            return []
+        return [value] if isinstance(value, str) else list(value)
+
+    # dict.fromkeys deduplicates while preserving insertion order; set() would
+    # make the result vary across processes under hash randomization.
+    return list(dict.fromkeys(_as_list(list1) + _as_list(list2)))
 
 
 def get_random_indices(*, start: int, size: int, proportion: float) -> list[int]:

--- a/pyrit/models/seeds/seed_dataset.py
+++ b/pyrit/models/seeds/seed_dataset.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from pyrit.common.utils import combine_list
 from pyrit.models.literals import SeedType  # noqa: TC001  (runtime-required by Pydantic field annotations)
 from pyrit.models.seeds.attack_seed_group import AttackSeedGroup
 from pyrit.models.seeds.seed import (  # AwareDatetimeUTC is runtime-required by Pydantic
@@ -43,37 +44,6 @@ logger = logging.getLogger(__name__)
 # (default_factory) are the source of truth.
 _SCALAR_DEFAULT_KEYS = ("name", "description", "source")
 _LIST_DEFAULT_KEYS = ("harm_categories", "authors", "groups")
-
-
-def _merge_unique(left: Any, right: Any) -> list[str]:
-    """
-    Concatenate two list-or-str inputs into a deterministic, order-preserving deduped list.
-
-    Treats ``None`` as empty, accepts bare strings as single-element lists, and preserves the
-    order of first occurrence (left first, then any new items from right). Used instead of
-    ``utils.combine_list`` because the latter goes through ``set()`` and is nondeterministic
-    across processes for non-trivial inputs.
-
-    Args:
-        left: First list (or string) of values; falsy values are treated as empty.
-        right: Second list (or string) of values; falsy values are treated as empty.
-
-    Returns:
-        list[str]: Deduplicated concatenation, preserving first-occurrence order.
-    """
-
-    def _as_list(v: Any) -> list[str]:
-        if not v:
-            return []
-        return [v] if isinstance(v, str) else list(v)
-
-    seen: set[str] = set()
-    result: list[str] = []
-    for item in _as_list(left) + _as_list(right):
-        if item not in seen:
-            seen.add(item)
-            result.append(item)
-    return result
 
 
 class SeedDataset(BaseModel):
@@ -160,7 +130,7 @@ class SeedDataset(BaseModel):
                 p["dataset_name"] = default_dataset_name
 
             for key in _LIST_DEFAULT_KEYS:
-                p[key] = _merge_unique(data.get(key), p.get(key))
+                p[key] = combine_list(data.get(key), p.get(key))
 
             if seed_type == "prompt":
                 if not p.get("data_type"):

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -6,17 +6,32 @@ from pyrit.common.utils import combine_list, to_sha256
 
 def test_combine_list_two_lists():
     result = combine_list(["a", "b"], ["b", "c"])
-    assert set(result) == {"a", "b", "c"}
+    assert result == ["a", "b", "c"]
 
 
 def test_combine_list_strings():
     result = combine_list("x", "y")
-    assert set(result) == {"x", "y"}
+    assert result == ["x", "y"]
 
 
 def test_combine_list_mixed():
     result = combine_list("a", ["a", "b"])
-    assert set(result) == {"a", "b"}
+    assert result == ["a", "b"]
+
+
+def test_combine_list_preserves_first_occurrence_order():
+    """Order must be stable, not whatever set() iteration happens to produce."""
+    left = ["harmful", "violence", "illegal"]
+    right = ["bias", "violence", "pii"]
+    assert combine_list(left, right) == ["harmful", "violence", "illegal", "bias", "pii"]
+    # Deterministic across repeated calls within a process too.
+    assert combine_list(left, right) == combine_list(left, right)
+
+
+def test_combine_list_treats_none_as_empty():
+    assert combine_list(None, ["a"]) == ["a"]
+    assert combine_list(["a"], None) == ["a"]
+    assert combine_list(None, None) == []
 
 
 def test_combine_list_duplicates_removed():


### PR DESCRIPTION
`combine_list` returns `list(set(list1 + list2))`, so the order of the result varies between processes under hash randomization:

```
['illegal', 'bias', 'violence', 'harmful', 'pii']
['pii', 'bias', 'violence', 'illegal', 'harmful']
['harmful', 'illegal', 'bias', 'pii', 'violence']
```

### The codebase already knows

`pyrit/models/seeds/seed_dataset.py` carries a private `_merge_unique` whose docstring says:

> Used instead of `utils.combine_list` because the latter goes through `set()` and is nondeterministic across processes for non-trivial inputs.

And the existing tests compare with `set(result) == {...}` rather than asserting a result, because there was no order to assert.

### Changes

Use `dict.fromkeys`, which deduplicates while preserving first-occurrence order, and accept `None` as empty so the function covers everything `_merge_unique` did. `_merge_unique` is then removed and its single call site uses `combine_list`.

`combine_list` is public API, but moving from an arbitrary order to a defined one cannot break a caller that was already correct.

Tests now assert exact order, including a case that pins first-occurrence ordering across both arguments, and cover the `None` inputs.

### Verification

- Repeated runs with `PYTHONHASHSEED=random` now return an identical result
- `pytest tests/unit`: **16955 passed, 126 skipped** (16953 on `main`, +2 new tests, nothing broken)
- `ruff format --check`, `ruff check`: clean
