### PR TITLE
MAINT Extract scenario progress read model

### DIFF
--- a/pyrit/backend/services/scenario_progress_read_model.py
+++ b/pyrit/backend/services/scenario_progress_read_model.py
@@ -1,0 +1,844 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""Incremental read model for persisted scenario progress."""
+
+import logging
+from collections import OrderedDict
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from threading import Lock
+from typing import Literal
+
+from pyrit.common.utils import to_sha256
+from pyrit.memory import AttackResultKeysetCursor
+from pyrit.memory.memory_interface import MemoryInterface
+from pyrit.models import (
+    AtomicAttackIdentifier,
+    AttackOutcome,
+    AttackResult,
+    AttackTechniqueIdentifier,
+    ComponentIdentifier,
+    ScenarioAtomicGroupProgress,
+    ScenarioAttackResultDelta,
+    ScenarioAttackTechniqueDetails,
+    ScenarioComponentIdentity,
+    ScenarioDisplayGroupProgress,
+    ScenarioObjectiveScorer,
+    ScenarioObjectiveScorerMetrics,
+    ScenarioProgressCounts,
+    ScenarioProgressResult,
+    ScenarioProgressSummary,
+    ScenarioResult,
+    ScenarioRunPlan,
+    ScenarioRunPlanAtomicGroup,
+    ScenarioRunPlanSeedGroup,
+    ScenarioScorerIdentity,
+    ScenarioSeedGroupProgress,
+    ScenarioTechniqueProgress,
+    ScorerEvaluationIdentifier,
+    ScorerIdentifier,
+    config_hash,
+    project_behavioral_identity,
+)
+from pyrit.score.scorer_evaluation.scorer_metrics_io import find_objective_metrics_by_eval_hash
+
+logger = logging.getLogger(__name__)
+
+# Technique seeds are rendered as content, so the REST payload carries only the
+# fields the UI displays. All other narrowing is declared by identifier types and
+# applied by ``project_behavioral_identity``.
+_TECHNIQUE_SEEDS_CHILD = "technique_seeds"
+_TECHNIQUE_SEED_DISPLAY_PARAMS = ("value", "data_type")
+
+
+@dataclass(frozen=True, slots=True)
+class ResultUnitIdentity:
+    """Stable identity of one planned scenario execution unit."""
+
+    atomic_group_id: str
+    seed_group_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioProgressSnapshot:
+    """Immutable boundary returned after refreshing one run's progress state."""
+
+    deltas: tuple[ScenarioAttackResultDelta, ...]
+    results: tuple[ScenarioProgressResult, ...]
+    summary: ScenarioProgressSummary
+    plan: ScenarioRunPlan
+
+
+@dataclass(frozen=True, slots=True)
+class _ProgressSummaryState:
+    """Inputs that determine whether a cached progress summary remains valid."""
+
+    active_group_ids: tuple[str, ...]
+    terminal: bool
+    plan_complete: bool
+
+
+@dataclass
+class _ProgressCacheEntry:
+    """Hydrated and mapped progress state for one scenario run."""
+
+    plan_signature: str | None = None
+    deltas: list[ScenarioAttackResultDelta] = field(default_factory=list)
+    results: list[ScenarioProgressResult] = field(default_factory=list)
+    cursor: AttackResultKeysetCursor | None = None
+    summary: ScenarioProgressSummary | None = None
+    summary_state: _ProgressSummaryState | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioPlanLookup:
+    """Pre-indexed run-plan data used while mapping persisted results."""
+
+    groups_by_identity: dict[tuple[str, str], ScenarioRunPlanAtomicGroup]
+    groups_by_name: dict[str, tuple[ScenarioRunPlanAtomicGroup, ...]]
+    seed_ids_by_group_and_objective: dict[tuple[str, str], tuple[str, ...]]
+    planned_units: frozenset[ResultUnitIdentity]
+
+    @classmethod
+    def from_plan(cls, *, plan: ScenarioRunPlan | None) -> "ScenarioPlanLookup":
+        """
+        Build constant-time lookup tables for one run plan.
+
+        Returns:
+            ScenarioPlanLookup: Indexed plan data.
+        """
+        if plan is None:
+            return cls(
+                groups_by_identity={},
+                groups_by_name={},
+                seed_ids_by_group_and_objective={},
+                planned_units=frozenset(),
+            )
+
+        groups_by_identity: dict[tuple[str, str], ScenarioRunPlanAtomicGroup] = {}
+        grouped_by_name: dict[str, list[ScenarioRunPlanAtomicGroup]] = {}
+        seeds_by_id = {seed.id: seed for seed in plan.seed_groups}
+        seed_ids_by_group_and_objective: dict[tuple[str, str], tuple[str, ...]] = {}
+        planned_units: set[ResultUnitIdentity] = set()
+        for group in plan.atomic_groups:
+            groups_by_identity[(group.atomic_attack_name, group.technique_eval_hash)] = group
+            grouped_by_name.setdefault(group.atomic_attack_name, []).append(group)
+            seed_ids_by_objective: dict[str, list[str]] = {}
+            for seed_id in group.seed_group_ids:
+                seed = seeds_by_id[seed_id]
+                seed_ids_by_objective.setdefault(seed.objective_sha256, []).append(seed_id)
+            seed_ids_by_group_and_objective.update(
+                {
+                    (group.id, objective_sha256): tuple(seed_ids)
+                    for objective_sha256, seed_ids in seed_ids_by_objective.items()
+                }
+            )
+            planned_units.update(
+                ResultUnitIdentity(atomic_group_id=group.id, seed_group_id=seed_group_id)
+                for seed_group_id in group.seed_group_ids
+            )
+
+        return cls(
+            groups_by_identity=groups_by_identity,
+            groups_by_name={name: tuple(groups) for name, groups in grouped_by_name.items()},
+            seed_ids_by_group_and_objective=seed_ids_by_group_and_objective,
+            planned_units=frozenset(planned_units),
+        )
+
+    def resolve_group(
+        self,
+        *,
+        atomic_attack_name: str,
+        technique_eval_hash: str | None,
+    ) -> ScenarioRunPlanAtomicGroup | None:
+        """
+        Resolve one planned group from persisted attribution.
+
+        Returns:
+            ScenarioRunPlanAtomicGroup | None: The uniquely matching group.
+        """
+        if technique_eval_hash is not None:
+            return self.groups_by_identity.get((atomic_attack_name, technique_eval_hash))
+        matching_groups = self.groups_by_name.get(atomic_attack_name, ())
+        return matching_groups[0] if len(matching_groups) == 1 else None
+
+
+class ScenarioProgressReadModel:
+    """Hydrate, map, cache, and summarize persisted scenario progress."""
+
+    _CACHE_MAX_RUNS = 32
+    _STORAGE_PAGE_SIZE = 500
+
+    def __init__(self, *, memory: MemoryInterface) -> None:
+        """Initialize a read model over the scenario-result store."""
+        self._memory = memory
+        self._cache: OrderedDict[str, _ProgressCacheEntry] = OrderedDict()
+        self._cache_lock = Lock()
+
+    def get_snapshot(
+        self,
+        *,
+        scenario_result_id: str,
+        plan: ScenarioRunPlan | None,
+        plan_complete: bool,
+        active_group_ids: Sequence[str],
+        terminal: bool,
+        objective_scorer_identifier: ComponentIdentifier | None,
+    ) -> ScenarioProgressSnapshot:
+        """
+        Refresh and return the mapped progress state for one run.
+
+        Returns:
+            ScenarioProgressSnapshot: Deltas, mapped results, summary, and effective plan.
+        """
+        plan_signature = plan.model_dump_json() if plan is not None else None
+        with self._cache_lock:
+            entry = self._cache.get(scenario_result_id)
+            if entry is not None and entry.plan_signature == plan_signature:
+                has_unenriched_identifier = any(
+                    delta.atomic_attack_identifier is not None and not delta.atomic_attack_identifier.seed_identifiers
+                    for delta in entry.deltas
+                )
+                was_terminal = entry.summary_state is not None and entry.summary_state.terminal
+                if has_unenriched_identifier and (not terminal or not was_terminal):
+                    entry = None
+            if entry is None or entry.plan_signature != plan_signature:
+                entry = _ProgressCacheEntry(plan_signature=plan_signature)
+                self._cache[scenario_result_id] = entry
+            self._cache.move_to_end(scenario_result_id)
+            while len(self._cache) > self._CACHE_MAX_RUNS:
+                self._cache.popitem(last=False)
+
+            first_new_index = len(entry.deltas)
+            self._hydrate_new_deltas(scenario_result_id=scenario_result_id, entry=entry)
+
+            summary_plan = plan or self._synthesize_legacy_plan(deltas=entry.deltas)
+            if len(entry.results) < len(entry.deltas):
+                plan_lookup = ScenarioPlanLookup.from_plan(plan=summary_plan)
+                entry.results.extend(
+                    self._map_progress_delta(delta=delta, plan_lookup=plan_lookup)
+                    for delta in entry.deltas[len(entry.results) :]
+                )
+
+            summary_state = _ProgressSummaryState(
+                active_group_ids=tuple(active_group_ids),
+                terminal=terminal,
+                plan_complete=plan_complete,
+            )
+            if entry.summary is None or first_new_index < len(entry.deltas) or entry.summary_state != summary_state:
+                technique_details_by_group = self._build_technique_details_by_group(
+                    deltas=entry.deltas,
+                    results=entry.results,
+                )
+                entry.summary = self._build_progress_summary(
+                    plan=summary_plan,
+                    plan_complete=plan_complete,
+                    results=entry.results,
+                    active_group_ids=active_group_ids,
+                    terminal=terminal,
+                    objective_scorer_identifier=objective_scorer_identifier,
+                    technique_details_by_group=technique_details_by_group,
+                )
+                entry.summary_state = summary_state
+
+            return ScenarioProgressSnapshot(
+                deltas=tuple(entry.deltas),
+                results=tuple(entry.results),
+                summary=entry.summary,
+                plan=summary_plan,
+            )
+
+    def _hydrate_new_deltas(self, *, scenario_result_id: str, entry: _ProgressCacheEntry) -> None:
+        """Hydrate every persisted delta after the cached keyset cursor."""
+        while True:
+            page, has_more = self._memory.get_scenario_attack_result_deltas(
+                scenario_result_id=scenario_result_id,
+                cursor=entry.cursor,
+                limit=self._STORAGE_PAGE_SIZE,
+            )
+            entry.deltas.extend(page)
+            if page:
+                last = page[-1]
+                entry.cursor = AttackResultKeysetCursor(
+                    timestamp=last.timestamp,
+                    attack_result_id=last.attack_result_id,
+                )
+            if not has_more:
+                return
+            if not page:
+                raise RuntimeError("Scenario progress storage returned an empty page with has_more=True.")
+
+    @staticmethod
+    def build_plan_lookup(*, plan: ScenarioRunPlan | None) -> ScenarioPlanLookup:
+        """
+        Build the shared lookup used for progress and legacy run summaries.
+
+        Returns:
+            ScenarioPlanLookup: Indexed plan data.
+        """
+        return ScenarioPlanLookup.from_plan(plan=plan)
+
+    @staticmethod
+    def resolve_result_unit_identity(
+        *,
+        atomic_attack_name: str,
+        attack_result: AttackResult,
+        plan_lookup: ScenarioPlanLookup,
+    ) -> ResultUnitIdentity:
+        """
+        Resolve one attack attempt to its stable planned-unit identity.
+
+        Returns:
+            ResultUnitIdentity: The atomic-group and seed-group IDs.
+        """
+        atomic_identifier = attack_result.atomic_attack_identifier
+        typed_identifier = (
+            AtomicAttackIdentifier.from_component_identifier(atomic_identifier)
+            if isinstance(atomic_identifier, ComponentIdentifier)
+            else None
+        )
+        objective = str(attack_result.objective)
+        attribution_data = attack_result.attribution_data
+        attributed_seed_group_id = attribution_data.get("seed_group_id") if isinstance(attribution_data, dict) else None
+        seed_group_id = str(attributed_seed_group_id) if attributed_seed_group_id else ""
+        if not seed_group_id and typed_identifier is not None and typed_identifier.seed_identifiers:
+            seed_group_id = typed_identifier.logical_seed_group_id
+
+        atomic_group_id = atomic_attack_name
+        eval_hash = attribution_data.get("parent_eval_hash") if isinstance(attribution_data, dict) else None
+        planned_group = plan_lookup.resolve_group(
+            atomic_attack_name=atomic_attack_name,
+            technique_eval_hash=str(eval_hash) if eval_hash is not None else None,
+        )
+        if planned_group is not None:
+            atomic_group_id = planned_group.id
+            if not seed_group_id:
+                objective_sha256 = to_sha256(objective)
+                matching_seed_ids = plan_lookup.seed_ids_by_group_and_objective.get(
+                    (planned_group.id, objective_sha256),
+                    (),
+                )
+                if len(matching_seed_ids) == 1:
+                    seed_group_id = matching_seed_ids[0]
+        if not seed_group_id:
+            seed_group_id = config_hash({"objective": objective})
+        return ResultUnitIdentity(atomic_group_id=atomic_group_id, seed_group_id=seed_group_id)
+
+    @classmethod
+    def calculate_progress_counts(
+        cls,
+        *,
+        scenario_result: ScenarioResult,
+        plan: ScenarioRunPlan | None,
+        plan_lookup: ScenarioPlanLookup,
+    ) -> tuple[int, int, int, int]:
+        """
+        Calculate planned-unit totals without inflating retries or error attempts.
+
+        Returns:
+            tuple[int, int, int, int]: Total, completed, success-rate percentage,
+                and successful-unit count.
+        """
+        latest_result_by_unit: dict[ResultUnitIdentity, AttackResult] = {}
+        for atomic_attack_name, results in scenario_result.attack_results.items():
+            for attack_result in results:
+                unit_identity = cls.resolve_result_unit_identity(
+                    atomic_attack_name=atomic_attack_name,
+                    attack_result=attack_result,
+                    plan_lookup=plan_lookup,
+                )
+                previous = latest_result_by_unit.get(unit_identity)
+                if previous is None or cls._result_order_key(attack_result) > cls._result_order_key(previous):
+                    latest_result_by_unit[unit_identity] = attack_result
+
+        planned_units = plan_lookup.planned_units if plan is not None else frozenset(latest_result_by_unit)
+        total = len(planned_units)
+        completed_results = [result for unit, result in latest_result_by_unit.items() if unit in planned_units]
+        completed = len(completed_results)
+        succeeded = sum(result.outcome == AttackOutcome.SUCCESS for result in completed_results)
+        rate = int((succeeded / completed) * 100) if completed else 0
+        return total, completed, rate, succeeded
+
+    @staticmethod
+    def _result_order_key(attack_result: AttackResult) -> tuple[datetime, str]:
+        """Return a deterministic chronological key for one hydrated result attempt."""
+        timestamp = attack_result.timestamp
+        if not isinstance(timestamp, datetime):
+            timestamp = datetime.min.replace(tzinfo=UTC)
+        return timestamp, str(attack_result.attack_result_id)
+
+    @staticmethod
+    def total_retry_pressure(*, attempts_per_unit: Iterable[int], persisted_retries: Iterable[int]) -> int:
+        """
+        Combine per-attempt retries with re-attempts of the same execution unit.
+
+        Returns:
+            int: Total retry pressure.
+        """
+        within_attempts = sum(max(0, retries) for retries in persisted_retries)
+        repeated_units = sum(max(0, count - 1) for count in attempts_per_unit)
+        return within_attempts + repeated_units
+
+    @staticmethod
+    def _build_technique_details_by_group(
+        *,
+        deltas: Sequence[ScenarioAttackResultDelta],
+        results: Sequence[ScenarioProgressResult],
+    ) -> dict[str, ScenarioAttackTechniqueDetails]:
+        """
+        Build one technique-details projection for each enriched atomic group.
+
+        Returns:
+            dict[str, ScenarioAttackTechniqueDetails]: Details keyed by atomic group ID.
+        """
+        details_by_group: dict[str, ScenarioAttackTechniqueDetails] = {}
+        for delta, result in zip(deltas, results, strict=True):
+            atomic_identifier = delta.atomic_attack_identifier
+            if (
+                result.atomic_group_id in details_by_group
+                or atomic_identifier is None
+                or not atomic_identifier.seed_identifiers
+                or atomic_identifier.attack_technique is None
+            ):
+                continue
+            details_by_group[result.atomic_group_id] = ScenarioProgressReadModel._build_attack_technique_details(
+                technique_identifier=atomic_identifier.attack_technique
+            )
+        return details_by_group
+
+    @staticmethod
+    def _build_progress_summary(
+        *,
+        plan: ScenarioRunPlan,
+        plan_complete: bool,
+        results: Sequence[ScenarioProgressResult],
+        active_group_ids: Sequence[str],
+        terminal: bool,
+        objective_scorer_identifier: ComponentIdentifier | None,
+        technique_details_by_group: dict[str, ScenarioAttackTechniqueDetails],
+    ) -> ScenarioProgressSummary:
+        """
+        Build canonical progress rollups from a plan and persisted attempts.
+
+        Returns:
+            ScenarioProgressSummary: Progress grouped for client display.
+        """
+        attempts_by_unit: dict[ResultUnitIdentity, list[ScenarioProgressResult]] = {}
+        for result in results:
+            identity = ResultUnitIdentity(
+                atomic_group_id=result.atomic_group_id,
+                seed_group_id=result.seed_group_id,
+            )
+            attempts_by_unit.setdefault(identity, []).append(result)
+
+        def aggregate(*, units: Sequence[ResultUnitIdentity], planned: int | None) -> ScenarioProgressCounts:
+            completed = 0
+            succeeded = 0
+            errors = 0
+            retries = 0
+            for unit in units:
+                attempts = attempts_by_unit.get(unit, [])
+                if attempts:
+                    completed += 1
+                    succeeded += int(attempts[-1].outcome == AttackOutcome.SUCCESS)
+                    errors += sum(int(attempt.outcome == AttackOutcome.ERROR) for attempt in attempts)
+                    retries += ScenarioProgressReadModel.total_retry_pressure(
+                        attempts_per_unit=[len(attempts)],
+                        persisted_retries=[attempt.total_retries for attempt in attempts],
+                    )
+            return ScenarioProgressCounts(
+                completed=completed,
+                planned=planned,
+                succeeded=succeeded,
+                success_percentage=int((succeeded / completed) * 100) if completed else None,
+                errors=errors,
+                retries=retries,
+            )
+
+        group_units: dict[str, list[ResultUnitIdentity]] = {
+            group.id: [
+                ResultUnitIdentity(atomic_group_id=group.id, seed_group_id=seed_group_id)
+                for seed_group_id in group.seed_group_ids
+            ]
+            for group in plan.atomic_groups
+        }
+        overall_units = (
+            [unit for units in group_units.values() for unit in units] if plan_complete else list(attempts_by_unit)
+        )
+        overall = aggregate(
+            units=overall_units,
+            planned=len(overall_units) if plan_complete else None,
+        )
+        planned_units = set(overall_units)
+        unattributed_attempts = sum(
+            len(attempts) for unit, attempts in attempts_by_unit.items() if unit not in planned_units
+        )
+        if unattributed_attempts:
+            logger.warning(
+                "%d persisted attempt(s) matched no planned execution unit and are excluded from "
+                "scenario progress rollups.",
+                unattributed_attempts,
+            )
+        latest_results = [attempts_by_unit[unit][-1] for unit in overall_units if attempts_by_unit.get(unit)]
+        objective_scorer = ScenarioProgressReadModel._build_objective_scorer(
+            scorer_identifier=objective_scorer_identifier,
+            results=latest_results,
+        )
+
+        active_ids = set(active_group_ids)
+        atomic_groups: list[ScenarioAtomicGroupProgress] = []
+        for group in plan.atomic_groups:
+            units = group_units[group.id]
+            counts = aggregate(
+                units=units,
+                planned=len(units) if plan_complete else None,
+            )
+            if not terminal and group.id in active_ids:
+                group_status: Literal["RUNNING", "PENDING", "INCOMPLETE", "COMPLETED"] = "RUNNING"
+            elif counts.planned is not None and counts.planned > 0 and counts.completed >= counts.planned:
+                group_status = "COMPLETED"
+            elif terminal:
+                group_status = "INCOMPLETE"
+            else:
+                group_status = "PENDING"
+            atomic_groups.append(
+                ScenarioAtomicGroupProgress(
+                    id=group.id,
+                    atomic_attack_name=group.atomic_attack_name,
+                    display_group=group.display_group,
+                    status=group_status,
+                    technique_details=technique_details_by_group.get(group.id),
+                    **counts.model_dump(),
+                )
+            )
+        status_order = {"RUNNING": 0, "PENDING": 1, "INCOMPLETE": 2, "COMPLETED": 3}
+        atomic_groups.sort(
+            key=lambda group: (
+                status_order[group.status],
+                group.display_group,
+                group.atomic_attack_name,
+            )
+        )
+
+        groups_by_technique: dict[str, list[ScenarioRunPlanAtomicGroup]] = {}
+        groups_by_display: dict[str, list[ScenarioRunPlanAtomicGroup]] = {}
+        for group in plan.atomic_groups:
+            technique_name = group.technique_name or group.display_group
+            groups_by_technique.setdefault(technique_name, []).append(group)
+            groups_by_display.setdefault(group.display_group, []).append(group)
+        display_groups: list[ScenarioDisplayGroupProgress] = []
+        for display_group, groups in groups_by_display.items():
+            units = [unit for group in groups for unit in group_units[group.id]]
+            counts = aggregate(
+                units=units,
+                planned=len(units) if plan_complete else None,
+            )
+            display_groups.append(
+                ScenarioDisplayGroupProgress(
+                    id=display_group,
+                    display_group=display_group,
+                    atomic_attack_names=list(dict.fromkeys(group.atomic_attack_name for group in groups)),
+                    atomic_group_ids=[group.id for group in groups],
+                    **counts.model_dump(),
+                )
+            )
+        display_groups.sort(key=lambda group: group.display_group)
+
+        techniques: list[ScenarioTechniqueProgress] = []
+        for technique_name, groups in groups_by_technique.items():
+            units = [unit for group in groups for unit in group_units[group.id]]
+            counts = aggregate(
+                units=units,
+                planned=len(units) if plan_complete else None,
+            )
+            descriptions = list(dict.fromkeys(group.description for group in groups if group.description))
+            tags = sorted({tag for group in groups for tag in group.tags})
+            techniques.append(
+                ScenarioTechniqueProgress(
+                    id=technique_name,
+                    display_group=technique_name,
+                    atomic_attack_names=list(dict.fromkeys(group.atomic_attack_name for group in groups)),
+                    atomic_group_ids=[group.id for group in groups],
+                    description=descriptions[0] if descriptions else None,
+                    tags=tags,
+                    **counts.model_dump(),
+                )
+            )
+        techniques.sort(key=lambda technique: technique.display_group)
+
+        seed_by_id = {seed.id: seed for seed in plan.seed_groups}
+        seed_groups: list[ScenarioSeedGroupProgress] = []
+        for seed_id, seed in seed_by_id.items():
+            units = [
+                ResultUnitIdentity(atomic_group_id=group.id, seed_group_id=seed_id)
+                for group in plan.atomic_groups
+                if seed_id in group.seed_group_ids
+            ]
+            counts = aggregate(
+                units=units,
+                planned=len(units) if plan_complete else None,
+            )
+            seed_groups.append(
+                ScenarioSeedGroupProgress(
+                    id=seed_id,
+                    objective=seed.objective,
+                    **counts.model_dump(),
+                )
+            )
+        seed_groups.sort(key=lambda seed: seed.objective or seed.id)
+
+        return ScenarioProgressSummary(
+            overall=overall,
+            objective_scorer=objective_scorer,
+            display_groups=display_groups,
+            techniques=techniques,
+            seed_groups=seed_groups,
+            atomic_groups=atomic_groups,
+            unattributed_attempts=unattributed_attempts,
+        )
+
+    @staticmethod
+    def _build_objective_scorer(
+        *,
+        scorer_identifier: ComponentIdentifier | None,
+        results: Sequence[ScenarioProgressResult],
+    ) -> ScenarioObjectiveScorer | None:
+        """
+        Build the objective scorer identity and its official evaluation metrics.
+
+        Returns:
+            ScenarioObjectiveScorer | None: Scorer information, or None when no scorer is known.
+        """
+        if scorer_identifier is None:
+            scorer_names = {result.score.scorer_name for result in results if result.score is not None}
+            if len(scorer_names) != 1:
+                return None
+            return ScenarioObjectiveScorer(component_name=next(iter(scorer_names)))
+
+        official_metrics = find_objective_metrics_by_eval_hash(
+            eval_hash=ScorerEvaluationIdentifier(scorer_identifier).eval_hash
+        )
+        metrics = (
+            ScenarioObjectiveScorerMetrics(
+                accuracy=official_metrics.accuracy,
+                accuracy_standard_error=official_metrics.accuracy_standard_error,
+                f1_score=official_metrics.f1_score,
+                precision=official_metrics.precision,
+                recall=official_metrics.recall,
+                average_score_time_seconds=official_metrics.average_score_time_seconds,
+            )
+            if official_metrics
+            else None
+        )
+        identity = ScenarioProgressReadModel._build_scorer_identity(scorer_identifier=scorer_identifier)
+        return ScenarioObjectiveScorer(**identity.model_dump(), metrics=metrics)
+
+    @staticmethod
+    def _build_scorer_identity(*, scorer_identifier: ComponentIdentifier) -> ScenarioScorerIdentity:
+        """
+        Project the complete scorer identity used to distinguish configurations.
+
+        Returns:
+            ScenarioScorerIdentity: Scorer parameters and nested component identities.
+        """
+        projected = project_behavioral_identity(
+            scorer_identifier,
+            identifier_type=ScorerIdentifier,
+        )
+        identity = ScenarioProgressReadModel._build_component_identity(component_identifier=projected)
+        return ScenarioScorerIdentity(
+            component_name=identity.component_name,
+            parameters=identity.parameters,
+            children=identity.children,
+        )
+
+    @staticmethod
+    def _build_component_identity(*, component_identifier: ComponentIdentifier) -> ScenarioComponentIdentity:
+        """
+        Project a component identifier without duplicating component-specific schemas.
+
+        Returns:
+            ScenarioComponentIdentity: Behavioral parameters and recursive child identities.
+        """
+        children: dict[str, list[ScenarioComponentIdentity]] = {}
+        for child_name, child_value in component_identifier.children.items():
+            child_identifiers = child_value if isinstance(child_value, list) else [child_value]
+            children[child_name] = [
+                ScenarioProgressReadModel._build_component_identity(component_identifier=child)
+                for child in child_identifiers
+            ]
+        return ScenarioComponentIdentity(
+            component_name=component_identifier.class_name,
+            parameters=dict(component_identifier.params),
+            children=children,
+        )
+
+    @staticmethod
+    def _build_attack_technique_details(
+        *,
+        technique_identifier: ComponentIdentifier,
+    ) -> ScenarioAttackTechniqueDetails:
+        """
+        Build REST details for an attack technique.
+
+        Returns:
+            ScenarioAttackTechniqueDetails: The projected technique details.
+        """
+        projected = project_behavioral_identity(
+            technique_identifier,
+            identifier_type=AttackTechniqueIdentifier,
+        )
+        details = ScenarioProgressReadModel._build_attack_technique_component_details(component_identifier=projected)
+        return ScenarioAttackTechniqueDetails(
+            component_name=details.component_name,
+            parameters=details.parameters,
+            children=details.children,
+        )
+
+    @staticmethod
+    def _build_attack_technique_component_details(
+        *,
+        component_identifier: ComponentIdentifier,
+    ) -> ScenarioComponentIdentity:
+        """
+        Map an already-projected technique component to its REST shape.
+
+        Returns:
+            ScenarioComponentIdentity: The mapped component details.
+        """
+        children: dict[str, list[ScenarioComponentIdentity]] = {}
+        for child_name, child_value in component_identifier.children.items():
+            child_identifiers = child_value if isinstance(child_value, list) else [child_value]
+            if child_name == _TECHNIQUE_SEEDS_CHILD:
+                children[child_name] = [
+                    ScenarioProgressReadModel._build_technique_seed_details(seed_identifier=child)
+                    for child in child_identifiers
+                ]
+            else:
+                children[child_name] = [
+                    ScenarioProgressReadModel._build_attack_technique_component_details(component_identifier=child)
+                    for child in child_identifiers
+                ]
+
+        return ScenarioComponentIdentity(
+            component_name=component_identifier.class_name,
+            parameters=dict(component_identifier.params),
+            children=children,
+        )
+
+    @staticmethod
+    def _build_technique_seed_details(*, seed_identifier: ComponentIdentifier) -> ScenarioComponentIdentity:
+        """
+        Keep only seed content needed by the REST attack details.
+
+        Returns:
+            ScenarioComponentIdentity: The simplified seed details.
+        """
+        parameters = {
+            name: seed_identifier.params[name]
+            for name in _TECHNIQUE_SEED_DISPLAY_PARAMS
+            if seed_identifier.params.get(name) is not None
+        }
+        return ScenarioComponentIdentity(
+            component_name=seed_identifier.class_name,
+            parameters=parameters,
+        )
+
+    @staticmethod
+    def _map_progress_delta(
+        *,
+        delta: ScenarioAttackResultDelta,
+        plan_lookup: ScenarioPlanLookup,
+    ) -> ScenarioProgressResult:
+        """
+        Map a lightweight memory row to its REST progress representation.
+
+        Returns:
+            ScenarioProgressResult: The mapped progress delta.
+        """
+        atomic_attack_name = str(delta.attribution_data.get("parent_collection") or "")
+        eval_hash = delta.attribution_data.get("parent_eval_hash")
+        atomic_group_id = config_hash(
+            {"atomic_attack_name": atomic_attack_name, "technique_eval_hash": eval_hash or ""}
+        )
+        planned_group = plan_lookup.resolve_group(
+            atomic_attack_name=atomic_attack_name,
+            technique_eval_hash=str(eval_hash) if eval_hash is not None else None,
+        )
+        if planned_group is not None:
+            atomic_group_id = planned_group.id
+        attributed_seed_group_id = delta.attribution_data.get("seed_group_id")
+        seed_group_id = str(attributed_seed_group_id) if attributed_seed_group_id else ""
+        if (
+            not seed_group_id
+            and delta.atomic_attack_identifier is not None
+            and delta.atomic_attack_identifier.seed_identifiers
+        ):
+            seed_group_id = delta.atomic_attack_identifier.logical_seed_group_id
+        if not seed_group_id and delta.objective_sha256:
+            matching_seed_ids = plan_lookup.seed_ids_by_group_and_objective.get(
+                (atomic_group_id, delta.objective_sha256),
+                (),
+            )
+            if len(matching_seed_ids) == 1:
+                seed_group_id = matching_seed_ids[0]
+        if not seed_group_id:
+            seed_group_id = config_hash({"objective": delta.objective})
+        return ScenarioProgressResult(
+            attack_result_id=delta.attack_result_id,
+            conversation_id=delta.conversation_id,
+            atomic_group_id=atomic_group_id,
+            atomic_attack_name=atomic_attack_name,
+            seed_group_id=seed_group_id,
+            outcome=delta.outcome,
+            execution_time_ms=delta.execution_time_ms,
+            timestamp=delta.timestamp,
+            total_retries=delta.total_retries,
+            retries=delta.retry_events,
+            error_type=delta.error_type,
+            error_message=delta.error_message,
+            score=delta.score,
+        )
+
+    @staticmethod
+    def _synthesize_legacy_plan(*, deltas: list[ScenarioAttackResultDelta]) -> ScenarioRunPlan:
+        """
+        Synthesize only known completed legacy units without claiming pending totals.
+
+        Returns:
+            ScenarioRunPlan: An incomplete plan containing only known units.
+        """
+        seeds: dict[str, ScenarioRunPlanSeedGroup] = {}
+        groups: dict[str, ScenarioRunPlanAtomicGroup] = {}
+        seen_seed_ids_by_group: dict[str, set[str]] = {}
+        empty_plan_lookup = ScenarioPlanLookup.from_plan(plan=None)
+        for delta in deltas:
+            mapped = ScenarioProgressReadModel._map_progress_delta(
+                delta=delta,
+                plan_lookup=empty_plan_lookup,
+            )
+            seeds.setdefault(
+                mapped.seed_group_id,
+                ScenarioRunPlanSeedGroup(
+                    id=mapped.seed_group_id,
+                    objective_sha256=delta.objective_sha256 or to_sha256(delta.objective),
+                    objective=delta.objective,
+                ),
+            )
+            group = groups.setdefault(
+                mapped.atomic_group_id,
+                ScenarioRunPlanAtomicGroup(
+                    id=mapped.atomic_group_id,
+                    atomic_attack_name=mapped.atomic_attack_name,
+                    display_group=mapped.atomic_attack_name,
+                    technique_eval_hash=str(delta.attribution_data.get("parent_eval_hash") or ""),
+                    seed_group_ids=[],
+                ),
+            )
+            seen_seed_ids = seen_seed_ids_by_group.setdefault(mapped.atomic_group_id, set())
+            if mapped.seed_group_id not in seen_seed_ids:
+                seen_seed_ids.add(mapped.seed_group_id)
+                group.seed_group_ids.append(mapped.seed_group_id)
+        return ScenarioRunPlan(atomic_groups=list(groups.values()), seed_groups=list(seeds.values()))

--- a/pyrit/backend/services/scenario_run_service.py
+++ b/pyrit/backend/services/scenario_run_service.py
@@ -15,13 +15,12 @@ import functools
 import json
 import logging
 import uuid
-from collections import OrderedDict
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from dataclasses import dataclass
+from datetime import datetime
 from threading import Lock
-from typing import Any, Literal
+from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
 from pydantic import TypeAdapter, ValidationError
@@ -35,7 +34,7 @@ from pyrit.backend.services.pagination import (
     normalize_label_filters,
 )
 from pyrit.backend.services.scenario_configuration_resolver import ScenarioConfigurationResolver
-from pyrit.common.utils import to_sha256
+from pyrit.backend.services.scenario_progress_read_model import ResultUnitIdentity, ScenarioProgressReadModel
 from pyrit.memory import AttackResultKeysetCursor, CentralMemory
 from pyrit.memory.memory_interface import (
     ScenarioHistoryAggregate,
@@ -44,37 +43,17 @@ from pyrit.memory.memory_interface import (
 )
 from pyrit.models import (
     SCENARIO_RUN_PLAN_METADATA_KEY,
-    AtomicAttackIdentifier,
     AttackOutcome,
-    AttackResult,
-    AttackTechniqueIdentifier,
     ComponentIdentifier,
-    ScenarioAtomicGroupProgress,
     ScenarioAttackResultDelta,
-    ScenarioAttackTechniqueDetails,
-    ScenarioComponentIdentity,
-    ScenarioDisplayGroupProgress,
     ScenarioIdentifier,
-    ScenarioObjectiveScorer,
-    ScenarioObjectiveScorerMetrics,
-    ScenarioProgressCounts,
     ScenarioProgressHeader,
-    ScenarioProgressResult,
-    ScenarioProgressSummary,
     ScenarioResult,
     ScenarioRunPlan,
     ScenarioRunPlanAtomicGroup,
-    ScenarioRunPlanSeedGroup,
     ScenarioRunProgress,
     ScenarioRunState,
-    ScenarioScorerIdentity,
-    ScenarioSeedGroupProgress,
-    ScenarioTechniqueProgress,
-    ScorerEvaluationIdentifier,
-    ScorerIdentifier,
     TargetIdentifier,
-    config_hash,
-    project_behavioral_identity,
 )
 from pyrit.models.catalog.scenario import (
     AttackErrorSummary,
@@ -87,20 +66,10 @@ from pyrit.models.catalog.scenario import (
 )
 from pyrit.registry import InitializerRegistry, ScenarioRegistry
 from pyrit.scenario import Scenario
-from pyrit.score.scorer_evaluation.scorer_metrics_io import find_objective_metrics_by_eval_hash
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_MAX_CONCURRENT_RUNS = 3
-_PROGRESS_CACHE_MAX_RUNS = 32
-
-# The only display decision this layer still owns: technique seeds are rendered as
-# content, so the REST payload carries just what the UI draws. Every other narrowing
-# (dropping operational target params, unwrapping multi-targets, dropping the
-# separately returned objective scorer) is declared by the identifier types
-# themselves and applied by project_behavioral_identity.
-_TECHNIQUE_SEEDS_CHILD = "technique_seeds"
-_TECHNIQUE_SEED_DISPLAY_PARAMS = ("value", "data_type")
 
 _SAFE_SCENARIO_PARAMETER_NAMES = frozenset(
     {
@@ -136,99 +105,6 @@ class _ActiveRunSnapshot:
     active_group_ids: tuple[str, ...] = ()
 
 
-@dataclass(frozen=True, slots=True)
-class _ResultUnitIdentity:
-    """Stable identity of one planned scenario execution unit."""
-
-    atomic_group_id: str
-    seed_group_id: str
-
-
-@dataclass
-class _ProgressCacheEntry:
-    """Mapped progress state for one scenario run."""
-
-    plan_signature: str | None = None
-    deltas: list[ScenarioAttackResultDelta] = field(default_factory=list)
-    results: list[ScenarioProgressResult] = field(default_factory=list)
-    cursor: AttackResultKeysetCursor | None = None
-    summary: ScenarioProgressSummary | None = None
-    summary_state: tuple[tuple[str, ...], bool, bool] | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class _ScenarioPlanLookup:
-    """Pre-indexed run-plan data used while mapping many attack results."""
-
-    groups_by_identity: dict[tuple[str, str], ScenarioRunPlanAtomicGroup]
-    groups_by_name: dict[str, tuple[ScenarioRunPlanAtomicGroup, ...]]
-    seed_ids_by_group_and_objective: dict[tuple[str, str], tuple[str, ...]]
-    planned_units: frozenset[_ResultUnitIdentity]
-
-    @classmethod
-    def from_plan(cls, *, plan: ScenarioRunPlan | None) -> "_ScenarioPlanLookup":
-        """
-        Build constant-time lookup tables for one run plan.
-
-        Returns:
-            _ScenarioPlanLookup: Indexed plan data.
-        """
-        if plan is None:
-            return cls(
-                groups_by_identity={},
-                groups_by_name={},
-                seed_ids_by_group_and_objective={},
-                planned_units=frozenset(),
-            )
-
-        groups_by_identity: dict[tuple[str, str], ScenarioRunPlanAtomicGroup] = {}
-        grouped_by_name: dict[str, list[ScenarioRunPlanAtomicGroup]] = {}
-        seeds_by_id = {seed.id: seed for seed in plan.seed_groups}
-        seed_ids_by_group_and_objective: dict[tuple[str, str], tuple[str, ...]] = {}
-        planned_units: set[_ResultUnitIdentity] = set()
-        for group in plan.atomic_groups:
-            groups_by_identity[(group.atomic_attack_name, group.technique_eval_hash)] = group
-            grouped_by_name.setdefault(group.atomic_attack_name, []).append(group)
-            seed_ids_by_objective: dict[str, list[str]] = {}
-            for seed_id in group.seed_group_ids:
-                seed = seeds_by_id[seed_id]
-                seed_ids_by_objective.setdefault(seed.objective_sha256, []).append(seed_id)
-            seed_ids_by_group_and_objective.update(
-                {
-                    (group.id, objective_sha256): tuple(seed_ids)
-                    for objective_sha256, seed_ids in seed_ids_by_objective.items()
-                }
-            )
-            planned_units.update(
-                _ResultUnitIdentity(atomic_group_id=group.id, seed_group_id=seed_group_id)
-                for seed_group_id in group.seed_group_ids
-            )
-
-        return cls(
-            groups_by_identity=groups_by_identity,
-            groups_by_name={name: tuple(groups) for name, groups in grouped_by_name.items()},
-            seed_ids_by_group_and_objective=seed_ids_by_group_and_objective,
-            planned_units=frozenset(planned_units),
-        )
-
-    def resolve_group(
-        self,
-        *,
-        atomic_attack_name: str,
-        technique_eval_hash: str | None,
-    ) -> ScenarioRunPlanAtomicGroup | None:
-        """
-        Resolve one planned group from persisted attribution.
-
-        Returns:
-            ScenarioRunPlanAtomicGroup | None: The uniquely matching group.
-        """
-        if technique_eval_hash is not None:
-            return self.groups_by_identity.get((atomic_attack_name, technique_eval_hash))
-        matching_groups = self.groups_by_name.get(atomic_attack_name, ())
-        return matching_groups[0] if len(matching_groups) == 1 else None
-
-
 class ScenarioRunService:
     """
     Service for managing scenario run lifecycle.
@@ -249,8 +125,7 @@ class ScenarioRunService:
         self._active_tasks: dict[str, _ActiveTask] = {}
         self._run_semaphore = asyncio.Semaphore(max_concurrent_runs)
         self._configuration_resolver = ScenarioConfigurationResolver()
-        self._progress_cache: OrderedDict[str, _ProgressCacheEntry] = OrderedDict()
-        self._progress_cache_lock = Lock()
+        self._progress_read_model = ScenarioProgressReadModel(memory=self._memory)
         self._technique_metadata_cache: dict[str, dict[str, ScenarioTechniqueSummary]] = {}
         self._technique_metadata_lock = Lock()
 
@@ -864,13 +739,15 @@ class ScenarioRunService:
                 scenario_result_id,
             )
             plan = None
-        plan_lookup = _ScenarioPlanLookup.from_plan(plan=plan)
+        plan_lookup = self._progress_read_model.build_plan_lookup(plan=plan)
 
         # Build result fields from DB (always computed so in-progress runs show progress)
-        total_attacks, completed_attacks, objective_achieved_rate, successful_attacks = self._calculate_progress_counts(
-            scenario_result=scenario_result,
-            plan=plan,
-            plan_lookup=plan_lookup,
+        total_attacks, completed_attacks, objective_achieved_rate, successful_attacks = (
+            self._progress_read_model.calculate_progress_counts(
+                scenario_result=scenario_result,
+                plan=plan,
+                plan_lookup=plan_lookup,
+            )
         )
         techniques_used = (
             list(dict.fromkeys(group.display_group for group in plan.atomic_groups))
@@ -886,10 +763,10 @@ class ScenarioRunService:
         failed_attacks: list[AttackErrorSummary] = []
         attack_retries: list[AttackRetrySummary] = []
         persisted_retries: list[int] = []
-        attempts_by_unit: dict[_ResultUnitIdentity, int] = {}
+        attempts_by_unit: dict[ResultUnitIdentity, int] = {}
         for atomic_attack_name, results in scenario_result.attack_results.items():
             for attack_result in results:
-                unit_identity = self._resolve_result_unit_identity(
+                unit_identity = self._progress_read_model.resolve_result_unit_identity(
                     atomic_attack_name=atomic_attack_name,
                     attack_result=attack_result,
                     plan_lookup=plan_lookup,
@@ -919,7 +796,7 @@ class ScenarioRunService:
                             total_retries=retries if isinstance(retries, int) else 0,
                         )
                     )
-        total_retries = self._total_retry_pressure(
+        total_retries = self._progress_read_model.total_retry_pressure(
             attempts_per_unit=attempts_by_unit.values(),
             persisted_retries=persisted_retries,
         )
@@ -1286,94 +1163,6 @@ class ScenarioRunService:
             self._technique_metadata_cache[scenario_name] = summaries
             return summaries
 
-    @staticmethod
-    def _resolve_result_unit_identity(
-        *,
-        atomic_attack_name: str,
-        attack_result: AttackResult,
-        plan_lookup: _ScenarioPlanLookup,
-    ) -> _ResultUnitIdentity:
-        """
-        Resolve one attack attempt to its stable planned-unit identity.
-
-        Returns:
-            _ResultUnitIdentity: The atomic-group and seed-group IDs.
-        """
-        atomic_identifier = attack_result.atomic_attack_identifier
-        typed_identifier = (
-            AtomicAttackIdentifier.from_component_identifier(atomic_identifier)
-            if isinstance(atomic_identifier, ComponentIdentifier)
-            else None
-        )
-        objective = str(attack_result.objective)
-        attribution_data = attack_result.attribution_data
-        attributed_seed_group_id = attribution_data.get("seed_group_id") if isinstance(attribution_data, dict) else None
-        seed_group_id = str(attributed_seed_group_id) if attributed_seed_group_id else ""
-        if not seed_group_id and typed_identifier is not None and typed_identifier.seed_identifiers:
-            seed_group_id = typed_identifier.logical_seed_group_id
-
-        atomic_group_id = atomic_attack_name
-        eval_hash = attribution_data.get("parent_eval_hash") if isinstance(attribution_data, dict) else None
-        planned_group = plan_lookup.resolve_group(
-            atomic_attack_name=atomic_attack_name,
-            technique_eval_hash=str(eval_hash) if eval_hash is not None else None,
-        )
-        if planned_group is not None:
-            atomic_group_id = planned_group.id
-            if not seed_group_id:
-                objective_sha256 = to_sha256(objective)
-                matching_seed_ids = plan_lookup.seed_ids_by_group_and_objective.get(
-                    (planned_group.id, objective_sha256),
-                    (),
-                )
-                if len(matching_seed_ids) == 1:
-                    seed_group_id = matching_seed_ids[0]
-        if not seed_group_id:
-            seed_group_id = config_hash({"objective": objective})
-        return _ResultUnitIdentity(atomic_group_id=atomic_group_id, seed_group_id=seed_group_id)
-
-    def _calculate_progress_counts(
-        self,
-        *,
-        scenario_result: ScenarioResult,
-        plan: ScenarioRunPlan | None,
-        plan_lookup: _ScenarioPlanLookup,
-    ) -> tuple[int, int, int, int]:
-        """
-        Calculate planned-unit totals without inflating retries or error attempts.
-
-        Returns:
-            tuple[int, int, int, int]: Total, completed, success-rate percentage,
-                and successful-unit count.
-        """
-        latest_result_by_unit: dict[_ResultUnitIdentity, AttackResult] = {}
-        for atomic_attack_name, results in scenario_result.attack_results.items():
-            for attack_result in results:
-                unit_identity = self._resolve_result_unit_identity(
-                    atomic_attack_name=atomic_attack_name,
-                    attack_result=attack_result,
-                    plan_lookup=plan_lookup,
-                )
-                previous = latest_result_by_unit.get(unit_identity)
-                if previous is None or self._result_order_key(attack_result) > self._result_order_key(previous):
-                    latest_result_by_unit[unit_identity] = attack_result
-
-        planned_units = plan_lookup.planned_units if plan is not None else frozenset(latest_result_by_unit)
-        total = len(planned_units)
-        completed_results = [result for unit, result in latest_result_by_unit.items() if unit in planned_units]
-        completed = len(completed_results)
-        succeeded = sum(result.outcome == AttackOutcome.SUCCESS for result in completed_results)
-        rate = int((succeeded / completed) * 100) if completed else 0
-        return total, completed, rate, succeeded
-
-    @staticmethod
-    def _result_order_key(attack_result: AttackResult) -> tuple[datetime, str]:
-        """Return a deterministic chronological key for one hydrated result attempt."""
-        timestamp = attack_result.timestamp
-        if not isinstance(timestamp, datetime):
-            timestamp = datetime.min.replace(tzinfo=UTC)
-        return timestamp, str(attack_result.attack_result_id)
-
     def get_run_progress(
         self,
         *,
@@ -1426,7 +1215,7 @@ class ScenarioRunService:
         objective_scorer_identifier = header_result.objective_scorer_identifier
         if not isinstance(objective_scorer_identifier, ComponentIdentifier):
             objective_scorer_identifier = None
-        all_deltas, all_results, summary, summary_plan = self._get_progress_snapshot(
+        progress_snapshot = self._progress_read_model.get_snapshot(
             scenario_result_id=scenario_result_id,
             plan=plan,
             plan_complete=plan_complete,
@@ -1436,7 +1225,7 @@ class ScenarioRunService:
         )
         available = [
             (delta, result)
-            for delta, result in zip(all_deltas, all_results, strict=True)
+            for delta, result in zip(progress_snapshot.deltas, progress_snapshot.results, strict=True)
             if cursor is None
             or (delta.timestamp, uuid.UUID(delta.attack_result_id))
             > (cursor.timestamp, uuid.UUID(cursor.attack_result_id))
@@ -1445,7 +1234,7 @@ class ScenarioRunService:
         deltas = [delta for delta, _ in page]
         results = [result for _, result in page]
         has_more = len(available) > limit
-        response_plan = summary_plan if since is None else None
+        response_plan = progress_snapshot.plan if since is None else None
         next_cursor = (
             self._encode_progress_cursor(scenario_result_id=scenario_result_id, delta=deltas[-1]) if deltas else since
         )
@@ -1475,585 +1264,11 @@ class ScenarioRunService:
             ),
             plan=response_plan,
             results=results,
-            summary=summary,
+            summary=progress_snapshot.summary,
             next_cursor=next_cursor,
             has_more=has_more,
             plan_complete=plan_complete,
         )
-
-    def _get_progress_snapshot(
-        self,
-        *,
-        scenario_result_id: str,
-        plan: ScenarioRunPlan | None,
-        plan_complete: bool,
-        active_group_ids: Sequence[str],
-        terminal: bool,
-        objective_scorer_identifier: ComponentIdentifier | None,
-    ) -> tuple[
-        list[ScenarioAttackResultDelta],
-        list[ScenarioProgressResult],
-        ScenarioProgressSummary,
-        ScenarioRunPlan,
-    ]:
-        """
-        Refresh and return cached mapped progress state.
-
-        Returns:
-            tuple: Deltas, mapped results, canonical summary, and effective plan.
-        """
-        plan_signature = plan.model_dump_json() if plan is not None else None
-        with self._progress_cache_lock:
-            entry = self._progress_cache.get(scenario_result_id)
-            if entry is not None and entry.plan_signature == plan_signature:
-                has_unenriched_identifier = any(
-                    delta.atomic_attack_identifier is not None and not delta.atomic_attack_identifier.seed_identifiers
-                    for delta in entry.deltas
-                )
-                was_terminal = entry.summary_state is not None and entry.summary_state[1]
-                if has_unenriched_identifier and (not terminal or not was_terminal):
-                    entry = None
-            if entry is None or entry.plan_signature != plan_signature:
-                entry = _ProgressCacheEntry(plan_signature=plan_signature)
-                self._progress_cache[scenario_result_id] = entry
-            self._progress_cache.move_to_end(scenario_result_id)
-            while len(self._progress_cache) > _PROGRESS_CACHE_MAX_RUNS:
-                self._progress_cache.popitem(last=False)
-
-            first_new_index = len(entry.deltas)
-            while True:
-                page, has_more = self._memory.get_scenario_attack_result_deltas(
-                    scenario_result_id=scenario_result_id,
-                    cursor=entry.cursor,
-                    limit=500,
-                )
-                entry.deltas.extend(page)
-                if page:
-                    last = page[-1]
-                    entry.cursor = AttackResultKeysetCursor(
-                        timestamp=last.timestamp,
-                        attack_result_id=last.attack_result_id,
-                    )
-                if not has_more:
-                    break
-                if not page:
-                    raise RuntimeError("Scenario progress storage returned an empty page with has_more=True.")
-
-            summary_plan = plan or self._synthesize_legacy_plan(deltas=entry.deltas)
-            if len(entry.results) < len(entry.deltas):
-                plan_lookup = _ScenarioPlanLookup.from_plan(plan=summary_plan)
-                entry.results.extend(
-                    self._map_progress_delta(delta=delta, plan_lookup=plan_lookup)
-                    for delta in entry.deltas[len(entry.results) :]
-                )
-
-            summary_state = (tuple(active_group_ids), terminal, plan_complete)
-            if entry.summary is None or first_new_index < len(entry.deltas) or entry.summary_state != summary_state:
-                technique_details_by_group = self._build_technique_details_by_group(
-                    deltas=entry.deltas,
-                    results=entry.results,
-                )
-                entry.summary = self._build_progress_summary(
-                    plan=summary_plan,
-                    plan_complete=plan_complete,
-                    results=entry.results,
-                    active_group_ids=active_group_ids,
-                    terminal=terminal,
-                    objective_scorer_identifier=objective_scorer_identifier,
-                    technique_details_by_group=technique_details_by_group,
-                )
-                entry.summary_state = summary_state
-
-            return (
-                list(entry.deltas),
-                list(entry.results),
-                entry.summary,
-                summary_plan,
-            )
-
-    @staticmethod
-    def _build_technique_details_by_group(
-        *,
-        deltas: Sequence[ScenarioAttackResultDelta],
-        results: Sequence[ScenarioProgressResult],
-    ) -> dict[str, ScenarioAttackTechniqueDetails]:
-        """
-        Build one technique-details projection for each enriched atomic group.
-
-        Returns:
-            Details keyed by atomic group ID.
-        """
-        details_by_group: dict[str, ScenarioAttackTechniqueDetails] = {}
-        for delta, result in zip(deltas, results, strict=True):
-            atomic_identifier = delta.atomic_attack_identifier
-            if (
-                result.atomic_group_id in details_by_group
-                or atomic_identifier is None
-                or not atomic_identifier.seed_identifiers
-                or atomic_identifier.attack_technique is None
-            ):
-                continue
-            details_by_group[result.atomic_group_id] = ScenarioRunService._build_attack_technique_details(
-                technique_identifier=atomic_identifier.attack_technique
-            )
-        return details_by_group
-
-    @staticmethod
-    def _build_progress_summary(
-        *,
-        plan: ScenarioRunPlan,
-        plan_complete: bool,
-        results: Sequence[ScenarioProgressResult],
-        active_group_ids: Sequence[str],
-        terminal: bool,
-        objective_scorer_identifier: ComponentIdentifier | None,
-        technique_details_by_group: dict[str, ScenarioAttackTechniqueDetails],
-    ) -> ScenarioProgressSummary:
-        """
-        Build canonical progress rollups from a plan and persisted attempts.
-
-        Returns:
-            ScenarioProgressSummary: Progress grouped for client display.
-        """
-        attempts_by_unit: dict[_ResultUnitIdentity, list[ScenarioProgressResult]] = {}
-        for result in results:
-            identity = _ResultUnitIdentity(
-                atomic_group_id=result.atomic_group_id,
-                seed_group_id=result.seed_group_id,
-            )
-            attempts_by_unit.setdefault(identity, []).append(result)
-
-        def aggregate(
-            *,
-            units: Sequence[_ResultUnitIdentity],
-            planned: int | None,
-        ) -> ScenarioProgressCounts:
-            completed = 0
-            succeeded = 0
-            errors = 0
-            retries = 0
-            for unit in units:
-                attempts = attempts_by_unit.get(unit, [])
-                if attempts:
-                    completed += 1
-                    succeeded += int(attempts[-1].outcome == AttackOutcome.SUCCESS)
-                    errors += sum(int(attempt.outcome == AttackOutcome.ERROR) for attempt in attempts)
-                    retries += ScenarioRunService._total_retry_pressure(
-                        attempts_per_unit=[len(attempts)],
-                        persisted_retries=[attempt.total_retries for attempt in attempts],
-                    )
-            return ScenarioProgressCounts(
-                completed=completed,
-                planned=planned,
-                succeeded=succeeded,
-                success_percentage=int((succeeded / completed) * 100) if completed else None,
-                errors=errors,
-                retries=retries,
-            )
-
-        group_units: dict[str, list[_ResultUnitIdentity]] = {
-            group.id: [
-                _ResultUnitIdentity(atomic_group_id=group.id, seed_group_id=seed_group_id)
-                for seed_group_id in group.seed_group_ids
-            ]
-            for group in plan.atomic_groups
-        }
-        overall_units = (
-            [unit for units in group_units.values() for unit in units] if plan_complete else list(attempts_by_unit)
-        )
-        overall = aggregate(
-            units=overall_units,
-            planned=len(overall_units) if plan_complete else None,
-        )
-        # When the plan is complete the rollups iterate planned units only, so any attempt
-        # that failed attribution would silently vanish from every count. Surface it instead.
-        planned_units = set(overall_units)
-        unattributed_attempts = sum(
-            len(attempts) for unit, attempts in attempts_by_unit.items() if unit not in planned_units
-        )
-        if unattributed_attempts:
-            logger.warning(
-                "%d persisted attempt(s) matched no planned execution unit and are excluded from "
-                "scenario progress rollups.",
-                unattributed_attempts,
-            )
-        latest_results = [attempts_by_unit[unit][-1] for unit in overall_units if attempts_by_unit.get(unit)]
-        objective_scorer = ScenarioRunService._build_objective_scorer(
-            scorer_identifier=objective_scorer_identifier,
-            results=latest_results,
-        )
-
-        active_ids = set(active_group_ids)
-        atomic_groups: list[ScenarioAtomicGroupProgress] = []
-        for group in plan.atomic_groups:
-            units = group_units[group.id]
-            counts = aggregate(
-                units=units,
-                planned=len(units) if plan_complete else None,
-            )
-            if not terminal and group.id in active_ids:
-                group_status: Literal["RUNNING", "PENDING", "INCOMPLETE", "COMPLETED"] = "RUNNING"
-            elif counts.planned is not None and counts.planned > 0 and counts.completed >= counts.planned:
-                group_status = "COMPLETED"
-            elif terminal:
-                group_status = "INCOMPLETE"
-            else:
-                group_status = "PENDING"
-            atomic_groups.append(
-                ScenarioAtomicGroupProgress(
-                    id=group.id,
-                    atomic_attack_name=group.atomic_attack_name,
-                    display_group=group.display_group,
-                    status=group_status,
-                    technique_details=technique_details_by_group.get(group.id),
-                    **counts.model_dump(),
-                )
-            )
-        status_order = {"RUNNING": 0, "PENDING": 1, "INCOMPLETE": 2, "COMPLETED": 3}
-        atomic_groups.sort(
-            key=lambda group: (
-                status_order[group.status],
-                group.display_group,
-                group.atomic_attack_name,
-            )
-        )
-
-        groups_by_technique: dict[str, list[ScenarioRunPlanAtomicGroup]] = {}
-        groups_by_display: dict[str, list[ScenarioRunPlanAtomicGroup]] = {}
-        for group in plan.atomic_groups:
-            technique_name = group.technique_name or group.display_group
-            groups_by_technique.setdefault(technique_name, []).append(group)
-            groups_by_display.setdefault(group.display_group, []).append(group)
-        display_groups: list[ScenarioDisplayGroupProgress] = []
-        for display_group, groups in groups_by_display.items():
-            units = [unit for group in groups for unit in group_units[group.id]]
-            counts = aggregate(
-                units=units,
-                planned=len(units) if plan_complete else None,
-            )
-            display_groups.append(
-                ScenarioDisplayGroupProgress(
-                    id=display_group,
-                    display_group=display_group,
-                    atomic_attack_names=list(dict.fromkeys(group.atomic_attack_name for group in groups)),
-                    atomic_group_ids=[group.id for group in groups],
-                    **counts.model_dump(),
-                )
-            )
-        display_groups.sort(key=lambda group: group.display_group)
-
-        techniques: list[ScenarioTechniqueProgress] = []
-        for technique_name, groups in groups_by_technique.items():
-            units = [unit for group in groups for unit in group_units[group.id]]
-            counts = aggregate(
-                units=units,
-                planned=len(units) if plan_complete else None,
-            )
-            descriptions = list(dict.fromkeys(group.description for group in groups if group.description))
-            tags = sorted({tag for group in groups for tag in group.tags})
-            techniques.append(
-                ScenarioTechniqueProgress(
-                    id=technique_name,
-                    display_group=technique_name,
-                    atomic_attack_names=list(dict.fromkeys(group.atomic_attack_name for group in groups)),
-                    atomic_group_ids=[group.id for group in groups],
-                    description=descriptions[0] if descriptions else None,
-                    tags=tags,
-                    **counts.model_dump(),
-                )
-            )
-        techniques.sort(key=lambda technique: technique.display_group)
-
-        seed_by_id = {seed.id: seed for seed in plan.seed_groups}
-        seed_groups: list[ScenarioSeedGroupProgress] = []
-        for seed_id, seed in seed_by_id.items():
-            units = [
-                _ResultUnitIdentity(atomic_group_id=group.id, seed_group_id=seed_id)
-                for group in plan.atomic_groups
-                if seed_id in group.seed_group_ids
-            ]
-            counts = aggregate(
-                units=units,
-                planned=len(units) if plan_complete else None,
-            )
-            seed_groups.append(
-                ScenarioSeedGroupProgress(
-                    id=seed_id,
-                    objective=seed.objective,
-                    **counts.model_dump(),
-                )
-            )
-        seed_groups.sort(key=lambda seed: seed.objective or seed.id)
-
-        return ScenarioProgressSummary(
-            overall=overall,
-            objective_scorer=objective_scorer,
-            display_groups=display_groups,
-            techniques=techniques,
-            seed_groups=seed_groups,
-            atomic_groups=atomic_groups,
-            unattributed_attempts=unattributed_attempts,
-        )
-
-    @staticmethod
-    def _build_objective_scorer(
-        *,
-        scorer_identifier: ComponentIdentifier | None,
-        results: Sequence[ScenarioProgressResult],
-    ) -> ScenarioObjectiveScorer | None:
-        """
-        Build the objective scorer identity and its official evaluation metrics.
-
-        Returns:
-            ScenarioObjectiveScorer | None: Scorer information, or None when no scorer is known.
-        """
-        if scorer_identifier is None:
-            scorer_names = {result.score.scorer_name for result in results if result.score is not None}
-            if len(scorer_names) != 1:
-                return None
-            return ScenarioObjectiveScorer(
-                component_name=next(iter(scorer_names)),
-            )
-
-        official_metrics = find_objective_metrics_by_eval_hash(
-            eval_hash=ScorerEvaluationIdentifier(scorer_identifier).eval_hash
-        )
-        metrics = (
-            ScenarioObjectiveScorerMetrics(
-                accuracy=official_metrics.accuracy,
-                accuracy_standard_error=official_metrics.accuracy_standard_error,
-                f1_score=official_metrics.f1_score,
-                precision=official_metrics.precision,
-                recall=official_metrics.recall,
-                average_score_time_seconds=official_metrics.average_score_time_seconds,
-            )
-            if official_metrics
-            else None
-        )
-        identity = ScenarioRunService._build_scorer_identity(scorer_identifier=scorer_identifier)
-        return ScenarioObjectiveScorer(**identity.model_dump(), metrics=metrics)
-
-    @staticmethod
-    def _build_scorer_identity(*, scorer_identifier: ComponentIdentifier) -> ScenarioScorerIdentity:
-        """
-        Project the complete scorer identity used to distinguish configurations.
-
-        Returns:
-            ScenarioScorerIdentity: Scorer parameters and nested component identities.
-        """
-        projected = project_behavioral_identity(
-            scorer_identifier,
-            identifier_type=ScorerIdentifier,
-        )
-        identity = ScenarioRunService._build_component_identity(component_identifier=projected)
-        return ScenarioScorerIdentity(
-            component_name=identity.component_name,
-            parameters=identity.parameters,
-            children=identity.children,
-        )
-
-    @staticmethod
-    def _total_retry_pressure(*, attempts_per_unit: Iterable[int], persisted_retries: Iterable[int]) -> int:
-        """
-        Combine per-attempt retries with re-attempts of the same execution unit.
-
-        Both the CLI-facing run summary and the GUI-facing progress rollups report
-        this same quantity, so the definition lives here once.
-
-        Returns:
-            int: Total retry pressure.
-        """
-        within_attempts = sum(max(0, retries) for retries in persisted_retries)
-        repeated_units = sum(max(0, count - 1) for count in attempts_per_unit)
-        return within_attempts + repeated_units
-
-    @staticmethod
-    def _build_component_identity(*, component_identifier: ComponentIdentifier) -> ScenarioComponentIdentity:
-        """
-        Project a component identifier without duplicating component-specific schemas.
-
-        Returns:
-            ScenarioComponentIdentity: Behavioral parameters and recursive child identities.
-        """
-        children: dict[str, list[ScenarioComponentIdentity]] = {}
-        for child_name, child_value in component_identifier.children.items():
-            child_identifiers = child_value if isinstance(child_value, list) else [child_value]
-            children[child_name] = [
-                ScenarioRunService._build_component_identity(component_identifier=child) for child in child_identifiers
-            ]
-        return ScenarioComponentIdentity(
-            component_name=component_identifier.class_name,
-            parameters=dict(component_identifier.params),
-            children=children,
-        )
-
-    @staticmethod
-    def _build_attack_technique_details(
-        *,
-        technique_identifier: ComponentIdentifier,
-    ) -> ScenarioAttackTechniqueDetails:
-        """
-        Build REST details for an attack technique.
-
-        Returns:
-            ScenarioAttackTechniqueDetails: The projected technique details.
-        """
-        projected = project_behavioral_identity(
-            technique_identifier,
-            identifier_type=AttackTechniqueIdentifier,
-        )
-        details = ScenarioRunService._build_attack_technique_component_details(component_identifier=projected)
-        return ScenarioAttackTechniqueDetails(
-            component_name=details.component_name,
-            parameters=details.parameters,
-            children=details.children,
-        )
-
-    @staticmethod
-    def _build_attack_technique_component_details(
-        *,
-        component_identifier: ComponentIdentifier,
-    ) -> ScenarioComponentIdentity:
-        """
-        Map an already-projected technique component to its REST shape.
-
-        Returns:
-            ScenarioComponentIdentity: The mapped component details.
-        """
-        children: dict[str, list[ScenarioComponentIdentity]] = {}
-        for child_name, child_value in component_identifier.children.items():
-            child_identifiers = child_value if isinstance(child_value, list) else [child_value]
-            if child_name == _TECHNIQUE_SEEDS_CHILD:
-                children[child_name] = [
-                    ScenarioRunService._build_technique_seed_details(seed_identifier=child)
-                    for child in child_identifiers
-                ]
-            else:
-                children[child_name] = [
-                    ScenarioRunService._build_attack_technique_component_details(component_identifier=child)
-                    for child in child_identifiers
-                ]
-
-        return ScenarioComponentIdentity(
-            component_name=component_identifier.class_name,
-            parameters=dict(component_identifier.params),
-            children=children,
-        )
-
-    @staticmethod
-    def _build_technique_seed_details(*, seed_identifier: ComponentIdentifier) -> ScenarioComponentIdentity:
-        """
-        Keep only seed content needed by the REST attack details.
-
-        Returns:
-            ScenarioComponentIdentity: The simplified seed details.
-        """
-        parameters = {
-            name: seed_identifier.params[name]
-            for name in _TECHNIQUE_SEED_DISPLAY_PARAMS
-            if seed_identifier.params.get(name) is not None
-        }
-        return ScenarioComponentIdentity(
-            component_name=seed_identifier.class_name,
-            parameters=parameters,
-        )
-
-    @staticmethod
-    def _map_progress_delta(
-        *,
-        delta: ScenarioAttackResultDelta,
-        plan_lookup: _ScenarioPlanLookup,
-    ) -> ScenarioProgressResult:
-        """
-        Map a lightweight memory row to its REST progress representation.
-
-        Returns:
-            ScenarioProgressResult: The mapped progress delta.
-        """
-        atomic_attack_name = str(delta.attribution_data.get("parent_collection") or "")
-        eval_hash = delta.attribution_data.get("parent_eval_hash")
-        atomic_group_id = config_hash(
-            {"atomic_attack_name": atomic_attack_name, "technique_eval_hash": eval_hash or ""}
-        )
-        planned_group = plan_lookup.resolve_group(
-            atomic_attack_name=atomic_attack_name,
-            technique_eval_hash=str(eval_hash) if eval_hash is not None else None,
-        )
-        if planned_group is not None:
-            atomic_group_id = planned_group.id
-        attributed_seed_group_id = delta.attribution_data.get("seed_group_id")
-        seed_group_id = str(attributed_seed_group_id) if attributed_seed_group_id else ""
-        if (
-            not seed_group_id
-            and delta.atomic_attack_identifier is not None
-            and delta.atomic_attack_identifier.seed_identifiers
-        ):
-            seed_group_id = delta.atomic_attack_identifier.logical_seed_group_id
-        if not seed_group_id and delta.objective_sha256:
-            matching_seed_ids = plan_lookup.seed_ids_by_group_and_objective.get(
-                (atomic_group_id, delta.objective_sha256),
-                (),
-            )
-            if len(matching_seed_ids) == 1:
-                seed_group_id = matching_seed_ids[0]
-        if not seed_group_id:
-            seed_group_id = config_hash({"objective": delta.objective})
-        return ScenarioProgressResult(
-            attack_result_id=delta.attack_result_id,
-            conversation_id=delta.conversation_id,
-            atomic_group_id=atomic_group_id,
-            atomic_attack_name=atomic_attack_name,
-            seed_group_id=seed_group_id,
-            outcome=delta.outcome,
-            execution_time_ms=delta.execution_time_ms,
-            timestamp=delta.timestamp,
-            total_retries=delta.total_retries,
-            retries=delta.retry_events,
-            error_type=delta.error_type,
-            error_message=delta.error_message,
-            score=delta.score,
-        )
-
-    @staticmethod
-    def _synthesize_legacy_plan(*, deltas: list[ScenarioAttackResultDelta]) -> ScenarioRunPlan:
-        """
-        Synthesize only known completed legacy units without claiming pending totals.
-
-        Returns:
-            ScenarioRunPlan: An incomplete plan containing only known units.
-        """
-        seeds: dict[str, ScenarioRunPlanSeedGroup] = {}
-        groups: dict[str, ScenarioRunPlanAtomicGroup] = {}
-        seen_seed_ids_by_group: dict[str, set[str]] = {}
-        empty_plan_lookup = _ScenarioPlanLookup.from_plan(plan=None)
-        for delta in deltas:
-            mapped = ScenarioRunService._map_progress_delta(
-                delta=delta,
-                plan_lookup=empty_plan_lookup,
-            )
-            seeds.setdefault(
-                mapped.seed_group_id,
-                ScenarioRunPlanSeedGroup(
-                    id=mapped.seed_group_id,
-                    objective_sha256=delta.objective_sha256 or to_sha256(delta.objective),
-                    objective=delta.objective,
-                ),
-            )
-            group = groups.setdefault(
-                mapped.atomic_group_id,
-                ScenarioRunPlanAtomicGroup(
-                    id=mapped.atomic_group_id,
-                    atomic_attack_name=mapped.atomic_attack_name,
-                    display_group=mapped.atomic_attack_name,
-                    technique_eval_hash=str(delta.attribution_data.get("parent_eval_hash") or ""),
-                    seed_group_ids=[],
-                ),
-            )
-            seen_seed_ids = seen_seed_ids_by_group.setdefault(mapped.atomic_group_id, set())
-            if mapped.seed_group_id not in seen_seed_ids:
-                seen_seed_ids.add(mapped.seed_group_id)
-                group.seed_group_ids.append(mapped.seed_group_id)
-        return ScenarioRunPlan(atomic_groups=list(groups.values()), seed_groups=list(seeds.values()))
 
     @staticmethod
     def _encode_progress_cursor(*, scenario_result_id: str, delta: ScenarioAttackResultDelta) -> str:

--- a/tests/unit/backend/test_scenario_progress_read_model.py
+++ b/tests/unit/backend/test_scenario_progress_read_model.py
@@ -1,0 +1,168 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""Tests for the scenario progress read model."""
+
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from pyrit.backend.services.scenario_progress_read_model import (
+    ScenarioProgressReadModel,
+    ScenarioProgressSnapshot,
+)
+from pyrit.memory import AttackResultKeysetCursor
+from pyrit.memory.memory_interface import MemoryInterface
+from pyrit.models import (
+    AttackOutcome,
+    ScenarioAttackResultDelta,
+    ScenarioRunPlan,
+    ScenarioRunPlanAtomicGroup,
+    ScenarioRunPlanSeedGroup,
+)
+
+
+def _make_delta(*, run_id: str, index: int = 0) -> ScenarioAttackResultDelta:
+    """Create one lightweight persisted row for a synthetic run."""
+    return ScenarioAttackResultDelta(
+        attack_result_id=str(uuid.uuid5(uuid.NAMESPACE_URL, f"{run_id}-{index}")),
+        conversation_id=f"conversation-{run_id}-{index}",
+        objective=f"objective-{run_id}-{index}",
+        objective_sha256=f"sha-{run_id}-{index}",
+        outcome=AttackOutcome.SUCCESS,
+        execution_time_ms=10,
+        timestamp=datetime(2025, 1, 1, tzinfo=UTC) + timedelta(seconds=index),
+        attribution_data={"parent_collection": "attack", "seed_group_id": f"seed-{index}"},
+    )
+
+
+def _get_snapshot(*, read_model: ScenarioProgressReadModel, run_id: str) -> ScenarioProgressSnapshot:
+    """Read one incomplete synthetic run through the public typed boundary."""
+    return read_model.get_snapshot(
+        scenario_result_id=run_id,
+        plan=None,
+        plan_complete=False,
+        active_group_ids=(),
+        terminal=False,
+        objective_scorer_identifier=None,
+    )
+
+
+def test_get_snapshot_evicts_least_recently_used_run() -> None:
+    memory = MagicMock(spec=MemoryInterface)
+    deltas = {run_id: _make_delta(run_id=run_id) for run_id in ("run-a", "run-b", "run-c")}
+
+    def get_deltas(
+        *,
+        scenario_result_id: str,
+        cursor: AttackResultKeysetCursor | None,
+        limit: int,
+    ) -> tuple[list[ScenarioAttackResultDelta], bool]:
+        assert limit == ScenarioProgressReadModel._STORAGE_PAGE_SIZE
+        return ([deltas[scenario_result_id]], False) if cursor is None else ([], False)
+
+    memory.get_scenario_attack_result_deltas.side_effect = get_deltas
+    read_model = ScenarioProgressReadModel(memory=memory)
+
+    with patch.object(ScenarioProgressReadModel, "_CACHE_MAX_RUNS", 2):
+        first = _get_snapshot(read_model=read_model, run_id="run-a")
+        _get_snapshot(read_model=read_model, run_id="run-b")
+        second = _get_snapshot(read_model=read_model, run_id="run-a")
+        _get_snapshot(read_model=read_model, run_id="run-c")
+        _get_snapshot(read_model=read_model, run_id="run-b")
+
+    assert isinstance(first, ScenarioProgressSnapshot)
+    assert isinstance(first.deltas, tuple)
+    assert first.results == second.results
+    run_a_cursors = [
+        call.kwargs["cursor"]
+        for call in memory.get_scenario_attack_result_deltas.call_args_list
+        if call.kwargs["scenario_result_id"] == "run-a"
+    ]
+    run_b_cursors = [
+        call.kwargs["cursor"]
+        for call in memory.get_scenario_attack_result_deltas.call_args_list
+        if call.kwargs["scenario_result_id"] == "run-b"
+    ]
+    assert run_a_cursors[0] is None
+    assert run_a_cursors[1] is not None
+    assert run_b_cursors == [None, None]
+
+
+def test_get_snapshot_invalidates_cache_when_plan_changes() -> None:
+    memory = MagicMock(spec=MemoryInterface)
+    delta = _make_delta(run_id="run-plan")
+    memory.get_scenario_attack_result_deltas.return_value = ([delta], False)
+    read_model = ScenarioProgressReadModel(memory=memory)
+
+    def make_plan(group_id: str) -> ScenarioRunPlan:
+        return ScenarioRunPlan(
+            atomic_groups=[
+                ScenarioRunPlanAtomicGroup(
+                    id=group_id,
+                    atomic_attack_name="attack",
+                    display_group="Attack",
+                    technique_eval_hash="",
+                    seed_group_ids=["seed-0"],
+                )
+            ],
+            seed_groups=[
+                ScenarioRunPlanSeedGroup(
+                    id="seed-0",
+                    objective_sha256=delta.objective_sha256 or "",
+                    objective=delta.objective,
+                )
+            ],
+        )
+
+    first = read_model.get_snapshot(
+        scenario_result_id="run-plan",
+        plan=make_plan("group-a"),
+        plan_complete=True,
+        active_group_ids=(),
+        terminal=False,
+        objective_scorer_identifier=None,
+    )
+    second = read_model.get_snapshot(
+        scenario_result_id="run-plan",
+        plan=make_plan("group-b"),
+        plan_complete=True,
+        active_group_ids=(),
+        terminal=False,
+        objective_scorer_identifier=None,
+    )
+
+    assert first.results[0].atomic_group_id == "group-a"
+    assert second.results[0].atomic_group_id == "group-b"
+    assert [call.kwargs["cursor"] for call in memory.get_scenario_attack_result_deltas.call_args_list] == [
+        None,
+        None,
+    ]
+
+
+def test_get_snapshot_keeps_concurrent_runs_isolated() -> None:
+    memory = MagicMock(spec=MemoryInterface)
+
+    def get_deltas(
+        *,
+        scenario_result_id: str,
+        cursor: AttackResultKeysetCursor | None,
+        limit: int,
+    ) -> tuple[list[ScenarioAttackResultDelta], bool]:
+        assert limit == ScenarioProgressReadModel._STORAGE_PAGE_SIZE
+        return ([_make_delta(run_id=scenario_result_id)], False) if cursor is None else ([], False)
+
+    memory.get_scenario_attack_result_deltas.side_effect = get_deltas
+    read_model = ScenarioProgressReadModel(memory=memory)
+    run_ids = [f"run-{index}" for index in range(8)]
+
+    def read_run(run_id: str) -> ScenarioProgressSnapshot:
+        return _get_snapshot(read_model=read_model, run_id=run_id)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        snapshots = list(executor.map(read_run, run_ids))
+
+    assert [snapshot.results[0].conversation_id for snapshot in snapshots] == [
+        f"conversation-{run_id}-0" for run_id in run_ids
+    ]

--- a/tests/unit/backend/test_scenario_progress_read_model.py
+++ b/tests/unit/backend/test_scenario_progress_read_model.py
@@ -8,6 +8,8 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from pyrit.backend.services.scenario_progress_read_model import (
     ScenarioProgressReadModel,
     ScenarioProgressSnapshot,
@@ -138,6 +140,92 @@ def test_get_snapshot_invalidates_cache_when_plan_changes() -> None:
     assert [call.kwargs["cursor"] for call in memory.get_scenario_attack_result_deltas.call_args_list] == [
         None,
         None,
+    ]
+
+
+@pytest.mark.parametrize(
+    ("active_group_ids", "terminal", "plan_complete", "expected_status", "expected_planned"),
+    [
+        pytest.param(("group",), False, True, "RUNNING", 2, id="active-group-change"),
+        pytest.param((), True, True, "INCOMPLETE", 2, id="terminal-state-change"),
+        pytest.param((), False, False, "PENDING", None, id="plan-completeness-change"),
+    ],
+)
+def test_get_snapshot_updates_summary_without_new_rows(
+    *,
+    active_group_ids: tuple[str, ...],
+    terminal: bool,
+    plan_complete: bool,
+    expected_status: str,
+    expected_planned: int | None,
+) -> None:
+    memory = MagicMock(spec=MemoryInterface)
+    deltas = [_make_delta(run_id="run-state", index=index) for index in range(2)]
+    plan = ScenarioRunPlan(
+        atomic_groups=[
+            ScenarioRunPlanAtomicGroup(
+                id="group",
+                atomic_attack_name="attack",
+                display_group="Attack",
+                technique_eval_hash="",
+                seed_group_ids=["seed-0", "seed-1"],
+            )
+        ],
+        seed_groups=[
+            ScenarioRunPlanSeedGroup(
+                id=f"seed-{index}",
+                objective_sha256=delta.objective_sha256 or "",
+                objective=delta.objective,
+            )
+            for index, delta in enumerate(deltas)
+        ],
+    )
+    memory.get_scenario_attack_result_deltas.side_effect = [([deltas[0]], False), ([], False), ([], False)]
+    read_model = ScenarioProgressReadModel(memory=memory)
+
+    with patch.object(read_model, "_map_progress_delta", wraps=read_model._map_progress_delta) as map_delta:
+        first = read_model.get_snapshot(
+            scenario_result_id="run-state",
+            plan=plan,
+            plan_complete=True,
+            active_group_ids=(),
+            terminal=False,
+            objective_scorer_identifier=None,
+        )
+        second = read_model.get_snapshot(
+            scenario_result_id="run-state",
+            plan=plan,
+            plan_complete=plan_complete,
+            active_group_ids=active_group_ids,
+            terminal=terminal,
+            objective_scorer_identifier=None,
+        )
+        restored = read_model.get_snapshot(
+            scenario_result_id="run-state",
+            plan=plan,
+            plan_complete=True,
+            active_group_ids=(),
+            terminal=False,
+            objective_scorer_identifier=None,
+        )
+
+    assert first.summary.atomic_groups[0].status == "PENDING"
+    assert first.summary.overall.planned == 2
+    assert second.summary.atomic_groups[0].status == expected_status
+    assert second.summary.overall.planned == expected_planned
+    assert second.summary.overall.completed == 1
+    assert second.summary.overall.succeeded == 1
+    assert restored.summary == first.summary
+    assert first.results == second.results == restored.results
+    map_delta.assert_called_once()
+    cursor = AttackResultKeysetCursor(
+        timestamp=deltas[0].timestamp,
+        attack_result_id=deltas[0].attack_result_id,
+    )
+    assert [call.kwargs["cursor"] for call in memory.get_scenario_attack_result_deltas.call_args_list] == [
+        None,
+        cursor,
+        cursor,
     ]
 
 

--- a/tests/unit/backend/test_scenario_run_service.py
+++ b/tests/unit/backend/test_scenario_run_service.py
@@ -27,7 +27,7 @@ from pyrit.backend.services.scenario_run_service import (
 )
 from pyrit.common.utils import to_sha256
 from pyrit.converter import Converter
-from pyrit.memory import ScenarioHistoryAggregate, ScenarioHistoryRunRecord
+from pyrit.memory import AttackResultKeysetCursor, ScenarioHistoryAggregate, ScenarioHistoryRunRecord
 from pyrit.models import (
     SCENARIO_RUN_PLAN_METADATA_KEY,
     AtomicAttackIdentifier,
@@ -2412,6 +2412,143 @@ def test_get_progress_cache_refreshes_identifier_enriched_after_insert(mock_memo
         appended.attack_result_id,
     ]
     assert mock_memory.get_scenario_attack_result_deltas.call_args_list[1].kwargs["cursor"] is None
+
+
+def test_get_progress_refreshes_enriched_rows_across_storage_pages(mock_memory: MagicMock) -> None:
+    attack_identifier = ComponentIdentifier(class_name="PromptSendingAttack", class_module="tests")
+    unenriched_identifier = AtomicAttackIdentifier.build(attack_identifier=attack_identifier)
+    deltas = [
+        ScenarioAttackResultDelta(
+            attack_result_id=str(uuid.UUID(int=index + 1)),
+            conversation_id=f"conversation-{index}",
+            objective=f"objective-{index}",
+            objective_sha256=f"sha-{index}",
+            outcome=AttackOutcome.SUCCESS,
+            execution_time_ms=10,
+            timestamp=datetime(2025, 1, 1, tzinfo=UTC),
+            atomic_attack_identifier=unenriched_identifier if index == 0 else None,
+            attribution_data={
+                "parent_collection": "attack",
+                "parent_eval_hash": "eval",
+                "seed_group_id": f"seed-{index}",
+            },
+        )
+        for index in range(501)
+    ]
+    plan = ScenarioRunPlan(
+        atomic_groups=[
+            ScenarioRunPlanAtomicGroup(
+                id="group",
+                atomic_attack_name="attack",
+                display_group="Attack",
+                technique_eval_hash="eval",
+                seed_group_ids=[f"seed-{index}" for index in range(501)],
+            )
+        ],
+        seed_groups=[
+            ScenarioRunPlanSeedGroup(
+                id=f"seed-{index}",
+                objective_sha256=delta.objective_sha256 or "",
+                objective=delta.objective,
+            )
+            for index, delta in enumerate(deltas)
+        ],
+    )
+    header = make_scenario_result(
+        attack_results={},
+        scenario_run_state=ScenarioRunState.IN_PROGRESS,
+        metadata={SCENARIO_RUN_PLAN_METADATA_KEY: plan.model_dump(mode="json")},
+    )
+    run_id = str(header.id)
+    stored_deltas = deltas[:500]
+
+    def get_deltas(
+        *,
+        scenario_result_id: str,
+        cursor: AttackResultKeysetCursor | None,
+        limit: int,
+    ) -> tuple[list[ScenarioAttackResultDelta], bool]:
+        assert scenario_result_id == run_id
+        assert limit == 500
+        available = [
+            delta
+            for delta in stored_deltas
+            if cursor is None
+            or (delta.timestamp, uuid.UUID(delta.attack_result_id))
+            > (cursor.timestamp, uuid.UUID(cursor.attack_result_id))
+        ]
+        return [delta.model_copy(deep=True) for delta in available[:limit]], len(available) > limit
+
+    mock_memory.get_scenario_result_header.return_value = header
+    mock_memory.get_scenario_attack_result_deltas.side_effect = get_deltas
+    service = ScenarioRunService()
+
+    first = service.get_run_progress(scenario_result_id=run_id, since=None, limit=100)
+
+    assert first is not None
+    assert first.plan == plan
+    assert first.plan_complete is True
+    assert len(first.results) == 100
+    assert first.has_more is True
+    assert first.summary.overall.completed == 500
+    assert first.summary.atomic_groups[0].technique_details is None
+    first_payload = first.model_dump(mode="json")
+
+    stored_deltas[0] = stored_deltas[0].model_copy(
+        update={
+            "atomic_attack_identifier": AtomicAttackIdentifier.build(
+                technique_identifier=ComponentIdentifier(
+                    class_name="AttackTechnique",
+                    class_module="tests",
+                    children={"attack": attack_identifier},
+                ),
+                seed_group=AttackSeedGroup(seeds=[SeedObjective(value=deltas[0].objective)]),
+            )
+        }
+    )
+    stored_deltas.append(deltas[500])
+
+    result_ids = [result.attack_result_id for result in first.results]
+    cursor = first.next_cursor
+    for offset in range(100, 501, 100):
+        page = service.get_run_progress(scenario_result_id=run_id, since=cursor, limit=100)
+
+        assert page is not None
+        assert page.plan is None
+        assert page.plan_complete is True
+        assert [result.attack_result_id for result in page.results] == [
+            delta.attack_result_id for delta in stored_deltas[offset : offset + 100]
+        ]
+        assert page.has_more is (offset + 100 < 501)
+        assert page.summary.overall.completed == 501
+        assert page.summary.overall.succeeded == 501
+        assert page.summary.overall.retries == 0
+        assert page.summary.overall.errors == 0
+        assert page.summary.atomic_groups[0].technique_details is not None
+        result_ids.extend(result.attack_result_id for result in page.results)
+        cursor = page.next_cursor
+
+    assert result_ids == [delta.attack_result_id for delta in stored_deltas]
+    assert len(set(result_ids)) == 501
+    assert first.model_dump(mode="json") == first_payload
+
+    empty = service.get_run_progress(scenario_result_id=run_id, since=cursor, limit=100)
+    assert empty is not None
+    assert empty.results == []
+    assert empty.has_more is False
+    assert empty.next_cursor == cursor
+
+    storage_cursors = [call.kwargs["cursor"] for call in mock_memory.get_scenario_attack_result_deltas.call_args_list]
+    assert storage_cursors[:3] == [
+        None,
+        None,
+        AttackResultKeysetCursor(timestamp=deltas[499].timestamp, attack_result_id=deltas[499].attack_result_id),
+    ]
+    assert all(
+        cursor
+        == AttackResultKeysetCursor(timestamp=deltas[500].timestamp, attack_result_id=deltas[500].attack_result_id)
+        for cursor in storage_cursors[3:]
+    )
 
 
 def test_get_progress_treats_duplicate_stored_plan_groups_as_incomplete(mock_memory) -> None:

--- a/tests/unit/backend/test_scenario_run_service.py
+++ b/tests/unit/backend/test_scenario_run_service.py
@@ -18,11 +18,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import pyrit.backend.services.scenario_configuration_resolver as _resolver_mod
+import pyrit.backend.services.scenario_progress_read_model as _progress_mod
 import pyrit.backend.services.scenario_run_service as _svc_mod
+from pyrit.backend.services.scenario_progress_read_model import ScenarioPlanLookup, ScenarioProgressReadModel
 from pyrit.backend.services.scenario_run_service import (
     _DEFAULT_MAX_CONCURRENT_RUNS,
     ScenarioRunService,
 )
+from pyrit.common.utils import to_sha256
 from pyrit.converter import Converter
 from pyrit.memory import ScenarioHistoryAggregate, ScenarioHistoryRunRecord
 from pyrit.models import (
@@ -1209,7 +1212,7 @@ class TestScenarioRunServiceGetRun:
                     seed_groups=[
                         ScenarioRunPlanSeedGroup(
                             id="seed-1",
-                            objective_sha256=_svc_mod.to_sha256("objective"),
+                            objective_sha256=to_sha256("objective"),
                             objective="objective",
                         )
                     ],
@@ -2208,7 +2211,7 @@ def test_planned_progress_maps_legacy_objective_hash_to_logical_seed_id(mock_mem
         seed_groups=[
             ScenarioRunPlanSeedGroup(
                 id=seed_group_id,
-                objective_sha256=_svc_mod.to_sha256(objective),
+                objective_sha256=to_sha256(objective),
                 objective=objective,
             )
         ],
@@ -2336,10 +2339,13 @@ def test_get_progress_cache_refreshes_identifier_enriched_after_insert(mock_memo
                 atomic_attack_name="attack",
                 display_group="Attack",
                 technique_eval_hash="eval",
-                seed_group_ids=["seed"],
+                seed_group_ids=["seed", "seed-2"],
             )
         ],
-        seed_groups=[ScenarioRunPlanSeedGroup(id="seed", objective_sha256="sha", objective="objective")],
+        seed_groups=[
+            ScenarioRunPlanSeedGroup(id="seed", objective_sha256="sha", objective="objective"),
+            ScenarioRunPlanSeedGroup(id="seed-2", objective_sha256="sha-2", objective="objective-2"),
+        ],
     )
     header = make_scenario_result(
         attack_results={},
@@ -2372,10 +2378,25 @@ def test_get_progress_cache_refreshes_identifier_enriched_after_insert(mock_memo
             )
         }
     )
+    appended = pre_enrichment.model_copy(
+        update={
+            "attack_result_id": str(uuid.uuid4()),
+            "conversation_id": "conversation-2",
+            "objective": "objective-2",
+            "objective_sha256": "sha-2",
+            "timestamp": datetime(2025, 1, 1, 0, 1, tzinfo=UTC),
+            "atomic_attack_identifier": None,
+            "attribution_data": {
+                "parent_collection": "attack",
+                "parent_eval_hash": "eval",
+                "seed_group_id": "seed-2",
+            },
+        }
+    )
     mock_memory.get_scenario_result_header.return_value = header
     mock_memory.get_scenario_attack_result_deltas.side_effect = [
         ([pre_enrichment], False),
-        ([post_enrichment], False),
+        ([post_enrichment, appended], False),
     ]
     service = ScenarioRunService()
 
@@ -2386,6 +2407,10 @@ def test_get_progress_cache_refreshes_identifier_enriched_after_insert(mock_memo
     assert second is not None
     assert first.summary.atomic_groups[0].technique_details is None
     assert second.summary.atomic_groups[0].technique_details is not None
+    assert [result.attack_result_id for result in second.results] == [
+        post_enrichment.attack_result_id,
+        appended.attack_result_id,
+    ]
     assert mock_memory.get_scenario_attack_result_deltas.call_args_list[1].kwargs["cursor"] is None
 
 
@@ -2444,9 +2469,9 @@ def test_progress_prefers_persisted_logical_seed_group_attribution() -> None:
         },
     )
 
-    mapped = ScenarioRunService._map_progress_delta(
+    mapped = ScenarioProgressReadModel._map_progress_delta(
         delta=delta,
-        plan_lookup=_svc_mod._ScenarioPlanLookup.from_plan(plan=None),
+        plan_lookup=ScenarioPlanLookup.from_plan(plan=None),
     )
 
     assert mapped.seed_group_id == "canonical-seed-id"
@@ -2515,11 +2540,11 @@ def test_progress_builds_attack_technique_details_once_per_atomic_group() -> Non
         ),
     )
 
-    mapped = ScenarioRunService._map_progress_delta(
+    mapped = ScenarioProgressReadModel._map_progress_delta(
         delta=delta,
-        plan_lookup=_svc_mod._ScenarioPlanLookup.from_plan(plan=None),
+        plan_lookup=ScenarioPlanLookup.from_plan(plan=None),
     )
-    details_by_group = ScenarioRunService._build_technique_details_by_group(
+    details_by_group = ScenarioProgressReadModel._build_technique_details_by_group(
         deltas=[delta],
         results=[mapped],
     )
@@ -2568,7 +2593,7 @@ def test_technique_details_normalize_every_declared_target_slot() -> None:
         children={"attack": attack_identifier},
     )
 
-    details = ScenarioRunService._build_attack_technique_details(technique_identifier=technique_identifier)
+    details = ScenarioProgressReadModel._build_attack_technique_details(technique_identifier=technique_identifier)
 
     projected_attack = details.children["attack"][0]
     assert projected_attack.children["objective_target"][0].parameters == {"underlying_model_name": "gpt-4o"}
@@ -2578,7 +2603,7 @@ def test_technique_details_normalize_every_declared_target_slot() -> None:
 
 def test_technique_seeds_child_name_matches_the_identifier_field() -> None:
     """The one display constant left in the service must track the typed field."""
-    assert _svc_mod._TECHNIQUE_SEEDS_CHILD in AttackTechniqueIdentifier.model_fields
+    assert _progress_mod._TECHNIQUE_SEEDS_CHILD in AttackTechniqueIdentifier.model_fields
 
 
 def test_synthesize_legacy_plan_deduplicates_seed_ids_in_first_seen_order() -> None:
@@ -2605,7 +2630,7 @@ def test_synthesize_legacy_plan_deduplicates_seed_ids_in_first_seen_order() -> N
         for attack_name, eval_hash, seed_group_id, objective in delta_units
     ]
 
-    plan = ScenarioRunService._synthesize_legacy_plan(deltas=deltas)
+    plan = ScenarioProgressReadModel._synthesize_legacy_plan(deltas=deltas)
 
     assert [group.atomic_attack_name for group in plan.atomic_groups] == ["attack", "other attack"]
     assert plan.atomic_groups[0].seed_group_ids == ["seed-b", "seed-a"]
@@ -2763,8 +2788,8 @@ def test_progress_summary_uses_latest_attempt_for_backend_owned_counts() -> None
         recall=0.92,
         average_score_time_seconds=0.25,
     )
-    with patch.object(_svc_mod, "find_objective_metrics_by_eval_hash", return_value=metrics):
-        summary = ScenarioRunService._build_progress_summary(
+    with patch.object(_progress_mod, "find_objective_metrics_by_eval_hash", return_value=metrics):
+        summary = ScenarioProgressReadModel._build_progress_summary(
             plan=plan,
             plan_complete=True,
             results=results,


### PR DESCRIPTION
## Description

Closes #2627.

This extracts scenario progress hydration and projection from `ScenarioRunService` into an internal typed `ScenarioProgressReadModel`.

The read model now owns:

- bounded per-run LRU state and keyset cursor advancement;
- incremental persistence hydration and identifier-enrichment refresh;
- plan lookup, plan-change invalidation, and legacy effective-plan synthesis;
- mapping persisted deltas into `ScenarioProgressResult`;
- canonical overall, display-group, technique, seed-group, and atomic-group summaries;
- retry/error accounting and objective-scorer projection.

The boundary is an immutable `ScenarioProgressSnapshot` rather than a positional tuple, and summary invalidation uses a named state dataclass. `ScenarioRunService` retains active-run capture, header and plan validation, client cursor pagination, and construction of the existing `ScenarioRunProgress` response. Superseded service branches were removed rather than wrapped, with no REST, persistence, or cursor schema changes.

Regression coverage adds direct checks for LRU eviction with recency refresh, plan-change remapping, concurrent run isolation, and the enrichment-plus-appended-row edge case without duplicate IDs or counts.

AI assistance disclosure: I used OpenAI Codex to help inspect, refactor, and validate this change. I reviewed the final diff and remain responsible for the contribution.

## Tests and Documentation

- `uv run --python 3.14 --frozen -m pytest -n 4 --dist=loadfile tests/unit` — **17,460 passed, 10 skipped**
- focused progress/service tests — **111 passed**
- `uv run --python 3.14 --frozen --extra all --link-mode=copy ty check pyrit`
- applicable pre-commit hooks on all four changed files, including Ruff, async-suffix validation, and `ty`
- `git diff --check upstream/main...HEAD`

Documentation was not changed because this is an internal responsibility extraction that preserves the public API and wire formats.