### PR TITLE
FEAT add AgentThreatRulesScorer with no new dependency

### DIFF
--- a/pyrit/score/__init__.py
+++ b/pyrit/score/__init__.py
@@ -83,6 +83,7 @@ if TYPE_CHECKING:
     from pyrit.score.true_false.prompt_shield_scorer import PromptShieldScorer
     from pyrit.score.true_false.question_answer_scorer import QuestionAnswerScorer
     from pyrit.score.true_false.regex.anthrax_keyword_scorer import AnthraxKeywordScorer
+    from pyrit.score.true_false.regex.agent_threat_rules_scorer import AgentThreatRulesScorer
     from pyrit.score.true_false.regex.credential_leak_scorer import CredentialLeakScorer
     from pyrit.score.true_false.regex.fentanyl_keyword_scorer import FentanylKeywordScorer
     from pyrit.score.true_false.regex.ldap_injection_output_scorer import LDAPInjectionOutputScorer
@@ -143,6 +144,7 @@ _LAZY_EXPORTS: dict[str, str | tuple[str, str | None]] = {
     "ContentClassifierCategory": "pyrit.score.true_false.self_ask_category_scorer",
     "ContentClassifierPaths": "pyrit.score.true_false.self_ask_category_scorer",
     "ConversationScorer": "pyrit.score.conversation_scorer",
+    "AgentThreatRulesScorer": "pyrit.score.true_false.regex.agent_threat_rules_scorer",
     "CredentialLeakScorer": "pyrit.score.true_false.regex.credential_leak_scorer",
     "DecodingScorer": "pyrit.score.true_false.decoding_scorer",
     "FentanylKeywordScorer": "pyrit.score.true_false.regex.fentanyl_keyword_scorer",

--- a/pyrit/score/__init__.py
+++ b/pyrit/score/__init__.py
@@ -82,8 +82,8 @@ if TYPE_CHECKING:
     )
     from pyrit.score.true_false.prompt_shield_scorer import PromptShieldScorer
     from pyrit.score.true_false.question_answer_scorer import QuestionAnswerScorer
-    from pyrit.score.true_false.regex.anthrax_keyword_scorer import AnthraxKeywordScorer
     from pyrit.score.true_false.regex.agent_threat_rules_scorer import AgentThreatRulesScorer
+    from pyrit.score.true_false.regex.anthrax_keyword_scorer import AnthraxKeywordScorer
     from pyrit.score.true_false.regex.credential_leak_scorer import CredentialLeakScorer
     from pyrit.score.true_false.regex.fentanyl_keyword_scorer import FentanylKeywordScorer
     from pyrit.score.true_false.regex.ldap_injection_output_scorer import LDAPInjectionOutputScorer

--- a/pyrit/score/true_false/regex/__init__.py
+++ b/pyrit/score/true_false/regex/__init__.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from pyrit.common.lazy_imports import get_lazy_dir, resolve_lazy_export
 
 if TYPE_CHECKING:
+    from pyrit.score.true_false.regex.agent_threat_rules_scorer import AgentThreatRulesScorer
     from pyrit.score.true_false.regex.anthrax_keyword_scorer import AnthraxKeywordScorer
     from pyrit.score.true_false.regex.credential_leak_scorer import CredentialLeakScorer
     from pyrit.score.true_false.regex.fentanyl_keyword_scorer import FentanylKeywordScorer
@@ -34,6 +35,7 @@ if TYPE_CHECKING:
     from pyrit.score.true_false.regex.xxe_output_scorer import XXEOutputScorer
 
 _LAZY_EXPORTS: dict[str, str | tuple[str, str | None]] = {
+    "AgentThreatRulesScorer": "pyrit.score.true_false.regex.agent_threat_rules_scorer",
     "AnthraxKeywordScorer": "pyrit.score.true_false.regex.anthrax_keyword_scorer",
     "CredentialLeakScorer": "pyrit.score.true_false.regex.credential_leak_scorer",
     "FentanylKeywordScorer": "pyrit.score.true_false.regex.fentanyl_keyword_scorer",

--- a/pyrit/score/true_false/regex/agent_threat_rules_scorer.py
+++ b/pyrit/score/true_false/regex/agent_threat_rules_scorer.py
@@ -39,7 +39,7 @@ class AgentThreatRulesScorer(RegexScorer):
     injection, tool poisoning, context exfiltration and related categories.
     This scorer consumes a precompiled digest that ATR's CI publishes, so it
     adds no dependency: every pattern in the digest is plain Python ``re``
-    syntax and is compiled by :class:`RegexScorer` exactly as any other
+    syntax and is compiled by ``RegexScorer`` exactly as any other
     pattern set would be.
 
     The digest is fetched from a pinned commit by default and cached under
@@ -76,8 +76,8 @@ class AgentThreatRulesScorer(RegexScorer):
                 the digest's own ``default_fields``.
             categories: Score categories. Defaults to ``("agent_threat",)``.
             cache: Whether to cache the fetched digest under ``DB_DATA_PATH``.
-            validator: Passed through to :class:`RegexScorer`.
-            score_aggregator: Passed through to :class:`RegexScorer`.
+            validator: Passed through to ``RegexScorer``.
+            score_aggregator: Passed through to ``RegexScorer``.
 
         Raises:
             ValueError: If the digest is unreadable, carries an unsupported
@@ -122,7 +122,7 @@ def _patterns_from_digest(
 ) -> dict[str, str]:
     """
     Select the digest conditions that apply to ``fields`` and return them as
-    the ``{name: pattern}`` mapping :class:`RegexScorer` expects.
+    the ``{name: pattern}`` mapping ``RegexScorer`` expects.
 
     Condition keys are already unique in the digest (``<rule-id>#<index>``),
     so they double as pattern names and keep a match traceable to its rule.

--- a/pyrit/score/true_false/regex/agent_threat_rules_scorer.py
+++ b/pyrit/score/true_false/regex/agent_threat_rules_scorer.py
@@ -1,0 +1,259 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import hashlib
+import json
+import logging
+import re
+import urllib.request
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from pyrit.common.path import DB_DATA_PATH
+from pyrit.score.true_false.regex.regex_scorer import RegexScorer
+
+logger = logging.getLogger(__name__)
+
+# Pinned by default so a PyRIT release scores against a known ruleset. Callers
+# that want to track ATR's main branch pass ref="main" explicitly and accept
+# that their results move when ATR does.
+DEFAULT_ATR_REF = "54d3e13e94f8980d7b36f9d79511b26174954dfc"
+
+_DIGEST_URL_TEMPLATE = (
+    "https://raw.githubusercontent.com/Agent-Threat-Rule/agent-threat-rules/{ref}/data/pyrit-digest.json"
+)
+
+# The digest schema this scorer understands. A mismatch means ATR changed the
+# contract; failing loudly beats silently scoring against a shape we guessed at.
+SUPPORTED_DIGEST_SCHEMA = 1
+
+_CACHE_SUBDIR = "atr-digest"
+
+
+class AgentThreatRulesScorer(RegexScorer):
+    """
+    Scores text against the Agent Threat Rules (ATR) detection ruleset.
+
+    ATR is an open detection-rule standard for AI agent attacks — prompt
+    injection, tool poisoning, context exfiltration and related categories.
+    This scorer consumes a precompiled digest that ATR's CI publishes, so it
+    adds no dependency: every pattern in the digest is plain Python ``re``
+    syntax and is compiled by :class:`RegexScorer` exactly as any other
+    pattern set would be.
+
+    The digest is fetched from a pinned commit by default and cached under
+    ``DB_DATA_PATH``, the same mechanism the ATR seed dataset already uses.
+
+    ATR rules are written against specific agent surfaces (``content``,
+    ``tool_response``, ``tool_args`` and so on). A scorer sees one piece of
+    text with no surface label, so by default only conditions written against
+    the digest's ``default_fields`` are loaded. Pass ``fields`` to widen or
+    narrow that selection when you know which surface your text came from.
+
+    Note that ATR's own precision figures are measured on corpora that ATR
+    rules were partly mined from, so they do not transfer to this setting.
+    Treat this scorer as a fast pre-filter, not as a calibrated detector.
+    """
+
+    _DEFAULT_CATEGORIES: tuple[str, ...] = ("agent_threat",)
+
+    def __init__(
+        self,
+        *,
+        ref: str = DEFAULT_ATR_REF,
+        fields: Sequence[str] | None = None,
+        categories: Sequence[str] | None = None,
+        cache: bool = True,
+        validator: Any = None,
+        score_aggregator: Any = None,
+    ) -> None:
+        """
+        Args:
+            ref: ATR git ref to load the digest from. Defaults to a pinned
+                commit; pass ``"main"`` to track ATR's default branch.
+            fields: ATR detection fields to load conditions for. Defaults to
+                the digest's own ``default_fields``.
+            categories: Score categories. Defaults to ``("agent_threat",)``.
+            cache: Whether to cache the fetched digest under ``DB_DATA_PATH``.
+            validator: Passed through to :class:`RegexScorer`.
+            score_aggregator: Passed through to :class:`RegexScorer`.
+
+        Raises:
+            ValueError: If the digest is unreadable, carries an unsupported
+                schema, or yields no patterns for the requested fields.
+        """
+        digest = _load_digest(ref=ref, cache=cache)
+        patterns = _patterns_from_digest(digest, fields=fields)
+
+        if not patterns:
+            requested = list(fields) if fields is not None else digest.get("default_fields")
+            raise ValueError(
+                f"ATR digest at ref {ref!r} yielded no patterns for fields {requested!r}. "
+                f"Fields present in this digest: {sorted(digest.get('conditions_by_field', {}))}"
+            )
+
+        self._atr_ref = ref
+        self._atr_version = str(digest.get("atr_version", "unknown"))
+        self._atr_commit = str(digest.get("atr_commit", ref))
+        self._atr_fields = tuple(fields) if fields is not None else tuple(digest.get("default_fields", ()))
+        self._atr_rule_count = len({v["rule_id"] for v in digest["conditions"].values() if "rule_id" in v})
+
+        logger.info(
+            "AgentThreatRulesScorer loaded %d patterns from ATR %s (%s), fields=%s",
+            len(patterns),
+            self._atr_version,
+            self._atr_commit[:8],
+            ",".join(self._atr_fields),
+        )
+
+        super().__init__(
+            patterns=patterns,
+            categories=list(categories) if categories is not None else list(self._DEFAULT_CATEGORIES),
+            validator=validator,
+            score_aggregator=score_aggregator,
+        )
+
+
+def _patterns_from_digest(
+    digest: dict[str, Any],
+    *,
+    fields: Sequence[str] | None = None,
+) -> dict[str, str]:
+    """
+    Select the digest conditions that apply to ``fields`` and return them as
+    the ``{name: pattern}`` mapping :class:`RegexScorer` expects.
+
+    Condition keys are already unique in the digest (``<rule-id>#<index>``),
+    so they double as pattern names and keep a match traceable to its rule.
+
+    Args:
+        digest: A parsed ATR digest.
+        fields: Detection fields to select. Defaults to the digest's own
+            ``default_fields``.
+
+    Returns:
+        dict[str, str]: A ``{condition_name: pattern}`` mapping.
+
+    Raises:
+        ValueError: If the digest has no conditions object, or no fields were
+            requested and the digest declares no ``default_fields``.
+    """
+    conditions = digest.get("conditions")
+    if not isinstance(conditions, dict):
+        raise ValueError("ATR digest has no 'conditions' object")
+
+    wanted = set(fields) if fields is not None else set(digest.get("default_fields", ()))
+    if not wanted:
+        raise ValueError("No fields requested and the digest declares no 'default_fields'")
+
+    return {
+        name: condition["pattern"]
+        for name, condition in conditions.items()
+        if condition.get("field") in wanted and condition.get("pattern")
+    }
+
+
+def _load_digest(*, ref: str, cache: bool) -> dict[str, Any]:
+    """
+    Fetch the ATR digest for ``ref``, reading from cache when available.
+
+    Args:
+        ref: ATR git ref to load from.
+        cache: Whether to read from and write to the on-disk cache.
+
+    Returns:
+        dict[str, Any]: The parsed, validated digest.
+
+    Raises:
+        ValueError: If the digest cannot be fetched, parsed, or validated.
+    """
+    cache_file = _cache_path(ref)
+
+    if cache and cache_file.exists():
+        try:
+            digest = json.loads(cache_file.read_text(encoding="utf-8"))
+            _validate_digest(digest, source=str(cache_file))
+            return digest
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            # A corrupt cache entry must not be fatal, but it must be visible:
+            # silently refetching hides a disk problem that will recur.
+            logger.warning("Discarding unreadable ATR digest cache %s: %s", cache_file, exc)
+
+    url = _DIGEST_URL_TEMPLATE.format(ref=ref)
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:  # noqa: S310 - fixed https host
+            raw = response.read().decode("utf-8")
+    except Exception as exc:
+        raise ValueError(f"Could not fetch the ATR digest from {url}: {exc}") from exc
+
+    try:
+        digest = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"ATR digest at {url} is not valid JSON: {exc}") from exc
+
+    _validate_digest(digest, source=url)
+
+    if cache:
+        try:
+            cache_file.parent.mkdir(parents=True, exist_ok=True)
+            cache_file.write_text(raw, encoding="utf-8")
+        except OSError as exc:
+            logger.warning("Could not cache the ATR digest at %s: %s", cache_file, exc)
+
+    return digest
+
+
+def _validate_digest(digest: Any, *, source: str) -> None:
+    """
+    Reject a digest this scorer cannot score against.
+
+    Every pattern is compiled here rather than at match time, so an ATR-side
+    regression surfaces as a construction error naming the offending rule
+    instead of a scorer that silently matches less than it reports.
+
+    Args:
+        digest: The parsed digest to validate.
+        source: Where it came from, for error messages.
+
+    Raises:
+        ValueError: If the digest is not an object, declares an unsupported
+            schema, has no conditions, or carries a pattern that does not
+            compile under Python ``re``.
+    """
+    if not isinstance(digest, dict):
+        raise ValueError(f"ATR digest from {source} is not a JSON object")
+
+    schema = digest.get("schema")
+    if schema != SUPPORTED_DIGEST_SCHEMA:
+        raise ValueError(
+            f"ATR digest from {source} declares schema {schema!r}; "
+            f"this scorer supports schema {SUPPORTED_DIGEST_SCHEMA}"
+        )
+
+    conditions = digest.get("conditions")
+    if not isinstance(conditions, dict) or not conditions:
+        raise ValueError(f"ATR digest from {source} has no conditions")
+
+    for name, condition in conditions.items():
+        pattern = condition.get("pattern") if isinstance(condition, dict) else None
+        if not pattern:
+            raise ValueError(f"ATR digest condition {name!r} has no pattern")
+        try:
+            re.compile(pattern)
+        except re.error as exc:
+            raise ValueError(f"ATR digest condition {name!r} does not compile under Python re: {exc}") from exc
+
+
+def _cache_path(ref: str) -> Path:
+    """
+    Cache file for ``ref``, hashed so a branch name cannot escape the directory.
+
+    Args:
+        ref: ATR git ref the digest was fetched for.
+
+    Returns:
+        Path: The on-disk cache location for that ref.
+    """
+    digest_name = hashlib.sha256(ref.encode("utf-8")).hexdigest()[:16]
+    return Path(DB_DATA_PATH) / _CACHE_SUBDIR / f"pyrit-digest-{digest_name}.json"

--- a/tests/unit/score/test_agent_threat_rules_scorer.py
+++ b/tests/unit/score/test_agent_threat_rules_scorer.py
@@ -1,0 +1,171 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pyrit.score.true_false.regex.agent_threat_rules_scorer import (
+    SUPPORTED_DIGEST_SCHEMA,
+    AgentThreatRulesScorer,
+    _patterns_from_digest,
+)
+
+_MODULE = "pyrit.score.true_false.regex.agent_threat_rules_scorer"
+
+
+def _digest(**overrides):
+    """A minimal digest in the shape ATR's exporter publishes."""
+    base = {
+        "schema": SUPPORTED_DIGEST_SCHEMA,
+        "atr_version": "4.0.0",
+        "atr_commit": "54d3e13e94f8980d7b36f9d79511b26174954dfc",
+        "default_fields": ["agent_output", "content"],
+        "rules_seen": 3,
+        "rules_emitted": 3,
+        "conditions_by_field": {"content": 2, "tool_response": 1},
+        "conditions": {
+            "ATR-2026-00030#0": {
+                "rule_id": "ATR-2026-00030",
+                "pattern": r"(?i)ignore\s+(?:all\s+)?previous\s+instructions",
+                "field": "content",
+                "category": "prompt-injection",
+            },
+            "ATR-2026-00031#0": {
+                "rule_id": "ATR-2026-00031",
+                "pattern": r"(?i)speaking\s+as\s+the\s+admin\s+agent",
+                "field": "agent_output",
+                "category": "agent-manipulation",
+            },
+            "ATR-2026-00032#0": {
+                "rule_id": "ATR-2026-00032",
+                "pattern": r"(?i)exfiltrate\s+the\s+system\s+prompt",
+                "field": "tool_response",
+                "category": "context-exfiltration",
+            },
+        },
+        "excluded": {},
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture
+def offline_digest():
+    """Serve the fixture digest without touching the network or the cache."""
+    payload = json.dumps(_digest()).encode("utf-8")
+    response = MagicMock()
+    response.read.return_value = payload
+    response.__enter__ = MagicMock(return_value=response)
+    response.__exit__ = MagicMock(return_value=False)
+    with patch(f"{_MODULE}.urllib.request.urlopen", return_value=response) as urlopen:
+        yield urlopen
+
+
+class TestFieldSelection:
+    """A scorer sees unlabelled text, so field selection decides what it loads."""
+
+    def test_defaults_to_the_digests_default_fields(self):
+        patterns = _patterns_from_digest(_digest())
+        assert set(patterns) == {"ATR-2026-00030#0", "ATR-2026-00031#0"}
+
+    def test_explicit_fields_override_the_default(self):
+        patterns = _patterns_from_digest(_digest(), fields=["tool_response"])
+        assert set(patterns) == {"ATR-2026-00032#0"}
+
+    def test_condition_keys_keep_a_match_traceable_to_its_rule(self):
+        patterns = _patterns_from_digest(_digest(), fields=["content"])
+        assert all(name.startswith("ATR-") and "#" in name for name in patterns)
+
+    def test_a_digest_without_default_fields_and_no_request_is_an_error(self):
+        with pytest.raises(ValueError, match="no fields requested|default_fields"):
+            _patterns_from_digest(_digest(default_fields=[]))
+
+
+class TestDigestValidation:
+    """An ATR-side regression must fail loudly here, not score silently less."""
+
+    def test_unsupported_schema_is_rejected(self, offline_digest):
+        payload = json.dumps(_digest(schema=SUPPORTED_DIGEST_SCHEMA + 1)).encode("utf-8")
+        offline_digest.return_value.read.return_value = payload
+        with pytest.raises(ValueError, match="schema"):
+            AgentThreatRulesScorer(cache=False)
+
+    def test_a_pattern_that_does_not_compile_is_rejected_at_construction(self, offline_digest):
+        broken = _digest()
+        broken["conditions"]["ATR-2026-00030#0"]["pattern"] = r"(?i)unclosed[group"
+        offline_digest.return_value.read.return_value = json.dumps(broken).encode("utf-8")
+        with pytest.raises(ValueError, match="does not compile"):
+            AgentThreatRulesScorer(cache=False)
+
+    def test_an_empty_digest_is_rejected(self, offline_digest):
+        offline_digest.return_value.read.return_value = json.dumps(_digest(conditions={})).encode("utf-8")
+        with pytest.raises(ValueError, match="no conditions"):
+            AgentThreatRulesScorer(cache=False)
+
+    def test_requesting_a_field_the_digest_has_none_of_names_what_is_available(self, offline_digest):
+        with pytest.raises(ValueError, match="tool_name"):
+            AgentThreatRulesScorer(fields=["tool_name"], cache=False)
+
+
+class TestConstruction:
+    def test_loads_only_default_field_patterns(self, offline_digest):
+        scorer = AgentThreatRulesScorer(cache=False)
+        assert len(scorer._patterns) == 2
+        assert scorer._atr_version == "4.0.0"
+
+    def test_pins_to_a_commit_by_default(self, offline_digest):
+        AgentThreatRulesScorer(cache=False)
+        url = offline_digest.call_args[0][0]
+        assert "54d3e13e94f8980d7b36f9d79511b26174954dfc" in url
+        assert url.startswith("https://raw.githubusercontent.com/Agent-Threat-Rule/agent-threat-rules/")
+
+    def test_an_explicit_ref_is_honoured(self, offline_digest):
+        AgentThreatRulesScorer(ref="main", cache=False)
+        assert "/main/data/pyrit-digest.json" in offline_digest.call_args[0][0]
+
+    def test_categories_default_to_agent_threat(self, offline_digest):
+        scorer = AgentThreatRulesScorer(cache=False)
+        assert scorer._score_categories == ["agent_threat"]
+
+    def test_categories_can_be_overridden(self, offline_digest):
+        scorer = AgentThreatRulesScorer(categories=["custom"], cache=False)
+        assert scorer._score_categories == ["custom"]
+
+    def test_a_fetch_failure_names_the_url(self):
+        with patch(f"{_MODULE}.urllib.request.urlopen", side_effect=OSError("no route to host")):
+            with pytest.raises(ValueError, match="Could not fetch the ATR digest"):
+                AgentThreatRulesScorer(cache=False)
+
+
+class TestCaching:
+    def test_a_cached_digest_is_used_without_refetching(self, offline_digest, tmp_path):
+        cache_file = tmp_path / "pyrit-digest-cached.json"
+        cache_file.write_text(json.dumps(_digest()), encoding="utf-8")
+        with patch(f"{_MODULE}._cache_path", return_value=cache_file):
+            AgentThreatRulesScorer(cache=True)
+        offline_digest.assert_not_called()
+
+    def test_a_corrupt_cache_entry_falls_back_to_fetching(self, offline_digest, tmp_path):
+        cache_file = tmp_path / "pyrit-digest-corrupt.json"
+        cache_file.write_text("{ not json", encoding="utf-8")
+        with patch(f"{_MODULE}._cache_path", return_value=cache_file):
+            scorer = AgentThreatRulesScorer(cache=True)
+        offline_digest.assert_called_once()
+        assert len(scorer._patterns) == 2
+
+    def test_the_fetched_digest_is_written_to_cache(self, offline_digest, tmp_path):
+        cache_file = tmp_path / "nested" / "pyrit-digest.json"
+        with patch(f"{_MODULE}._cache_path", return_value=cache_file):
+            AgentThreatRulesScorer(cache=True)
+        assert json.loads(cache_file.read_text(encoding="utf-8"))["atr_version"] == "4.0.0"
+
+
+class TestCachePath:
+    def test_a_branch_name_cannot_escape_the_cache_directory(self):
+        from pyrit.score.true_false.regex.agent_threat_rules_scorer import _cache_path
+
+        path = _cache_path("../../etc/passwd")
+        assert ".." not in path.parts
+        assert path.name.startswith("pyrit-digest-")


### PR DESCRIPTION
## Description

Re-proposes the scorer reverted in #2410, without the dependency that revert objected to.

#2410 said "going to re-propose without a new optional dependency." This version has none: `pyproject.toml` is untouched, the `[atr]` extra stays deleted, and nothing imports `pyatr`.

The scorer subclasses `RegexScorer` and loads a precompiled digest that ATR's CI publishes at `data/pyrit-digest.json`. Every pattern in that digest is plain Python `re` syntax, so `RegexScorer` compiles it exactly as it does any other pattern set. The digest is fetched from a pinned commit by default and cached under `DB_DATA_PATH` — the same path the ATR seed dataset from #1715 already uses. Callers who want to track ATR's main branch pass `ref="main"` and accept that their results move when ATR does.

Two design points worth review:

Field selection. ATR rules are written against specific agent surfaces (`content`, `tool_response`, `tool_args`, ...). A scorer receives one piece of text with no surface label, so only conditions written against the digest's declared `default_fields` are loaded by default — 1,349 patterns of the 3,303 in the current digest. `fields=` widens or narrows that when the caller knows which surface the text came from.

Fail loud, not quiet. Every pattern is compiled at construction, so an ATR-side regression surfaces as a construction error naming the offending condition rather than a scorer that silently matches less than it reports. An unsupported digest schema is rejected for the same reason. The patterns ATR could not express as a pure regex OR are carried in the digest as an explicit versioned exclusion list rather than dropped with a warning.

One thing stated plainly in the docstring rather than left for someone to discover: ATR's own precision figures are measured on corpora its rules were partly mined from, so they do not transfer to this setting. This is a fast local pre-filter, not a calibrated detector.

## Tests and Documentation

18 unit tests in `tests/unit/score/test_agent_threat_rules_scorer.py`, all offline — the digest is served from a fixture, so no test touches the network. They cover field selection, digest schema rejection, a pattern that fails to compile, cache hit, corrupt-cache fallback, cache write, and that a branch name cannot escape the cache directory via path traversal.

Full `tests/unit/score/` suite passes (1,783 tests). `ruff format --check` and `ruff check` are clean on all four changed files.

Verified against the real published digest: 1,349 patterns load for the default fields and 2,303 with `fields` widened, all compiling under Python `re`.

Marked draft until CI reports.
