### PR TITLE
FIX: Improve selected configuration path contrast

### DIFF
--- a/frontend/src/components/EditorWorkspace.tsx
+++ b/frontend/src/components/EditorWorkspace.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 
-import { Button, makeStyles, Text, tokens } from '@fluentui/react-components'
+import { Button, makeStyles, mergeClasses, Text, tokens } from '@fluentui/react-components'
 
 import {
   MINIMUM_TOUCH_TARGET_SIZE,
@@ -92,6 +92,9 @@ const useStyles = makeStyles({
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   },
+  selectedSecondaryText: {
+    color: tokens.colorNeutralForegroundOnBrand,
+  },
   editorPane: {
     display: 'flex',
     flexDirection: 'column',
@@ -141,7 +144,15 @@ export default function EditorWorkspace({
                 <span className={styles.navigationContent}>
                   <span>{item.label}</span>
                   {item.secondaryText && (
-                    <span className={styles.secondaryText} title={item.secondaryText}>{item.secondaryText}</span>
+                    <span
+                      className={mergeClasses(
+                        styles.secondaryText,
+                        item.id === selectedId && styles.selectedSecondaryText,
+                      )}
+                      title={item.secondaryText}
+                    >
+                      {item.secondaryText}
+                    </span>
                   )}
                 </span>
               </Button>


### PR DESCRIPTION
## Description

Fixes #2641.

The selected `EditorWorkspace` navigation item uses a primary brand background, but its secondary path retained `colorNeutralForeground3`. Apply `colorNeutralForegroundOnBrand` only to the selected item's secondary text while preserving the muted color for unselected items.

With the Fluent UI 9.74.7 web themes, the selected-state contrast is now:

- Light: `#ffffff` on `#0f6cbd` — 5.38:1
- Dark: `#ffffff` on `#115ea3` — 6.66:1

Both exceed the 4.5:1 requirement.

## Tests and Documentation

- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test -- --runInBand src/components/Configuration/Configuration.test.tsx` — 10 passed
- `npm test -- --runInBand --testPathIgnorePatterns=LabelsBar.test.tsx` — 1,346 passed

The full suite passed 1,423 of 1,424 tests. The remaining existing `LabelsBar` click-away test failed independently when rerun alone and does not import or exercise `EditorWorkspace`. No documentation change is needed for this visual bug fix.
