### PR TITLE
MAINT: Updating License

### DIFF
--- a/.azuredevops/component-governance.yml
+++ b/.azuredevops/component-governance.yml
@@ -17,6 +17,7 @@ steps:
     inputs:
       outputfile: $(System.DefaultWorkingDirectory)/obj/NOTICE
       outputformat: text
+      additionaldata: $(System.DefaultWorkingDirectory)/THIRD_PARTY_NOTICES.txt
 
   - publish: $(System.DefaultWorkingDirectory)/obj/NOTICE
     artifact: NOTICE

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,5 +9,8 @@ recursive-include pyrit *.jpg
 recursive-include pyrit *.wav
 recursive-include pyrit *.mp4
 recursive-include pyrit *.md
+include THIRD_PARTY_NOTICES.txt
+recursive-include LICENSES *.txt
+recursive-include third_party *.json
 include pyrit/executor/promptgen/gcg/src/Dockerfile
 recursive-include pyrit/backend/frontend *

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -1,0 +1,18 @@
+---------------------------------------------------------
+
+garak source portions - Apache-2.0
+https://github.com/NVIDIA/garak
+
+Portions Copyright (c) 2023 Leon Derczynski
+Portions Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+PyRIT includes source code, prompt templates, regular expressions, and payload data
+derived from garak. Microsoft Corporation modified these portions for PyRIT.
+
+The garak-derived portions are licensed under the Apache License, Version 2.0.
+A copy of the license is provided in LICENSES/Apache-2.0.txt.
+
+The provenance inventory in third_party/garak-provenance.json identifies the
+garak revision, source paths, and modified PyRIT files.
+
+---------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,6 +285,14 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 include = ["pyrit", "pyrit.*"]
 
+[tool.setuptools]
+license-files = [
+    "LICENSE",
+    "LICENSES/Apache-2.0.txt",
+    "THIRD_PARTY_NOTICES.txt",
+    "third_party/garak-provenance.json",
+]
+
 [tool.setuptools.package-data]
 pyrit = [
     "backend/frontend/**/*",

--- a/pyrit/converter/ansi_escape/ansi_attack_converter.py
+++ b/pyrit/converter/ansi_escape/ansi_attack_converter.py
@@ -1,5 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# Portions Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Garak-derived portions are licensed under Apache-2.0 and modified by Microsoft Corporation.
+# See THIRD_PARTY_NOTICES.txt for attribution and source details.
 
 import logging
 

--- a/pyrit/converter/ask_to_decode_converter.py
+++ b/pyrit/converter/ask_to_decode_converter.py
@@ -1,5 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# Portions Copyright (c) 2023 Leon Derczynski and NVIDIA CORPORATION & AFFILIATES.
+# Garak-derived portions are licensed under Apache-2.0 and modified by Microsoft Corporation.
+# See THIRD_PARTY_NOTICES.txt for attribution and source details.
 
 from pyrit.converter.converter import Converter, ConverterResult
 from pyrit.models import ComponentIdentifier, PromptDataType
@@ -15,7 +18,8 @@ class AskToDecodeConverter(Converter):
     This is useful for testing whether AI systems will decode potentially harmful
     encoded content when explicitly asked.
 
-    Credit to Garak: https://github.com/NVIDIA/garak/blob/main/garak/probes/encoding.py
+    Credit to Garak:
+    https://github.com/NVIDIA/garak/blob/3f50ea5ff9cd7050099940647c15c39b07a93392/garak/probes/encoding.py
     """
 
     SUPPORTED_INPUT_TYPES = ("text",)

--- a/pyrit/converter/braille_converter.py
+++ b/pyrit/converter/braille_converter.py
@@ -1,5 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# Portions Copyright (c) 2023 Leon Derczynski and NVIDIA CORPORATION & AFFILIATES.
+# Garak-derived portions are licensed under Apache-2.0 and modified by Microsoft Corporation.
+# See THIRD_PARTY_NOTICES.txt for attribution and source details.
 
 
 from pyrit.converter.converter import Converter, ConverterResult
@@ -20,7 +23,7 @@ class BrailleConverter(Converter):
 
     The letter, digit, and core punctuation mappings are based on the
     implementation from Garak:
-    https://github.com/NVIDIA/garak/blob/main/garak/probes/encoding.py
+    https://github.com/NVIDIA/garak/blob/3f50ea5ff9cd7050099940647c15c39b07a93392/garak/probes/encoding.py
     The ASCII symbol cells follow Unified English Braille (UEB).
 
     Note: This converter is useful for testing how AI systems handle Braille-encoded
@@ -55,7 +58,8 @@ class BrailleConverter(Converter):
         """
         Retrieve the braille representation of the input text.
 
-        Taken from Garak https://github.com/NVIDIA/garak/blob/main/garak/probes/encoding.py
+        Taken from Garak:
+        https://github.com/NVIDIA/garak/blob/3f50ea5ff9cd7050099940647c15c39b07a93392/garak/probes/encoding.py
 
         Args:
             text (str): The input text to be converted to braille.

--- a/pyrit/datasets/converters/policy_puppetry_converter.yaml
+++ b/pyrit/datasets/converters/policy_puppetry_converter.yaml
@@ -1,3 +1,6 @@
+# Portions Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Garak-derived portions are licensed under Apache-2.0 and modified by Microsoft Corporation.
+# See THIRD_PARTY_NOTICES.txt for attribution and source details.
 name: policy_puppetry_converter
 description: |
   Policy Puppetry prompt-injection templates. Policy Puppetry is a

--- a/pyrit/datasets/seed_datasets/local/garak/access_shell_commands.prompt
+++ b/pyrit/datasets/seed_datasets/local/garak/access_shell_commands.prompt
@@ -1,7 +1,10 @@
+# Portions Copyright (c) 2023 Leon Derczynski and NVIDIA CORPORATION & AFFILIATES.
+# Licensed under Apache-2.0 and modified by Microsoft Corporation.
+# See THIRD_PARTY_NOTICES.txt for attribution and source details.
 dataset_name: garak_access_shell_commands
 harm_categories: cyber
-source: https://github.com/NVIDIA/garak/blob/main/garak/data/payloads/access_shell_commands.json
-groups: Nvida/Garak
+source: https://github.com/NVIDIA/garak/blob/3f50ea5ff9cd7050099940647c15c39b07a93392/garak/data/payloads/access_shell_commands.json
+groups: NVIDIA/garak
 data_type: text
 description: Attempts to get access to underlying shell (Fetched 2025-10-19)
 seed_type: prompt

--- a/pyrit/datasets/seed_datasets/local/garak/doctor.prompt
+++ b/pyrit/datasets/seed_datasets/local/garak/doctor.prompt
@@ -1,7 +1,10 @@
+# Portions Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Licensed under Apache-2.0 and modified by Microsoft Corporation.
+# See THIRD_PARTY_NOTICES.txt for attribution and source details.
 dataset_name: garak_doctor
 harm_categories: illegal
-source: https://github.com/NVIDIA/garak/blob/main/garak/probes/doctor.py
-groups: Nvidia/Garak
+source: https://github.com/NVIDIA/garak/blob/3f50ea5ff9cd7050099940647c15c39b07a93392/garak/probes/doctor.py
+groups: NVIDIA/garak
 data_type: text
 description: >-
   Objectives ported from Garak's "doctor" probe, which implements the HiddenLayer

--- a/pyrit/datasets/seed_datasets/local/garak/example_domains_xss.prompt
+++ b/pyrit/datasets/seed_datasets/local/garak/example_domains_xss.prompt
@@ -1,7 +1,10 @@
+# Portions Copyright (c) 2023 Leon Derczynski and NVIDIA CORPORATION & AFFILIATES.
+# Licensed under Apache-2.0 and modified by Microsoft Corporation.
+# See THIRD_PARTY_NOTICES.txt for attribution and source details.
 dataset_name: garak_example_domains_xss
 harm_categories: cyber
-source: https://github.com/NVIDIA/garak/blob/main/garak/data/payloads/example_domains_xss.json
-groups: Nvida/Garak
+source: https://github.com/NVIDIA/garak/blob/3f50ea5ff9cd7050099940647c15c39b07a93392/garak/data/payloads/example_domains_xss.json
+groups: NVIDIA/garak
 data_type: text
 description: Example attacker-controlled domains used in web injection exfiltration payloads (Fetched 2025-10-19)
 seed_type: prompt

--- a/pyrit/datasets/seed_datasets/local/garak/markdown_js.prompt
+++ b/pyrit/datasets/seed_datasets/local/garak/markdown_js.prompt
@@ -1,7 +1,10 @@
+# Portions Copyright (c) 2023 Leon Derczynski and NVIDIA CORPORATION & AFFILIATES.
+# Licensed under Apache-2.0 and modified by Microsoft Corporation.
+# See THIRD_PARTY_NOTICES.txt for attribution and source details.
 dataset_name: garak_markdown_js
 harm_categories: cyber
-source: https://github.com/NVIDIA/garak/blob/main/garak/data/payloads/markdown_js.json
-groups: Nvida/Garak
+source: https://github.com/NVIDIA/garak/blob/3f50ea5ff9cd7050099940647c15c39b07a93392/garak/data/payloads/markdown_js.json
+groups: NVIDIA/garak
 data_type: text
 description: Javascript payloads intended for rendering via Markdown links (Fetched 2025-10-19)
 seed_type: prompt

--- a/pyrit/datasets/seed_datasets/local/garak/normal_instructions.prompt
+++ b/pyrit/datasets/seed_datasets/local/garak/normal_instructions.prompt
@@ -1,7 +1,10 @@
+# Portions Copyright (c) 2023 Leon Derczynski and NVIDIA CORPORATION & AFFILIATES.
+# Licensed under Apache-2.0 and modified by Microsoft Corporation.
+# See THIRD_PARTY_NOTICES.txt for attribution and source details.
 dataset_name: garak_xss_normal_instructions
 harm_categories: cyber
-source: https://github.com/NVIDIA/garak/blob/main/garak/data/payloads/normal_instructions.json
-groups: Nvida/Garak
+source: https://github.com/NVIDIA/garak/blob/3f50ea5ff9cd7050099940647c15c39b07a93392/garak/data/payloads/normal_instructions.json
+groups: NVIDIA/garak
 data_type: text
 description: Benign LLM tasks used as carriers for XSS prompt injection (Fetched 2025-10-19)
 seed_type: prompt

--- a/pyrit/datasets/seed_datasets/local/garak/package_hallucination_real_tasks.prompt
+++ b/pyrit/datasets/seed_datasets/local/garak/package_hallucination_real_tasks.prompt
@@ -1,7 +1,10 @@
+# Portions Copyright (c) 2023 Leon Derczynski and NVIDIA CORPORATION & AFFILIATES.
+# Licensed under Apache-2.0 and modified by Microsoft Corporation.
+# See THIRD_PARTY_NOTICES.txt for attribution and source details.
 dataset_name: garak_package_hallucination_real_tasks
 harm_categories: cyber
-source: https://github.com/NVIDIA/garak/blob/main/garak/probes/packagehallucination.py
-groups: Nvida/Garak
+source: https://github.com/NVIDIA/garak/blob/3f50ea5ff9cd7050099940647c15c39b07a93392/garak/probes/packagehallucination.py
+groups: NVIDIA/garak
 data_type: text
 description: garak packagehallucination real code tasks - plausible programming tasks substituted into the stub templates as the <task> value (Fetched 2025-10-19).
 seed_type: prompt

--- a/pyrit/datasets/seed_datasets/local/garak/package_hallucination_stubs.prompt
+++ b/pyrit/datasets/seed_datasets/local/garak/package_hallucination_stubs.prompt
@@ -1,7 +1,10 @@
+# Portions Copyright (c) 2023 Leon Derczynski and NVIDIA CORPORATION & AFFILIATES.
+# Licensed under Apache-2.0 and modified by Microsoft Corporation.
+# See THIRD_PARTY_NOTICES.txt for attribution and source details.
 dataset_name: garak_package_hallucination_stubs
 harm_categories: cyber
-source: https://github.com/NVIDIA/garak/blob/main/garak/probes/packagehallucination.py
-groups: Nvida/Garak
+source: https://github.com/NVIDIA/garak/blob/3f50ea5ff9cd7050099940647c15c39b07a93392/garak/probes/packagehallucination.py
+groups: NVIDIA/garak
 data_type: text
 description: garak packagehallucination stub prompt templates. Each contains <language> and <task> placeholders that the scenario substitutes to elicit code that may import non-existent packages (Fetched 2025-10-19).
 seed_type: prompt

--- a/pyrit/datasets/seed_datasets/local/garak/package_hallucination_unreal_tasks.prompt
+++ b/pyrit/datasets/seed_datasets/local/garak/package_hallucination_unreal_tasks.prompt
@@ -1,7 +1,10 @@
+# Portions Copyright (c) 2023 Leon Derczynski and NVIDIA CORPORATION & AFFILIATES.
+# Licensed under Apache-2.0 and modified by Microsoft Corporation.
+# See THIRD_PARTY_NOTICES.txt for attribution and source details.
 dataset_name: garak_package_hallucination_unreal_tasks
 harm_categories: cyber
-source: https://github.com/NVIDIA/garak/blob/main/garak/probes/packagehallucination.py
-groups: Nvida/Garak
+source: https://github.com/NVIDIA/garak/blob/3f50ea5ff9cd7050099940647c15c39b07a93392/garak/probes/packagehallucination.py
+groups: NVIDIA/garak
 data_type: text
 description: garak packagehallucination unreal code tasks - fictional programming tasks substituted into the stub templates as the <task> value to increase the chance of hallucinated package imports (Fetched 2025-10-19).
 seed_type: prompt

--- a/pyrit/datasets/seed_datasets/local/garak/slur_terms_en.prompt
+++ b/pyrit/datasets/seed_datasets/local/garak/slur_terms_en.prompt
@@ -1,7 +1,10 @@
+# Portions Copyright (c) 2023 Leon Derczynski and NVIDIA CORPORATION & AFFILIATES.
+# Licensed under Apache-2.0 and modified by Microsoft Corporation.
+# See THIRD_PARTY_NOTICES.txt for attribution and source details.
 dataset_name: garak_slur_terms_en
 harm_categories: hate
-source: https://github.com/NVIDIA/garak/blob/main/garak/data/payloads/slur_terms_en.json
-groups: Nvida/Garak
+source: https://github.com/NVIDIA/garak/blob/3f50ea5ff9cd7050099940647c15c39b07a93392/garak/data/payloads/slur_terms_en.json
+groups: NVIDIA/garak
 data_type: text
 description: English ethnic slurs (Fetched 2025-10-19)
 seed_type: prompt

--- a/pyrit/datasets/seed_datasets/local/garak/system_prompt_extraction.prompt
+++ b/pyrit/datasets/seed_datasets/local/garak/system_prompt_extraction.prompt
@@ -1,7 +1,10 @@
+# Portions Copyright (c) 2023 Leon Derczynski and NVIDIA CORPORATION & AFFILIATES.
+# Licensed under Apache-2.0 and modified by Microsoft Corporation.
+# See THIRD_PARTY_NOTICES.txt for attribution and source details.
 dataset_name: garak_system_prompt_extraction
 harm_categories: prompt_injection
-source: https://github.com/NVIDIA/garak/blob/main/garak/data/sysprompt_extraction/attacks.json
-groups: Nvidia/Garak
+source: https://github.com/NVIDIA/garak/blob/3f50ea5ff9cd7050099940647c15c39b07a93392/garak/data/sysprompt_extraction/attacks.json
+groups: NVIDIA/garak
 data_type: text
 description: >-
   Extraction request templates ported verbatim from Garak's "sysprompt_extraction" probe.

--- a/pyrit/datasets/seed_datasets/local/garak/web_html_js.prompt
+++ b/pyrit/datasets/seed_datasets/local/garak/web_html_js.prompt
@@ -1,7 +1,10 @@
+# Portions Copyright (c) 2023 Leon Derczynski and NVIDIA CORPORATION & AFFILIATES.
+# Licensed under Apache-2.0 and modified by Microsoft Corporation.
+# See THIRD_PARTY_NOTICES.txt for attribution and source details.
 dataset_name: garak_web_html_js
 harm_categories: cyber
-source: https://github.com/NVIDIA/garak/blob/main/garak/data/payloads/web_html_js.json
-groups: Nvida/Garak
+source: https://github.com/NVIDIA/garak/blob/3f50ea5ff9cd7050099940647c15c39b07a93392/garak/data/payloads/web_html_js.json
+groups: NVIDIA/garak
 data_type: text
 description: Javascript embedded in HTML (Fetched 2025-10-19)
 seed_type: prompt

--- a/pyrit/scenario/scenarios/garak/audio_achilles_heel.py
+++ b/pyrit/scenario/scenarios/garak/audio_achilles_heel.py
@@ -1,5 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# Portions Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Garak-derived portions are licensed under Apache-2.0 and modified by Microsoft Corporation.
+# See THIRD_PARTY_NOTICES.txt for attribution and source details.
 
 """
 Audio Achilles Heel scenario — a PyRIT port of Garak's ``audio.AudioAchillesHeel`` probe.

--- a/pyrit/scenario/scenarios/garak/package_hallucination.py
+++ b/pyrit/scenario/scenarios/garak/package_hallucination.py
@@ -1,5 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# Portions Copyright (c) 2023 Leon Derczynski and NVIDIA CORPORATION & AFFILIATES.
+# Garak-derived portions are licensed under Apache-2.0 and modified by Microsoft Corporation.
+# See THIRD_PARTY_NOTICES.txt for attribution and source details.
 
 from __future__ import annotations
 

--- a/pyrit/scenario/scenarios/garak/web_injection.py
+++ b/pyrit/scenario/scenarios/garak/web_injection.py
@@ -1,5 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# Portions Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Garak-derived portions are licensed under Apache-2.0 and modified by Microsoft Corporation.
+# See THIRD_PARTY_NOTICES.txt for attribution and source details.
 
 from __future__ import annotations
 

--- a/pyrit/score/float_scale/system_prompt_extraction_scorer.py
+++ b/pyrit/score/float_scale/system_prompt_extraction_scorer.py
@@ -1,5 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# Portions Copyright (c) 2023 Leon Derczynski and NVIDIA CORPORATION & AFFILIATES.
+# Garak-derived portions are licensed under Apache-2.0 and modified by Microsoft Corporation.
+# See THIRD_PARTY_NOTICES.txt for attribution and source details.
 
 import re
 

--- a/pyrit/score/true_false/regex/package_hallucination_scorer.py
+++ b/pyrit/score/true_false/regex/package_hallucination_scorer.py
@@ -1,5 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+# Portions Copyright (c) 2023 Leon Derczynski and NVIDIA CORPORATION & AFFILIATES.
+# Garak-derived portions are licensed under Apache-2.0 and modified by Microsoft Corporation.
+# See THIRD_PARTY_NOTICES.txt for attribution and source details.
 
 """
 Package-hallucination scorer, ported from garak's ``packagehallucination`` detector.

--- a/tests/unit/test_garak_license_compliance.py
+++ b/tests/unit/test_garak_license_compliance.py
@@ -1,0 +1,66 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import json
+from pathlib import Path
+from typing import Any
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+PROVENANCE_PATH = REPOSITORY_ROOT / "third_party" / "garak-provenance.json"
+REQUIRED_NOTICE_TEXT = (
+    "Apache-2.0",
+    "modified by Microsoft Corporation",
+    "THIRD_PARTY_NOTICES.txt",
+)
+
+
+def _load_provenance() -> dict[str, Any]:
+    return json.loads(PROVENANCE_PATH.read_text(encoding="utf-8"))
+
+
+def test_garak_provenance_uses_immutable_revision() -> None:
+    provenance = _load_provenance()
+
+    revision = provenance["revision"]
+    assert len(revision) == 40
+    assert all(character in "0123456789abcdef" for character in revision)
+
+
+def test_garak_redistributed_files_have_attribution() -> None:
+    provenance = _load_provenance()
+
+    for entry in provenance["redistributed_files"]:
+        file_path = REPOSITORY_ROOT / entry["path"]
+        assert file_path.is_file(), f"Missing redistributed file: {entry['path']}"
+        content = file_path.read_text(encoding="utf-8")
+        for required_text in REQUIRED_NOTICE_TEXT:
+            assert required_text in content, f"{entry['path']} is missing {required_text!r}"
+
+
+def test_garak_local_datasets_do_not_use_moving_source_urls() -> None:
+    provenance = _load_provenance()
+    revision = provenance["revision"]
+    local_dataset_dir = REPOSITORY_ROOT / "pyrit" / "datasets" / "seed_datasets" / "local" / "garak"
+    manifest_paths = {entry["path"] for entry in provenance["redistributed_files"]}
+
+    for file_path in local_dataset_dir.glob("*.prompt"):
+        content = file_path.read_text(encoding="utf-8")
+        assert "NVIDIA/garak/blob/main" not in content
+        assert revision in content
+        assert file_path.relative_to(REPOSITORY_ROOT).as_posix() in manifest_paths
+
+
+def test_garak_license_files_are_configured_for_distribution() -> None:
+    pyproject = (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    manifest = (REPOSITORY_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+
+    assert "LICENSES/Apache-2.0.txt" in pyproject
+    assert "THIRD_PARTY_NOTICES.txt" in pyproject
+    assert "recursive-include LICENSES *.txt" in manifest
+    assert "include THIRD_PARTY_NOTICES.txt" in manifest
+
+
+def test_notice_task_includes_garak_notice() -> None:
+    pipeline = (REPOSITORY_ROOT / ".azuredevops" / "component-governance.yml").read_text(encoding="utf-8")
+
+    assert "additionaldata: $(System.DefaultWorkingDirectory)/THIRD_PARTY_NOTICES.txt" in pipeline

--- a/third_party/garak-provenance.json
+++ b/third_party/garak-provenance.json
@@ -1,0 +1,91 @@
+{
+  "component": "NVIDIA/garak",
+  "license": "Apache-2.0",
+  "repository": "https://github.com/NVIDIA/garak",
+  "revision": "3f50ea5ff9cd7050099940647c15c39b07a93392",
+  "license_file": "LICENSES/Apache-2.0.txt",
+  "notice_file": "THIRD_PARTY_NOTICES.txt",
+  "scope_note": "This inventory covers garak-derived material distributed by PyRIT. It does not audit licenses from garak's upstream dataset sources.",
+  "redistributed_files": [
+    {
+      "path": "pyrit/converter/ansi_escape/ansi_attack_converter.py",
+      "sources": ["garak/probes/ansiescape.py", "garak/resources/ansi.py"]
+    },
+    {
+      "path": "pyrit/converter/ask_to_decode_converter.py",
+      "sources": ["garak/probes/encoding.py"]
+    },
+    {
+      "path": "pyrit/converter/braille_converter.py",
+      "sources": ["garak/probes/encoding.py"]
+    },
+    {
+      "path": "pyrit/datasets/converters/policy_puppetry_converter.yaml",
+      "sources": ["garak/probes/doctor.py"]
+    },
+    {
+      "path": "pyrit/datasets/seed_datasets/local/garak/access_shell_commands.prompt",
+      "sources": ["garak/data/payloads/access_shell_commands.json"]
+    },
+    {
+      "path": "pyrit/datasets/seed_datasets/local/garak/doctor.prompt",
+      "sources": ["garak/probes/doctor.py"]
+    },
+    {
+      "path": "pyrit/datasets/seed_datasets/local/garak/example_domains_xss.prompt",
+      "sources": ["garak/data/payloads/example_domains_xss.json"]
+    },
+    {
+      "path": "pyrit/datasets/seed_datasets/local/garak/markdown_js.prompt",
+      "sources": ["garak/data/payloads/markdown_js.json"]
+    },
+    {
+      "path": "pyrit/datasets/seed_datasets/local/garak/normal_instructions.prompt",
+      "sources": ["garak/data/payloads/normal_instructions.json"]
+    },
+    {
+      "path": "pyrit/datasets/seed_datasets/local/garak/package_hallucination_real_tasks.prompt",
+      "sources": ["garak/probes/packagehallucination.py"]
+    },
+    {
+      "path": "pyrit/datasets/seed_datasets/local/garak/package_hallucination_stubs.prompt",
+      "sources": ["garak/probes/packagehallucination.py"]
+    },
+    {
+      "path": "pyrit/datasets/seed_datasets/local/garak/package_hallucination_unreal_tasks.prompt",
+      "sources": ["garak/probes/packagehallucination.py"]
+    },
+    {
+      "path": "pyrit/datasets/seed_datasets/local/garak/slur_terms_en.prompt",
+      "sources": ["garak/data/payloads/slur_terms_en.json"]
+    },
+    {
+      "path": "pyrit/datasets/seed_datasets/local/garak/system_prompt_extraction.prompt",
+      "sources": ["garak/data/sysprompt_extraction/attacks.json"]
+    },
+    {
+      "path": "pyrit/datasets/seed_datasets/local/garak/web_html_js.prompt",
+      "sources": ["garak/data/payloads/web_html_js.json"]
+    },
+    {
+      "path": "pyrit/scenario/scenarios/garak/audio_achilles_heel.py",
+      "sources": ["garak/probes/audio.py"]
+    },
+    {
+      "path": "pyrit/scenario/scenarios/garak/package_hallucination.py",
+      "sources": ["garak/probes/packagehallucination.py"]
+    },
+    {
+      "path": "pyrit/scenario/scenarios/garak/web_injection.py",
+      "sources": ["garak/probes/web_injection.py", "garak/data/xss"]
+    },
+    {
+      "path": "pyrit/score/float_scale/system_prompt_extraction_scorer.py",
+      "sources": ["garak/detectors/sysprompt_extraction.py"]
+    },
+    {
+      "path": "pyrit/score/true_false/regex/package_hallucination_scorer.py",
+      "sources": ["garak/detectors/packagehallucination.py"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- retain PyRIT's MIT license while preserving Apache-2.0 obligations for redistributed NVIDIA garak-derived material
- add the Apache-2.0 license, a supplemental third-party notice, and an immutable provenance inventory pinned to garak commit `3f50ea5ff9cd7050099940647c15c39b07a93392`
- add attribution and Microsoft modification notices to redistributed files and replace mutable upstream links with pinned links
- package the legal and provenance files in wheels and source distributions
- pass `THIRD_PARTY_NOTICES.txt` to the existing Component Governance `notice@0` task through `additionaldata`
- add compliance regression tests

## NOTICE handling

This PR intentionally does not change the checked-in `NOTICE.txt`. The existing pipeline will generate the combined NOTICE artifact through Component Governance. After merge, we can inspect that exact artifact and update the checked-in file in a follow-up if required. If `additionaldata` does not behave as expected, the pipeline change is small and can be reverted or replaced with explicit concatenation.
