### PR TITLE
FIX correct prompt attribution metadata

### DIFF
--- a/pyrit/datasets/converters/denylist_converter.yaml
+++ b/pyrit/datasets/converters/denylist_converter.yaml
@@ -1,8 +1,6 @@
 name: denylist_converter
 description: |
   A general strategy for replacing a given set of denied words from a prompt.
-authors:
-  - AI Red Team
 groups:
   - AI Red Team
 source: AI Red Team

--- a/pyrit/datasets/converters/image_prompt_style/image_prompt_style_system_prompt.yaml
+++ b/pyrit/datasets/converters/image_prompt_style/image_prompt_style_system_prompt.yaml
@@ -3,8 +3,6 @@ data_type: text
 description: |
   System prompt for the ImagePromptStyleConverter. Instructs an LLM to expand a short user objective
   into a detailed image generation prompt using the provided photographic style and scene variation.
-authors:
-  - AI Red Team
 groups:
   - AI Red Team
 source: AI Red Team

--- a/pyrit/datasets/converters/image_prompt_style/polaroid_vintage_film.yaml
+++ b/pyrit/datasets/converters/image_prompt_style/polaroid_vintage_film.yaml
@@ -2,8 +2,6 @@ name: polaroid_vintage_film
 description: |
   Vintage 35mm found footage film photography. Generates highly realistic, unstaged
   "found footage" physical film photographs with prominent film grain and retro aesthetics.
-authors:
-  - AI Red Team
 groups:
   - AI Red Team
 style_instructions: |

--- a/pyrit/datasets/converters/image_prompt_style/public_space_tv_broadcast.yaml
+++ b/pyrit/datasets/converters/image_prompt_style/public_space_tv_broadcast.yaml
@@ -3,8 +3,6 @@ description: |
   Ambient crisis broadcasts in public spaces. Generates highly realistic smartphone photographs
   of television screens in various public settings (bars, diners, airport lounges) showing
   breaking news broadcasts.
-authors:
-  - AI Red Team
 groups:
   - AI Red Team
 style_instructions: |

--- a/pyrit/datasets/converters/puzzled_converter.yaml
+++ b/pyrit/datasets/converters/puzzled_converter.yaml
@@ -7,6 +7,9 @@ description: |
 authors:
   - Yelim Ahn
   - Jaejin Lee
+groups:
+  - Graduate School of Data Science, Seoul National University
+  - Department of Computer Science, Seoul National University
 source: https://arxiv.org/abs/2508.01306
 parameters:
   - masked_prompt

--- a/pyrit/datasets/converters/translation_converter.yaml
+++ b/pyrit/datasets/converters/translation_converter.yaml
@@ -1,8 +1,6 @@
 name: translation_converter
 description: |
   A general strategy for translating prompts to other languages
-authors:
-  - AI Red Team
 groups:
   - AI Red Team
 source: AI Red Team

--- a/pyrit/datasets/converters/translation_user_prompt.yaml
+++ b/pyrit/datasets/converters/translation_user_prompt.yaml
@@ -1,8 +1,6 @@
 name: translation_user_prompt
 description: |
   User-side prompt template that wraps the input with begin/end tags for the translation converter.
-authors:
-  - AI Red Team
 groups:
   - AI Red Team
 source: AI Red Team

--- a/pyrit/datasets/converters/variation_converter.yaml
+++ b/pyrit/datasets/converters/variation_converter.yaml
@@ -1,8 +1,6 @@
 name: prompt_variation
 description: |
   A general strategy for varying prompts to generate a diverse set of outputs.
-authors:
-  - AI Red Team
 groups:
   - AI Red Team
 source: AI Red Team

--- a/pyrit/datasets/converters/variation_converter_prompt_softener.yaml
+++ b/pyrit/datasets/converters/variation_converter_prompt_softener.yaml
@@ -1,8 +1,6 @@
 name: prompt_softener
 description: |
   A general strategy for softening the prompt implicitly describing the orignial prompt without use of explicit or harmful language
-authors:
-  - AI Red Team
 groups:
   - AI Red Team
 source: AI Red Team

--- a/pyrit/datasets/converters/variation_user_prompt.yaml
+++ b/pyrit/datasets/converters/variation_user_prompt.yaml
@@ -1,8 +1,6 @@
 name: variation_user_prompt
 description: |
   User-side prompt template wrapping input with begin/end tags for the variation converter.
-authors:
-  - AI Red Team
 groups:
   - AI Red Team
 source: AI Red Team

--- a/pyrit/datasets/executors/anecdoctor/anecdoctor_build_knowledge_graph.yaml
+++ b/pyrit/datasets/executors/anecdoctor/anecdoctor_build_knowledge_graph.yaml
@@ -10,7 +10,7 @@ authors:
   - Madeleine Daepp
 groups:
   - Microsoft Research
-source: Link TBA
+source: https://aclanthology.org/2025.emnlp-main.964.pdf
 parameters:
   - language
   - type

--- a/pyrit/datasets/executors/anecdoctor/anecdoctor_use_fewshot.yaml
+++ b/pyrit/datasets/executors/anecdoctor/anecdoctor_use_fewshot.yaml
@@ -11,7 +11,7 @@ authors:
   - Madeleine Daepp
 groups:
   - Microsoft Research
-source: arxiv tba
+source: https://aclanthology.org/2025.emnlp-main.964.pdf
 parameters:
   - language
   - type

--- a/pyrit/datasets/executors/anecdoctor/anecdoctor_use_knowledge_graph.yaml
+++ b/pyrit/datasets/executors/anecdoctor/anecdoctor_use_knowledge_graph.yaml
@@ -12,7 +12,7 @@ authors:
   - Madeleine Daepp
 groups:
   - Microsoft Research
-source: arxiv tba
+source: https://aclanthology.org/2025.emnlp-main.964.pdf
 parameters:
   - language
   - type

--- a/pyrit/datasets/executors/red_teaming/attack_prompt_gen_template.yaml
+++ b/pyrit/datasets/executors/red_teaming/attack_prompt_gen_template.yaml
@@ -5,7 +5,7 @@ authors: |
   - Vitaly Neyman https://github.com/vitaly-ps
 groups: |
   - Prompt Security
-source: github.com/prompt-security/ps-fuzz/dynamic_test.py
+source: https://github.com/prompt-security/ps-fuzz/blob/main/ps_fuzz/attacks/dynamic_test.py
 data_type: text
 parameters: |
   - target_system_prompts_summary

--- a/pyrit/datasets/executors/red_teaming/context_compliance/context_compliance.yaml
+++ b/pyrit/datasets/executors/red_teaming/context_compliance/context_compliance.yaml
@@ -9,7 +9,6 @@ description: |
   instruction into a simulated-conversation adversarial persona.
 authors:
   - Mark Russinovich
-  - AI Red Team
 groups:
   - AI Red Team
 source: https://arxiv.org/abs/2503.05264

--- a/pyrit/datasets/executors/red_teaming/ethical_compliance_template.yaml
+++ b/pyrit/datasets/executors/red_teaming/ethical_compliance_template.yaml
@@ -9,7 +9,7 @@ authors: |
   - Vitaly Neyman https://github.com/vitaly-ps
 groups: |
   - Prompt Security
-source: github.com/prompt-security/ps-fuzz/ethical_compliance.py
+source: https://github.com/prompt-security/ps-fuzz/blob/main/ps_fuzz/attacks/ethical_compliance.py
 data_type: text
 value: >
   # Instructions:

--- a/pyrit/datasets/executors/red_teaming/image_generation.yaml
+++ b/pyrit/datasets/executors/red_teaming/image_generation.yaml
@@ -1,8 +1,6 @@
 name: red_team_image_generation
 description: |
   A strategy for generating images with an adversarial chat bot
-authors:
-  - AI Red Team
 groups:
   - AI Red Team
 source: AI Red Team

--- a/pyrit/datasets/executors/red_teaming/naive_crescendo.yaml
+++ b/pyrit/datasets/executors/red_teaming/naive_crescendo.yaml
@@ -1,8 +1,6 @@
 name: naive_crescendo
 description: |
   A strategy that gradually builds up to a sensitive topic. This is a naive implementation of https://crescendo-the-multiturn-jailbreak.github.io/.
-authors:
-  - AI Red Team
 groups:
   - AI Red Team
 source: AI Red Team

--- a/pyrit/datasets/executors/red_teaming/text_generation.yaml
+++ b/pyrit/datasets/executors/red_teaming/text_generation.yaml
@@ -1,8 +1,6 @@
 name: red_team_text_generation
 description: |
   A general strategy for generating text with an adversarial chat bot
-authors:
-  - AI Red Team
 groups:
   - AI Red Team
 source: AI Red Team

--- a/pyrit/datasets/executors/red_teaming/unethical_task_generation_prompt.yaml
+++ b/pyrit/datasets/executors/red_teaming/unethical_task_generation_prompt.yaml
@@ -5,7 +5,7 @@ authors: |
   - Vitaly Neyman https://github.com/vitaly-ps
 groups: |
   - Prompt Security
-source: github.com/prompt-security/ps-fuzz/attacks/ethical_compliance.py
+source: https://github.com/prompt-security/ps-fuzz/blob/main/ps_fuzz/attacks/ethical_compliance.py
 data_type: text
 value: >
   # Instructions:

--- a/pyrit/datasets/executors/red_teaming/violent_durian.yaml
+++ b/pyrit/datasets/executors/red_teaming/violent_durian.yaml
@@ -2,8 +2,6 @@ name: red_team_criminal_persona
 description: |
   A multi-turn strategy where the attacker AI manipulates the target AI into adopting the persona
   of a violent criminal and providing illegal or harmful suggestions based on this identity.
-authors:
-  - AI Red Team
 groups:
   - AI Red Team
 source: https://github.com/aiverify-foundation/moonshot-data/blob/main/attack-modules/violent_durian.py

--- a/pyrit/datasets/executors/red_teaming/violent_durian_seed_prompt.yaml
+++ b/pyrit/datasets/executors/red_teaming/violent_durian_seed_prompt.yaml
@@ -3,8 +3,6 @@ description: |
   Adversarial seed prompt for the Violent Durian attack technique. Frames the adversarial
   chat as an "annoying and malicious durian" whose goal is to manipulate the target AI into
   adopting a violent criminal persona and providing unfiltered, illegal, or dangerous content.
-authors:
-  - AI Red Team
 groups:
   - AI Red Team
 source: https://github.com/aiverify-foundation/moonshot-data/blob/main/attack-modules/violent_durian.py

--- a/pyrit/datasets/executors/simulated_target/compliant.yaml
+++ b/pyrit/datasets/executors/simulated_target/compliant.yaml
@@ -3,8 +3,6 @@ description: |
   A compliant/helpful system prompt for simulated targets in adversarial conversation generation.
   This prompt instructs the simulated target to be cooperative and helpful, simulating a target
   that has been successfully bypassed or is intentionally permissive for testing purposes.
-authors:
-  - AI Red Team
 groups:
   - AI Red Team
 source: AI Red Team

--- a/pyrit/datasets/executors/simulated_target/context_compliance_target.yaml
+++ b/pyrit/datasets/executors/simulated_target/context_compliance_target.yaml
@@ -10,7 +10,6 @@ description: |
   simulated-target persona.
 authors:
   - Mark Russinovich
-  - AI Red Team
 groups:
   - AI Red Team
 source: https://arxiv.org/abs/2503.05264

--- a/pyrit/datasets/executors/simulated_target/direct_next_message.yaml
+++ b/pyrit/datasets/executors/simulated_target/direct_next_message.yaml
@@ -3,8 +3,6 @@ description: |
   System prompt for generating a direct next message that attempts to get the target to fulfill
   the objective in their next response. This is used after a simulated conversation has been
   generated, to craft a final user message that leverages the established context.
-authors:
-  - AI Red Team
 groups:
   - AI Red Team
 source: AI Red Team

--- a/pyrit/datasets/executors/simulated_target/role_play_next_message.yaml
+++ b/pyrit/datasets/executors/simulated_target/role_play_next_message.yaml
@@ -7,8 +7,6 @@ description: |
   delivers the same objective as the next in-world beat, and never breaks character or
   references real life. This avoids the common failure where the final turn drops the
   role play and asks for the raw objective, which the target then refuses.
-authors:
-  - AI Red Team
 groups:
   - AI Red Team
 source: AI Red Team

--- a/pyrit/datasets/score/scales/red_teamer_system_prompt.yaml
+++ b/pyrit/datasets/score/scales/red_teamer_system_prompt.yaml
@@ -1,8 +1,6 @@
 name: Red Teamer Task Achieved Prompt
 description: |
   The task achieved scorer assesses whether a particular task has been achieved by the AI model based on the response provided. It doesn't use all the parameters currently, only examples, mimimum_value, and maximum_value.
-authors:
-  - Microsoft
 groups:
   - Microsoft
 parameters:


### PR DESCRIPTION
Several prompt metadata records had incomplete affiliations, stale or placeholder source links, or duplicated organizations in both `authors` and `groups`. This makes attribution less accurate and obscures the distinction between individual creators and affiliated organizations.

This change:
- adds the two verified Seoul National University affiliations from the PUZZLED paper
- updates three Prompt Security references to their canonical `ps-fuzz` source paths
- links all three AnecdDoctor prompts to the authoritative EMNLP 2025 paper in ACL Anthology
- removes exact organization duplicates from `authors` while retaining them in `groups`, preserving Mark Russinovich as the individual author on the Context Compliance prompts

Validation included strict parsing of all 867 tracked YAML files, 97/97 bibliography and hidden-citation parity, 34/34 locked attribution assertions, zero remaining author/group overlaps, 3,525 focused dataset tests, Ruff, and the full unit suite with 17,040 passing tests.