### PR TITLE
FIX: Raise on missing key path in HTTP JSON response callback instead of returning empty string

### DIFF
--- a/pyrit/prompt_target/http_target/http_target_callback_functions.py
+++ b/pyrit/prompt_target/http_target/http_target_callback_functions.py
@@ -87,16 +87,27 @@ def _fetch_key(data: dict[str, Any], key: str) -> Any:
         key (str): The key path to fetch the value.
 
     Returns:
-        Any: The fetched value.
+        Any: The fetched value ("" when the resolved value is JSON null).
+
+    Raises:
+        ValueError: If any path segment is missing, so a misconfigured key
+            surfaces immediately instead of silently degrading to "".
     """
     pattern = re.compile(r"([a-zA-Z_]+)|\[(-?\d+)\]")
     keys = pattern.findall(key)
     result: Any = data
     for key_part, index_part in keys:
         if key_part:
-            result = result.get(key_part, None) if isinstance(result, dict) else None
-        elif index_part and isinstance(result, list):
-            result = result[int(index_part)] if -len(result) <= int(index_part) < len(result) else None
-        if result is None:
-            return ""
+            if not isinstance(result, dict) or key_part not in result:
+                raise ValueError(f"Key path {key!r} not found in HTTP JSON response: missing segment {key_part!r}.")
+            result = result[key_part]
+        elif index_part:
+            index = int(index_part)
+            if not isinstance(result, list) or not -len(result) <= index < len(result):
+                raise ValueError(
+                    f"Key path {key!r} not found in HTTP JSON response: index [{index_part}] out of range."
+                )
+            result = result[index]
+    if result is None:
+        return ""
     return result

--- a/tests/unit/prompt_target/target/test_http_target_parsing.py
+++ b/tests/unit/prompt_target/target/test_http_target_parsing.py
@@ -41,8 +41,8 @@ def mock_http_response() -> MagicMock:
 
 def test_parse_json_response_no_match(mock_http_response):
     parse_json_response = get_http_target_json_response_callback_function(key="nonexistant_key")
-    result = parse_json_response(mock_http_response)
-    assert result == ""
+    with pytest.raises(ValueError, match="nonexistant_key"):
+        parse_json_response(mock_http_response)
 
 
 def test_parse_json_response_match(mock_http_response, mock_callback_function):
@@ -132,3 +132,27 @@ def test_parse_json_response_negative_array_index():
     parse_json_response = get_http_target_json_response_callback_function(key="data[0].items[-1]")
     result = parse_json_response(mock_response)
     assert result == "c"
+
+
+def test_parse_json_response_missing_key_raises():
+    mock_response = MagicMock()
+    mock_response.content = b'{"mock_key": "value1"}'
+    parse_json_response = get_http_target_json_response_callback_function(key="nonexistant_key")
+    with pytest.raises(ValueError, match="nonexistant_key"):
+        parse_json_response(mock_response)
+
+
+def test_parse_json_response_missing_nested_key_raises():
+    mock_response = MagicMock()
+    mock_response.content = b'{"data": [{"items": ["a", "b", "c"]}]}'
+    parse_json_response = get_http_target_json_response_callback_function(key="data[0].missing")
+    with pytest.raises(ValueError, match="missing"):
+        parse_json_response(mock_response)
+
+
+def test_parse_json_response_out_of_range_index_raises():
+    mock_response = MagicMock()
+    mock_response.content = b'{"data": [{"items": ["a", "b", "c"]}]}'
+    parse_json_response = get_http_target_json_response_callback_function(key="data[5]")
+    with pytest.raises(ValueError, match=r"data\[5\]"):
+        parse_json_response(mock_response)


### PR DESCRIPTION
## Problem

`_fetch_key` in `pyrit/prompt_target/http_target/http_target_callback_functions.py` returned `""` whenever a key-path segment missed (absent dict key, out-of-range index, or indexing into a non-list). `HTTPTarget._send_prompt_to_target_async` stores the callback output via `str(response_content)` with no empty check, so a misconfigured `key=` (or a JSON error body such as `{"error": ...}` returned with HTTP 200) silently converts every target response into an empty assistant message. Scorers then score empty strings and attacks are recorded as unsuccessful rather than erroring — a misconfiguration masquerading as target behavior, with no exception and no log.

## Symmetry evidence

- Same file, sibling callback: `get_http_target_regex_matching_callback_function` returns the full response content on no-match (data-preserving; pinned by `test_parse_regex_response_no_match`). The JSON callback destroyed all signal on miss. This PR aligns the two: misses are now loud in both paths.
- Repo-wide convention: every chat target raises `EmptyResponseException` on empty content (`azure_ml_chat_target`, `litellm_chat_target`, `openai_chat_target`, `hugging_face_chat_target`, `websocket_target`, both Copilot targets); `HTTPTarget` was the only target that could persist `""` as a normal response. (This PR fixes the parser side; it does not add an empty guard to `HTTPTarget` itself.)
- Preserved behavior: an explicit JSON `null` at a *resolved* path still yields `""`, and all previously passing match/index tests are untouched.

## Verification

- Pre-fix: 3 new regression tests failed with `DID NOT RAISE ValueError` on unpatched code.
- Post-fix: `tests/unit/prompt_target/target/test_http_target_parsing.py` + `test_http_target.py` — 39 passed.
- `ruff check` clean and `ruff format --check` clean (ruff 0.16.6, matching `uv.lock`).
- No other callers of `_fetch_key` in `pyrit/`, `tests/`, or `doc/`; no open issue/PR covers this (searched issues and PRs for `_fetch_key` / `http_target_json_response_callback`; only related hit is #1014, which fixed negative-index parsing — a different behavior, unaffected here).